### PR TITLE
Fix StarryNight variables

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,4 +28,4 @@ jobs:
         python -m pip install --upgrade pip
         pip install --upgrade platformio
     - name: Run PlatformIO
-      run: pio run -e demo -e spectrum -e treeset -e m5plusdemo -e heltecdemo -e brooklynroom
+      run: pio run -e demo -e spectrum -e treeset -e m5plusdemo -e heltecdemo -e brooklynroom -e ledstrip

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,4 +28,4 @@ jobs:
         python -m pip install --upgrade pip
         pip install --upgrade platformio
     - name: Run PlatformIO
-      run: pio run -e demo -e spectrum -e treeset -e m5plusdemo -e heltecdemo
+      run: pio run -e demo -e spectrum -e treeset -e m5plusdemo -e heltecdemo -e brooklynroom

--- a/include/globals.h
+++ b/include/globals.h
@@ -801,12 +801,12 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 #define USE_TFT 0
 #endif
 
-#ifndef MULT
-#define MULT CRGB::Black
+#ifndef STARRYNIGHT_PROBABILITY
+#define STARRYNIGHT_PROBABILITY 0.9
 #endif
 
-#ifndef PROB
-#define PROB 0.9
+#ifndef STARRYNIGHT_MUSICFACTOR
+#define STARRYNIGHT_MUSICFACTOR 1.0
 #endif
 
 // gRingSizeTable

--- a/include/globals.h
+++ b/include/globals.h
@@ -800,6 +800,14 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 #define USE_TFT 0
 #endif
 
+#ifndef MULT
+#define MULT CRGB::Black
+#endif
+
+#ifndef PROB
+#define PROB 0.9
+#endif
+
 // gRingSizeTable
 //
 // Items with rings must provide a table indicating how big each ring is.  If an insulator had 60 LEDs grouped

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -259,7 +259,7 @@ unique_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color)
 }
 #endif
 
-CRGB mult = CRGB::Black; float prob = 0.9; // These constants are referenced by several project's effects
+
 
 // AllEffects
 // 
@@ -360,7 +360,7 @@ DRAM_ATTR LEDStripEffect * AllEffects[] =
     new VUFlameEffect("Multicolor Sound Flame", VUFlameEffect::MULTICOLOR),
     new BouncingBallEffect(),
     new MeteorEffect(),                                                                                                     // Our overlapping color meteors
-    new StarryNightEffect<BubblyStar>("Little Blooming Rainbow Stars", BlueColors_p, prob, 4, LINEARBLEND, 2.0, 0.0, mult), // Blooming Little Rainbow Stars
+    new StarryNightEffect<BubblyStar>("Little Blooming Rainbow Stars", BlueColors_p, PROB, 4, LINEARBLEND, 2.0, 0.0, MULT), // Blooming Little Rainbow Stars
     new StarryNightEffect<BubblyStar>("Big Blooming Rainbow Stars", RainbowColors_p, 2, 12, LINEARBLEND, 1.0),              // Blooming Rainbow Stars
     new StarryNightEffect<BubblyStar>("Neon Bars", RainbowColors_p, 0.5, 64, NOBLEND, 0),                                   // Neon Bars
     new StarryNightEffect<MusicStar>("RGB Music Blend Stars", RGBColors_p, 0.8, 1, NOBLEND, 15.0, 0.1, 10.0),      // RGB Music Blur - Can You Hear Me Knockin'
@@ -371,12 +371,12 @@ DRAM_ATTR LEDStripEffect * AllEffects[] =
 
     new SimpleRainbowTestEffect(8, 4),                                                                            // Rainbow palette simple test of walking pixels
     new PaletteEffect(RainbowColors_p),                                                                           // Rainbow palette
-    new StarryNightEffect<QuietStar>("Green Twinkle Stars", GreenColors_p, prob, 1, LINEARBLEND, 2.0, 0.0, mult), // Green Twinkle
-    new StarryNightEffect<Star>("Blue Sparkle Stars", BlueColors_p, prob, 1, LINEARBLEND, 2.0, 0.0, mult),        // Blue Sparkle
+    new StarryNightEffect<QuietStar>("Green Twinkle Stars", GreenColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT), // Green Twinkle
+    new StarryNightEffect<Star>("Blue Sparkle Stars", BlueColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT),        // Blue Sparkle
 
     new StarryNightEffect<QuietStar>("Red Twinkle Stars", RedColors_p, 1.0, 1, LINEARBLEND, 2.0),                     // Red Twinkle
