### PR TITLE
Enable response packet over sockets to give server our current status

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -63,6 +63,7 @@
 //              Sep-18-2021  v021       Davepl      Github Release
 //              Nov-07-2021  v022       Davepl      Rev'd with new Github PRs to date
 //              Mar-16-2022  v023       Davepl      Response packet on socket with stats
+//              Mar-17-2022  v024       Davepl      Catchup clock to server when in future
 //---------------------------------------------------------------------------
 
 // The goal here is to get two variables, one numeric and one string, from the *same* version
@@ -73,7 +74,7 @@
 //
 // If you know a cleaner way, please improve this!
 
-#define FLASH_VERSION           23  // Update ONLY this to increment the version number
+#define FLASH_VERSION          24   // Update ONLY this to increment the version number
 
 #define XSTR(x) STR(x)              // The defs will generate the stringized version of it
 #define STR(x) "v0"#x               // Remove the zero when we exceed 100, or make this dynamic
@@ -583,7 +584,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define MATRIX_WIDTH    (8*144)   
     #define MATRIX_HEIGHT   1
     #define NUM_LEDS        (MATRIX_WIDTH * MATRIX_HEIGHT)
-    #define RESERVE_MEMORY  180000                // WiFi needs about 100K free to be able to (re)connect!
+    #define RESERVE_MEMORY  170000                // WiFi needs about 100K free to be able to (re)connect!
     #define ENABLE_REMOTE   0                     // IR Remote Control
     #define ENABLE_AUDIO    0                     // Listen for audio from the microphone and process it
 

--- a/include/globals.h
+++ b/include/globals.h
@@ -62,6 +62,7 @@
 //              Jul-08-2021  v020       Davepl      Particle System, Insulators, lib deps
 //              Sep-18-2021  v021       Davepl      Github Release
 //              Nov-07-2021  v022       Davepl      Rev'd with new Github PRs to date
+//              Mar-16-2022  v023       Davepl      Response packet on socket with stats
 //---------------------------------------------------------------------------
 
 // The goal here is to get two variables, one numeric and one string, from the *same* version
@@ -72,10 +73,10 @@
 //
 // If you know a cleaner way, please improve this!
 
-#define FLASH_VERSION          022  // Update ONLY this to increment the version number
+#define FLASH_VERSION           23  // Update ONLY this to increment the version number
 
 #define XSTR(x) STR(x)              // The defs will generate the stringized version of it
-#define STR(x) "v"#x
+#define STR(x) "v0"#x               // Remove the zero when we exceed 100, or make this dynamic
 #define FLASH_VERSION_NAME_X(x) "v"#x 
 #define FLASH_VERSION_NAME XSTR(FLASH_VERSION)
 
@@ -113,11 +114,11 @@
 // We have a half-dozen workers and these are their relative priorities.  It might survive if all were set equal,
 // but I think drawing should be lower than audio so that a bad or greedy effect doesn't starve the audio system.
 
-#define DRAWING_PRIORITY        tskIDLE_PRIORITY+3
-#define SOCKET_PRIORITY         tskIDLE_PRIORITY+2
-#define NET_PRIORITY            tskIDLE_PRIORITY+2
+#define DRAWING_PRIORITY        tskIDLE_PRIORITY+4      // Draw any available frames first
+#define SOCKET_PRIORITY         tskIDLE_PRIORITY+3      // ...then process and decompress incoming frames
 #define AUDIO_PRIORITY          tskIDLE_PRIORITY+2
 #define SCREEN_PRIORITY         tskIDLE_PRIORITY+2
+#define NET_PRIORITY            tskIDLE_PRIORITY+2
 #define DEBUG_PRIORITY          tskIDLE_PRIORITY+1
 #define REMOTE_PRIORITY         tskIDLE_PRIORITY+1
 
@@ -135,11 +136,11 @@
 
 #define DRAWING_CORE            1
 #define INCOMING_CORE           0
