### PR TITLE
Provide an optional alternative path for platformio project dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ NightDriverStrip.code-workspace
 src/uzlib/src/*.o
 .history
 include/secrets.h
+lib/*

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,1 @@
+You can use this folder as an optional alternate path to store project dependencies. Placing common dependencies in this folder will prevent platformio from re-downloading them for every project. Files in this directory will not be tracked by git. 

--- a/platformio.ini
+++ b/platformio.ini
@@ -41,6 +41,7 @@ build_type      = debug
 build_unflags   = -std=gnu++11
 
 lib_deps        = ${common.lib_deps}
+lib_extra_dirs = ${PROJECT_DIR}/lib
 
 ; This partition table attempts to fit everything in 4M of flash.
 board_build.partitions = partitions_custom.csv


### PR DESCRIPTION
## Description
The purpose of this PR is to provide an optional alternative path for platformio project dependencies. 

Placing common project dependencies into this folder will prevent platformio from redownloading those dependencies for each project in NightDriverStrip. 

Note: I've include lib/* into the .gitignore so local copies of dependencies are not added to the repo. 

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).