### PR TITLE
Fix effect text size when effect name is longer than 18 characters

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -205,7 +205,9 @@ void IRAM_ATTR UpdateScreen()
             Screen::drawString(sEffect.c_str(),yh);     
             
             yh += Screen::fontHeight();
-            Screen::setTextSize(Screen::screenWidth() > 160 ? Screen::MEDIUM : Screen::SMALL);
+			// get effect name length and switch text size accordingly
+            int effectnamelen = strlen(g_pEffectManager->GetCurrentEffectName());
+            Screen::setTextSize((Screen::screenWidth() > 160) && (effectnamelen <= 18) ? Screen::MEDIUM : Screen::SMALL);
             Screen::setTextColor(WHITE16, backColor);
             Screen::drawString(g_pEffectManager->GetCurrentEffectName(), yh);  
 


### PR DESCRIPTION
## Description
When a effect name has more than 18 characters, the name gets cut off.
This switches the text size to small if the name has more than 18 characters

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).