-#define NET_CORE                1
+#define NET_CORE                0
 #define AUDIO_CORE              1
 #define SCREEN_CORE             1       
 #define DEBUG_CORE              1
-#define SOCKET_CORE             1
+#define SOCKET_CORE             0
 #define REMOTE_CORE             1
 
 #define FASTLED_INTERNAL        1   // Suppresses the compilation banner from FastLED
@@ -827,7 +828,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 #endif
 
 #define STACK_SIZE (ESP_TASK_MAIN_STACK) // Stack size for each new thread
-#define TIME_CHECK_INTERVAL_MS (1000 * 60 * 15)   // 15 min - How often in ms we resync the clock from NTP
+#define TIME_CHECK_INTERVAL_MS (1000 * 60 * 1)   // 15 min - How often in ms we resync the clock from NTP
 #define MIN_BRIGHTNESS  4                   
 #define MAX_BRIGHTNESS  255
 #define BRIGHTNESS_STEP 10          // Amount to step brightness on each remote control repeat 

--- a/include/ledbuffer.h
+++ b/include/ledbuffer.h
@@ -37,6 +37,8 @@
 #include <memory>
 #include <iostream>
 
+#include "ledmatrixgfx.h"
+
 using namespace std;
 
 #ifdef USE_PSRAM

--- a/include/ntptimeclient.h
+++ b/include/ntptimeclient.h
@@ -39,8 +39,8 @@
 #include <mutex>
 
 // define the NTP server to connect too (replace . [dots] in IP addresses with , [commas])
-#define cszNTPServer  192, 168, 1, 2
-//#define cszNTPServer  94, 199, 173, 123     // 0.pool.ntp.org
+//#define cszNTPServer  192, 168, 1, 2
+#define cszNTPServer  94, 199, 173, 123     // 0.pool.ntp.org
 //#define cszNTPServer 216, 239, 35, 12     // google time
 //#define cszNTPServer 17, 253, 16, 253     // apple time
 

--- a/include/socketserver.h
+++ b/include/socketserver.h
@@ -67,6 +67,7 @@ struct SocketResponse
     double   oldestPacket;      // 8
     double   newestPacket;      // 8
     double   brightness;        // 8
+    double   wifiSignal;        // 8
     uint32_t bufferSize;        // 4
     uint32_t bufferPos;         // 4
     uint32_t fpsDrawing;        // 4    
@@ -78,7 +79,7 @@ struct SocketResponse
 // doubles land on byte multiples of 8, otherwise you'll get packing bytes inserted.  Welcome to my world! Once upon
 // a time, I ported about a billion lines of x86 'pragma_pack(1)' code to the MIPS (davepl)!
 
-static_assert( sizeof(SocketResponse) == 56, "SocketResponse struct size is not what is expected - check alignment and double size" );            
+static_assert( sizeof(SocketResponse) == 64, "SocketResponse struct size is not what is expected - check alignment and double size" );            
 
 extern AppTime g_AppTime;
 extern double g_BufferAgeNewest;
@@ -425,6 +426,7 @@ public:
                                         .oldestPacket = g_BufferAgeOldest,
                                         .newestPacket = g_BufferAgeNewest,
                                         .brightness   = g_Brite,
+                                        .wifiSignal   = (double) WiFi.RSSI(),
                                         .bufferSize   = g_apBufferManager[0]->BufferCount(),
                                         .bufferPos    = g_apBufferManager[0]->Depth(),
                                         .fpsDrawing   = g_FPS,

--- a/platformio.ini
+++ b/platformio.ini
@@ -103,7 +103,7 @@ upload_port   = COM11
 build_flags   = -DLEDSTRIP=1
                 -DUSE_SCREEN=1
                 -DUNITY_INCLUDE_DOUBLE 
