### PR TITLE
Small Wifi module optimization and improvements.

### DIFF
--- a/include/network.h
+++ b/include/network.h
@@ -31,11 +31,12 @@
 #include "ntptimeclient.h"
 #include "secrets.h"                          // copy include/secrets.example.h to include/secrets.h
 
+#if ENABLE_WIFI
 extern uint8_t g_Brightness;
 extern bool g_bUpdateStarted;
 extern WiFiUDP g_Udp;
 #if INCOMING_WIFI_ENABLED
-    extern SocketServer g_SocketServer;
+extern SocketServer g_SocketServer;
 #endif
 void processRemoteDebugCmd();
 
@@ -45,3 +46,33 @@ extern RemoteControl g_RemoteControl;
 
 bool ConnectToWiFi(uint cRetries);
 void SetupOTA(const char *pszHostname);
+
+// Static Helpers
+//
+// Simple utility functions
+
+#define WL_NO_SHIELD "WL_NO_SHIELD";
+#define WL_IDLE_STATUS "WL_IDLE_STATUS";
+#define WL_NO_SSID_AVAIL "WL_NO_SSID_AVAIL";
+#define WL_SCAN_COMPLETED "WL_SCAN_COMPLETED";
+#define WL_CONNECTED "WL_CONNECTED";
+#define WL_CONNECT_FAILED "WL_CONNECT_FAILED";
+#define WL_CONNECTION_LOST "WL_CONNECTION_LOST";
+#define WL_DISCONNECTED "WL_DISCONNECTED";
+#define WL_UNKNOWN_STATUS "WL_UNKNOWN_STATUS";
+
+inline static const char* WLtoString(wl_status_t status) {
+  switch (status) {
+    case 255: return WL_NO_SHIELD;
+    case 0: return WL_IDLE_STATUS;
+    case 1: return WL_NO_SSID_AVAIL;
+    case 2: return WL_SCAN_COMPLETED;
+    case 3: return WL_CONNECTED;
+    case 4: return WL_CONNECT_FAILED;
+    case 5: return WL_CONNECTION_LOST;
+    case 6: return WL_DISCONNECTED;
+    default: return WL_UNKNOWN_STATUS;
+  }
+}
+
+#endif

--- a/include/network.h
+++ b/include/network.h
@@ -37,12 +37,12 @@
     extern bool g_bUpdateStarted;
     extern WiFiUDP g_Udp;
     #if INCOMING_WIFI_ENABLED
-      extern SocketServer g_SocketServer;
+        extern SocketServer g_SocketServer;
     #endif
     void processRemoteDebugCmd();
 
     #if ENABLE_REMOTE
-      extern RemoteControl g_RemoteControl;
+        extern RemoteControl g_RemoteControl;
     #endif
 
     bool ConnectToWiFi(uint cRetries);

--- a/include/network.h
+++ b/include/network.h
@@ -37,12 +37,12 @@
     extern bool g_bUpdateStarted;
     extern WiFiUDP g_Udp;
     #if INCOMING_WIFI_ENABLED
-    extern SocketServer g_SocketServer;
+      extern SocketServer g_SocketServer;
     #endif
     void processRemoteDebugCmd();
 
     #if ENABLE_REMOTE
-    extern RemoteControl g_RemoteControl;
+      extern RemoteControl g_RemoteControl;
     #endif
 
     bool ConnectToWiFi(uint cRetries);

--- a/include/network.h
+++ b/include/network.h
@@ -25,6 +25,7 @@
 //    Network related functions and definitons
 //
 //---------------------------------------------------------------------------
+#pragma once
 
 #include "remotecontrol.h"
 #include "socketserver.h"
@@ -32,47 +33,47 @@
 #include "secrets.h"                          // copy include/secrets.example.h to include/secrets.h
 
 #if ENABLE_WIFI