-    new StarryNightEffect<Star>("Lava Stars", LavaColors_p, prob, 1, LINEARBLEND, 2.0, 0.0, mult),                    // Lava Stars
-    new StarryNightEffect<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, prob, 1, LINEARBLEND, 2.0, 0.0, mult), // Rainbow Twinkle
+    new StarryNightEffect<Star>("Lava Stars", LavaColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT),                    // Lava Stars
+    new StarryNightEffect<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT), // Rainbow Twinkle
     new DoublePaletteEffect(),
 #elif ATOMLIGHT
     new ColorFillEffect(CRGB::White, 1),
@@ -416,7 +416,7 @@ DRAM_ATTR LEDStripEffect * AllEffects[] =
     new PaletteFlameEffect("Smooth Purple Fire", purpleflame_pal),
 
     new MeteorEffect(),                                                                                                     // Our overlapping color meteors
-    new StarryNightEffect<BubblyStar>("Little Blooming Rainbow Stars", BlueColors_p, prob, 4, LINEARBLEND, 2.0, 0.0, mult), // Blooming Little Rainbow Stars
+    new StarryNightEffect<BubblyStar>("Little Blooming Rainbow Stars", BlueColors_p, PROB, 4, LINEARBLEND, 2.0, 0.0, MULT), // Blooming Little Rainbow Stars
     new StarryNightEffect<BubblyStar>("Big Blooming Rainbow Stars", RainbowColors_p, 2, 12, LINEARBLEND, 1.0),              // Blooming Rainbow Stars
     new StarryNightEffect<BubblyStar>("Neon Bars", RainbowColors_p, 0.5, 64, NOBLEND, 0),                                   // Neon Bars
 
@@ -428,12 +428,12 @@ DRAM_ATTR LEDStripEffect * AllEffects[] =
 
     new SimpleRainbowTestEffect(8, 4),                                                                            // Rainbow palette simple test of walking pixels
     new PaletteEffect(RainbowColors_p),                                                                           // Rainbow palette
-    new StarryNightEffect<QuietStar>("Green Twinkle Stars", GreenColors_p, prob, 1, LINEARBLEND, 2.0, 0.0, mult), // Green Twinkle
-    new StarryNightEffect<Star>("Blue Sparkle Stars", BlueColors_p, prob, 1, LINEARBLEND, 2.0, 0.0, mult),        // Blue Sparkle
+    new StarryNightEffect<QuietStar>("Green Twinkle Stars", GreenColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT), // Green Twinkle
+    new StarryNightEffect<Star>("Blue Sparkle Stars", BlueColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT),        // Blue Sparkle
 
-    new StarryNightEffect<QuietStar>("Red Twinkle Stars", RedColors_p, 1.0, 1, LINEARBLEND, 2.0, 0.0, mult),          // Red Twinkle
-    new StarryNightEffect<Star>("Lava Stars", LavaColors_p, prob, 1, LINEARBLEND, 2.0, 0.0, mult),                    // Lava Stars
-    new StarryNightEffect<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, prob, 1, LINEARBLEND, 2.0, 0.0, mult), // Rainbow Twinkle
+    new StarryNightEffect<QuietStar>("Red Twinkle Stars", RedColors_p, 1.0, 1, LINEARBLEND, 2.0, 0.0, MULT),          // Red Twinkle
+    new StarryNightEffect<Star>("Lava Stars", LavaColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT),                    // Lava Stars
+    new StarryNightEffect<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT), // Rainbow Twinkle
     new DoublePaletteEffect(),
     new VUEffect()
 
@@ -446,11 +446,11 @@ DRAM_ATTR LEDStripEffect * AllEffects[] =
     new RainbowFillEffect(),
 
     new StarryNightEffect<MusicStar>("RGB Music Bubbles", RGBColors_p, 0.25, 1, NOBLEND, 3.0, 0.0, 75.0),                   // RGB Music Bubbles