-                -DUNITY_DOUBLE_PRECISION=1e-12
+                -DUNITY_DOUBLE_PRECISION=1e-12      ; Make doubles real 8 byte doubles
                 -std=gnu++17
                 -Ofast 
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -99,9 +99,11 @@ debug_init_break =
 board         = heltec_wifi_kit_32
 monitor_speed = 115200
 upload_speed  = 921600
-upload_port   = /dev/cu.usbserial-0001
+upload_port   = COM11
 build_flags   = -DLEDSTRIP=1
                 -DUSE_SCREEN=1
+                -DUNITY_INCLUDE_DOUBLE 
+                -DUNITY_DOUBLE_PRECISION=1e-12
                 -std=gnu++17
                 -Ofast 
 

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -202,7 +202,7 @@ void IRAM_ATTR DrawLoopTaskEntry(void *)
                     auto pNewest = g_apBufferManager[iChannel]->PeekNewestBuffer();                    
                     g_BufferAgeNewest = (pNewest->Seconds() + pNewest->MicroSeconds() / (double) MICROS_PER_SECOND) - dClockTime;
                             g_BufferAgeOldest = (pOldest->Seconds() + pOldest->MicroSeconds() / (double) MICROS_PER_SECOND) - dClockTime;
-                    debugI("Clock: %+04.2lf, Oldest: %+04.2lf, Newest: %+04.2lf", dClockTime, g_BufferAgeOldest, g_BufferAgeNewest);
+                    debugV("Clock: %+04.2lf, Oldest: %+04.2lf, Newest: %+04.2lf", dClockTime, g_BufferAgeOldest, g_BufferAgeNewest);
                 }
                 else
                 {

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -44,10 +44,13 @@ extern std::mutex         g_buffer_mutex;
 
 extern DRAM_ATTR unique_ptr<LEDBufferManager> g_apBufferManager[NUM_CHANNELS];
 extern DRAM_ATTR unique_ptr<LEDMatrixGFX []>  g_aStrands;
+extern DRAM_ATTR shared_ptr<LEDMatrixGFX>     g_pStrands[NUM_CHANNELS];        
+extern DRAM_ATTR unique_ptr<EffectManager> g_pEffectManager;
 extern uint32_t           g_FPS;
 extern AppTime            g_AppTime;
-extern unique_ptr<EffectManager> g_pEffectManager;
 extern bool               g_bUpdateStarted;
+extern double             g_Brite;
+extern uint32_t           g_Watts; 
 
 
 void ShowTM1814();
@@ -68,7 +71,7 @@ void DrawPlaceholderDisplay()
         else
             color = color.setHue((iChannel - 1) * 36);                      
 
-        g_aStrands[iChannel].fillScreen(CRGB::Black);
+        //g_aStrands[iChannel].fillScreen(CRGB::Black);
 
         static float iOffset = 0.0f;
 
@@ -117,8 +120,8 @@ void DrawPlaceholderDisplay()
 #else
         const int step = 1;
 #endif
-        for (float i = iOffset; i < g_aStrands[iChannel].GetLEDCount(); i += step)
-            g_aStrands[iChannel].drawPixel(i, color);
+        //for (float i = iOffset; i < g_aStrands[iChannel].GetLEDCount(); i += step)
+        //    g_aStrands[iChannel].drawPixel(i, color);
     }
 #if ATOMISTRING
     ShowTM1814();
@@ -272,6 +275,9 @@ void IRAM_ATTR DrawLoopTaskEntry(void *)
                 #endif
 
                 g_FPS = FastLED.getFPS(); //     1.0/elapsed;    
+                g_Brite = 255.0 * 100.0 / calculate_max_brightness_for_power_mW(g_Brightness, POWER_LIMIT_MW);
+                g_Watts = calculate_unscaled_power_mW( g_pStrands[0]->GetLEDBuffer(), cPixelsDrawnThisFrame )/ 1000;
+
                 
                 // If we draw, we delay at least a bit so that anything else on our core, like the TFT, can get more CPU and update.
 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -331,17 +331,6 @@ bool ProcessIncomingData(uint8_t *payloadData, size_t payloadLength)
 
             double dServer = seconds + (micros / (double) MICROS_PER_SECOND);
             double delta = abs(dServer - AppTime::CurrentTime());
