### PR TITLE
Implement HueFireFanEffect class. Removed GreenFireFanEffect and BlueFireFanEffect classes.

### DIFF
--- a/include/effects/faneffects.h
+++ b/include/effects/faneffects.h
@@ -779,6 +779,7 @@ class FireFanEffect : public LEDStripEffect
     bool    bReversed;          // If reversed we draw from 0 outwards
     bool    bMirrored;          // If mirrored we split and duplicate the drawing
     bool    bMulticolor;        // If each arm of the atomlight should have its own color
+    int     _hue;               // Hue "color" from FastLED, int or HSVHue color name
 
     PixelOrder Order;
 
@@ -807,7 +808,8 @@ class FireFanEffect : public LEDStripEffect
                   PixelOrder order = Sequential, 
                   bool breversed = false, 
                   bool bmirrored = false, 
-                  bool bmulticolor = false)
+                  bool bmulticolor = false,
+                  int hue = HUE_RED)
         : LEDStripEffect("FireFanEffect"),
           LEDCount(ledCount),
           CellsPerLED(cellsPerLED),
@@ -818,6 +820,7 @@ class FireFanEffect : public LEDStripEffect
           bReversed(breversed),
           bMirrored(bmirrored),
           bMulticolor(bmulticolor),
+          _hue(hue),
           Order(order)          
     {
         if (bMirrored)
@@ -950,7 +953,7 @@ class FireFanEffect : public LEDStripEffect
     }
 };
 
