### PR TITLE
Added an additional check to pass the assertion later

### DIFF
--- a/include/effects/misceffects.h
+++ b/include/effects/misceffects.h
@@ -295,6 +295,9 @@ class TwinkleEffect : public LEDStripEffect
 				size_t i = random(0, NUM_LEDS);
 				if (pPixels[i] != CRGB(0,0,0))
 					continue;
+				std::deque<size_t>::iterator found = find(litPixels.begin(), litPixels.end(), i);
+				if (litPixels.end() != found)
+					litPixels.erase(found);
 				iNew = i;
 				break;
 			}


### PR DESCRIPTION
The pixel picker loop tries to find a black pixel, but there is an assertion later that the found pixel has to not be in the litPixel deque. However, there is no check or anything if the newly picked iNew pixel is actually in the deque. I've added a few lines to delete the chosen pixel from the deque if it is chosen.

Thanks to @steve-git-hub for his help in [this](https://github.com/PlummersSoftwareLLC/NightDriverStrip/discussions/69) discussion.

## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).