-extern uint8_t g_Brightness;
-extern bool g_bUpdateStarted;
-extern WiFiUDP g_Udp;
-#if INCOMING_WIFI_ENABLED
-extern SocketServer g_SocketServer;
-#endif
-void processRemoteDebugCmd();
+    extern uint8_t g_Brightness;
+    extern bool g_bUpdateStarted;
+    extern WiFiUDP g_Udp;
+    #if INCOMING_WIFI_ENABLED
+    extern SocketServer g_SocketServer;
+    #endif
+    void processRemoteDebugCmd();
 
-#if ENABLE_REMOTE
-extern RemoteControl g_RemoteControl;
-#endif
+    #if ENABLE_REMOTE
+    extern RemoteControl g_RemoteControl;
+    #endif
 
-bool ConnectToWiFi(uint cRetries);
-void SetupOTA(const char *pszHostname);
+    bool ConnectToWiFi(uint cRetries);
+    void SetupOTA(const char *pszHostname);
 
-// Static Helpers
-//
-// Simple utility functions
+    // Static Helpers
+    //
+    // Simple utility functions
 
-#define WL_NO_SHIELD "WL_NO_SHIELD";
-#define WL_IDLE_STATUS "WL_IDLE_STATUS";
-#define WL_NO_SSID_AVAIL "WL_NO_SSID_AVAIL";
-#define WL_SCAN_COMPLETED "WL_SCAN_COMPLETED";
-#define WL_CONNECTED "WL_CONNECTED";
-#define WL_CONNECT_FAILED "WL_CONNECT_FAILED";
-#define WL_CONNECTION_LOST "WL_CONNECTION_LOST";
-#define WL_DISCONNECTED "WL_DISCONNECTED";
-#define WL_UNKNOWN_STATUS "WL_UNKNOWN_STATUS";
+    #define WL_NO_SHIELD "WL_NO_SHIELD";
+    #define WL_IDLE_STATUS "WL_IDLE_STATUS";
+    #define WL_NO_SSID_AVAIL "WL_NO_SSID_AVAIL";
+    #define WL_SCAN_COMPLETED "WL_SCAN_COMPLETED";
+    #define WL_CONNECTED "WL_CONNECTED";
+    #define WL_CONNECT_FAILED "WL_CONNECT_FAILED";
+    #define WL_CONNECTION_LOST "WL_CONNECTION_LOST";
+    #define WL_DISCONNECTED "WL_DISCONNECTED";
+    #define WL_UNKNOWN_STATUS "WL_UNKNOWN_STATUS";
 
-inline static const char* WLtoString(wl_status_t status) {
-  switch (status) {
-    case 255: return WL_NO_SHIELD;
-    case 0: return WL_IDLE_STATUS;
-    case 1: return WL_NO_SSID_AVAIL;
-    case 2: return WL_SCAN_COMPLETED;
-    case 3: return WL_CONNECTED;
-    case 4: return WL_CONNECT_FAILED;
-    case 5: return WL_CONNECTION_LOST;
-    case 6: return WL_DISCONNECTED;
-    default: return WL_UNKNOWN_STATUS;
-  }
-}
+    inline static const char* WLtoString(wl_status_t status) {
+      switch (status) {
+        case 255: return WL_NO_SHIELD;
+        case 0: return WL_IDLE_STATUS;
+        case 1: return WL_NO_SSID_AVAIL;
+        case 2: return WL_SCAN_COMPLETED;
+        case 3: return WL_CONNECTED;
+        case 4: return WL_CONNECT_FAILED;
+        case 5: return WL_CONNECTION_LOST;
+        case 6: return WL_DISCONNECTED;
+        default: return WL_UNKNOWN_STATUS;
+      }
+    }
 
 #endif

--- a/include/socketserver.h
+++ b/include/socketserver.h
@@ -52,7 +52,7 @@ extern "C"
 #define COMPRESSED_HEADER (0x44415645)                                              // asci "DAVE" as header 
 bool ProcessIncomingData(uint8_t * payloadData, size_t payloadLength);              // In main file
 
