### PR TITLE
reintroduce starrynight defines

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -1013,6 +1013,14 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 #define USE_TFTSPI 0
 #endif
 
+#ifndef STARRYNIGHT_PROBABILITY
+#define STARRYNIGHT_PROBABILITY 0.9
+#endif
+
+#ifndef STARRYNIGHT_MUSICFACTOR
+#define STARRYNIGHT_MUSICFACTOR 1.0
+#endif
+
 // gRingSizeTable
 //
 // Items with rings must provide a table indicating how big each ring is.  If an insulator had 60 LEDs grouped


### PR DESCRIPTION
## Description
This reintroduces the `STARRYNIGHT_*` defines in globals.h that accidentally got removed yesterday.

## Contributing requirements
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).