### PR TITLE
CI: Install platformio framework and libdeps before builds, seperate ci build steps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,20 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade platformio
+    - name: Install Dependencies
+      run: |
+        pio platform install espressif32 --with-package framework-arduinoespressif32 --with-package tool-esptoolpy
+        pio lib -e all-deps install --no-save
+        mv .pio/libdeps/all-deps/* lib/
     - name: Copy secrets
       run: cp include/secrets.example.h include/secrets.h
-    - name: Run PlatformIO
-      run: pio run -e demo -e spectrum -e treeset -e m5plusdemo -e heltecdemo -e xmastrees
+    - name: Build demo
+      run: pio run -e demo
+    - name: Build spectrum
+      run: pio run -e spectrum
+    - name: Build m5plusdemo
+      run: pio run -e m5plusdemo
+    - name: Build heltecdemo
+      run: pio run -e heltecdemo
+    - name: Build xmastrees
+      run: pio run -e xmastrees

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,1 @@
+You can use this folder as an optional alternate path to store project dependencies. Placing common dependencies in this folder will prevent platformio from re-downloading them for every project. Files in this directory will not be tracked by git. 

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,8 +35,13 @@ lib_deps        = ${common.lib_deps}
 lib_deps        = ${common.lib_deps}
                   m5stack/M5StickCPlus @ ^0.0.2
 
+[all]
+lib_deps        = ${common.lib_deps}
+                  ${m5stick-c.lib_deps}
+                  ${m5stick-c-plus.lib_deps}
+
 [env]
-platform        = https://github.com/platformio/platform-espressif32.git
+platform        = espressif32
 framework       = arduino
 build_type      = debug
 build_unflags   = -std=gnu++11
@@ -49,8 +54,10 @@ board_build.partitions = partitions_custom.csv
 
 monitor_filters = esp32_exception_decoder
 
+[env:all-deps]
+lib_deps      =  ${all.lib_deps}
+
 [env:demo]
-platform      = espressif32
 board         = esp32dev
 monitor_speed = 115200
 upload_speed  = 921600
@@ -60,7 +67,6 @@ build_flags   = -DDEMO=1
                 -Ofast 
 
 [env:wrover-demo]
-platform        = espressif32
 board           = esp-wrover-kit
 monitor_speed   = 115200
 upload_speed    = 1500000


### PR DESCRIPTION
## Description
This removes the need for the CI to download the dependencies for each project build. 
It also separates the builds into their own steps to make it easier to see which failed. 

This has a nice side-effect of decreasing the amount of time it takes for the CI to complete by about 1-2 minutes. 

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).