-#if INCOMING_WIFI_ENABLED
+#if ENABLE_WIFI && INCOMING_WIFI_ENABLED
 
 // SocketResponse
 //

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -295,12 +295,11 @@ void IRAM_ATTR DebugLoopTaskEntry(void *)
 
     for (;;)                                                // Call Debug.handle() 20 times a second
     {
-        #if ENABLE_WIFI
-            EVERY_N_MILLIS(50)
-            {
-                Debug.handle();
-            }
-        #endif
+        EVERY_N_MILLIS(50)
+        {
+            Debug.handle();
+        }
+        
         delay(10);        
     }    
 }
@@ -855,26 +854,39 @@ void loop()
 
         EVERY_N_SECONDS(5)
         {
-            #if ENABLE_AUDIO
-                debugI("Mem: %u LED FPS: %d, LED Watt: %d, LED Brite: %0.0lf%%, Audio FPS: %d, Serial FPS: %d, PeakVU: %0.2lf, MinVU: %0.2lf, VURatio: %0.2lf, CPU: %02.0f%%, %02.0f%%, FreeDraw: %lf",
-                        ESP.getFreeHeap(),
-                        g_FPS, g_Watts, g_Brite, g_AudioFPS, g_serialFPS, gPeakVU, gMinVU, gVURatio, g_TaskManager.GetCPUUsagePercent(0), g_TaskManager.GetCPUUsagePercent(1), g_FreeDrawTime);
-            #elif ENABLE_WIFI
-                debugI("Wifi: %s, IP: %s, Mem: %u LargestBlk: %u PSRAM Free: %u/%u Buffer: %d/%d LED FPS: %d, LED Watt: %d, LED Brite: %0.0lf%%, CPU: %02.0f%%, %02.0f%%, FreeDraw: %lf",
-                   WLtoString(WiFi.status()),
-                   WiFi.localIP().toString().c_str(),
-                   ESP.getFreeHeap(),
-                   ESP.getMaxAllocHeap(),
-                   ESP.getFreePsram(), ESP.getPsramSize(),
-                   g_apBufferManager[0]->Depth(), g_apBufferManager[0]->BufferCount(),
-                   g_FPS, g_Watts, g_Brite, g_TaskManager.GetCPUUsagePercent(0), g_TaskManager.GetCPUUsagePercent(1), g_FreeDrawTime);
+            #if ENABLE_AUDIO && ENABLE_WIFI
+                debugI("Wifi: %s, IP: %s, Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, Buffer: %d/%d, LED FPS: %d, LED Watt: %d, LED Brite: %0.0lf%%, Audio FPS: %d, Serial FPS: %d, PeakVU: %0.2lf, MinVU: %0.2lf, VURatio: %0.2lf, CPU: %02.0f%%, %02.0f%%, FreeDraw: %lf",
+                        WLtoString(WiFi.status()), WiFi.localIP().toString().c_str(), // Wifi
+                        ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize(), // Mem
+                        g_FPS, g_Watts, g_Brite, // LED
+                        g_AudioFPS, g_serialFPS, gPeakVU, gMinVU, gVURatio, // Audio
+                        g_TaskManager.GetCPUUsagePercent(0), g_TaskManager.GetCPUUsagePercent(1), 
+                        g_FreeDrawTime);
+            #elif ENABLE_AUDIO // Implied !ENABLE_WIFI from 1st condition
+                debugI("Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, Buffer: %d/%d, LED FPS: %d, LED Watt: %d, LED Brite: %0.0lf%%, Audio FPS: %d, Serial FPS: %d, PeakVU: %0.2lf, MinVU: %0.2lf, VURatio: %0.2lf, CPU: %02.0f%%, %02.0f%%, FreeDraw: %lf",
+                    ESP.getFreeHeap(), ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize(), // Mem
+                    g_apBufferManager[0]->Depth(), g_apBufferManager[0]->BufferCount(), // Buffer
+                    g_FPS, g_Watts, g_Brite, // LED
+                    g_AudioFPS, g_serialFPS, gPeakVU, gMinVU, gVURatio, // Audio
+                    g_TaskManager.GetCPUUsagePercent(0), g_TaskManager.GetCPUUsagePercent(1), 
+                    g_FreeDrawTime);
+            #elif ENABLE_WIFI // Implied !ENABLE_AUDIO from 1st condition
+                debugI("Wifi: %s, IP: %s, Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, Buffer: %d/%d, LED FPS: %d, LED Watt: %d, LED Brite: %0.0lf%%, CPU: %02.0f%%, %02.0f%%, FreeDraw: %lf",
+                   WLtoString(WiFi.status()), WiFi.localIP().toString().c_str(), // Wifi
+                   ESP.getFreeHeap(), ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize(), // Mem
+                   g_apBufferManager[0]->Depth(), g_apBufferManager[0]->BufferCount(), // Buffer
+                   g_FPS, g_Watts, g_Brite, // LED
+                   g_TaskManager.GetCPUUsagePercent(0), g_TaskManager.GetCPUUsagePercent(1),  // CPU
+                   g_FreeDrawTime); // FreeDraw
             #else
-                debugI("Mem: %u LargestBlk: %u PSRAM Free: %u/%u Buffer: %d/%d LED FPS: %d, LED Watt: %d, LED Brite: %0.0lf%%, CPU: %02.0f%%, %02.0f%%, FreeDraw: %lf",
-                   ESP.getFreeHeap(),
-                   ESP.getMaxAllocHeap(),
-                   ESP.getFreePsram(), ESP.getPsramSize(),
-                   g_apBufferManager[0]->Depth(), g_apBufferManager[0]->BufferCount(),
-                   g_FPS, g_Watts, g_Brite, g_TaskManager.GetCPUUsagePercent(0), g_TaskManager.GetCPUUsagePercent(1), g_FreeDrawTime);
+                debugI("Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, Buffer: %d/%d, LED FPS: %d, LED Watt: %d, LED Brite: %0.0lf%%, CPU: %02.0f%%, %02.0f%%, FreeDraw: %lf",
+                   ESP.getFreeHeap(), // Mem
+                   ESP.getMaxAllocHeap(), // LargestBlk
+                   ESP.getFreePsram(), ESP.getPsramSize(), // PSRAM
+                   g_apBufferManager[0]->Depth(), g_apBufferManager[0]->BufferCount(), // Buffer
+                   g_FPS, g_Watts, g_Brite, // LED
+                   g_TaskManager.GetCPUUsagePercent(0), g_TaskManager.GetCPUUsagePercent(1),  // CPU
+                   g_FreeDrawTime); // FreeDraw
             #endif
         }
 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -68,63 +68,63 @@ extern volatile float gMinVU;
 // in order to allow us to add custom commands.  I've added a clock reset and stats command, for example.
 
 #if ENABLE_WIFI
