### PR TITLE
Add RGB Cube configuration

### DIFF
--- a/include/effects/faneffects.h
+++ b/include/effects/faneffects.h
@@ -73,6 +73,11 @@ static const int FanPixelsVertical[FAN_SIZE] =
 {
   0, 11, 1, 10, 2, 9, 3, 8, 4, 7, 5, 6
 };
+#elif CUBE
+static const int FanPixelsVertical[FAN_SIZE] =
+{
+  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24
+};
 #elif TREESET
 static const int FanPixelsVertical[FAN_SIZE] =
 {

--- a/include/globals.h
+++ b/include/globals.h
@@ -670,6 +670,10 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 #define NUM_INFO_PAGES 1
 #endif
 
+#ifndef COLOR_ORDER
+#define COLOR_ORDER EOrder::GRB
+#endif
+
 // Define fan ordering for drawing into the fan directionally
 
 #define LED_FAN_OFFSET_LR  (LED_FAN_OFFSET_BU + (FAN_SIZE * 1 / 4))         // High level stuff right here!

--- a/include/globals.h
+++ b/include/globals.h
@@ -608,6 +608,43 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
     #define TOGGLE_BUTTON  37
     #define NUM_INFO_PAGES 1
+
+#elif CUBE
+
+    // A cube of 5 x 5 x 5 LEDs
+
+    #define ENABLE_WIFI             1   // Connect to WiFi
+    #define INCOMING_WIFI_ENABLED   1   // Accepting incoming color data and commands
+    #define WAIT_FOR_WIFI           0   // Hold in setup until we have WiFi - for strips without effects
+    #define TIME_BEFORE_LOCAL       5   // How many seconds before the cube times out and shows local content
+    #define ENABLE_WEBSERVER        1   // Enable the webserver to control the effects
+
+    #define DEFAULT_EFFECT_INTERVAL     (1000 * 60 * 10)    // 10 min
+
+    #define LED_PIN0          26
+    #define NUM_CHANNELS      1
+    #define RING_SIZE_0       25                    // Treat each layer as one ring
+    #define BONUS_PIXELS      0
+    #define MATRIX_WIDTH      5                     // 5 layers
+    #define MATRIX_HEIGHT     RING_SIZE_0
+    #define NUM_FANS          MATRIX_WIDTH
+    #define FAN_SIZE          MATRIX_HEIGHT
+    #define NUM_BANDS         16
+    #define NUM_LEDS          (MATRIX_WIDTH*MATRIX_HEIGHT)
+    #define RESERVE_MEMORY    150000
+    #define ENABLE_REMOTE     0                     // IR Remote Control
+    #define ENABLE_AUDIO      1                     // Listen for audio from the microphone and process it
+    #define IR_REMOTE_PIN     26                    
+    #define LED_FAN_OFFSET_BU 6
+    #define POWER_LIMIT_MW    5000
+
+    #define NOISE_CUTOFF   75
+    #define NOISE_FLOOR    200.0f
+
+    #define TOGGLE_BUTTON  37
+    #define NUM_INFO_PAGES 1
+
+    #define COLOR_ORDER EOrder::RGB
 #endif
 
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -195,3 +195,15 @@ build_flags   = -DATOMISTRING=1
                 -DUSE_TFT=1
                 -std=gnu++17
                 -Ofast 
+
+[env:cube]
+board         = m5stick-c
+upload_speed  = 1500000
+monitor_speed = 115200
+upload_port   = COM6
+build_flags   = -DM5STICKCPLUS=1
+                -DUSE_OLED=1
+                -DCUBE=1
+                -std=gnu++17
+                -Ofast 
+lib_deps      = ${m5stick-c-plus.lib_deps}

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -315,7 +315,19 @@ DRAM_ATTR LEDStripEffect * AllEffects[] =
     new SparklySpinningMusicEffect(RainbowColors_p), 
     new MoltenGlassOnVioletBkgnd(RainbowColors_p),
 */
-          
+
+  #elif CUBE
+    // Simple rainbow pallette
+    new PaletteEffect(rainbowPalette, 256/16, .2, 0),
+
+    new SparklySpinningMusicEffect("SparklySpinningMusical", RainbowColors_p), 
+    new ColorBeatOverRedBkgnd("ColorBeatOnRedBkgnd"),
+    new ColorBeatWithFlash("ColorBeatWithFlash"),
+    new SimpleInsulatorBeatEffect2("SimpleInsulatorColorBeat"),
+    new InsulatorSpectrumEffect("InsulatorSpectrumEffect"),
+    new StarryNightEffect<MusicStar>("Rainbow Music Stars", RainbowColors_p, 2.0, 2, LINEARBLEND, 5.0, 0.0, 10.0), // Rainbow Music Star
+
+    new FireFanEffect(NUM_LEDS,      1, 15, 80, 2, 7, Sequential, true, false),
 
   #elif BELT
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -532,51 +532,51 @@ extern U8G2_SSD1306_128X64_NONAME_F_HW_I2C g_TFT;
 #endif
 
 #if STRAND
-    FastLED.addLeds<WS2812B, LED_PIN0, RGB>(g_pStrands[0]->GetLEDBuffer(), g_pStrands[0]->GetLEDCount()); // Neopixel strand uses RGB color order, others are all GRB
-    //FastLED.addLeds<AtomiController, LED_PIN0, RGB>(g_pStrands[0]->GetLEDBuffer(), g_pStrands[0]->GetLEDCount());
+    FastLED.addLeds<WS2812B, LED_PIN0, COLOR_ORDER>(g_pStrands[0]->GetLEDBuffer(), g_pStrands[0]->GetLEDCount()); // Neopixel strand uses RGB color order, others are all GRB
+    //FastLED.addLeds<AtomiController, LED_PIN0, COLOR_ORDER>(g_pStrands[0]->GetLEDBuffer(), g_pStrands[0]->GetLEDCount());
 #elif NUM_CHANNELS == 1
     debugI("Adding %d LEDs to FastLED.", g_pStrands[0]->GetLEDCount());
-    FastLED.addLeds<WS2812B, LED_PIN0, GRB>(g_pStrands[0]->GetLEDBuffer(), 3*144);
+    FastLED.addLeds<WS2812B, LED_PIN0, COLOR_ORDER>(g_pStrands[0]->GetLEDBuffer(), 3*144);
     FastLED[0].setLeds(g_pStrands[0]->GetLEDBuffer(), g_pStrands[0]->GetLEDCount());
     FastLED.setMaxRefreshRate(0, false);  // turn OFF the refresh rate constraint
     pinMode(LED_PIN0, OUTPUT);
 #endif
 
 #if NUM_CHANNELS >= 2
-    FastLED.addLeds<WS2812B, LED_PIN0, GRB>(g_pStrands[0]->GetLEDBuffer(), g_pStrands[0]->GetLEDCount());
+    FastLED.addLeds<WS2812B, LED_PIN0, COLOR_ORDER>(g_pStrands[0]->GetLEDBuffer(), g_pStrands[0]->GetLEDCount());
     pinMode(LED_PIN0, OUTPUT);
 
-    FastLED.addLeds<WS2812B, LED_PIN1, GRB>(g_pStrands[1]->GetLEDBuffer(), g_pStrands[1]->GetLEDCount());
+    FastLED.addLeds<WS2812B, LED_PIN1, COLOR_ORDER>(g_pStrands[1]->GetLEDBuffer(), g_pStrands[1]->GetLEDCount());
     pinMode(LED_PIN1, OUTPUT);
 #endif
 
 #if NUM_CHANNELS >= 3
-    FastLED.addLeds<WS2812B, LED_PIN2, GRB>(g_pStrands[2]->GetLEDBuffer(), g_pStrands[2]->GetLEDCount());
+    FastLED.addLeds<WS2812B, LED_PIN2, COLOR_ORDER>(g_pStrands[2]->GetLEDBuffer(), g_pStrands[2]->GetLEDCount());
     pinMode(LED_PIN2, OUTPUT);
 #endif
 
 #if NUM_CHANNELS >= 4
-    FastLED.addLeds<WS2812B, LED_PIN3, GRB>(g_pStrands[3]->GetLEDBuffer(), g_pStrands[3]->GetLEDCount());
+    FastLED.addLeds<WS2812B, LED_PIN3, COLOR_ORDER>(g_pStrands[3]->GetLEDBuffer(), g_pStrands[3]->GetLEDCount());
     pinMode(LED_PIN3, OUTPUT);
 #endif
 
 #if NUM_CHANNELS >= 5
-    FastLED.addLeds<WS2812B, LED_PIN4, GRB>(g_pStrands[4]->GetLEDBuffer(), g_pStrands[4]->GetLEDCount());
+    FastLED.addLeds<WS2812B, LED_PIN4, COLOR_ORDER>(g_pStrands[4]->GetLEDBuffer(), g_pStrands[4]->GetLEDCount());
     pinMode(LED_PIN4, OUTPUT);
 #endif
 
 #if NUM_CHANNELS >= 6
-    FastLED.addLeds<WS2812B, LED_PIN5, GRB>(g_pStrands[5]->GetLEDBuffer(), g_pStrands[5]->GetLEDCount());
+    FastLED.addLeds<WS2812B, LED_PIN5, COLOR_ORDER>(g_pStrands[5]->GetLEDBuffer(), g_pStrands[5]->GetLEDCount());
     pinMode(LED_PIN5, OUTPUT);
 #endif
 
 #if NUM_CHANNELS >= 7
-    FastLED.addLeds<WS2812B, LED_PIN6, GRB>(g_pStrands[6]->GetLEDBuffer(), g_pStrands[6]->GetLEDCount());
+    FastLED.addLeds<WS2812B, LED_PIN6, COLOR_ORDER>(g_pStrands[6]->GetLEDBuffer(), g_pStrands[6]->GetLEDCount());
     pinMode(LED_PIN6, OUTPUT);
 #endif
 
 #if NUM_CHANNELS >= 8
-    FastLED.addLeds<WS2812B, LED_PIN7, GRB>(g_pStrands[7]->GetLEDBuffer(), g_pStrands[7]->GetLEDCount());
+    FastLED.addLeds<WS2812B, LED_PIN7, COLOR_ORDER>(g_pStrands[7]->GetLEDBuffer(), g_pStrands[7]->GetLEDCount());
     pinMode(LED_PIN7, OUTPUT);
 #endif
 


### PR DESCRIPTION
## Description
This config is made to drive a 5x5x5 LED cube.
The used LEDs use RGB instead of GRB, hence the requirement to change the color order.

Using the insulator effects, each layer of the cube represents one "insulator", which generates especially with the spectrum effect some nice 3D effects

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).