### PR TITLE
Fixed the PalleteFlameEffect Constructor

### DIFF
--- a/include/effects/fireeffect.h
+++ b/include/effects/fireeffect.h
@@ -184,10 +184,11 @@ public:
                        int cellsPerLED = 1,
                        int cooling = 20,         // Was 1.8 for NightDriverStrip
                        int sparking = 100,
+                       int sparks = 3,
                        int sparkHeight = 3,
                        bool reversed = false,
                        bool mirrored = false)
-        : FireEffect(ledCount, cellsPerLED, cooling, sparking, sparking, sparkHeight, reversed, mirrored),
+        : FireEffect(ledCount, cellsPerLED, cooling, sparking, sparks, sparkHeight, reversed, mirrored),
           _palette(palette)
     {
     }


### PR DESCRIPTION
In the constructor for the PalleteFlameEffect, the arguments don't include the number of sparks. And the arguments given for FireEffect in that constructor have the sparking argument given twice. I believe this isn't what you intended

## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).