-void processRemoteDebugCmd() 
-{
-    String str = Debug.getLastCommand();
-    if (str.equalsIgnoreCase("clock"))
+    void processRemoteDebugCmd() 
     {
-        debugI("Refreshing Time from Server...");
-
-        digitalWrite(BUILTIN_LED_PIN, 1);
-        NTPTimeClient::UpdateClockFromWeb(&g_Udp);
-        digitalWrite(BUILTIN_LED_PIN, 0);
-    }
-    else if (str.equalsIgnoreCase("stats"))
-    {
-        debugI("Displaying statistics....");
-
-        char szBuffer[256];
-        snprintf(szBuffer, ARRAYSIZE(szBuffer), "%s:%dx%d %dK\n", FLASH_VERSION_NAME, NUM_CHANNELS, NUM_LEDS, ESP.getFreeHeap() / 1024);
-        debugI("%s", szBuffer);
-
-
-        snprintf(szBuffer, ARRAYSIZE(szBuffer), "%sdB:%s\n", 
-                                                String(WiFi.RSSI()).substring(1).c_str(), 
-                                                WiFi.isConnected() ? WiFi.localIP().toString().c_str() : "None");
-        debugI("%s", szBuffer);
-
-        snprintf(szBuffer, ARRAYSIZE(szBuffer), "BUFR:%02d/%02d [%dfps]\n", g_apBufferManager[0]->Depth(), g_apBufferManager[0]->BufferCount(), g_FPS);
-        debugI("%s", szBuffer);
-
-        snprintf(szBuffer, ARRAYSIZE(szBuffer), "DATA:%+04.2lf-%+04.2lf\n", g_BufferAgeOldest, g_BufferAgeNewest);
-        debugI("%s", szBuffer);
-
-        snprintf(szBuffer, ARRAYSIZE(szBuffer), "CLCK:%.2lf\n", g_AppTime.CurrentTime());
-        debugI("%s", szBuffer);
-
-        #if ENABLE_AUDIO
-            snprintf(szBuffer, ARRAYSIZE(szBuffer), "gVU: %.2f, gMinVU: %.2f, gPeakVU: %.2f, gVURatio: %.2f", gVU, gMinVU, gPeakVU, gVURatio);
-            debugI("%s", szBuffer);
-        #endif
-
-        #if INCOMING_WIFI_ENABLED
-        snprintf(szBuffer, ARRAYSIZE(szBuffer), "Socket Buffer _cbReceived: %d", g_SocketServer._cbReceived);
-        debugI("%s", szBuffer);
-        #endif
-
-        // Print out a buffer log with timestamps and deltas 
-        
-        for (size_t i = 0; i < g_apBufferManager[0]->Depth(); i++)
+        String str = Debug.getLastCommand();
+        if (str.equalsIgnoreCase("clock"))
         {
-            auto pBufferManager = g_apBufferManager[0].get();
-            std::shared_ptr<LEDBuffer> pBuffer = (*pBufferManager)[i];
-            double t = pBuffer->Seconds() + (double) pBuffer->MicroSeconds() / MICROS_PER_SECOND;
-            snprintf(szBuffer, ARRAYSIZE(szBuffer), "Frame: %03d, Clock: %lf, Offset: %lf", i, t, g_AppTime.CurrentTime() - t);
-            debugI("%s", szBuffer);
-        }
+            debugI("Refreshing Time from Server...");
 
+            digitalWrite(BUILTIN_LED_PIN, 1);
+            NTPTimeClient::UpdateClockFromWeb(&g_Udp);
+            digitalWrite(BUILTIN_LED_PIN, 0);
+        }
+        else if (str.equalsIgnoreCase("stats"))
+        {
+            debugI("Displaying statistics....");
+
+            char szBuffer[256];
+            snprintf(szBuffer, ARRAYSIZE(szBuffer), "%s:%dx%d %dK\n", FLASH_VERSION_NAME, NUM_CHANNELS, NUM_LEDS, ESP.getFreeHeap() / 1024);
+            debugI("%s", szBuffer);
+
+
+            snprintf(szBuffer, ARRAYSIZE(szBuffer), "%sdB:%s\n", 
+                                                    String(WiFi.RSSI()).substring(1).c_str(), 
+                                                    WiFi.isConnected() ? WiFi.localIP().toString().c_str() : "None");
+            debugI("%s", szBuffer);
+
+            snprintf(szBuffer, ARRAYSIZE(szBuffer), "BUFR:%02d/%02d [%dfps]\n", g_apBufferManager[0]->Depth(), g_apBufferManager[0]->BufferCount(), g_FPS);
+            debugI("%s", szBuffer);
+
+            snprintf(szBuffer, ARRAYSIZE(szBuffer), "DATA:%+04.2lf-%+04.2lf\n", g_BufferAgeOldest, g_BufferAgeNewest);
+            debugI("%s", szBuffer);
+
+            snprintf(szBuffer, ARRAYSIZE(szBuffer), "CLCK:%.2lf\n", g_AppTime.CurrentTime());
+            debugI("%s", szBuffer);
+
+            #if ENABLE_AUDIO
+                snprintf(szBuffer, ARRAYSIZE(szBuffer), "gVU: %.2f, gMinVU: %.2f, gPeakVU: %.2f, gVURatio: %.2f", gVU, gMinVU, gPeakVU, gVURatio);
+                debugI("%s", szBuffer);
+            #endif
+
+            #if INCOMING_WIFI_ENABLED
+            snprintf(szBuffer, ARRAYSIZE(szBuffer), "Socket Buffer _cbReceived: %d", g_SocketServer._cbReceived);
+            debugI("%s", szBuffer);
+            #endif
+
+            // Print out a buffer log with timestamps and deltas 
+            
+            for (size_t i = 0; i < g_apBufferManager[0]->Depth(); i++)
+            {
+                auto pBufferManager = g_apBufferManager[0].get();
+                std::shared_ptr<LEDBuffer> pBuffer = (*pBufferManager)[i];
+                double t = pBuffer->Seconds() + (double) pBuffer->MicroSeconds() / MICROS_PER_SECOND;
+                snprintf(szBuffer, ARRAYSIZE(szBuffer), "Frame: %03d, Clock: %lf, Offset: %lf", i, t, g_AppTime.CurrentTime() - t);
+                debugI("%s", szBuffer);
+            }
+
+        }
     }
