### PR TITLE
Fix brooklynroom break

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -895,9 +895,17 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 #endif
 // Define fan ordering for drawing into the fan directionally
 
+#ifndef LED_FAN_OFFSET_LR
 #define LED_FAN_OFFSET_LR  (LED_FAN_OFFSET_BU + (FAN_SIZE * 1 / 4))         // High level stuff right here!
+#endif
+
+#ifndef LED_FAN_OFFSET_TD
 #define LED_FAN_OFFSET_TD  (LED_FAN_OFFSET_BU + (FAN_SIZE * 2 / 4))
+#endif
+
+#ifndef LED_FAN_OFFSET_RL
 #define LED_FAN_OFFSET_RL  (LED_FAN_OFFSET_BU + (FAN_SIZE * 3 / 4))
+#endif
 
 #ifndef RING_SIZE_0
 #define RING_SIZE_0 0

--- a/include/screen.h
+++ b/include/screen.h
@@ -105,6 +105,8 @@ class Screen
         #if USE_OLED
             return g_u8g2.getDisplayWidth();
         #endif
+
+        return 1;
     }
 
     static uint16_t fontHeight()
@@ -123,7 +125,9 @@ class Screen
 
         #if USE_OLED
             return 12;
-        #endif        
+        #endif   
+
+        return 1;     
     }
 
     static uint16_t textWidth(const char * psz)
@@ -142,7 +146,9 @@ class Screen
 
         #if USE_OLED
             return 9 * strlen(psz);
-        #endif        
+        #endif       
+
+        return 1; 
     }
 
     static uint16_t screenHeight()
@@ -162,6 +168,8 @@ class Screen
         #if USE_OLED
             return g_u8g2.getDisplayHeight();
         #endif
+
+        return 1;
     }
 
     static void fillScreen(uint16_t color)
@@ -288,7 +296,7 @@ class Screen
         #endif
 
         #if USE_OLED
-            g_u8g2.setCursor(x, y);
+            g_u8g2.setCursor(x, y + fontHeight() - 1);
         #endif
     }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 data_dir    = ./data
-default_envs = heltecdemo
+default_envs = brooklynroom
 
 [common]
 lib_deps        = crankyoldgit/IRremoteESP8266  @ ^2.7.20
@@ -150,8 +150,8 @@ lib_deps      = ${m5stick-c-plus.lib_deps}
 board         = heltec_wifi_kit_32
 monitor_speed = 115200
 upload_speed  = 921600
-upload_port   = COM7
-monitor_port  = COM7
+upload_port   = COM13
+monitor_port  = COM13
 build_flags   = -DDEMO=1
                 -DUSE_SCREEN=1
                 -std=gnu++17

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -259,7 +259,8 @@ unique_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color)
 }
 #endif
 
-
+#define STARRYNIGHT_PROBABILITY 1.0
+#define STARRYNIGHT_MUSICFACTOR 1.0
 
 // AllEffects
 // 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -483,7 +483,6 @@ void setup()
     // Init the U8G2 compatible SSD1306, 128X64 OLED display on the Heltec board
 
 #if USE_OLED
-extern U8G2_SSD1306_128X64_NONAME_F_HW_I2C g_u8g2;
     debugI("Intializizing OLED display");
     g_u8g2.begin();
 #endif

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -91,6 +91,10 @@ void IRAM_ATTR UpdateScreen()
 
 	std::lock_guard<std::mutex> guard(Screen::_screenMutex);
 
+    #if USE_OLED
+        g_u8g2.clearBuffer(); 
+    #endif
+    
     if (giInfoPage == 0)
     {
         if (gbInfoPageDirty)
@@ -349,6 +353,10 @@ void IRAM_ATTR UpdateScreen()
             gbInfoPageDirty = false;
         }
     }
+
+    #if USE_OLED
+        g_u8g2.sendBuffer();
+    #endif
 }
 
 


### PR DESCRIPTION
Fixes the build break for configs with no screen like brooklynroom

## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).