### PR TITLE
Count enabled effects

### DIFF
--- a/include/effects/effectmanager.h
+++ b/include/effects/effectmanager.h
@@ -67,12 +67,13 @@ class EffectManager
 {
 	LEDStripEffect ** _ppEffects;
 	size_t            _cEffects;
+	size_t			 _cEnabled;
 
 	size_t			 _iCurrentEffect;
 	uint    		 _effectStartTime;
 	uint    		 _effectInterval;
 	bool             _bPlayAll;
-	
+
 	unique_ptr<bool []> _abEffectEnabled;
 	shared_ptr<LEDMatrixGFX> * _gfx;
 	unique_ptr<LEDStripEffect> _pRemoteEffect;
@@ -85,6 +86,7 @@ public:
 	EffectManager(LEDStripEffect ** pEffects, size_t cEffects, shared_ptr<LEDMatrixGFX> * gfx)
 		  : _ppEffects(pEffects),
 	  	    _cEffects(cEffects),
+			_cEnabled(0),
 		    _effectInterval(DEFAULT_EFFECT_INTERVAL),
 		    _bPlayAll(false),
 			_gfx(gfx)
@@ -157,6 +159,12 @@ public:
 			return;
 		}
 		_abEffectEnabled[i] = true;
+		
+		if (_cEnabled < 1)
+		{
+			ClearRemoteColor();
+		}
+		_cEnabled++;
 	}
 
 	void DisableEffect(size_t i)
@@ -167,6 +175,12 @@ public:
 			return;
 		}
 		_abEffectEnabled[i] = false;
+		
+		_cEnabled--;
+		if (_cEnabled < 1)
+		{
+			SetGlobalColor(CRGB::Black);
+		}
 	}
 
 	bool IsEffectEnabled(size_t i) const
@@ -264,7 +278,7 @@ public:
 			_iCurrentEffect++;						//   ... if so advance to next effect
 			_iCurrentEffect %= EffectCount();
 			_effectStartTime = millis();
-		} while (false == _bPlayAll && false == IsEffectEnabled(_iCurrentEffect));
+		} while (0 < _cEnabled && false == _bPlayAll && false == IsEffectEnabled(_iCurrentEffect));
 	}
 
 	// Go back to the previous effect and abort the current one.  
@@ -278,7 +292,7 @@ public:
 
 			_iCurrentEffect--;
 			_effectStartTime = millis();
-		} while (false == _bPlayAll && false == IsEffectEnabled(_iCurrentEffect));
+		} while (0 < _cEnabled && false == _bPlayAll && false == IsEffectEnabled(_iCurrentEffect));
 	}
 
 	bool Init()

--- a/include/effects/effectmanager.h
+++ b/include/effects/effectmanager.h
@@ -158,13 +158,17 @@ public:
 			debugW("Invalid index for EnableEffect");
 			return;
 		}
-		_abEffectEnabled[i] = true;
-		
-		if (_cEnabled < 1)
+
+		if (!_abEffectEnabled[i])
 		{
-			ClearRemoteColor();
+			_abEffectEnabled[i] = true;
+
+			if (_cEnabled < 1)
+			{
+				ClearRemoteColor();
+			}
+			_cEnabled++;
 		}
-		_cEnabled++;
 	}
 
 	void DisableEffect(size_t i)
@@ -174,12 +178,16 @@ public:
 			debugW("Invalid index for DisableEffect");
 			return;
 		}
-		_abEffectEnabled[i] = false;
-		
-		_cEnabled--;
-		if (_cEnabled < 1)
+
+		if (_abEffectEnabled[i])
 		{
-			SetGlobalColor(CRGB::Black);
+			_abEffectEnabled[i] = false;
+
+			_cEnabled--;
+			if (_cEnabled < 1)
+			{
+				SetGlobalColor(CRGB::Black);
+			}
 		}
 	}
 

--- a/include/effects/effectmanager.h
+++ b/include/effects/effectmanager.h
@@ -67,7 +67,7 @@ class EffectManager
 {
 	LEDStripEffect ** _ppEffects;
 	size_t            _cEffects;
-	size_t			 _cEnabled;
+	size_t			  _cEnabled;
 
 	size_t			 _iCurrentEffect;
 	uint    		 _effectStartTime;
@@ -225,6 +225,11 @@ public:
 	const size_t EffectCount() const
 	{
 		return _cEffects;
+	}
+
+	const size_t EnabledCount() const
+	{
+		return _cEnabled;
 	}
 
 	const size_t GetCurrentEffectIndex() const


### PR DESCRIPTION
## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->
With this fix, disabling all effects will now:
- Immediately turn off all LEDs
- No longer get stuck in NextEffect()

This partially addresses [Issue #90](https://github.com/PlummersSoftwareLLC/NightDriverStrip/issues/90).

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).