### PR TITLE
Add .click() handler to webserver checkboxes

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -185,7 +185,7 @@
             });
         }
    
-        function EnableEffect(i) 
+        function DisableEffect(i) 
         {
             jQuery.support.cors = true;
             $.post(BasePageForRequests() +  "/disableEffect",
@@ -220,7 +220,14 @@
 
                 var inp = $('<input type="checkbox"/> ')
                     .addClass('single-checkbox')
-                    .appendTo(li);
+                    .appendTo(li)
+                    .click(function() {
+                        if ($(this).is(':checked')) {
+                            EnableEffect($(this).parent().attr('id'));
+                        } else {
+                            DisableEffect($(this).parent().attr('id'));
+                        }
+                    });
 
                 inp.prop('checked', effectData.Effects[i].enabled);
 


### PR DESCRIPTION
## Description
Adds a .click() event handler to the checkboxes in index.html. 
When a checkbox is checked, EnableEffect() is called, otherwise DisableEffect() is called.

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).