### PR TITLE
Cleanup "ENABLE_AUDIO" bugs

### DIFF
--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -178,8 +178,11 @@ public:
         if (color == CRGB(CRGB::White))
             effect = make_shared<ColorFillEffect>(CRGB::White, 1);
         else
+#if ENABLE_AUDIO
             effect = make_shared<MusicalPaletteFire>("Custom Fire", CRGBPalette256(CRGB::Black, color, CRGB::Yellow, CRGB::White), NUM_LEDS, 1, 8, 50, 1, 24, true, false);
-        
+#else
+            effect = make_shared<PaletteFlameEffect>("Custom Fire", CRGBPalette256(CRGB::Black, color, CRGB::Yellow, CRGB::White), NUM_LEDS, 1, 8, 50, 1, 24, true, false);
+#endif
         if (effect->Init(g_pDevices))
         {
             _pRemoteEffect = effect;

--- a/include/effects/strip/meteoreffect.h
+++ b/include/effects/strip/meteoreffect.h
@@ -131,8 +131,10 @@ public:
         for (int i = 0; i < meteorCount; i++)
         {
             float spd = speed[i];
+#if ENABLE_AUDIO
             if (gVURatio > 1.0)
                 spd *= gVURatio;
+#endif
 
             iPos[i] = (bLeft[i]) ? iPos[i]-spd : iPos[i]+spd;
             if (iPos[i]< meteorSize)

--- a/include/effects/strip/stareffect.h
+++ b/include/effects/strip/stareffect.h
@@ -154,6 +154,29 @@ class MusicStar : public Star
 
 };
 float MusicStar::_baseHue = 0.0f;
+
+
+class MusicPulseStar : public Star
+{
+    public:
+
+    MusicPulseStar(const CRGBPalette256 & palette, TBlendType blendType = LINEARBLEND, double maxSpeed = 0.0, double size = 0.0)
+      : Star(palette, blendType, maxSpeed, size)
+    {
+
+    }
+
+    virtual ~MusicPulseStar()
+    {
+    }
+
+    virtual float PreignitionTime() const { return 0.00f;  }
+    virtual float IgnitionTime()    const { return 0.00f; }
+    virtual float HoldTime()        const { return 1.00f;  }
+    virtual float FadeTime()        const { return 2.00f; } 
+    virtual double GetStarSize()    const { return 1 + _objectSize * gVURatio; }
+};
+
 #endif
 
 class BubblyStar : public Star
@@ -310,26 +333,7 @@ class HotWhiteStar : public Star
     }      
 };
 
-class MusicPulseStar : public Star
-{
-    public:
 
-    MusicPulseStar(const CRGBPalette256 & palette, TBlendType blendType = LINEARBLEND, double maxSpeed = 0.0, double size = 0.0)
-      : Star(palette, blendType, maxSpeed, size)
-    {
-
-    }
-
-    virtual ~MusicPulseStar()
-    {
-    }
-
-    virtual float PreignitionTime() const { return 0.00f;  }
-    virtual float IgnitionTime()    const { return 0.00f; }
-    virtual float HoldTime()        const { return 1.00f;  }
-    virtual float FadeTime()        const { return 2.00f; } 
-    virtual double GetStarSize()    const { return 1 + _objectSize * gVURatio; }
-};
 
 /*
 template <typename ObjectType> class BeatStarterEffect : public BeatEffectBase
@@ -444,11 +448,13 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
         {
             float prob = _newStarProbability;
 
+#if ENABLE_AUDIO
             if (_musicFactor != 1.0)
             {
                 // 
                 prob = prob * (gVURatio - 0.5) * _musicFactor; 
-            }   
+            }
+#endif
 
             if (randomDouble(0, 1.0) < g_AppTime.DeltaTime() * prob * (float) _cLEDs / 5000.0f)
             {

--- a/include/spiffswebserver.h
+++ b/include/spiffswebserver.h
@@ -137,8 +137,12 @@ class CSPIFFSWebServer
         auto j = response->getRoot();
 
         j["LED_FPS"]               = g_FPS;
+#if ENABLE_AUDIOSERIAL
         j["SERIAL_FPS"]            = g_serialFPS;
+#endif
+#if ENABLE_AUDIO
         j["AUDIO_FPS"]             = g_AudioFPS;
+#endif
 
         j["HEAP_SIZE"]             = ESP.getHeapSize();
         j["HEAP_FREE"]             = ESP.getFreeHeap();


### PR DESCRIPTION
## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->
When ENABLE_AUDIO is set to 0, stareffect.h and meteoreffect.h have compilation errors because of gVURatio being referenced.
The web server also fails to build when ENABLE_AUDIO is 0.
Finally, a remote effect fails to build when ENABLE_AUDIO is 0.

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).