### PR TITLE
Move secrets to a new file secrets.h add add to gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 NightDriverStrip.code-workspace
 src/uzlib/src/*.o
 .history
-
+lib/*
+include/secrets.h

--- a/include/network.h
+++ b/include/network.h
@@ -29,6 +29,7 @@
 #include "remotecontrol.h"
 #include "socketserver.h"
 #include "ntptimeclient.h"
+#include "secrets.h"
 
 extern byte g_Brightness;
 extern bool g_bUpdateStarted;
@@ -41,10 +42,6 @@ void processRemoteDebugCmd();
 #if ENABLE_REMOTE
 extern RemoteControl g_RemoteControl;
 #endif
-
-#define cszSSID      "Your SSID"
-#define cszPassword  "Your PASS"
-#define cszHostname  "NightDriverStrip"
 
 bool ConnectToWiFi(uint cRetries);
 void SetupOTA(const char *pszHostname);

--- a/include/ntptimeclient.h
+++ b/include/ntptimeclient.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "globals.h"
+#include "secrets.h"
 #include <sys/cdefs.h>
 #include <sys/time.h>
 #include <time.h>
@@ -43,6 +44,8 @@
 // Basically, I took some really ancient NTP code that I had on hand that I knew
 // worked and wrapped it in a class.  As expected, it works, but it could likely
 // benefit from cleanup or even wholesale replacement.
+
+
 
 class NTPTimeClient
 {
@@ -93,7 +96,7 @@ class NTPTimeClient
 
 		// Send the ntp packet.
 
-		IPAddress ipNtpServer(192, 168, 1, 2); 								// My Synology NAS
+		IPAddress ipNtpServer(cszNTPServer); 								// cszNTPServer defined in secrets.h
 		//IPAddress ipNtpServer(216, 239, 35, 12); 							// 216.239.35.12 Google Time
 		//IPAddress ipNtpServer(17, 253, 16, 253);							// Apple time
 

--- a/include/ntptimeclient.h
+++ b/include/ntptimeclient.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "globals.h"
-#include "secrets.h"
 #include <sys/cdefs.h>
 #include <sys/time.h>
 #include <time.h>
@@ -39,13 +38,17 @@
 #include <WiFiUdp.h>
 #include <mutex>
 
+// define the NTP server to connect too (replace . [dots] in IP addresses with , [commas])
+#define cszNTPServer  94, 199, 173, 123     // 0.pool.ntp.org
+//#define cszNTPServer 216, 239, 35, 12     // google time
+//#define cszNTPServer 17, 253, 16, 253     // apple time
+
+
 // NTPTimeClient
 //
 // Basically, I took some really ancient NTP code that I had on hand that I knew
 // worked and wrapped it in a class.  As expected, it works, but it could likely
 // benefit from cleanup or even wholesale replacement.
-
-
 
 class NTPTimeClient
 {
@@ -95,10 +98,7 @@ class NTPTimeClient
 		chNtpPacket[0] = 0b00011011;
 
 		// Send the ntp packet.
-
-		IPAddress ipNtpServer(cszNTPServer); 								// cszNTPServer defined in secrets.h
-		//IPAddress ipNtpServer(216, 239, 35, 12); 							// 216.239.35.12 Google Time
-		//IPAddress ipNtpServer(17, 253, 16, 253);							// Apple time
+		IPAddress ipNtpServer(cszNTPServer); 								
 
 		pUDP->beginPacket(ipNtpServer, 123);
 		pUDP->write((const uint8_t *)chNtpPacket, NTP_PACKET_LENGTH);

--- a/include/secrets.h
+++ b/include/secrets.h
@@ -1,6 +1,6 @@
 //+--------------------------------------------------------------------------
 //
-// File:        network.h
+// File:        secrets.h
 //
 // NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
 //
@@ -22,13 +22,11 @@
 //
 // Description:
 //
-//    secret definations 
+//    secret definitions, at the moment this is just network secrets, 
+//    but could be expanded in the future
 //
 //---------------------------------------------------------------------------
 
-#define cszSSID      "Your SSID"
-#define cszPassword  "Your PASS"
-#define cszHostname  "NightDriverStrip"
-#define cszNTPServer 192, 168, 1, 2    // 0.pool.ntp.org
-//#define cszNTPServer 192, 168, 1, 2    // 0.pool.ntp.org
-//#define cszNTPServer 192, 168, 1, 2    // 0.pool.ntp.org
+#define cszSSID       "Your SSID"
+#define cszPassword   "Your PASS"
+#define cszHostname   "NightDriverStrip"

--- a/include/secrets.h
+++ b/include/secrets.h
@@ -1,0 +1,34 @@
+//+--------------------------------------------------------------------------
+//
+// File:        network.h
+//
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+//
+// This file is part of the NightDriver software project.
+//
+//    NightDriver is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//   
+//    NightDriver is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//   
+//    You should have received a copy of the GNU General Public License
+//    along with Nightdriver.  It is normally found in copying.txt
+//    If not, see <https://www.gnu.org/licenses/>.
+//
+// Description:
+//
+//    secret definations 
+//
+//---------------------------------------------------------------------------
+
+#define cszSSID      "Your SSID"
+#define cszPassword  "Your PASS"
+#define cszHostname  "NightDriverStrip"
+#define cszNTPServer 192, 168, 1, 2    // 0.pool.ntp.org
+//#define cszNTPServer 192, 168, 1, 2    // 0.pool.ntp.org
+//#define cszNTPServer 192, 168, 1, 2    // 0.pool.ntp.org


### PR DESCRIPTION
## Description
- Move secrets, such as Wifi network, and credentials to secrets.h. This file is added to .gitignore. 
 This should make it so users don't need to worry about publishing their network SSID/password when committing changes. 

- Also, moves NTP network address to define at top of ntptimeclient.h

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).