### PR TITLE
Fix math error in partitions_custom.csv, enable 4M storage partition by default

### DIFF
--- a/partitions_custom.csv
+++ b/partitions_custom.csv
@@ -1,12 +1,13 @@
 # ESP-IDF Partition Table
 # This gives us some additional space for code. 
 # It should also fix the OTA regression.  
+# The default storage config assumes 4M flash
 # Name,   Type, SubType,     Offset,      Size, Flags
 
 nvs,        data,   nvs,     0x9000,    0x5000,
 otadata,    data,   ota,     0xe000,    0x2000,
-app0,       app,    ota_0,   0x10000,   0x150000,
-app1,       app,    ota_1,   0x160000,  0x150000,
-# storage,    data,   spiffs,  0x330000,  0xF0000,  # If  4M Flash
-# storage,    data,   spiffs,  0x330000,  0x4F0000, # If  8M Flash  
-# storage,    data,   spiffs,  0x330000,  0x8F0000, # If 16M Flash   
+app0,       app,    ota_0,   0x10000,   0x190000,
+app1,       app,    ota_1,   0x1a0000,  0x190000,
+storage,    data,   spiffs,  0x330000,  0xD0000, 
+# storage,    data,   spiffs,  0x330000,  0x4D0000, # If  8M Flash  
+# storage,    data,   spiffs,  0x330000,  0xCD0000, # If 16M Flash  


### PR DESCRIPTION
## Description
I made a few math errors in my previous PR modifying the partitions_custom.csv file. 
This PR fixes them, and enables the 4M storage partition by default. 

I have folks from the discord to thank for figuring this out. Thanks!

This was tested: 

```
> pio run --target uploadfs --environment demo
 <snipped>
Building SPIFFS image from 'data' directory to .pio\build\demo\spiffs.bin
<snipped>
Auto-detected Flash size: 4MB
<snipped>
Environment    Status    Duration
-------------  --------  ------------
demo           SUCCESS   00:00:11.208
```


## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).