### PR TITLE
Draft: Fix brooklynroom project build

### DIFF
--- a/include/effects/spectrumeffects.h
+++ b/include/effects/spectrumeffects.h
@@ -118,8 +118,10 @@ class VUMeterEffect : public LEDStripEffect
 
         pGFXChannel->fillRect(0, yVU, MATRIX_WIDTH, 1, BLACK16);
 
+#if USE_TFT
         if (giInfoPage == 1)
             M5.Lcd.fillRect(0, 0, M5.Lcd.width(), 10, BLACK16);
+#endif
 
         if (iPeakVUy > 1)
         {
@@ -345,6 +347,7 @@ class SpectrumAnalyzerEffect : public VUMeterEffect
         else
             fillSolidOnAllChannels(CRGB::Black);
 
+#if USE_TFT
         if (giInfoPage == 1)
         {
             if (gbInfoPageDirty)
@@ -353,7 +356,8 @@ class SpectrumAnalyzerEffect : public VUMeterEffect
                 M5.Lcd.fillScreen(BLACK16);
             }
         }
-        
+#endif
+    
         DrawVUMeter(0);
         for (int i = 0; i < NUM_BANDS; i++)
         {

--- a/include/globals.h
+++ b/include/globals.h
@@ -461,7 +461,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define MATRIX_HEIGHT   1
     #define RESERVE_MEMORY  150000
     #define ENABLE_REMOTE   1                     // IR Remote Control
-    #define FAN_SIZE        NUM_LEDS
+    #define FAN_SIZE        1
     #define NUM_FANS        1
     #define ENABLE_AUDIO    1
     #define LED_FAN_OFFSET_BU  0                    
@@ -471,6 +471,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define IR_REMOTE_PIN 36
     #define POWER_LIMIT_MW (1000 * 12 * 8)
     #define ENABLE_AUDIO    1                     // Listen for audio from the microphone and process it
+    #define NUM_BANDS      16
 
     #if M5STICKC || M5STICKCPLUS
         #define LED_PIN0 26
@@ -479,6 +480,9 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #endif
 
     #define DEFAULT_EFFECT_INTERVAL     (5*60*24)
+
+    #define NOISE_CUTOFF   75
+    #define NOISE_FLOOR    200.0f
 
 #elif FANSET
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -176,6 +176,15 @@ build_flags   = -DATOMLIGHT=1
                 -std=gnu++17
                 -Ofast 
 
+[env:brooklynroom]
+board         = heltec_wifi_kit_32
+monitor_speed = 115200
+upload_speed  = 921600
+upload_port   = COM10
+build_flags   = -DBROOKLYNROOM=1
+                -std=gnu++17
+                -Ofast 
+
 [env:fanset]
 board         = m5stick-c
 upload_speed  = 1500000

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -259,6 +259,8 @@ unique_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color)
 }
 #endif
 
+CRGB mult = CRGB::Black; float prob = 0.9; // These constants are referenced by several project's effects
+
 // AllEffects
 // 
 // A list of internal effects, if any.  


### PR DESCRIPTION
## Description
The purpose of this PR to fix the brooklynroom project's build errors. I also added a brooklynroom env in the platformio.ini file so the project can be added to the github CI if desired. 

Here are the build issues and how I solved them. So we're clear, I'm not sure these are the best ways to solve these issues. 

1) The FAN_SIZE setting for this project was previously set to NUM_LEDS, but there is no matching definition in faneffects.h for a FAN_SIZE > 16. This causes FanPixelsVertical not to be declared.   To solve this build error I have set the FAN_SIZE to 1 for the project in globals.h. 
   
2) I added #if USE_TFT sections around the M5 LCD update code in spectrumeffects.h to allow it to build on both heltec and m5 boards. I think this makes sense as NightDriverStrip is supposed to support I2S microphones. 

3) I added NUM_BANDS, NOISE_FLOOR, and NOISE_CUTOFF to the project in globals.h so audio.cpp and soundanalyzer.h would compile. 

4) I added variable declarations for mult, and prob above the AllEffects array in effects.cpp. @laufersteppenwolf noticed that several projects reference these variables in their effects, but they weren't declared.  So, we used this very simple solution to fix the build. 

As noted in #73 there seem to be issues with ArduinoOTA while using this project. This does not fix those issues. It just makes the project build and run. 

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).