-    new StarryNightEffect<HotWhiteStar>("Lava Stars", HeatColors_p, prob, 1, LINEARBLEND, 2.0, 0.0, mult),                  // Lava Stars
-    new StarryNightEffect<BubblyStar>("Little Blooming Rainbow Stars", BlueColors_p, prob, 4, LINEARBLEND, 2.0, 0.0, mult), // Blooming Little Rainbow Stars
-    new StarryNightEffect<QuietStar>("Green Twinkle Stars", GreenColors_p, prob, 1, LINEARBLEND, 2.0, 0.0, mult),           // Green Twinkle
+    new StarryNightEffect<HotWhiteStar>("Lava Stars", HeatColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT),                  // Lava Stars
+    new StarryNightEffect<BubblyStar>("Little Blooming Rainbow Stars", BlueColors_p, PROB, 4, LINEARBLEND, 2.0, 0.0, MULT), // Blooming Little Rainbow Stars
+    new StarryNightEffect<QuietStar>("Green Twinkle Stars", GreenColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT),           // Green Twinkle
     new StarryNightEffect<QuietStar>("Red Twinkle Stars", RedColors_p, 1.0, 1, LINEARBLEND, 2.0),                           // Red Twinkle
-    new StarryNightEffect<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, prob, 1, LINEARBLEND, 2.0, 0.0, mult),       // Rainbow Twinkle
+    new StarryNightEffect<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT),       // Rainbow Twinkle
     new BouncingBallEffect(),
     new VUEffect()
 
@@ -518,14 +518,14 @@ DRAM_ATTR LEDStripEffect * AllEffects[] =
 
     new MeteorEffect(),                                                                                                     // Our overlapping color meteors
 
-    new StarryNightEffect<QuietStar>("Magenta Twinkle Stars", GreenColors_p, prob, 1, LINEARBLEND, 2.0, 0.0, mult), // Green Twinkle
-    new StarryNightEffect<Star>("Blue Sparkle Stars", BlueColors_p, prob, 1, LINEARBLEND, 2.0, 0.0, mult),        // Blue Sparkle
+    new StarryNightEffect<QuietStar>("Magenta Twinkle Stars", GreenColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT), // Green Twinkle
+    new StarryNightEffect<Star>("Blue Sparkle Stars", BlueColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT),        // Blue Sparkle
 
     new StarryNightEffect<QuietStar>("Red Twinkle Stars", MagentaColors_p, 1.0, 1, LINEARBLEND, 2.0),                     // Red Twinkle
-    new StarryNightEffect<Star>("Lava Stars", MagentaColors_p, prob, 1, LINEARBLEND, 2.0, 0.0, mult),                    // Lava Stars
-    new StarryNightEffect<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, prob, 1, LINEARBLEND, 2.0, 0.0, mult), // Rainbow Twinkle
+    new StarryNightEffect<Star>("Lava Stars", MagentaColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT),                    // Lava Stars
+    new StarryNightEffect<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT), // Rainbow Twinkle
 
