### PR TITLE
FEATURE: Webserver: Current Effect Status

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -206,13 +206,30 @@
                 dataType: "text",
                 success: function (responseData, textStatus, jqXHR) {
                     var obj = JSON.parse(responseData);
-                    UpdateEffectList(obj);
+                    UpdateAll(obj);
                 },
                 error: function (responseData, textStatus, errorThrown) {
-                    UpdateEffectList(null);
+                    UpdateAll(null);
                     setTimeout(RequestEffectList, 2000);
                 }
             });
+        }
+
+        // UpdateAll
+        //
+        // Update the status on the page based on the state received from the server
+
+        var initialized = false;
+        function UpdateAll(obj)
+        {
+            if (!initialized)
+            {
+                UpdateEffectList(obj);
+                initialized = true;
+            }
+
+            UpdateEnabled(obj);
+            UpdateCurrentEffect(obj);
         }
     </script>
 
@@ -241,6 +258,24 @@
         function NextStep()
         {
             // Add here when needed
+        }
+
+        // UpdateEnabled
+        //
+        // Update the status on the page to reflect the currently enabled effects
+
+        function UpdateEnabled(effectData)
+        {
+
+        }
+
+        // UpdateCurrentEffect
+        //
+        // Update the status on the page to reflect the currently running effect
+
+        function UpdateCurrentEffect(effectData)
+        {
+
         }
 
         // UpdateEffectList

--- a/data/index.html
+++ b/data/index.html
@@ -210,7 +210,6 @@
                 },
                 error: function (responseData, textStatus, errorThrown) {
                     UpdateAll(null);
-                    setTimeout(RequestEffectList, 2000);
                 }
             });
         }

--- a/data/index.html
+++ b/data/index.html
@@ -266,7 +266,25 @@
 
         function UpdateEnabled(effectData)
         {
+            if (null == effectData)
+                return;
+            
+            $('#enabledCount').empty();
+            $('#enabledCount').append(text = "Effects Enabled: " + effectData.enabledCount + "/" + effectData.Effects.length);
 
+            if (effectData.enabledCount > 0)
+            {
+                $('#currentEffectProgress').css('background-color', 'green');
+            }
+            else
+            {
+                $('#currentEffectProgress').css('background-color', 'red');
+            }
+
+            $.each($('#effectList li input'), function(i, v)
+            {
+                v.checked = effectData.Effects[i].enabled;
+            });
         }
 
         // UpdateCurrentEffect
@@ -275,7 +293,16 @@
 
         function UpdateCurrentEffect(effectData)
         {
+            if (null == effectData)
+                return;
 
+            $('#currentEffect').empty();
+            $('#currentEffect').append(text = "Current Effect: " + effectData.Effects[effectData.currentEffect].name);
+            $('#currentEffectProgress').width(((1 - (effectData.millisecondsRemaining / effectData.effectInterval)) * $('#currentEffect').width()) + "px");
+
+            
+            $('.ui-selectee').removeClass('ui-selected');
+            $('#effectList li').eq(effectData.currentEffect).addClass('ui-selected');
         }
 
         // UpdateEffectList

--- a/data/index.html
+++ b/data/index.html
@@ -244,6 +244,7 @@
             {
                 effectIndex: i,
             });
+            RequestEffectList();
         }
    
         function DisableEffect(i) 
@@ -253,6 +254,7 @@
             {
                 effectIndex: i,
             });
+            RequestEffectList();
         }
 
         function NextStep()
@@ -395,7 +397,7 @@
         } );
 
         UpdateEffectList(null);
-        RequestEffectList();
+        setInterval(RequestEffectList, 2000);
 
         $("body").fadeIn(1000);
 

--- a/data/index.html
+++ b/data/index.html
@@ -74,6 +74,42 @@
             float: left;
         }
 
+        #statusBar
+        {
+            border: 1px lightgray solid;
+            height: 1em;
+            position: relative;
+            width: 450px;
+        }
+
+        .effectStatusItem
+        {
+            font-size: 0.8em;
+            height: 100%;
+            width: 50%;
+        }
+
+        #currentEffect
+        {
+            background-color: #DDD;
+            float: left;
+            z-index: 0;
+        }
+
+        #currentEffectProgress
+        {
+            float: left;
+            opacity: 0.4;
+            position: absolute;
+            z-index: 1;
+        }
+
+        #enabledCount
+        {
+            float: right;
+            text-align: right;
+        }
+
     </style>
 </head>
 <body>
@@ -94,6 +130,14 @@
                 <ol id="effectList" class="effectList">
                 </ol>
                 <div id="Adjustments">
+                </div>
+                <div id="statusBar">
+                    <div id="currentEffect" class="effectStatusItem">
+                    </div>
+                    <div id="currentEffectProgress" class="effectStatusItem">
+                    </div>
+                    <div id="enabledCount" class="effectStatusItem">
+                    </div>
                 </div>
             <div id="tabs-2" style="text-align:left;">
                 If you can see this page, you're reading it live on the NightDriverStrip.  Not on a page written -about- the NightDriverStrip

--- a/include/spiffswebserver.h
+++ b/include/spiffswebserver.h
@@ -91,6 +91,7 @@ class CSPIFFSWebServer
 		j["currentEffect"] 		   = g_pEffectManager->GetCurrentEffectIndex();
 		j["millisecondsRemaining"] = g_pEffectManager->GetTimeRemainingForCurrentEffect();
 		j["effectInterval"] 	   = g_pEffectManager->GetInterval();
+		j["enabledCount"]		   = g_pEffectManager->EnabledCount();
 		
 		for (int i = 0; i < g_pEffectManager->EffectCount(); i++) {
 			j["Effects"][i]["name"]    = g_pEffectManager->EffectsList()[i]->FriendlyName();


### PR DESCRIPTION
## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->
This feature was designed to address parts of [Issue #90](https://github.com/PlummersSoftwareLLC/NightDriverStrip/issues/90). The goal was to improve the visual feedback on the web page in a number of ways:
- The currently running effect will automatically appear selected (without triggering the selected event)
- A new status bar is included below the list of effects:
  - The left side displays the name of the currently running effect and a progress bar showing the amount of time remaining for that effect
  - The right side shows a count of currently enabled effects
- This information is updated on the web page every 2 seconds by polling the /getEffectList endpoint in RequestEffectList()

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).