-}
 #endif
 
 // RemoteLoopEntry

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -67,6 +67,7 @@ extern volatile float gMinVU;
 // Callback function that the debug library (which exposes a little console over telnet and serial) calls
 // in order to allow us to add custom commands.  I've added a clock reset and stats command, for example.
 
+#if ENABLE_WIFI
 void processRemoteDebugCmd() 
 {
     String str = Debug.getLastCommand();
@@ -124,6 +125,7 @@ void processRemoteDebugCmd()
 
     }
 }
+#endif
 
 // RemoteLoopEntry
 //
@@ -150,18 +152,18 @@ void IRAM_ATTR RemoteLoopEntry(void *)
 // ConnectToWiFi
 //
 // Connect to the pre-configured WiFi network.  
-//
-// BUGBUG I'm guessing this is exposed in all builds so anyone can call it and it just returns false if wifi
-// isn't being used, but do we need that?  If no one really needs to call it put the whole thing in the ifdef
 
+#if ENABLE_WIFI
 #define WIFI_RETRIES 5
 
 bool ConnectToWiFi(uint cRetries)
 {
-    #if !ENABLE_WIFI
-        return false;
-    #endif
-
+    // Already connected, Go no further.
+    if (WiFi.isConnected())
+    {
+            return true;
+    }
+    
     debugI("Setting host name to %s...", cszHostname);
 
 #if USE_WIFI_MANAGER
@@ -189,11 +191,12 @@ bool ConnectToWiFi(uint cRetries)
             }
         }
 