-
-            if (delta > 1000)
-            {
-                /*
-                debugI("Server is wildly different so adjusting time by %lf to %lf", delta, dServer);
-                auto tv = AppTime::TimevalFromTime(dServer);
-                settimeofday(&tv, nullptr);
-                time_t newtime = time(NULL);
-                debugI("New Time: %s", ctime(&newtime));
-                */
-            };
            
             debugV("ProcessIncomingData -- Channel: %u, Length: %u, Seconds: %llu, Micros: %llu ... ", 
                    channel16, 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -328,6 +328,21 @@ bool ProcessIncomingData(uint8_t *payloadData, size_t payloadLength)
             uint64_t seconds   = ULONGFromMemory(&payloadData[8]);
             uint64_t micros    = ULONGFromMemory(&payloadData[16]);
 
+
+            double dServer = seconds + (micros / (double) MICROS_PER_SECOND);
+            double delta = abs(dServer - AppTime::CurrentTime());
+
+            if (delta > 1000)
+            {
+                /*
+                debugI("Server is wildly different so adjusting time by %lf to %lf", delta, dServer);
+                auto tv = AppTime::TimevalFromTime(dServer);
+                settimeofday(&tv, nullptr);
+                time_t newtime = time(NULL);
+                debugI("New Time: %s", ctime(&newtime));
+                */
+            };
+           
             debugV("ProcessIncomingData -- Channel: %u, Length: %u, Seconds: %llu, Micros: %llu ... ", 
                    channel16, 
                    length32, 
@@ -415,26 +430,16 @@ bool ProcessIncomingData(uint8_t *payloadData, size_t payloadLength)
             
             double dOld = tvOld.tv_sec + (tvOld.tv_usec / (double) MICROS_PER_SECOND);
             double dNew = tvNew.tv_sec + (tvNew.tv_usec / (double) MICROS_PER_SECOND);
- 
-            const double ClockCreepBackLimit = 5.0;
+            auto   delta = abs(dNew - dOld);
 
-            if (dNew > dOld)                                    // If clock goes forward
+            /*
+            if (false == NTPTimeClient::HasClockBeenSet() && delta > 1.0)
             {
                 settimeofday(&tvNew, nullptr);
                 debugI("Old clock, new clock: %lf, %lf\n", dOld, dNew);
                 debugI("Server clock: Updated clock received, time written to ESP32 rtc: %ld.%ld, DELTA: %lf", tvNew.tv_sec, tvNew.tv_usec, dNew - dOld );
             }
-            else if (dNew < dOld - ClockCreepBackLimit)         // If clock goes backwards, we stay stable unless its more than 'ClockCreepBackLimit' behind us
-            {                                                   //  in which case we also track it backwards by a max of that little step amount
-                debugI("Server clock: Creeping time back by %lf to to %lf, as clock was ahead by %lf\n", ClockCreepBackLimit, dOld - ClockCreepBackLimit, dNew-dOld);
-                timeval tv = AppTime::TimevalFromTime(dOld - ClockCreepBackLimit);
-                settimeofday(&tv, nullptr);
-            }
-            else
-            {                                                   // Clock received and it's old but not old enough to matter, so its a discard
-                debugV("Server clock: Updated clock TOO OLD, NOT written to ESP32 rtc: %ld.%ld, DELTA: %lf", tvNew.tv_sec, tvNew.tv_usec, dOld - dNew );
-            }
-            
+            */
             return true;
         }
 


### PR DESCRIPTION
## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->
Adds a "ResponsePacket" that is sent back to the host every time we receive a data frame.  This packet includes information like our firmware version, current FPS, buffer size, buffer pos, and so on.

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [Xttp://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [ X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [ X] I selected `main` as the target branch.
* [X ] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).