-    new StarryNightEffect<BubblyStar>("Little Blooming Rainbow Stars", MagentaColors_p, prob, 4, LINEARBLEND, 2.0, 0.0, mult), // Blooming Little Rainbow Stars
+    new StarryNightEffect<BubblyStar>("Little Blooming Rainbow Stars", MagentaColors_p, PROB, 4, LINEARBLEND, 2.0, 0.0, MULT), // Blooming Little Rainbow Stars
     new StarryNightEffect<BubblyStar>("Big Blooming Rainbow Stars", MagentaColors_p, 2, 12, LINEARBLEND, 1.0),              // Blooming Rainbow Stars
     new StarryNightEffect<BubblyStar>("Neon Bars", MagentaColors_p, 0.5, 64, NOBLEND, 0),                                   // Neon Bars
 /*

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -360,7 +360,7 @@ DRAM_ATTR LEDStripEffect * AllEffects[] =
     new VUFlameEffect("Multicolor Sound Flame", VUFlameEffect::MULTICOLOR),
     new BouncingBallEffect(),
     new MeteorEffect(),                                                                                                     // Our overlapping color meteors
-    new StarryNightEffect<BubblyStar>("Little Blooming Rainbow Stars", BlueColors_p, PROB, 4, LINEARBLEND, 2.0, 0.0, MULT), // Blooming Little Rainbow Stars
+    new StarryNightEffect<BubblyStar>("Little Blooming Rainbow Stars", BlueColors_p, STARRYNIGHT_PROBABILITY, 4, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR), // Blooming Little Rainbow Stars
     new StarryNightEffect<BubblyStar>("Big Blooming Rainbow Stars", RainbowColors_p, 2, 12, LINEARBLEND, 1.0),              // Blooming Rainbow Stars
     new StarryNightEffect<BubblyStar>("Neon Bars", RainbowColors_p, 0.5, 64, NOBLEND, 0),                                   // Neon Bars
     new StarryNightEffect<MusicStar>("RGB Music Blend Stars", RGBColors_p, 0.8, 1, NOBLEND, 15.0, 0.1, 10.0),      // RGB Music Blur - Can You Hear Me Knockin'
@@ -371,12 +371,12 @@ DRAM_ATTR LEDStripEffect * AllEffects[] =
 
     new SimpleRainbowTestEffect(8, 4),                                                                            // Rainbow palette simple test of walking pixels
     new PaletteEffect(RainbowColors_p),                                                                           // Rainbow palette
-    new StarryNightEffect<QuietStar>("Green Twinkle Stars", GreenColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT), // Green Twinkle
-    new StarryNightEffect<Star>("Blue Sparkle Stars", BlueColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT),        // Blue Sparkle
+    new StarryNightEffect<QuietStar>("Green Twinkle Stars", GreenColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR), // Green Twinkle
+    new StarryNightEffect<Star>("Blue Sparkle Stars", BlueColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),        // Blue Sparkle
 
     new StarryNightEffect<QuietStar>("Red Twinkle Stars", RedColors_p, 1.0, 1, LINEARBLEND, 2.0),                     // Red Twinkle
-    new StarryNightEffect<Star>("Lava Stars", LavaColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT),                    // Lava Stars
-    new StarryNightEffect<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT), // Rainbow Twinkle
+    new StarryNightEffect<Star>("Lava Stars", LavaColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),                    // Lava Stars
+    new StarryNightEffect<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR), // Rainbow Twinkle
     new DoublePaletteEffect(),
 #elif ATOMLIGHT
     new ColorFillEffect(CRGB::White, 1),
@@ -416,7 +416,7 @@ DRAM_ATTR LEDStripEffect * AllEffects[] =
     new PaletteFlameEffect("Smooth Purple Fire", purpleflame_pal),
 
     new MeteorEffect(),                                                                                                     // Our overlapping color meteors
-    new StarryNightEffect<BubblyStar>("Little Blooming Rainbow Stars", BlueColors_p, PROB, 4, LINEARBLEND, 2.0, 0.0, MULT), // Blooming Little Rainbow Stars
+    new StarryNightEffect<BubblyStar>("Little Blooming Rainbow Stars", BlueColors_p, STARRYNIGHT_PROBABILITY, 4, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR), // Blooming Little Rainbow Stars
     new StarryNightEffect<BubblyStar>("Big Blooming Rainbow Stars", RainbowColors_p, 2, 12, LINEARBLEND, 1.0),              // Blooming Rainbow Stars
     new StarryNightEffect<BubblyStar>("Neon Bars", RainbowColors_p, 0.5, 64, NOBLEND, 0),                                   // Neon Bars
 
@@ -428,12 +428,12 @@ DRAM_ATTR LEDStripEffect * AllEffects[] =
 
     new SimpleRainbowTestEffect(8, 4),                                                                            // Rainbow palette simple test of walking pixels
     new PaletteEffect(RainbowColors_p),                                                                           // Rainbow palette
-    new StarryNightEffect<QuietStar>("Green Twinkle Stars", GreenColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT), // Green Twinkle
-    new StarryNightEffect<Star>("Blue Sparkle Stars", BlueColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT),        // Blue Sparkle
+    new StarryNightEffect<QuietStar>("Green Twinkle Stars", GreenColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR), // Green Twinkle
+    new StarryNightEffect<Star>("Blue Sparkle Stars", BlueColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),        // Blue Sparkle
 
-    new StarryNightEffect<QuietStar>("Red Twinkle Stars", RedColors_p, 1.0, 1, LINEARBLEND, 2.0, 0.0, MULT),          // Red Twinkle
-    new StarryNightEffect<Star>("Lava Stars", LavaColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT),                    // Lava Stars
-    new StarryNightEffect<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT), // Rainbow Twinkle
+    new StarryNightEffect<QuietStar>("Red Twinkle Stars", RedColors_p, 1.0, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),          // Red Twinkle
+    new StarryNightEffect<Star>("Lava Stars", LavaColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),                    // Lava Stars
+    new StarryNightEffect<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR), // Rainbow Twinkle
     new DoublePaletteEffect(),
     new VUEffect()
 
@@ -446,11 +446,11 @@ DRAM_ATTR LEDStripEffect * AllEffects[] =
     new RainbowFillEffect(),
 
     new StarryNightEffect<MusicStar>("RGB Music Bubbles", RGBColors_p, 0.25, 1, NOBLEND, 3.0, 0.0, 75.0),                   // RGB Music Bubbles
-    new StarryNightEffect<HotWhiteStar>("Lava Stars", HeatColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT),                  // Lava Stars
-    new StarryNightEffect<BubblyStar>("Little Blooming Rainbow Stars", BlueColors_p, PROB, 4, LINEARBLEND, 2.0, 0.0, MULT), // Blooming Little Rainbow Stars
-    new StarryNightEffect<QuietStar>("Green Twinkle Stars", GreenColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT),           // Green Twinkle
+    new StarryNightEffect<HotWhiteStar>("Lava Stars", HeatColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),                  // Lava Stars
+    new StarryNightEffect<BubblyStar>("Little Blooming Rainbow Stars", BlueColors_p, STARRYNIGHT_PROBABILITY, 4, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR), // Blooming Little Rainbow Stars
+    new StarryNightEffect<QuietStar>("Green Twinkle Stars", GreenColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),           // Green Twinkle
     new StarryNightEffect<QuietStar>("Red Twinkle Stars", RedColors_p, 1.0, 1, LINEARBLEND, 2.0),                           // Red Twinkle
-    new StarryNightEffect<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT),       // Rainbow Twinkle
+    new StarryNightEffect<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),       // Rainbow Twinkle
     new BouncingBallEffect(),
     new VUEffect()
 
@@ -518,14 +518,14 @@ DRAM_ATTR LEDStripEffect * AllEffects[] =
 
     new MeteorEffect(),                                                                                                     // Our overlapping color meteors
 
-    new StarryNightEffect<QuietStar>("Magenta Twinkle Stars", GreenColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT), // Green Twinkle
-    new StarryNightEffect<Star>("Blue Sparkle Stars", BlueColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT),        // Blue Sparkle
+    new StarryNightEffect<QuietStar>("Magenta Twinkle Stars", GreenColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR), // Green Twinkle
+    new StarryNightEffect<Star>("Blue Sparkle Stars", BlueColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),        // Blue Sparkle
 
     new StarryNightEffect<QuietStar>("Red Twinkle Stars", MagentaColors_p, 1.0, 1, LINEARBLEND, 2.0),                     // Red Twinkle
-    new StarryNightEffect<Star>("Lava Stars", MagentaColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT),                    // Lava Stars
-    new StarryNightEffect<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, PROB, 1, LINEARBLEND, 2.0, 0.0, MULT), // Rainbow Twinkle
+    new StarryNightEffect<Star>("Lava Stars", MagentaColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),                    // Lava Stars
+    new StarryNightEffect<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR), // Rainbow Twinkle
 
-    new StarryNightEffect<BubblyStar>("Little Blooming Rainbow Stars", MagentaColors_p, PROB, 4, LINEARBLEND, 2.0, 0.0, MULT), // Blooming Little Rainbow Stars
+    new StarryNightEffect<BubblyStar>("Little Blooming Rainbow Stars", MagentaColors_p, STARRYNIGHT_PROBABILITY, 4, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR), // Blooming Little Rainbow Stars
     new StarryNightEffect<BubblyStar>("Big Blooming Rainbow Stars", MagentaColors_p, 2, 12, LINEARBLEND, 1.0),              // Blooming Rainbow Stars
     new StarryNightEffect<BubblyStar>("Neon Bars", MagentaColors_p, 0.5, 64, NOBLEND, 0),                                   // Neon Bars
 /*


### PR DESCRIPTION
## Description
This:
- converts the `mult` and `glob` variables that were added in #75 into globals.h `#define`s.
- adds the brooklynroom and ledstrip (#81) configurations to the CI workflow.
- removed the treeset config from CI, based on [a comment on PR #95](https://github.com/PlummersSoftwareLLC/NightDriverStrip/pull/95#issuecomment-980639164).

## Contributing requirements
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).