### PR TITLE
Add m5plusdemo and heltecdemo to CI build configs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,4 +28,4 @@ jobs:
         python -m pip install --upgrade pip
         pip install --upgrade platformio
     - name: Run PlatformIO
-      run: pio run -e demo -e spectrum -e treeset
+      run: pio run -e demo -e spectrum -e treeset -e m5plusdemo -e heltecdemo


### PR DESCRIPTION
## Description
This adds the `m5plusdemo` and `heltecdemo` configurations to the CI workflow after the merge of #46.

## Contributing requirements
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).