-        if (WiFi.isConnected())
+        if (WiFi.isConnected()) {
             break;
+        } 
     }
 #endif
-
+    // Additional Services onwwards reliant on network so close if not up.
     if (false == WiFi.isConnected())
     {
         debugW("Giving up on WiFi\n");
@@ -269,6 +272,7 @@ bool ConnectToWiFi(uint cRetries)
 
     return true;
 }
+#endif
 
 // SetupOTA
 //

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -154,124 +154,126 @@ void IRAM_ATTR RemoteLoopEntry(void *)
 // Connect to the pre-configured WiFi network.  
 
 #if ENABLE_WIFI
-#define WIFI_RETRIES 5
 
-bool ConnectToWiFi(uint cRetries)
-{
-    // Already connected, Go no further.
-    if (WiFi.isConnected())
+    #define WIFI_RETRIES 5
+
+    bool ConnectToWiFi(uint cRetries)
     {
+        // Already connected, Go no further.
+        if (WiFi.isConnected())
+        {
             return true;
-    }
-    
-    debugI("Setting host name to %s...", cszHostname);
-
-#if USE_WIFI_MANAGER
-    g_WifiManager.setDebugOutput(true);
-    g_WifiManager.autoConnect("NightDriverWiFi");
-#else
-    for (uint iPass = 0; iPass < cRetries; iPass++)
-    {
-        Serial.printf("Pass %u of %u: Connecting to Wifi SSID: %s - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u\n",
-            iPass, cRetries, cszSSID, ESP.getFreeHeap(), ESP.getPsramSize(), ESP.getFreePsram());
-
-        //WiFi.disconnect();
-        WiFi.begin(cszSSID, cszPassword);
-
-        for (uint i = 0; i < WIFI_RETRIES; i++)
-        {
-            if (WiFi.isConnected())
-            {
-                Serial.printf("Connected to AP with BSSID: %s\n", WiFi.BSSIDstr().c_str());
-                break;
-            }
-            else
-            {
-                delay(1000);
-            }
         }
+        
+        debugI("Setting host name to %s...", cszHostname);
 
-        if (WiFi.isConnected()) {
-            break;
-        } 
-    }
-#endif
-    // Additional Services onwwards reliant on network so close if not up.
-    if (false == WiFi.isConnected())
-    {
-        debugW("Giving up on WiFi\n");
-        return false;
-    }
-    debugW("Received IP: %s", WiFi.localIP().toString().c_str());
-
-    #if INCOMING_WIFI_ENABLED
-        // Start listening for incoming data
-        debugI("Starting/restarting Socket Server...");
-        g_SocketServer.release();
-        if (false == g_SocketServer.begin())
-            throw runtime_error("Could not start socket server!");
-
-        debugI("Socket server started.");
-    #endif
-
-    #if ENABLE_OTA
-        debugI("Publishing OTA...");
-        SetupOTA(cszHostname);
-    #endif
-
-    #if ENABLE_NTP
-        debugI("Setting Clock...");
-        NTPTimeClient::UpdateClockFromWeb(&g_Udp);
-    #endif
-
-    #if ENABLE_WEBSERVER
-        debugI("Starting Web Server...");
-        g_WebServer.begin();
-        debugI("Web Server begin called!");
-    #endif
-
-    #if USEMATRIX
-        //LEDStripEffect::mgraphics()->SetCaption(WiFi.localIP().toString().c_str(), 3000);
-    #endif
-
-    /*
-    {
-        WiFiClientSecure secClient;
-
-        secClient.setInsecure();
-
-        Serial.println("\nStarting secure connection to server...");
-        uint32_t start = millis();
-        int r = secClient.connect("google.com", 443, 5000);
-        Serial.printf("Connection took: %lums\n", millis()-start);
-        if(!r) 
+    #if USE_WIFI_MANAGER
+        g_WifiManager.setDebugOutput(true);
+        g_WifiManager.autoConnect("NightDriverWiFi");
+    #else
+        for (uint iPass = 0; iPass < cRetries; iPass++)
         {
-            Serial.println("Connection failed!");
-        } 
-        else 
-        {
-            Serial.println("Connected!  Sending GET!");
-            secClient.println("GET https://www.google.com/search?q=tsla+stock+quote HTTP/1.0");
-            secClient.println("Host: www.google.com");
-            secClient.println("Connection: close");
-            secClient.println();
-            
-            while (secClient.connected()) 
+            Serial.printf("Pass %u of %u: Connecting to Wifi SSID: %s - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u\n",
+                iPass, cRetries, cszSSID, ESP.getFreeHeap(), ESP.getPsramSize(), ESP.getFreePsram());
+
+            //WiFi.disconnect();
+            WiFi.begin(cszSSID, cszPassword);
+
+            for (uint i = 0; i < WIFI_RETRIES; i++)
             {
-                String line = secClient.readStringUntil('\n');
-                secClient.printf("Data: %s", line.c_str());
-                if (line == "\r") {
-                    Serial.println("headers received");
+                if (WiFi.isConnected())
+                {
+                    Serial.printf("Connected to AP with BSSID: %s\n", WiFi.BSSIDstr().c_str());
                     break;
                 }
+                else
+                {
+                    delay(1000);
+                }
             }
-        }
-        secClient.stop();
-    }
-    */
 
-    return true;
-}
+            if (WiFi.isConnected()) {
+                break;
+            } 
+        }
+    #endif
+        // Additional Services onwwards reliant on network so close if not up.
+        if (false == WiFi.isConnected())
+        {
+            debugW("Giving up on WiFi\n");
+            return false;
+        }
+        debugW("Received IP: %s", WiFi.localIP().toString().c_str());
+
+        #if INCOMING_WIFI_ENABLED
+            // Start listening for incoming data
+            debugI("Starting/restarting Socket Server...");
+            g_SocketServer.release();
+            if (false == g_SocketServer.begin())
+                throw runtime_error("Could not start socket server!");
+
+            debugI("Socket server started.");
+        #endif
+
+        #if ENABLE_OTA
+            debugI("Publishing OTA...");
+            SetupOTA(cszHostname);
+        #endif
+
+        #if ENABLE_NTP
+            debugI("Setting Clock...");
+            NTPTimeClient::UpdateClockFromWeb(&g_Udp);
+        #endif
+
+        #if ENABLE_WEBSERVER
+            debugI("Starting Web Server...");
+            g_WebServer.begin();
+            debugI("Web Server begin called!");
+        #endif
+
+        #if USEMATRIX
+            //LEDStripEffect::mgraphics()->SetCaption(WiFi.localIP().toString().c_str(), 3000);
+        #endif
+
+        /*
+        {
+            WiFiClientSecure secClient;
+
+            secClient.setInsecure();
+
+            Serial.println("\nStarting secure connection to server...");
+            uint32_t start = millis();
+            int r = secClient.connect("google.com", 443, 5000);
+            Serial.printf("Connection took: %lums\n", millis()-start);
+            if(!r) 
+            {
+                Serial.println("Connection failed!");
+            } 
+            else 
+            {
+                Serial.println("Connected!  Sending GET!");
+                secClient.println("GET https://www.google.com/search?q=tsla+stock+quote HTTP/1.0");
+                secClient.println("Host: www.google.com");
+                secClient.println("Connection: close");
+                secClient.println();
+                
+                while (secClient.connected()) 
+                {
+                    String line = secClient.readStringUntil('\n');
+                    secClient.printf("Data: %s", line.c_str());
+                    if (line == "\r") {
+                        Serial.println("headers received");
+                        break;
+                    }
+                }
+            }
+            secClient.stop();
+        }
+        */
+
+        return true;
+    }
+    
 #endif
 
 // SetupOTA