-class BlueFireFanEffect : public FireFanEffect
+class HueFireFanEffect : public FireFanEffect
 {
     using FireFanEffect::FireFanEffect;
 
@@ -960,24 +963,7 @@ class BlueFireFanEffect : public FireFanEffect
       byte heatramp = t192 & 0x3F; // 0..63
       heatramp <<= 2; // scale up to 0..252
 
-      CHSV hsv(HUE_BLUE, 255, heatramp);
-      CRGB rgb;
-      hsv2rgb_rainbow(hsv, rgb);
-      return rgb;
-    }
-};
-
-class GreenFireFanEffect : public FireFanEffect
-{
-    using FireFanEffect::FireFanEffect;
-
-    virtual CRGB MapHeatToColor(byte temperature, int iChannel = 0)
-    {
-      byte t192 = round((temperature/255.0)*191);
-      byte heatramp = t192 & 0x3F; // 0..63
-      heatramp <<= 2; // scale up to 0..252
-
-      CHSV hsv(HUE_GREEN, 255, heatramp);
+      CHSV hsv(_hue, 255, heatramp);
       CRGB rgb;
       hsv2rgb_rainbow(hsv, rgb);
       return rgb;

--- a/include/effects/faneffects.h
+++ b/include/effects/faneffects.h
@@ -779,7 +779,7 @@ class FireFanEffect : public LEDStripEffect
     bool    bReversed;          // If reversed we draw from 0 outwards
     bool    bMirrored;          // If mirrored we split and duplicate the drawing
     bool    bMulticolor;        // If each arm of the atomlight should have its own color
-    int     _hue;               // Hue "color" from FastLED, int or HSVHue color name
+    int     iHue;               // Hue "color" from FastLED, int or HSVHue color name
 
     PixelOrder Order;
 
@@ -820,7 +820,7 @@ class FireFanEffect : public LEDStripEffect
           bReversed(breversed),
           bMirrored(bmirrored),
           bMulticolor(bmulticolor),
-          _hue(hue),
+          iHue(hue),
           Order(order)          
     {
         if (bMirrored)
@@ -963,7 +963,7 @@ class HueFireFanEffect : public FireFanEffect
       byte heatramp = t192 & 0x3F; // 0..63
       heatramp <<= 2; // scale up to 0..252
 
-      CHSV hsv(_hue, 255, heatramp);
+      CHSV hsv(iHue, 255, heatramp);
       CRGB rgb;
       hsv2rgb_rainbow(hsv, rgb);
       return rgb;

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -287,8 +287,8 @@ DRAM_ATTR LEDStripEffect * AllEffects[] =
     new ColorBeatOverRedBkgnd("ColorBeatOverRedBkgnd"),
 
     new FireFanEffect(NUM_LEDS,      1, 12, 210, 2, NUM_LEDS / 2, Sequential, false, true),
-    new GreenFireFanEffect(NUM_LEDS,      1, 12, 200, 2, NUM_LEDS / 2, Sequential, false, true),
-    new BlueFireFanEffect(NUM_LEDS,      2, 10, 200, 2, NUM_LEDS / 2, Sequential, false, true),
+    new HueFireFanEffect(NUM_LEDS,      1, 12, 200, 2, NUM_LEDS / 2, Sequential, false, true, false, HUE_GREEN),
+    new HueFireFanEffect(NUM_LEDS,      2, 10, 200, 2, NUM_LEDS / 2, Sequential, false, true, false, HUE_BLUE),
 
     new ColorCycleEffect(BottomUp, 6),
     new ColorCycleEffect(BottomUp, 2),
@@ -411,8 +411,8 @@ DRAM_ATTR LEDStripEffect * AllEffects[] =
     new ColorFillEffect(CRGB::White, 1),
     new FireFanEffect(NUM_LEDS,      1, 15, 80, 2, 7, Sequential, true, false),
     new FireFanEffect(NUM_LEDS,      1, 15, 80, 2, 7, Sequential, true, false, true),
-    new BlueFireFanEffect(NUM_LEDS,      2, 5, 120, 1, 1, Sequential, true, false),
-    new GreenFireFanEffect(NUM_LEDS,      2, 3, 100, 1, 1, Sequential, true, false),
+    new HueFireFanEffect(NUM_LEDS,      2, 5, 120, 1, 1, Sequential, true, false, false, HUE_BLUE),
+    new HueFireFanEffect(NUM_LEDS,      2, 3, 100, 1, 1, Sequential, true, false, false, HUE_GREEN),
     new RainbowFillEffect(60, 0),
     new ColorCycleEffect(Sequential),
     new PaletteEffect(RainbowColors_p, 4, 0.1, 0.0, 1.0, 0.0),
@@ -512,15 +512,15 @@ DRAM_ATTR LEDStripEffect * AllEffects[] =
     new FireFanEffect(NUM_LEDS,      2, 10, 200, 2, NUM_LEDS / 2, Sequential, false, true),
     new FireFanEffect(NUM_LEDS,      1, 12, 200, 2, NUM_LEDS / 2, Sequential, false, true),
 
-    new BlueFireFanEffect(NUM_LEDS,      4, 7, 200, 2, NUM_LEDS / 2, Sequential, false, true),
-    new BlueFireFanEffect(NUM_LEDS,      3, 8, 200, 2, NUM_LEDS / 2, Sequential, false, true),
-    new BlueFireFanEffect(NUM_LEDS,      2, 10, 200, 2, NUM_LEDS / 2, Sequential, false, true),
-    new BlueFireFanEffect(NUM_LEDS,      1, 12, 200, 2, NUM_LEDS / 2, Sequential, false, true),
+    new HueFireFanEffect(NUM_LEDS,      4, 7, 200, 2, NUM_LEDS / 2, Sequential, false, true, false, HUE_BLUE),
+    new HueFireFanEffect(NUM_LEDS,      3, 8, 200, 2, NUM_LEDS / 2, Sequential, false, true, false, HUE_BLUE),
+    new HueFireFanEffect(NUM_LEDS,      2, 10, 200, 2, NUM_LEDS / 2, Sequential, false, true, false, HUE_BLUE),
+    new HueFireFanEffect(NUM_LEDS,      1, 12, 200, 2, NUM_LEDS / 2, Sequential, false, true, false, HUE_BLUE),
     
-    new GreenFireFanEffect(NUM_LEDS,      4, 7, 200, 2, NUM_LEDS / 2, Sequential, false, true),
-    new GreenFireFanEffect(NUM_LEDS,      3, 8, 200, 2, NUM_LEDS / 2, Sequential, false, true),
-    new GreenFireFanEffect(NUM_LEDS,      2, 10, 200, 2, NUM_LEDS / 2, Sequential, false, true),
-    new GreenFireFanEffect(NUM_LEDS,      1, 12, 200, 2, NUM_LEDS / 2, Sequential, false, true),
+    new HueFireFanEffect(NUM_LEDS,      4, 7, 200, 2, NUM_LEDS / 2, Sequential, false, true, false, HUE_GREEN),
+    new HueFireFanEffect(NUM_LEDS,      3, 8, 200, 2, NUM_LEDS / 2, Sequential, false, true, false, HUE_GREEN),
+    new HueFireFanEffect(NUM_LEDS,      2, 10, 200, 2, NUM_LEDS / 2, Sequential, false, true, false, HUE_GREEN),
+    new HueFireFanEffect(NUM_LEDS,      1, 12, 200, 2, NUM_LEDS / 2, Sequential, false, true, false, HUE_GREEN),
 
     #if ENABLE_AUDIO
       


### PR DESCRIPTION
## Description
Implements HueFireFanEffect, a replacement for existing BlueFireFanEffect and GreenFireFanEffect that allows for easy access to many more color options.

Removed BlueFireFanEffect and GreenFireFanEffect.

Fixed up effects.cpp to reflect changes. Didn't add any new colors as examples, but usage is clear from existing, re-worked effect entries.

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).