### PR TITLE
Don't duplicate deps in platformio.ini; add heltec_wifi_kit_32_v2 board support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -64,6 +64,17 @@ build_flags   = -DSPECTRUM=1
                 -std=gnu++17
                 -Ofast 
 
+[env:heltec_wifi_kit_32_v2]  ; V2 board has 8M flash
+board = heltec_wifi_kit_32_v2
+monitor_speed = 115200
+upload_speed  = 921600
+upload_port   = COM7
+monitor_port  = COM7
+build_flags   = -DSPECTRUM=1
+                -DUSE_TFT=1
+                -std=gnu++17
+                -Ofast 
+
 [env:spectrum]
 board         = m5stick-c
 ;board_build.partitions = partitions_custom.csv

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,25 +12,34 @@
 data_dir    = ./data
 default_envs = demo
 
+[common]
+lib_deps        = crankyoldgit/IRremoteESP8266  @ ^2.7.20
+                  fastled/FastLED               @ ^3.4.0
+                  adafruit/Adafruit BusIO       @ ^1.9.1
+                  adafruit/Adafruit GFX Library @ ^1.10.12
+                  bblanchon/ArduinoJson         @ ^6.8.14
+                  olikraus/U8g2                 @ ^2.28.8
+                  joaolopesf/RemoteDebug        @ ^3.0.5
+                  kosme/arduinoFFT              @ ^1.5.6
+                  me-no-dev/AsyncTCP            @ ^1.1.1
+                  thomasfredericks/Bounce2      @ ^2.7.0
+                  me-no-dev/ESP Async WebServer @ ^1.2.3
+
+[m5stick-c]
+lib_deps        = ${common.lib_deps}
+                  m5stack/M5StickC @ ^0.2.3
+
+[m5stick-c-plus]
+lib_deps        = ${common.lib_deps}
+                  m5stack/M5StickCPlus @ ^0.0.2
+
 [env]
 platform        = https://github.com/platformio/platform-espressif32.git
 framework       = arduino
 build_type      = debug
 build_unflags   = -std=gnu++11
 
-lib_deps        = https://github.com/crankyoldgit/IRremoteESP8266
-                  FastLED                       @ ^3.4.0
-                  Adafruit BusIO                @ ^1.9.1
-                  Adafruit GFX Library          @ ^1.10.12
-                  ArduinoJson                   @ ^6.8.14
-                  U8g2                          @ ^2.28.8
-                  RemoteDebug                   @ ^3.0.5
-                  arduinoFFT                    @ ^1.5.6
-                  AsyncTCP                      @ ^1.1.1
-                  Bounce2                       @ ^2.7.0
-                  me-no-dev/ESP Async WebServer @ ^1.2.3
-                  Wire                
-                  M5StickC
+lib_deps        = ${common.lib_deps}
 
 monitor_filters = esp32_exception_decoder
 
@@ -69,19 +78,7 @@ build_flags   = -DM5STICKCPLUS=1
                 -DDECODE_NEC=true            ; enable whichever you need for your remote.  Try not disabling above to figure out which it is.
                 -std=gnu++17
                 -Ofast 
-lib_deps     =  M5StickCPlus
-                https://github.com/crankyoldgit/IRremoteESP8266
-                https://github.com/FastLED/FastLED.git
-                Adafruit BusIO
-                Adafruit GFX Library
-                ArduinoJson
-                U8g2 
-                RemoteDebug
-                arduinoFFT
-                AsyncTCP
-                Wire                
-                Bounce2
-                me-no-dev/ESP Async WebServer @ ^1.2.3
+lib_deps      = ${m5stick-c-plus.lib_deps}
 
 [env:insulators]
 board         = m5stick-c
@@ -93,6 +90,7 @@ build_flags   = -DM5STICKC=1
                 -DINSULATORS=1
                 -std=gnu++17
                 -Ofast 
+lib_deps      = ${m5stick-c.lib_deps}
 
 [env:magicmirror]
 board         = m5stick-c
@@ -104,6 +102,8 @@ build_flags   = -DM5STICKC=1
                 -DMAGICMIRROR=1
                 -std=gnu++17
                 -Ofast                 
+lib_deps      = ${m5stick-c.lib_deps}
+                
 
 [env:atomlight]
 board         = heltec_wifi_kit_32
@@ -124,6 +124,7 @@ build_flags   = -DM5STICKC=1
                 -DFANSET=1
                 -std=gnu++17
                 -Ofast 
+lib_deps      = ${m5stick-c.lib_deps}
 
 [env:atomi]
 board         = heltec_wifi_kit_32


### PR DESCRIPTION
## Description
This fixes the duplicated deps issue Dave mentioned in his video.

It does this by moving all common deps to a common section, and board specific deps to their own board specific section.
Then these sections are referenced in the env lib_deps and in env subsections where applicable. 

It also makes all deps use the same import format $group/$dependency @ $version_spec (this was just because the different formats was bothering me. I can revert if desired)

Also, I don't think Wire is a necessary dependency as the projects compile without it, so I've removed it.  

--

Also, on a side note: it looks like the spectrum example has code that only works on the M5Stick.  I had to comment these M5.Lcd lines from the spectrumeffects.h file to get the project to compile on the heltec_wifi_kit_32_v2 board. (**I did not include these changes in this pull-request.**) It's just an FYI.

``` diff
diff --git a/include/effects/spectrumeffects.h b/include/effects/spectrumeffects.h
index 64fcf7b..3047ce9 100644
--- a/include/effects/spectrumeffects.h
+++ b/include/effects/spectrumeffects.h
@@ -116,8 +116,10 @@ class VUMeterEffect : public LEDStripEffect

         pGFXChannel->fillRect(0, yVU, MATRIX_WIDTH, 1, BLACK16);

+/*^M
         if (giInfoPage == 1)
             M5.Lcd.fillRect(0, 0, M5.Lcd.width(), 10, BLACK16);
+*/^M
 
         if (iPeakVUy > 1)
         {
@@ -348,10 +350,10 @@ class SpectrumAnalyzerEffect : public VUMeterEffect
             if (gbInfoPageDirty)
             {
                 gbInfoPageDirty = false;
-                M5.Lcd.fillScreen(BLACK16);
+                // M5.Lcd.fillScreen(BLACK16);^M
             }
         }
-        
+^M
         DrawVUMeter(0);
         for (int i = 0; i < NUM_BANDS; i++)
         {
```

## Contributing requirements

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).