### PR TITLE
TwinkleEffect: Check selected pixel isn't already lit

### DIFF
--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -269,6 +269,8 @@ class TwinkleEffect : public LEDStripEffect
                 size_t i = random(0, NUM_LEDS);
                 if (_GFX[0]->getPixel(i) != CRGB(0,0,0))
                     continue;
+                if (litPixels.end() != find(litPixels.begin(), litPixels.end(), i))
+                    continue;
                 iNew = i;
                 break;
             }


### PR DESCRIPTION
## Description

This is an alternative solution for the issue addressed in #146. It has also been written to align with the current state of the codebase (after the merge of #150).

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).