### PR DESCRIPTION
Add Wifi status to Heartbeat. Updating WIFI_ENABLED usage to remove unrequired dependent capabilities.

## Description
- Add Wifi Status to Heartbeat; Useful for my use-case where various issues cause loss of access and this helps diagnose.
- Optimized pre-processing of network.h/.cpp when WIFI_ENABLED is disabled.
- Add  WIFI_ENABLED checks where required/necessary on transitive dependencies. i.e. #if ENABLE_WIFI && INCOMING_WIFI_ENABLED

- Samples from WIFI_ENABLED|AUDIO_ENABLED * 0|1 against single env.
----
audio, wifi
(I) (loop)(C1) Wifi: WL_CONNECTED, IP: 10.0.0.41, Mem: 46088, LargestBlk: 40948, PSRAM Free: 0/0, Buffer: 46/7, LED FPS: 0, LED Watt: 1079574528, LED Brite: 0%, Audio FPS: 0, Serial FPS: 1086324736, PeakVU: 0.00, MinVU: 1.00, VURatio: 1.20, CPU: 06%, 00%, FreeDraw: -1.407352

----
audio, no wifi
(I) (loop)(C1) Mem: 77584, LargestBlk: 59380, PSRAM Free: 0/0, Buffer: 0/369, LED FPS: 46, LED Watt: 7, LED Brite: 100%, Audio FPS: 35, Serial FPS: 0, PeakVU: 0.00, MinVU: 0.00, VURatio: 0.00, CPU: 00%, 19%, FreeDraw: 0.018975

----
wifi, no audio
(I) (loop)(C1) Wifi: WL_CONNECTION_LOST, IP: 0.0.0.0, Mem: 45916, LargestBlk: 42996, PSRAM Free: 0/0, Buffer: 0/286, LED FPS: 46, LED Watt: 8, LED Brite: 100%, CPU: 02%, 34%, FreeDraw: 0.016148

----
default
(I) (loop)(C1) Mem: 88064, LargestBlk: 61428, PSRAM Free: 0/0, Buffer: 0/375, LED FPS: 45, LED Watt: 7, LED Brite: 100%, CPU: 00%, 05%, FreeDraw: 0.015849


## Contributing requirements
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).