### PR TITLE
Implement Hardware SPI, fix debug logging, refactor all headers to global.h

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ _(This is an exact copy of the equally-named section of [README.md](README.md))_
 
 Rather than produce a complex set of guidelines, here's what I hope open-source collaboration will bring to the project: that folks will add important features and fix defects and shortcomings in the code.  When they're adding features, they'll do it in a way consistent with the way things are done in the existing code.  They resist the urge to rearchitect and rewrite everything in their own image and instead put their efforts towards maximizing functional improvement while reducing source code thrash and change.
 
-Let's consider the inconsistent naming, which should be fixed.  Some is camelCase, some is pszHungarian, and so on, depending on the source. I'd prefer it were all updated to a single standard TBD.  Until the TBD is determined, I lean towards [the Win32 standard](https://docs.microsoft.com/en-us/windows/win32/stg/coding-style-conventions?redirectedfrom=MSDN).  
+Let's consider the inconsistent naming, which should be fixed.  Some is camelCase, some is strHungarian, and so on, depending on the source. I'd prefer it were all updated to a single standard TBD.  Until the TBD is determined, I lean towards [the Win32 standard](https://docs.microsoft.com/en-us/windows/win32/stg/coding-style-conventions?redirectedfrom=MSDN).  
 
 When working in a function, work in the style of the function.  When working on a class, work in the style of the class.  When working on a file, work in the style of the file.  If those are inconsistent, do whatever minimizes changes.  Stylistic changes should only be introduced after discussion in the group, and generally should entain owning that style change across the entire project.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ _(This is an exact copy of the equally-named section of [README.md](README.md))_
 
 Rather than produce a complex set of guidelines, here's what I hope open-source collaboration will bring to the project: that folks will add important features and fix defects and shortcomings in the code.  When they're adding features, they'll do it in a way consistent with the way things are done in the existing code.  They resist the urge to rearchitect and rewrite everything in their own image and instead put their efforts towards maximizing functional improvement while reducing source code thrash and change.
 
-Let's consider the inconsistent naming, which should be fixed.  Some is camelCase, some is strHungarian, and so on, depending on the source. I'd prefer it were all updated to a single standard TBD.  Until the TBD is determined, I lean towards [the Win32 standard](https://docs.microsoft.com/en-us/windows/win32/stg/coding-style-conventions?redirectedfrom=MSDN).  
+Let's consider the inconsistent naming, which should be fixed.  Some is camelCase, some is pszHungarian, and so on, depending on the source. I'd prefer it were all updated to a single standard TBD.  Until the TBD is determined, I lean towards [the Win32 standard](https://docs.microsoft.com/en-us/windows/win32/stg/coding-style-conventions?redirectedfrom=MSDN).  
 
 When working in a function, work in the style of the function.  When working on a class, work in the style of the class.  When working on a file, work in the style of the file.  If those are inconsistent, do whatever minimizes changes.  Stylistic changes should only be introduced after discussion in the group, and generally should entain owning that style change across the entire project.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Generate a series of 24 frames per second (or 30 if under 500 LEDs) and set the 
 
 Rather than produce a complex set of guidelines, here's what I hope open-source collaboration will bring to the project: that folks will add important features and fix defects and shortcomings in the code.  When they're adding features, they'll do it in a way consistent with the way things are done in the existing code.  They resist the urge to rearchitect and rewrite everything in their own image and instead put their efforts towards maximizing functional improvement while reducing source code thrash and change.
 
-Let's consider the inconsistent naming, which should be fixed.  Some is camelCase, some is strHungarian, and so on, depending on the source. I'd prefer it were all updated to a single standard TBD.  Until the TBD is determined, I lean towards [the Win32 standard](https://docs.microsoft.com/en-us/windows/win32/stg/coding-style-conventions?redirectedfrom=MSDN).  
+Let's consider the inconsistent naming, which should be fixed.  Some is camelCase, some is pszHungarian, and so on, depending on the source. I'd prefer it were all updated to a single standard TBD.  Until the TBD is determined, I lean towards [the Win32 standard](https://docs.microsoft.com/en-us/windows/win32/stg/coding-style-conventions?redirectedfrom=MSDN).  
 
 When working in a function, work in the style of the function.  When working on a class, work in the style of the class.  When working on a file, work in the style of the file.  If those are inconsistent, do whatever minimizes changes.  Stylistic changes should only be introduced after discussion in the group, and generally should entain owning that style change across the entire project.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Generate a series of 24 frames per second (or 30 if under 500 LEDs) and set the 
 
 Rather than produce a complex set of guidelines, here's what I hope open-source collaboration will bring to the project: that folks will add important features and fix defects and shortcomings in the code.  When they're adding features, they'll do it in a way consistent with the way things are done in the existing code.  They resist the urge to rearchitect and rewrite everything in their own image and instead put their efforts towards maximizing functional improvement while reducing source code thrash and change.
 
-Let's consider the inconsistent naming, which should be fixed.  Some is camelCase, some is pszHungarian, and so on, depending on the source. I'd prefer it were all updated to a single standard TBD.  Until the TBD is determined, I lean towards [the Win32 standard](https://docs.microsoft.com/en-us/windows/win32/stg/coding-style-conventions?redirectedfrom=MSDN).  
+Let's consider the inconsistent naming, which should be fixed.  Some is camelCase, some is strHungarian, and so on, depending on the source. I'd prefer it were all updated to a single standard TBD.  Until the TBD is determined, I lean towards [the Win32 standard](https://docs.microsoft.com/en-us/windows/win32/stg/coding-style-conventions?redirectedfrom=MSDN).  
 
 When working in a function, work in the style of the function.  When working on a class, work in the style of the class.  When working on a file, work in the style of the file.  If those are inconsistent, do whatever minimizes changes.  Stylistic changes should only be introduced after discussion in the group, and generally should entain owning that style change across the entire project.
 

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -42,7 +42,6 @@
 #include <vector>
 #include <math.h>
 
-#include "ntptimeclient.h"
 #include "effects/strip/misceffects.h"
 #include "effects/strip/fireeffect.h"
 

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -42,15 +42,9 @@
 #include <vector>
 #include <math.h>
 
-#include "globals.h"
-#include "soundanalyzer.h"
-#include "ledstripeffect.h"
-#include "effectmanager.h"
-#include "colorutils.h"
+#include "ntptimeclient.h"
 #include "effects/strip/misceffects.h"
 #include "effects/strip/fireeffect.h"
-#include "gfxbase.h"
-#include "ledmatrixgfx.h"
 
 #define MAX_EFFECTS 32
 
@@ -82,7 +76,7 @@ class EffectManager
     CRGB lastManualColor = CRGB::Red;
 
     std::unique_ptr<bool[]> _abEffectEnabled;
-    std::shared_ptr<GFXTYPE> *_gfx;
+    std::shared_ptr<GFXTYPE> * _gfx;
     std::shared_ptr<LEDStripEffect> _pRemoteEffect = nullptr;
 
 public:
@@ -314,7 +308,7 @@ public:
         return _ppEffects[_iCurrentEffect];
     }
 
-    const String GetCurrentEffectName() const
+    const String & GetCurrentEffectName() const
     {
         if (_pRemoteEffect)
             return _pRemoteEffect->FriendlyName();

--- a/include/effects/matrix/Boid.h
+++ b/include/effects/matrix/Boid.h
@@ -66,10 +66,10 @@
 
 #pragma once
 
-#include "globals.h"
 #include "Vector.h"
 
-class Boid {
+class Boid 
+{
   public:
 
     PVector location;

--- a/include/effects/matrix/PatternAlienText.h
+++ b/include/effects/matrix/PatternAlienText.h
@@ -57,10 +57,6 @@
 #ifndef PatternAlienText_H
 #define PatternAlienText_H
 
-#include "globals.h"
-#include "ledstripeffect.h"
-#include "gfxbase.h"
-
 class PatternAlienText : public LEDStripEffect
 {
 private:

--- a/include/effects/matrix/PatternBounce.h
+++ b/include/effects/matrix/PatternBounce.h
@@ -54,7 +54,6 @@
 #ifndef PatternBounce_H
 #define PatternBounce_H
 
-#include "globals.h"
 #include "Vector.h"
 #include "Boid.h"
 

--- a/include/effects/matrix/PatternCircuit.h
+++ b/include/effects/matrix/PatternCircuit.h
@@ -58,10 +58,6 @@
 #ifndef PatternCircuit_H
 #define PatternCircuit_H
 
-#include "globals.h"
-#include "ledstripeffect.h"
-#include "gfxbase.h"
-
 class PatternCircuit : public LEDStripEffect
 {
 private:

--- a/include/effects/matrix/PatternClock.h
+++ b/include/effects/matrix/PatternClock.h
@@ -31,10 +31,6 @@
 #ifndef PatternClock_H
 #define PatternClock_H
 
-#include "globals.h"
-#include "ledstripeffect.h"
-#include "gfxbase.h"
-
 class PatternClock : public LEDStripEffect
 {
     // Radius is the lesser of the height and width so that the round clock can fit

--- a/include/effects/matrix/PatternCube.h
+++ b/include/effects/matrix/PatternCube.h
@@ -60,10 +60,6 @@
 #ifndef PatternCube_H
 #define PatternCube_H
 
-#include "globals.h"
-#include "soundanalyzer.h"
-#include "ledstripeffect.h"
-#include "gfxbase.h"
 #include "Geometry.h"
 
 class PatternCube : public LEDStripEffect

--- a/include/effects/matrix/PatternFlowField.h
+++ b/include/effects/matrix/PatternFlowField.h
@@ -53,9 +53,6 @@
 
 #pragma once
 
-#include "globals.h"
-#include "ledstripeffect.h"
-
 #if USEMATRIX
 
 class PatternFlowField : public LEDStripEffect

--- a/include/effects/matrix/PatternLife.h
+++ b/include/effects/matrix/PatternLife.h
@@ -62,9 +62,6 @@
 #ifndef PatternLife_H
 #define PatternLife_H
 
-#include "globals.h"
-#include "ledstripeffect.h"
-#include "gfxbase.h"
 #include <bitset>
 
 extern "C" 

--- a/include/effects/matrix/PatternMandala.h
+++ b/include/effects/matrix/PatternMandala.h
@@ -60,10 +60,6 @@
 #define PatternMandala_H
 #if     USEMATRIX
 
-#include "globals.h"
-#include "ledstripeffect.h"
-#include "gfxbase.h"
-
 class PatternMandala : public LEDStripEffect
 {
 private:

--- a/include/effects/matrix/PatternMisc.h
+++ b/include/effects/matrix/PatternMisc.h
@@ -56,7 +56,6 @@
 #ifndef PatternMisc_H
 #define PatternMisc_H
 
-#include "globals.h"
 #include "Geometry.h"
 
 class PatternSunburst : public LEDStripEffect 

--- a/include/effects/matrix/PatternNoiseSmearing.h
+++ b/include/effects/matrix/PatternNoiseSmearing.h
@@ -58,9 +58,6 @@
 #ifndef PatternNoiseSmearing_H
 #define PatternNoiseSmearing_H
 
-#include "globals.h"
-#include "ledstripeffect.h"
-
 uint8_t patternNoiseSmearingHue = 0;
 
 

--- a/include/effects/matrix/PatternPongClock.h
+++ b/include/effects/matrix/PatternPongClock.h
@@ -66,10 +66,6 @@
 #ifndef PatternPongClock_H
 #define PatternPongClock_H
 
-#include "globals.h"
-#include "ledstripeffect.h"
-#include "gfxbase.h"
-
 #define BAT1_X 2 // Pong left bat x pos (this is where the ball collision occurs, the bat is drawn 1 behind these coords)
 #define BAT2_X (MATRIX_WIDTH - 4)
 #define BAT_HEIGHT (MATRIX_HEIGHT / 4)

--- a/include/effects/matrix/PatternPulse.h
+++ b/include/effects/matrix/PatternPulse.h
@@ -58,10 +58,6 @@
 #ifndef PatternPulse_H
 #define PatternPulse_H
 
-#include "globals.h"
-#include "ledstripeffect.h"
-#include "gfxbase.h"
-
 class PatternPulse : public LEDStripEffect
 {
   private:

--- a/include/effects/matrix/PatternQR.h
+++ b/include/effects/matrix/PatternQR.h
@@ -56,8 +56,6 @@
 #ifndef PatternQR_H
 #define PatternQR_H
 
-#include "globals.h"
-#include "ledstripeffect.h"
 #include "Geometry.h"
 #include "qrcode.h"
 
@@ -108,7 +106,7 @@ public:
             const uint16_t backgroundColor = graphics()->to16bit(CRGB(0,0,144));
             const uint16_t borderColor = BLUE16;
             if (qrcode.size + topMargin + borderSize > MATRIX_HEIGHT - 1)
-            throw new std::runtime_error("Matrix can't hold the QR code height");
+            throw std::runtime_error("Matrix can't hold the QR code height");
 
             int w = qrcode.size + borderSize * 2;
             int h = w;

--- a/include/effects/matrix/PatternRadar.h
+++ b/include/effects/matrix/PatternRadar.h
@@ -54,10 +54,6 @@
 #ifndef PatternRadar_H
 #define PatternRadar_H
 
-#include "globals.h"
-#include "ledstripeffect.h"
-#include "gfxbase.h"
-
 class PatternRadar : public LEDStripEffect
 {
 private:

--- a/include/effects/matrix/PatternSerendipity.h
+++ b/include/effects/matrix/PatternSerendipity.h
@@ -58,10 +58,6 @@
 #ifndef PatternSpiral_H
 #define PatternSpiral_H
 
-#include "globals.h"
-#include "ledstripeffect.h"
-#include "gfxbase.h"
-
 class PatternSerendipity : public LEDStripEffect
 {
 private:

--- a/include/effects/matrix/PatternSpark.h
+++ b/include/effects/matrix/PatternSpark.h
@@ -57,8 +57,6 @@
 #ifndef PatternSpark_H
 #define PatternSpark_H
 
-#include "globals.h"
-
 class PatternSpark : public LEDStripEffect 
 {
   private:

--- a/include/effects/matrix/PatternSpin.h
+++ b/include/effects/matrix/PatternSpin.h
@@ -54,8 +54,6 @@
 #ifndef PatternSpin_H
 #define PatternSpin_H
 
-#include "globals.h"
-
 class PatternSpin : public LEDStripEffect
 {
 public:

--- a/include/effects/matrix/PatternSpiro.h
+++ b/include/effects/matrix/PatternSpiro.h
@@ -60,10 +60,6 @@
 #ifndef PatternSpiro_H
 #define PatternSpiro_H
 
-#include "globals.h"
-#include "ledstripeffect.h"
-#include "gfxbase.h"
-
 class PatternSpiro : public LEDStripEffect
 {
 private:

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -32,11 +32,6 @@
 #ifndef PatternSub_H
 #define PatternSub_H
 
-#include "globals.h"
-#include "ledstripeffect.h"
-#include "gfxbase.h"
-#include "ledmatrixgfx.h"
-
 class PatternSubscribers : public LEDStripEffect
 {
   private:

--- a/include/effects/matrix/PatternSwirl.h
+++ b/include/effects/matrix/PatternSwirl.h
@@ -57,10 +57,6 @@
 
 #ifndef PatternSwirl_H
 
-#include "globals.h"
-#include "ledstripeffect.h"
-#include "gfxbase.h"
-
 class PatternSwirl : public LEDStripEffect
 {
 private:

--- a/include/effects/matrix/PatternWave.h
+++ b/include/effects/matrix/PatternWave.h
@@ -58,10 +58,6 @@
 #ifndef PatternWave_H
 #define PatternWave_H
 
-#include "globals.h"
-#include "ledstripeffect.h"
-#include "gfxbase.h"
-
 class PatternWave : public LEDStripEffect 
 {
 private:

--- a/include/effects/matrix/Vector.h
+++ b/include/effects/matrix/Vector.h
@@ -56,8 +56,6 @@
 #ifndef Vector_H
 #define Vector_H
 
-#include "globals.h"
-
 template <class T>
 class Vector2 {
 public:

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -177,7 +177,7 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeterEffe
 
     virtual size_t DesiredFramesPerSecond() const
     {
-        return 45;
+        return 60;
     }
 
     virtual bool RequiresDoubleBuffering() const

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -31,12 +31,6 @@
 
 #pragma once
 
-#include <sys/types.h>
-#include <errno.h>
-#include <iostream>
-#include <vector>
-#include <math.h>
-#include <deque>
 
 #include "effects/strip/musiceffect.h"
 #include "effects/strip/particles.h"

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -38,15 +38,8 @@
 #include <math.h>
 #include <deque>
 
-#include "globals.h"
-#include "soundanalyzer.h"
-#include "effectmanager.h"
-#include "colorutils.h"
-#include "ledstripeffect.h"
 #include "effects/strip/musiceffect.h"
 #include "effects/strip/particles.h"
-#include "screen.h"
-#include "gfxbase.h"
 
 extern AppTime  g_AppTime;
 extern DRAM_ATTR uint8_t giInfoPage;                   // Which page of the display is being shown
@@ -62,8 +55,8 @@ class InsulatorSpectrumEffect : public LEDStripEffect, public BeatEffectBase, pu
     
   public:
 
-    InsulatorSpectrumEffect(const String pszName, const CRGBPalette16 & Palette) : 
-        LEDStripEffect(pszName),
+    InsulatorSpectrumEffect(const String & strName, const CRGBPalette16 & Palette) : 
+        LEDStripEffect(strName),
         BeatEffectBase(0.25, 1.75, .25),
         ParticleSystem<SpinningPaletteRingParticle>(),
         _Palette(Palette)
@@ -392,7 +385,7 @@ class WaveformEffect : public LEDStripEffect
 
   public:
     
-    WaveformEffect(const String pszFriendlyName, const TProgmemRGBPalette16 * pPalette = nullptr, uint8_t increment = 0) 
+    WaveformEffect(const String & pszFriendlyName, const TProgmemRGBPalette16 * pPalette = nullptr, uint8_t increment = 0) 
         : LEDStripEffect(pszFriendlyName)
     {
         _pPalette = pPalette;
@@ -455,7 +448,7 @@ class GhostWave : public WaveformEffect
     int                       _fade     = 0;
   public:
 
-    GhostWave(const String pszFriendlyName, const TProgmemRGBPalette16 * pPalette = nullptr, uint8_t increment = 0, uint8_t blur = 0, bool erase = true, int fade = 20) 
+    GhostWave(const String & pszFriendlyName, const TProgmemRGBPalette16 * pPalette = nullptr, uint8_t increment = 0, uint8_t blur = 0, bool erase = true, int fade = 20) 
         : WaveformEffect(pszFriendlyName, pPalette, increment),
           _blur(blur),
           _erase(erase),

--- a/include/effects/strip/bouncingballeffect.h
+++ b/include/effects/strip/bouncingballeffect.h
@@ -30,11 +30,6 @@
 
 #pragma once
 
-#include <sys/types.h>
-#include <errno.h>
-#include <iostream>
-#include <vector>
-#include <math.h>
 
 extern AppTime g_AppTime;
 

--- a/include/effects/strip/bouncingballeffect.h
+++ b/include/effects/strip/bouncingballeffect.h
@@ -35,9 +35,6 @@
 #include <iostream>
 #include <vector>
 #include <math.h>
-#include "colorutils.h"
-#include "globals.h"
-#include "ledstripeffect.h"
 
 extern AppTime g_AppTime;
 

--- a/include/effects/strip/doublepaletteeffect.h
+++ b/include/effects/strip/doublepaletteeffect.h
@@ -30,11 +30,6 @@
 
 #pragma once
 
-#include <sys/types.h>
-#include <errno.h>
-#include <iostream>
-#include <vector>
-#include <math.h>
 
 extern AppTime g_AppTime;
 

--- a/include/effects/strip/doublepaletteeffect.h
+++ b/include/effects/strip/doublepaletteeffect.h
@@ -35,10 +35,6 @@
 #include <iostream>
 #include <vector>
 #include <math.h>
-#include "colorutils.h"
-#include "globals.h"
-#include "ledstripeffect.h"
-#include "paletteeffect.h"
 
 extern AppTime g_AppTime;
 

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -32,13 +32,6 @@
 
 #pragma once
 
-#include <sys/types.h>
-#include <errno.h>
-#include <iostream>
-#include <vector>
-#include <memory>
-#include <math.h>
-
 #include "paletteeffect.h"
 
 // Simple definitions of what direction we're talking about

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -39,14 +39,7 @@
 #include <memory>
 #include <math.h>
 
-#include "globals.h"
-#include "soundanalyzer.h"
-#include "effectmanager.h"
-#include "colorutils.h"
-#include "gfxbase.h"
-#include "ledstripeffect.h"
 #include "paletteeffect.h"
-
 
 // Simple definitions of what direction we're talking about
 
@@ -674,8 +667,8 @@ class PaletteSpinEffect : public LEDStripEffect
     int   ColorOffset[NUM_FANS] = { 0 };
   public:
 
-    PaletteSpinEffect(const String pszName, const CRGBPalette256 & palette, bool bReplace, double sparkleChance = 0.0) 
-      : LEDStripEffect(pszName), _Palette(palette), _bReplaceMagenta(bReplace), _sparkleChance(sparkleChance)
+    PaletteSpinEffect(const String & strName, const CRGBPalette256 & palette, bool bReplace, double sparkleChance = 0.0) 
+      : LEDStripEffect(strName), _Palette(palette), _bReplaceMagenta(bReplace), _sparkleChance(sparkleChance)
     {
 
     }
@@ -1273,7 +1266,7 @@ class LanternParticle
     {
         val = min(val, 255);
         val = max(val, 0);
-#ifdef LANTERN        
+#if LANTERN        
         return CRGB( val,  val*.30, val*.05);
 #else
         return LEDStripEffect::GetBlackBodyHeatColor(val/255.0f*.20 + 0.25);

--- a/include/effects/strip/fireeffect.h
+++ b/include/effects/strip/fireeffect.h
@@ -39,12 +39,7 @@
 #include <memory>
 #include <algorithm>
 
-#include "soundanalyzer.h"
-#include "colorutils.h"
-#include "globals.h"
-#include "ledstripeffect.h"
 #include "musiceffect.h"
-#include "effectmanager.h"
 
 extern AppTime g_AppTime;
 class FireEffect : public LEDStripEffect
@@ -75,8 +70,8 @@ class FireEffect : public LEDStripEffect
 
   public:
 
-    FireEffect(const String pszName, int ledCount = NUM_LEDS, int cellsPerLED = 1, int cooling = 20, int sparking = 100, int sparks = 3, int sparkHeight = 4,  bool breversed = false, bool bmirrored = false)
-        : LEDStripEffect(pszName),
+    FireEffect(const String & strName, int ledCount = NUM_LEDS, int cellsPerLED = 1, int cooling = 20, int sparking = 100, int sparks = 3, int sparkHeight = 4,  bool breversed = false, bool bmirrored = false)
+        : LEDStripEffect(strName),
           LEDCount(ledCount),
           CellsPerLED(cellsPerLED),
           Cooling(cooling),
@@ -192,7 +187,7 @@ class PaletteFlameEffect : public FireEffect
     CRGBPalette256 _palette;
 
 public:
-    PaletteFlameEffect(const String pszName,
+    PaletteFlameEffect(const String & strName,
                        const CRGBPalette256 &palette,
                        int ledCount = NUM_LEDS,
                        int cellsPerLED = 1,
@@ -202,7 +197,7 @@ public:
                        int sparkHeight = 3,
                        bool reversed = false,
                        bool mirrored = false)
-        : FireEffect(pszName,ledCount, cellsPerLED, cooling, sparking, sparks, sparkHeight, reversed, mirrored),
+        : FireEffect(strName,ledCount, cellsPerLED, cooling, sparking, sparks, sparkHeight, reversed, mirrored),
           _palette(palette)
     {
     }
@@ -218,12 +213,12 @@ public:
     }
 };
 
-#ifdef ENABLE_AUDIO
-class MusicalPaletteFire : public PaletteFlameEffect, protected virtual BeatEffectBase2
+#if ENABLE_AUDIO
+class MusicalPaletteFire : public PaletteFlameEffect, protected BeatEffectBase2
 {
   public:
 
-    MusicalPaletteFire(const String pszName,
+    MusicalPaletteFire(const String & strName,
                        const CRGBPalette256 &palette,
                        int ledCount = NUM_LEDS,
                        int cellsPerLED = 1,
@@ -234,7 +229,7 @@ class MusicalPaletteFire : public PaletteFlameEffect, protected virtual BeatEffe
                        bool reversed = false,
                        bool mirrored = false)
         :   BeatEffectBase2(1.00, 0.01),
-            PaletteFlameEffect(pszName, palette, ledCount, cellsPerLED, cooling, sparking, sparks, sparkHeight, reversed, mirrored)
+            PaletteFlameEffect(strName, palette, ledCount, cellsPerLED, cooling, sparking, sparks, sparkHeight, reversed, mirrored)
           
     {
     }

--- a/include/effects/strip/fireeffect.h
+++ b/include/effects/strip/fireeffect.h
@@ -31,13 +31,6 @@
 
 #pragma once
 
-#include <sys/types.h>
-#include <errno.h>
-#include <iostream>
-#include <vector>
-#include <math.h>
-#include <memory>
-#include <algorithm>
 
 #include "musiceffect.h"
 

--- a/include/effects/strip/laserline.h
+++ b/include/effects/strip/laserline.h
@@ -37,14 +37,6 @@
 #include <vector>
 #include <math.h>
 
-#include "globals.h"
-#include "soundanalyzer.h"
-#include "colorutils.h"
-#include "ledstripeffect.h"
-#include "gfxbase.h"
-
-
-
 extern AppTime g_AppTime;
 
 class LaserShot

--- a/include/effects/strip/laserline.h
+++ b/include/effects/strip/laserline.h
@@ -31,12 +31,6 @@
 
 #pragma once
 
-#include <sys/types.h>
-#include <errno.h>
-#include <iostream>
-#include <vector>
-#include <math.h>
-
 extern AppTime g_AppTime;
 
 class LaserShot

--- a/include/effects/strip/meteoreffect.h
+++ b/include/effects/strip/meteoreffect.h
@@ -31,12 +31,6 @@
 
 #pragma once
 
-#include <sys/types.h>
-#include <errno.h>
-#include <iostream>
-#include <vector>
-#include <math.h>
-
 extern AppTime g_AppTime;
 
 class MeteorChannel

--- a/include/effects/strip/meteoreffect.h
+++ b/include/effects/strip/meteoreffect.h
@@ -36,14 +36,6 @@
 #include <iostream>
 #include <vector>
 #include <math.h>
-#include "colorutils.h"
-#include "globals.h"
-#include "ledstripeffect.h"
-#include "gfxbase.h"
-#if ENABLE_AUDIO
-#include "soundanalyzer.h"
-#endif
-
 
 extern AppTime g_AppTime;
 

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -37,10 +37,6 @@
 #include <vector>
 #include <math.h>
 
-#include "colorutils.h"
-#include "globals.h"
-#include "ledstripeffect.h"
-
 // SimpleRainbowTestEffect
 //
 // Fills the spokes with a rainbow palette, skipping dots as specified

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -31,12 +31,6 @@
 
 #pragma once
 
-#include <sys/types.h>
-#include <errno.h>
-#include <iostream>
-#include <vector>
-#include <math.h>
-
 // SimpleRainbowTestEffect
 //
 // Fills the spokes with a rainbow palette, skipping dots as specified

--- a/include/effects/strip/musiceffect.h
+++ b/include/effects/strip/musiceffect.h
@@ -13,7 +13,7 @@
 //   
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    MERHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
 //   
 //    You should have received a copy of the GNU General Public License
@@ -37,13 +37,7 @@
 #include <deque>
 #include <math.h>
 
-#include "globals.h"
-#include "soundanalyzer.h"
-#include "effectmanager.h"
-#include "colorutils.h"
-#include "ledstripeffect.h" 
 #include "faneffects.h"
-#include "gfxbase.h"
 
 extern DRAM_ATTR AppTime g_AppTime;
 
@@ -307,8 +301,8 @@ class SimpleColorBeat : public BeatEffectBase, public LEDStripEffect
 
   public:
   
-    SimpleColorBeat(const String pszName)
-      : BeatEffectBase(1.0, 1.0, 0.25), LEDStripEffect(pszName)
+    SimpleColorBeat(const String & strName)
+      : BeatEffectBase(1.0, 1.0, 0.25), LEDStripEffect(strName)
     {
     }
 

--- a/include/effects/strip/musiceffect.h
+++ b/include/effects/strip/musiceffect.h
@@ -30,13 +30,6 @@
 
 #pragma once
 
-#include <sys/types.h>
-#include <errno.h>
-#include <iostream>
-#include <vector>
-#include <deque>
-#include <math.h>
-
 #include "faneffects.h"
 
 extern DRAM_ATTR AppTime g_AppTime;

--- a/include/effects/strip/paletteeffect.h
+++ b/include/effects/strip/paletteeffect.h
@@ -35,14 +35,8 @@
 #include <iostream>
 #include <vector>
 #include <math.h>
-#include "colorutils.h"
-#include "globals.h"
-#include "ledstripeffect.h"
-#include "colordata.h"
-
 
 extern AppTime g_AppTime;
-
 
 class PaletteEffect : public LEDStripEffect
 {

--- a/include/effects/strip/paletteeffect.h
+++ b/include/effects/strip/paletteeffect.h
@@ -30,12 +30,6 @@
 
 #pragma once
 
-#include <sys/types.h>
-#include <errno.h>
-#include <iostream>
-#include <vector>
-#include <math.h>
-
 extern AppTime g_AppTime;
 
 class PaletteEffect : public LEDStripEffect

--- a/include/effects/strip/particles.h
+++ b/include/effects/strip/particles.h
@@ -32,13 +32,6 @@
 
 #pragma once
 
-#include <sys/types.h>
-#include <errno.h>
-#include <iostream>
-#include <vector>
-#include <math.h>
-#include <deque>
-
 extern AppTime g_AppTime;
 
 // Lifespan

--- a/include/effects/strip/particles.h
+++ b/include/effects/strip/particles.h
@@ -39,16 +39,6 @@
 #include <math.h>
 #include <deque>
 
-#include "globals.h"
-#include "soundanalyzer.h"
-#include "colorutils.h"
-#include "ledstripeffect.h"
-#include "faneffects.h"
-
-#if ENABLE_AUDIO
-#include "musiceffect.h"
-#endif
-
 extern AppTime g_AppTime;
 
 // Lifespan
@@ -397,7 +387,7 @@ class ColorBeatWithFlash : public BeatEffectBase, public ParticleSystem<RingPart
 
   public:
 
-    ColorBeatWithFlash(const String pszName) : LEDStripEffect(pszName), BeatEffectBase(), ParticleSystem<RingParticle>()
+    ColorBeatWithFlash(const String & strName) : LEDStripEffect(strName), BeatEffectBase(), ParticleSystem<RingParticle>()
     {
     }
 
@@ -448,8 +438,8 @@ class ColorBeatOverRed : public LEDStripEffect, public virtual BeatEffectBase2, 
 
   public:
 
-    ColorBeatOverRed(const String pszName)
-      : LEDStripEffect(pszName),
+    ColorBeatOverRed(const String & strName)
+      : LEDStripEffect(strName),
         BeatEffectBase2(1.75, 0.2),
         ParticleSystem<RingParticle>()
     {
@@ -708,8 +698,8 @@ class MoltenGlassOnVioletBkgnd : public LEDStripEffect, public virtual BeatEffec
 
   public:
 
-    MoltenGlassOnVioletBkgnd(const String pszName, const CRGBPalette256 & Palette)
-      : LEDStripEffect(pszName),
+    MoltenGlassOnVioletBkgnd(const String & strName, const CRGBPalette256 & Palette)
+      : LEDStripEffect(strName),
         BeatEffectBase(0.25, 1.75, .05),
         ParticleSystem<SpinningPaletteRingParticle>(),
         _Palette(Palette)
@@ -777,8 +767,8 @@ class NewMoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase
 
   public:
 
-    NewMoltenGlassOnVioletBkgnd(const String pszName, const CRGBPalette256 & Palette)
-      : LEDStripEffect(pszName),
+    NewMoltenGlassOnVioletBkgnd(const String & strName, const CRGBPalette256 & Palette)
+      : LEDStripEffect(strName),
         BeatEffectBase2(1.0, 0.25 ),
         ParticleSystem<SpinningPaletteRingParticle>(),
         _Palette(Palette)
@@ -846,8 +836,8 @@ class SparklySpinningMusicEffect : public LEDStripEffect, public BeatEffectBase,
 
   public:
 
-    SparklySpinningMusicEffect(const String pszName, const CRGBPalette256 & Palette)
-      : LEDStripEffect(pszName), BeatEffectBase(), ParticleSystem<SpinningPaletteRingParticle>(), _Palette(Palette)
+    SparklySpinningMusicEffect(const String & strName, const CRGBPalette256 & Palette)
+      : LEDStripEffect(strName), BeatEffectBase(), ParticleSystem<SpinningPaletteRingParticle>(), _Palette(Palette)
     {
 
     }
@@ -889,7 +879,7 @@ class MusicalHotWhiteInsulatorEffect : public LEDStripEffect, public BeatEffectB
 
   public:
 
-    MusicalHotWhiteInsulatorEffect(const String pszName) : LEDStripEffect(pszName), BeatEffectBase(), ParticleSystem<HotWhiteRingParticle>()
+    MusicalHotWhiteInsulatorEffect(const String & strName) : LEDStripEffect(strName), BeatEffectBase(), ParticleSystem<HotWhiteRingParticle>()
     {
       
     }

--- a/include/effects/strip/snakeeffect.h
+++ b/include/effects/strip/snakeeffect.h
@@ -31,14 +31,6 @@
 
 #pragma once
 
-#include <sys/types.h>
-#include <errno.h>
-#include <iostream>
-#include <vector>
-#include <math.h>
-#include <memory>
-#include <algorithm>
-
 class SnakeEffect : public LEDStripEffect
 {
   protected:

--- a/include/effects/strip/snakeeffect.h
+++ b/include/effects/strip/snakeeffect.h
@@ -38,10 +38,6 @@
 #include <math.h>
 #include <memory>
 #include <algorithm>
-#include "colorutils.h"
-#include "globals.h"
-#include "ledstripeffect.h"
-
 
 class SnakeEffect : public LEDStripEffect
 {
@@ -67,8 +63,8 @@ class SnakeEffect : public LEDStripEffect
 
   public:
 
-    SnakeEffect(const char * pszName, int ledCount = NUM_LEDS, int snakeSpeed = dSnakeSpeed)
-        : LEDStripEffect(pszName),
+    SnakeEffect(const char * strName, int ledCount = NUM_LEDS, int snakeSpeed = dSnakeSpeed)
+        : LEDStripEffect(strName),
           LEDCount(ledCount),
           SnakeSpeed(snakeSpeed)
     {

--- a/include/effects/strip/stareffect.h
+++ b/include/effects/strip/stareffect.h
@@ -31,13 +31,6 @@
 
 #pragma once
 
-#include <sys/types.h>
-#include <errno.h>
-#include <iostream>
-#include <vector>
-#include <math.h>
-#include <deque>
-
 #include "particles.h"
 
 extern AppTime g_AppTime;

--- a/include/effects/strip/stareffect.h
+++ b/include/effects/strip/stareffect.h
@@ -38,10 +38,6 @@
 #include <math.h>
 #include <deque>
 
-#include "globals.h"
-#include "soundanalyzer.h"
-#include "colorutils.h"
-#include "ledstripeffect.h"
 #include "particles.h"
 
 extern AppTime g_AppTime;
@@ -383,7 +379,7 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
   public:
 
 
-    StarryNightEffect<StarType>(const String pszName,
+    StarryNightEffect<StarType>(const String & strName,
                                 const CRGBPalette256& palette, 
                                 float probability = 1.0, 
                                 float starSize = 1.0, 
@@ -392,7 +388,7 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
                                 double blurFactor = 0.0,
                                 double musicFactor = 1.0,
                                 CRGB skyColor = CRGB::Black)
-      : LEDStripEffect(pszName),
+      : LEDStripEffect(strName),
         _palette(palette),
         _newStarProbability(probability),
         _starSize(starSize),

--- a/include/effects/strip/tempeffect.h
+++ b/include/effects/strip/tempeffect.h
@@ -39,13 +39,6 @@
 #include <vector>
 #include <math.h>
 
-#include "globals.h"
-#include "soundanalyzer.h"
-#include "colorutils.h"
-#include "ledstripeffect.h" 
-#include "faneffects.h"
-#include "musiceffect.h"
-
 extern DRAM_ATTR AppTime g_AppTime;
 
 class SimpleInsulatorBeatEffect : public LEDStripEffect, public BeatEffectBase
@@ -81,8 +74,8 @@ class SimpleInsulatorBeatEffect : public LEDStripEffect, public BeatEffectBase
 
     using BeatEffectBase::BeatEffectBase;
  
-    SimpleInsulatorBeatEffect(const String pszName) 
-      : LEDStripEffect(pszName), BeatEffectBase(1.0, 1.0, 0.01)
+    SimpleInsulatorBeatEffect(const String & strName) 
+      : LEDStripEffect(strName), BeatEffectBase(1.0, 1.0, 0.01)
     {
     }
 };
@@ -118,7 +111,7 @@ class SimpleInsulatorBeatEffect2 : public LEDStripEffect, public BeatEffectBase
 
   public:
  
-    SimpleInsulatorBeatEffect2(const String pszName) : LEDStripEffect(pszName), BeatEffectBase()
+    SimpleInsulatorBeatEffect2(const String & strName) : LEDStripEffect(strName), BeatEffectBase()
     {
     }
 };

--- a/include/effects/strip/tempeffect.h
+++ b/include/effects/strip/tempeffect.h
@@ -33,12 +33,6 @@
 
 #if ENABLE_AUDIO
 
-#include <sys/types.h>
-#include <errno.h>
-#include <iostream>
-#include <vector>
-#include <math.h>
-
 extern DRAM_ATTR AppTime g_AppTime;
 
 class SimpleInsulatorBeatEffect : public LEDStripEffect, public BeatEffectBase

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -63,23 +63,10 @@
  */
 
 #pragma once
-#include "globals.h"
-#include "Adafruit_GFX.h"
+
 #include <stdexcept>
-
-
-// 5:6:5 Color definitions
-#define BLACK16 0x0000
-#define BLUE16 0x001F
-#define RED16 0xF800
-#define GREEN16 0x07E0
-#define CYAN16 0x07FF
-#define MAGENTA16 0xF81F
-#define YELLOW16 0xFFE0
-#define WHITE16 0xFFFF
-
-#include "screen.h"
-
+#include "Adafruit_GFX.h"
+#include "pixeltypes.h"
 
 class GFXBase : public Adafruit_GFX
 {
@@ -107,8 +94,6 @@ protected:
     // THey should be turned into member variables, etc.
 
     friend class PatternMandala;
-
-    CRGB * leds2;
 
 #if USEMATRIX    
     static uint32_t noise_x;
@@ -140,12 +125,10 @@ public:
                             _width(w),
                             _height(h)
     {
-        leds2 = new CRGB[NUM_LEDS]();
     }
 
     virtual ~GFXBase()
     {
-        delete [] leds2;
     }
 
     inline static CRGB from16Bit(uint16_t color) // Convert 16bit 5:6:5 to 24bit color using lookup table for gamma
@@ -1227,7 +1210,6 @@ public:
         }       
     }
 
-    // non leds2 memory version.
     // MoveX - Shift the content on the matrix left or right
     
     inline void MoveX(uint8_t delta)
@@ -1265,6 +1247,8 @@ public:
 #if USEMATRIX
     void MoveFractionalNoiseX(uint8_t amt = 16)
     {
+        std::unique_ptr<CRGB []> ledsTemp = std::make_unique<CRGB []>(NUM_LEDS);
+
         // move delta pixelwise
         for (int y = 0; y < MATRIX_HEIGHT; y++)
         {
@@ -1273,11 +1257,11 @@ public:
 
             // Process up to the end less the dekta
             for (int x = 0; x < MATRIX_WIDTH - delta; x++)
-                leds2[xy(x, y)] = leds[xy(x + delta, y)];
+                ledsTemp[xy(x, y)] = leds[xy(x + delta, y)];
 
             // Do the tail portion while wrapping around
             for (int x = MATRIX_WIDTH - delta; x < MATRIX_WIDTH; x++)
-                leds2[xy(x, y)] = leds[xy(x + delta - MATRIX_WIDTH, y)];
+                ledsTemp[xy(x, y)] = leds[xy(x + delta - MATRIX_WIDTH, y)];
         }
 
         // move fractions
@@ -1292,8 +1276,8 @@ public:
 
             for (uint8_t x = 1; x < MATRIX_WIDTH; x++)
             {
-                PixelA = leds2[xy(x, y)];
-                PixelB = leds2[xy(x - 1, y)];
+                PixelA = ledsTemp[xy(x, y)];
+                PixelB = ledsTemp[xy(x - 1, y)];
 
                 PixelA %= 255 - fractions;
                 PixelB %= fractions;
@@ -1301,8 +1285,8 @@ public:
                 leds[xy(x, y)] = PixelA + PixelB;
             }
 
-            PixelA = leds2[xy(0, y)];
-            PixelB = leds2[xy(MATRIX_WIDTH - 1, y)];
+            PixelA = ledsTemp[xy(0, y)];
+            PixelB = ledsTemp[xy(MATRIX_WIDTH - 1, y)];
 
             PixelA %= 255 - fractions;
             PixelB %= fractions;
@@ -1313,6 +1297,8 @@ public:
 
     void MoveFractionalNoiseY(uint8_t amt = 16)
     {
+        std::unique_ptr<CRGB []> ledsTemp = std::make_unique<CRGB []>(NUM_LEDS);
+
         // move delta pixelwise
         for (int x = 0; x < MATRIX_WIDTH; x++)
         {
@@ -1321,11 +1307,11 @@ public:
 
             for (int y = 0; y < MATRIX_HEIGHT - delta; y++)
             {
-                leds2[xy(x, y)] = leds[xy(x, y + delta)];
+                ledsTemp[xy(x, y)] = leds[xy(x, y + delta)];
             }
             for (int y = MATRIX_HEIGHT - delta; y < MATRIX_HEIGHT; y++)
             {
-                leds2[xy(x, y)] = leds[xy(x, y + delta - MATRIX_HEIGHT)];
+                ledsTemp[xy(x, y)] = leds[xy(x, y + delta - MATRIX_HEIGHT)];
             }
         }
 
@@ -1341,8 +1327,8 @@ public:
 
             for (uint8_t y = 1; y < MATRIX_HEIGHT; y++)
             {
-                PixelA = leds2[xy(x, y)];
-                PixelB = leds2[xy(x, y - 1)];
+                PixelA = ledsTemp[xy(x, y)];
+                PixelB = ledsTemp[xy(x, y - 1)];
 
                 PixelA %= 255 - fractions;
                 PixelB %= fractions;
@@ -1350,8 +1336,8 @@ public:
                 leds[xy(x, y)] = PixelA + PixelB;
             }
 
-            PixelA = leds2[xy(x, 0)];
-            PixelB = leds2[xy(x, MATRIX_HEIGHT - 1)];
+            PixelA = ledsTemp[xy(x, 0)];
+            PixelB = ledsTemp[xy(x, MATRIX_HEIGHT - 1)];
 
             PixelA %= 255 - fractions;
             PixelB %= fractions;

--- a/include/globals.h
+++ b/include/globals.h
@@ -1504,16 +1504,16 @@ inline bool CheckBlueBuffer(CRGB * prgb, size_t count)
     return bOK;
 }
 
+// 16-bit (5:6:5) color definitions for common colors
 
-// 5:6:5 Color definitions
-#define BLACK16 0x0000
-#define BLUE16 0x001F
-#define RED16 0xF800
-#define GREEN16 0x07E0
-#define CYAN16 0x07FF
-#define MAGENTA16 0xF81F
-#define YELLOW16 0xFFE0
-#define WHITE16 0xFFFF
+#define BLACK16     0x0000
+#define BLUE16      0x001F
+#define RED16       0xF800
+#define GREEN16     0x07E0
+#define CYAN16      0x07FF
+#define MAGENTA16   0xF81F
+#define YELLOW16    0xFFE0
+#define WHITE16     0xFFFF
 
 // Main includes 
 

--- a/include/globals.h
+++ b/include/globals.h
@@ -94,7 +94,10 @@
 #include <algorithm>
 
 #include <Arduino.h>
+
+#define FASTLED_INTERNAL 1               // Suppresses build banners
 #include <FastLED.h>
+
 #include <WiFi.h>
 
 #include "RemoteDebug.h"
@@ -1512,13 +1515,15 @@ inline bool CheckBlueBuffer(CRGB * prgb, size_t count)
 #define YELLOW16 0xFFE0
 #define WHITE16 0xFFFF
 
+// Main includes 
 
 #include "gfxbase.h"                            // GFXBase drawing interface
 #include "screen.h"                             // LCD/TFT/OLED handling
 #include "socketserver.h"                       // Incoming WiFi data connections
 #include "soundanalyzer.h"                      // for audio sound processing
-#include "ledstripeffect.h"                     // Defines base led effect classes
 #include "ledstripgfx.h"                        // Essential drawing code for strips
+#include "ledmatrixgfx.h"                       // For drawing to HUB75 matrices
+#include "ledstripeffect.h"                     // Defines base led effect classes
 #include "ntptimeclient.h"                      // setting the system clock from ntp
 #include "effectmanager.h"                      // For g_EffectManagerf
 #include "network.h"                            // Networking 
@@ -1528,22 +1533,19 @@ inline bool CheckBlueBuffer(CRGB * prgb, size_t count)
 #include "drawing.h"                            // drawing code
 #include "taskmgr.h"                            // for cpu usage, etc
 
+// Conditional includes depending on which project is being build
+
+#if USEMATRIX
+    #include <YouTubeSight.h>                       // For fetching YouTube sub count
+    #include "effects/matrix/PatternSubscribers.h"  // For subscriber count effect
+#endif
+
 #if USE_SCREEN
     #include "freefonts.h"
 #endif
 
 #if ENABLE_WIFI && ENABLE_WEBSERVER
     #include "spiffswebserver.h"
-#endif
-
-#if USEMATRIX
-    #include "ledmatrixgfx.h"
-    #include <YouTubeSight.h>                       // For fetching YouTube sub count
-    #include "effects/matrix/PatternSubscribers.h"  // For subscriber count effect
-#endif
-
-#if USESTRIP
-    #include "ledstripgfx.h"
 #endif
 
 #if ENABLE_REMOTE

--- a/include/globals.h
+++ b/include/globals.h
@@ -424,7 +424,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define NUM_LEDS        (MATRIX_WIDTH*MATRIX_HEIGHT)
     #define RESERVE_MEMORY  150000
     #define LED_FAN_OFFSET_BU 6
-    #define POWER_LIMIT_MW  (8 * 5 * 1000)         // Expects at least a 5V, 20A supply (100W)
+    #define POWER_LIMIT_MW  (10 * 5 * 1000)         // Expects at least a 5V, 20A supply (100W)
 
     #define NOISE_CUTOFF   20
     #define NOISE_FLOOR    200.0f

--- a/include/ledbuffer.h
+++ b/include/ledbuffer.h
@@ -36,8 +36,6 @@
 #include <pixeltypes.h>
 #include <memory>
 #include <iostream>
-#include "gfxbase.h"
-#include "globals.h"
 
 extern DRAM_ATTR AppTime g_AppTime;                       
 

--- a/include/ledmatrixgfx.h
+++ b/include/ledmatrixgfx.h
@@ -33,7 +33,6 @@
 //---------------------------------------------------------------------------
 
 #pragma once
-#include "gfxbase.h"
 
 #if USEMATRIX
 
@@ -50,7 +49,7 @@
 class LEDMatrixGFX : public GFXBase
 {
 protected:
-    String pszCaption;
+    String strCaption;
     unsigned long captionStartTime;
     double captionDuration;
     const double captionFadeInTime = 500;
@@ -96,15 +95,15 @@ public:
         leds = pLeds;
     }
 
-    const String GetCaption()
+    const String & GetCaption()
     {
-        return pszCaption;
+        return strCaption;
     }
 
     double GetCaptionTransparency()
     {
         unsigned long now = millis();
-        if (pszCaption == nullptr)
+        if (strCaption == nullptr)
             return 0;
 
         if (now > (captionStartTime + captionDuration + captionFadeInTime + captionFadeOutTime))
@@ -121,10 +120,10 @@ public:
         return 1.0;
     }
 
-    void SetCaption(const String psz, uint32_t duration)
+    void SetCaption(const String & str, uint32_t duration)
     {
         captionDuration = duration;
-        pszCaption = psz;
+        strCaption = str;
         captionStartTime = millis();
     }
 

--- a/include/ledstripeffect.h
+++ b/include/ledstripeffect.h
@@ -35,14 +35,6 @@
 #include <iostream>
 #include <vector>
 #include <math.h>
-#include "globals.h"
-#include "colorutils.h"
-#include "ntptimeclient.h"
-#include "effectmanager.h"
-#include "gfxbase.h"
-#include "ledmatrixgfx.h"
-#include "ledstripeffect.h"
-
 #include <deque>
 #include <memory>
 
@@ -70,10 +62,10 @@ class LEDStripEffect
 
   public:
 
-    LEDStripEffect(const String pszName)
+    LEDStripEffect(const String & strName)
     {
-        if (pszName)
-            _friendlyName = pszName;
+        if (strName)
+            _friendlyName = strName;
     }
 
     virtual ~LEDStripEffect()
@@ -108,7 +100,7 @@ class LEDStripEffect
     virtual void Start() {}                                         // Optional method called when time to clean/init the effect
     virtual void Draw() = 0;                                        // Your effect must implement these
     
-    virtual const String FriendlyName() const
+    virtual const String & FriendlyName() const
     {
         return _friendlyName;
     }

--- a/include/ledstripeffect.h
+++ b/include/ledstripeffect.h
@@ -30,13 +30,6 @@
 
 #pragma once
 
-#include <sys/types.h>
-#include <errno.h>
-#include <iostream>
-#include <vector>
-#include <math.h>
-#include <deque>
-#include <memory>
 
 extern bool                      g_bUpdateStarted;
 extern DRAM_ATTR std::shared_ptr<GFXBase> g_pDevices[NUM_CHANNELS];

--- a/include/network.h
+++ b/include/network.h
@@ -27,32 +27,21 @@
 //---------------------------------------------------------------------------
 #pragma once
 
-#include "globals.h"
-#include "soundanalyzer.h"
-#include "effectmanager.h"
-#if ENABLE_REMOTE
-#include "remotecontrol.h"
-#endif
-
-#include "socketserver.h"
-#include "ntptimeclient.h"
 #include "secrets.h"                          // copy include/secrets.example.h to include/secrets.h
+
+#if INCOMING_WIFI_ENABLED
+    #include "socketserver.h"
+    extern SocketServer g_SocketServer;
+#endif
 
 #if ENABLE_WIFI
     extern uint8_t g_Brightness;
     extern bool g_bUpdateStarted;
     extern WiFiUDP g_Udp;
-    #if INCOMING_WIFI_ENABLED
-        extern SocketServer g_SocketServer;
-    #endif
     void processRemoteDebugCmd();
 
-    #if ENABLE_REMOTE
-        extern RemoteControl g_RemoteControl;
-    #endif
-
     bool ConnectToWiFi(uint cRetries);
-    void SetupOTA(const String pszHostname);
+    void SetupOTA(const String & strHostname);
 
     // Static Helpers
     //

--- a/include/ntptimeclient.h
+++ b/include/ntptimeclient.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "globals.h"
 #include <sys/cdefs.h>
 #include <sys/time.h>
 #include <time.h>

--- a/include/remotecontrol.h
+++ b/include/remotecontrol.h
@@ -34,13 +34,6 @@
 #include <IRutils.h>
 #include <limits>
 
-#include "globals.h"
-#include "soundanalyzer.h"
-#include "effectmanager.h"
-#include "gfxbase.h"
-#include "pixeltypes.h"
-
-
 extern DRAM_ATTR uint8_t g_Brightness;
 extern DRAM_ATTR uint8_t g_Fader;
 

--- a/include/screen.h
+++ b/include/screen.h
@@ -33,10 +33,8 @@
 
 #pragma once
 
-#include "globals.h"
-#include "gfxbase.h"
-#include "freefonts.h"
 #include <mutex>
+#include "freefonts.h"
 
 // A project with a screen will define one of these screen types (TFT, OLED, LCD, etc) and one object of the
 // correct type will be created and assigned to g_pDisplay, which will have the appropriate type.
@@ -59,7 +57,7 @@
 #if USE_TFTSPI
     #include <TFT_eSPI.h>
     #include <SPI.h>
-    extern TFT_eSPI * g_pDisplay;
+    extern std::unique_ptr<TFT_eSPI> g_pDisplay;
 #endif
 
 class Screen
@@ -88,14 +86,14 @@ class Screen
     // 
     // Display a single string of text on the TFT screen, useful during boot for status, etc.
 
-    static void IRAM_ATTR ScreenStatus(const String pszStatus)
+    static void IRAM_ATTR ScreenStatus(const String & strStatus)
     {
     #if USE_OLED 
         g_pDisplay->clear();
         g_pDisplay->clearBuffer();                   // clear the internal memory
         g_pDisplay->setFont(u8g2_font_profont15_tf); // choose a suitable font
         g_pDisplay->setCursor(0, 10);
-        g_pDisplay->println(pszStatus);
+        g_pDisplay->println(strStatus);
         g_pDisplay->sendBuffer();
     #elif USE_TFTSPI || USE_M5DISPLAY
         g_pDisplay->fillScreen(TFT_BLACK);
@@ -103,7 +101,7 @@ class Screen
         g_pDisplay->setTextColor(0xFBE0);
         auto xh = 10;
         auto yh = 0; 
-        g_pDisplay->drawString(pszStatus, xh, yh);
+        g_pDisplay->drawString(strStatus, xh, yh);
     #elif USE_LCD
         g_pDisplay->fillScreen(BLUE16);
         g_pDisplay->setFont(FM9);
@@ -111,7 +109,7 @@ class Screen
         auto xh = 10;
         auto yh = 0; 
         g_pDisplay->setCursor(xh, yh);
-        g_pDisplay->print(pszStatus);
+        g_pDisplay->print(strStatus);
     #endif
     }
 
@@ -144,19 +142,19 @@ class Screen
         #endif
     }
 
-    static uint16_t textWidth(const String psz)
+    static uint16_t textWidth(const String & str)
     {
         #if USE_OLED
-            return g_pDisplay->getStrWidth(psz.c_str());
+            return g_pDisplay->getStrWidth(str.c_str());
         #elif USE_TFTSPI || USE_M5DISPLAY            
-            return g_pDisplay->textWidth(psz);            
+            return g_pDisplay->textWidth(str);            
         #elif USE_LCD
             int16_t x1, y1;
             uint16_t w, h;
-            g_pDisplay->getTextBounds(psz, 0, 0, &x1, &y1, &w, &h);
+            g_pDisplay->getTextBounds(str, 0, 0, &x1, &y1, &w, &h);
             return w;
         #else 
-            return 8 * psz.length();
+            return 8 * str.length();
         #endif
     }
 
@@ -273,35 +271,35 @@ class Screen
         #endif
     }
 
-    static void println(const char * pszText)
+    static void println(const char * strText)
     {
         #if USE_SCREEN
-            g_pDisplay->println(pszText);
+            g_pDisplay->println(strText);
         #endif
     }
 
-    static void println(const String pszText)
+    static void println(const String & strText)
     {
         #if USE_SCREEN
-            g_pDisplay->println(pszText.c_str());
+            g_pDisplay->println(strText.c_str());
         #endif
     }
 
-    static void drawString(const String pszText, uint16_t x, uint16_t y)
+    static void drawString(const String & strText, uint16_t x, uint16_t y)
     {
         #if USE_M5DISPLAY || USE_TFTSPI || USE_OLED
         setCursor(x, y);
-        println(pszText.c_str());
+        println(strText.c_str());
         #endif
     }
 
     // drawString with no x component assumed you want it centered on the display
 
-    static void drawString(const String pszText, uint16_t y)
+    static void drawString(const String & strText, uint16_t y)
     {
         #if USE_M5DISPLAY || USE_TFTSPI || USE_OLED
-        setCursor(screenWidth() / 2 - textWidth(pszText) / 2, y);
-        println(pszText.c_str());
+        setCursor(screenWidth() / 2 - textWidth(strText) / 2, y);
+        println(strText.c_str());
         #endif
     }
 

--- a/include/soundanalyzer.h
+++ b/include/soundanalyzer.h
@@ -36,7 +36,7 @@
 #include <arduinoFFT.h>
 #include <driver/i2s.h>
 #include <driver/adc.h>
-#include <driver/adc_deprecated.h>
+//#include <driver/adc_deprecated.h>
 
 extern DRAM_ATTR bool g_bUpdateStarted;                     // Has an OTA update started?
 

--- a/include/soundanalyzer.h
+++ b/include/soundanalyzer.h
@@ -33,13 +33,6 @@
 
 #pragma once
 
-#include <sys/types.h>
-#include <errno.h>
-#include <iostream>
-#include <vector>
-#include <deque>
-#include <algorithm>
-#include <math.h>
 #include <arduinoFFT.h>
 #include <driver/i2s.h>
 #include <driver/adc.h>

--- a/include/soundanalyzer.h
+++ b/include/soundanalyzer.h
@@ -241,7 +241,6 @@ struct AudioVariables
         const size_t MAX_SAMPLES = 256;
         const size_t SAMPLING_FREQUENCY = 24000;
 
-        arduinoFFT _FFT;           // Perhaps could be static, but might have state info, so one per buffer
         size_t _MaxSamples;        // Number of samples we will take, must be a power of 2
         size_t _SamplingFrequency; // Sampling Frequency should be at least twice that of highest freq sampled
         size_t _BandCount;

--- a/include/soundanalyzer.h
+++ b/include/soundanalyzer.h
@@ -238,8 +238,12 @@ struct AudioVariables
 
     class SoundAnalyzer : public AudioVariables
     {
-        const size_t MAX_SAMPLES = 256;
-        const size_t SAMPLING_FREQUENCY = 24000;
+        const size_t MAX_SAMPLES = 512;
+
+        // I'm old enough I can only hear up to about 12K, but feel free to adjust.  Remember from
+        // school that you need to sample at doube the frequency you want to process, so 24000 is 12K
+
+        const size_t SAMPLING_FREQUENCY = 24000;        
 
         size_t _MaxSamples;        // Number of samples we will take, must be a power of 2
         size_t _SamplingFrequency; // Sampling Frequency should be at least twice that of highest freq sampled
@@ -306,9 +310,7 @@ struct AudioVariables
         void FFT()
         {
             arduinoFFT _FFT(_vReal, _vImaginary, _MaxSamples, _SamplingFrequency);
-            _FFT.DCRemoval();
             _FFT.Compute(FFT_FORWARD);
-            _FFT.ComplexToMagnitude();
         }
 
         inline bool IsBufferFull() const __attribute__((always_inline))
@@ -432,31 +434,6 @@ struct AudioVariables
                     _vReal[i] = byteBuffer[i];
                 #endif
             }
-        }
-
-        // SampleBuffer::AcquireSampleAnalogRead
-        //
-        // IRQ calls here through the IRQ stub
-
-        void AcquireSampleAnalogRead()
-        {
-            if (false == IsBufferFull())
-            {
-                //_vReal[_cSamples] = adcEnd(_InputPin);
-                _vReal[_cSamples] = analogRead(_InputPin);
-                _vImaginary[_cSamples] = 0;
-                _cSamples++;
-                _cSamples++;
-
-                if (_cSamples % 16 == 0)
-                    delay(1);
-            }
-        }
-
-        void FillBufferAnalogRead()
-        {
-            while (false == IsBufferFull())
-                AcquireSampleAnalogRead();
         }
 
         // SampleBuffer::ProcessPeaks

--- a/include/spiffswebserver.h
+++ b/include/spiffswebserver.h
@@ -74,11 +74,11 @@ class CSPIFFSWebServer
     //
     // Sends an empty OK/200 response; normally used to finish up things that don't return anything, like "NextEffect"
 
-    void AddCORSHeaderAndSendOKResponse(AsyncWebServerRequest * pRequest, const char * pszText = nullptr)
+    void AddCORSHeaderAndSendOKResponse(AsyncWebServerRequest * pRequest, const char * strText = nullptr)
     {
-        AsyncWebServerResponse * pResponse = (pszText == nullptr) ? 
+        AsyncWebServerResponse * pResponse = (strText == nullptr) ? 
                                                     pRequest->beginResponse(200) :
-                                                    pRequest->beginResponse(200, "text/json",  pszText);    
+                                                    pRequest->beginResponse(200, "text/json",  strText);    
         pResponse->addHeader("Access-Control-Allow-Origin", "*");
         pRequest->send(pResponse);      
     }
@@ -87,13 +87,13 @@ class CSPIFFSWebServer
     {
         static size_t jsonBufferSize = JSON_BUFFER_BASE_SIZE;
         bool bufferOverflow;
-        AsyncJsonResponse * response;
+        std::unique_ptr<AsyncJsonResponse> response;
 
         debugI("GetEffectListText");
 
         do {
             bufferOverflow = false;
-            response = new AsyncJsonResponse(false, jsonBufferSize);
+            response = std::make_unique<AsyncJsonResponse>(false, jsonBufferSize);
             response->addHeader("Server","NightDriverStrip");
             auto j = response->getRoot();
 
@@ -109,7 +109,6 @@ class CSPIFFSWebServer
 
                 if (!j["Effects"].add(effectDoc)) {
                     bufferOverflow = true;
-                    delete response;
                     jsonBufferSize += JSON_BUFFER_INCREMENT;
                     debugV("JSON reponse buffer overflow! Increased buffer to %zu bytes", jsonBufferSize);
                     break;
@@ -119,17 +118,16 @@ class CSPIFFSWebServer
 
         response->addHeader("Access-Control-Allow-Origin", "*");
         response->setLength();
-        pRequest->send(response);
+        pRequest->send(response.get());
     }
 
     void GetStatistics(AsyncWebServerRequest * pRequest)
     {
         static size_t jsonBufferSize = JSON_BUFFER_BASE_SIZE;
-        AsyncJsonResponse * response;
 
         debugI("GetStatistics");
 
-        response = new AsyncJsonResponse(false, jsonBufferSize);
+        auto response = std::make_unique<AsyncJsonResponse>(false, jsonBufferSize);
         response->addHeader("Server","NightDriverStrip");
         auto j = response->getRoot();
 
@@ -164,7 +162,7 @@ class CSPIFFSWebServer
 
         response->addHeader("Access-Control-Allow-Origin", "*");
         response->setLength();
-        pRequest->send(response);
+        pRequest->send(response.get());
     }    
 
     void SetSettings(AsyncWebServerRequest * pRequest)
@@ -172,12 +170,12 @@ class CSPIFFSWebServer
         debugI("SetSettings");
 
         // Look for the parameter by name
-        const String pszEffectInterval = "effectInterval";
-        if (pRequest->hasParam(pszEffectInterval, true, false))
+        const String strEffectInterval = "effectInterval";
+        if (pRequest->hasParam(strEffectInterval, true, false))
         {
             debugI("found EffectInterval");
             // If found, parse it and pass it off to the EffectManager, who will validate it
-            AsyncWebParameter * param = pRequest->getParam(pszEffectInterval, true, false);
+            AsyncWebParameter * param = pRequest->getParam(strEffectInterval, true, false);
             size_t effectInterval = strtoul(param->value().c_str(), NULL, 10);  
             g_pEffectManager->SetInterval(effectInterval);
         }       
@@ -204,12 +202,12 @@ class CSPIFFSWebServer
         }   
         */
 
-        const String pszCurrentEffectIndex = "currentEffectIndex";
-        if (pRequest->hasParam(pszCurrentEffectIndex, true))
+        const String strCurrentEffectIndex = "currentEffectIndex";
+        if (pRequest->hasParam(strCurrentEffectIndex, true))
         {
             debugV("currentEffectIndex param found");
             // If found, parse it and pass it off to the EffectManager, who will validate it
-            AsyncWebParameter * param = pRequest->getParam(pszCurrentEffectIndex, true);
+            AsyncWebParameter * param = pRequest->getParam(strCurrentEffectIndex, true);
             size_t currentEffectIndex = strtoul(param->value().c_str(), NULL, 10);  
             g_pEffectManager->SetCurrentEffectIndex(currentEffectIndex);
         }
@@ -222,11 +220,11 @@ class CSPIFFSWebServer
         debugI("EnableEffect");
 
         // Look for the parameter by name
-        const String pszEffectIndex = "effectIndex";
-        if (pRequest->hasParam(pszEffectIndex, true))
+        const String strEffectIndex = "effectIndex";
+        if (pRequest->hasParam(strEffectIndex, true))
         {
             // If found, parse it and pass it off to the EffectManager, who will validate it
-            AsyncWebParameter * param = pRequest->getParam(pszEffectIndex, true);
+            AsyncWebParameter * param = pRequest->getParam(strEffectIndex, true);
             size_t effectIndex = strtoul(param->value().c_str(), NULL, 10); 
             g_pEffectManager->EnableEffect(effectIndex);
         }
@@ -239,11 +237,11 @@ class CSPIFFSWebServer
         debugI("DisableEffect");
 
         // Look for the parameter by name
-        const String pszEffectIndex = "effectIndex";
-        if (pRequest->hasParam(pszEffectIndex, true))
+        const String strEffectIndex = "effectIndex";
+        if (pRequest->hasParam(strEffectIndex, true))
         {
             // If found, parse it and pass it off to the EffectManager, who will validate it
-            AsyncWebParameter * param = pRequest->getParam(pszEffectIndex, true);
+            AsyncWebParameter * param = pRequest->getParam(strEffectIndex, true);
             size_t effectIndex = strtoul(param->value().c_str(), NULL, 10); 
             g_pEffectManager->DisableEffect(effectIndex);
             debugV("Disabled Effect %d", effectIndex);
@@ -272,12 +270,12 @@ class CSPIFFSWebServer
     // the entire thing in RAM, and it chokes.  So, for files that are too large to serve from RAM, 
     // I use this function.  It registers a file-specific handler and then does chunk based IO.
     
-    void ServeLargeStaticFile(const char pszName[], const char pszType[])
+    void ServeLargeStaticFile(const char strName[], const char strType[])
     {
-       _server.on(pszName, HTTP_GET, [pszName, pszType](AsyncWebServerRequest *request)
+       _server.on(strName, HTTP_GET, [strName, strType](AsyncWebServerRequest *request)
         {
-            Serial.printf("GET for: %s\n", pszName);
-            fs::File SPIFFSfile = SPIFFS.open(pszName, FILE_READ);
+            Serial.printf("GET for: %s\n", strName);
+            fs::File SPIFFSfile = SPIFFS.open(strName, FILE_READ);
             if (SPIFFSfile)
             {
                 Serial.printf("[HTTP]\tOpening [%d]\r\n", SPIFFSfile);
@@ -287,7 +285,7 @@ class CSPIFFSWebServer
                 Serial.printf("[HTTP]\tSPIFFS File DOESN'T exists [%d] <<< ERROR !!!\r\n", SPIFFSfile);
             }
             AsyncWebServerResponse *response = 
-                request->beginChunkedResponse(pszType, [SPIFFSfile](uint8_t *buffer, size_t maxLen, size_t index) -> size_t 
+                request->beginChunkedResponse(strType, [SPIFFSfile](uint8_t *buffer, size_t maxLen, size_t index) -> size_t 
                 {
                     auto localHandle = SPIFFSfile;
                     //Serial.printf("[HTTP]  [%6d]    INDEX [%6d]    BUFFER_MAX_LENGTH [%6d]\r\n", index, localHandle.size(), maxLen);

--- a/include/spiffswebserver.h
+++ b/include/spiffswebserver.h
@@ -44,15 +44,8 @@
 #include <ESPAsyncWebServer.h>
 #include <SPIFFS.h>
 #include <Arduino.h>
-#include <vector>
 #include <AsyncJson.h>
 #include <ArduinoJson.h>
-
-#include "soundanalyzer.h"
-#include "effectmanager.h"
-#include "gfxbase.h"
-#include "taskmgr.h"
-
 
 #define JSON_BUFFER_BASE_SIZE 2048
 #define JSON_BUFFER_INCREMENT 2048

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 data_dir    = ./data
-default_envs = spectrum
+default_envs = ledstrip
 
 ; Link libs
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 data_dir    = ./data
-default_envs = spectrum
+default_envs = generic
 
 ; Link libs
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 data_dir    = ./data
-default_envs = generic
+default_envs = mesmerizer
 
 ; Link libs
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,7 @@
 
 [platformio]
 data_dir    = ./data
-default_envs = mesmerizer
+default_envs = spectrum
 
 ; Link libs
 

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -33,7 +33,11 @@
 // The SoundAnalyzer is present even when Audio is not defined, but it then a mere stub class
 // with a few stats fields. In the Audio case, it's the full class
 
-SoundAnalyzer g_Analyzer(INPUT_PIN);
+#if ENABLE_AUDIO
+    SoundAnalyzer g_Analyzer(INPUT_PIN);                    // Dummy stub class in non-audio case
+#else
+    SoundAnalyzer g_Analyzer;                               // Real AudioAnalyzer in audio case
+#endif
 
 #if ENABLE_AUDIO
 

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -29,13 +29,16 @@
 //              
 //---------------------------------------------------------------------------
 
-#include "globals.h"                      // CONFIG and global headers
-#include "soundanalyzer.h"
-#include "network.h"
+#include "globals.h"
+// The SoundAnalyzer is present even when Audio is not defined, but it then a mere stub class
+// with a few stats fields. In the Audio case, it's the full class
+
+SoundAnalyzer g_Analyzer(INPUT_PIN);
+
 #if ENABLE_AUDIO
 
 #include <esp_task_wdt.h>
-#include "taskmgr.h"
+
 
 extern NightDriverTaskManager g_TaskManager;
 extern DRAM_ATTR uint32_t g_FPS;          // Our global framerate
@@ -51,8 +54,6 @@ float PeakData::_Min[NUM_BANDS] = { 0.0 };
 float PeakData::_Max[NUM_BANDS] = { 0.0 }; 
 float PeakData::_Last[NUM_BANDS] = { 0.0 }; 
 float PeakData::_allBandsMax = 1.0;
-
-SoundAnalyzer g_Analyzer(INPUT_PIN);
 
 // AudioSamplerTaskEntry
 // A background task that samples audio, computes the VU, stores it for effect use, etc.

--- a/src/colordata.cpp
+++ b/src/colordata.cpp
@@ -30,7 +30,6 @@
 //---------------------------------------------------------------------------
 
 #include "globals.h"
-#include "gfxbase.h"
 
 DEFINE_GRADIENT_PALETTE( vu_gpGreen ) 
 {

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -29,24 +29,9 @@
 //
 //---------------------------------------------------------------------------
 
-#include <globals.h>
 #include <mutex>
 #include <ArduinoOTA.h> // Over-the-air helper object so we can be flashed via WiFi
-
-#include "effectmanager.h"
-#include "ledbuffer.h"
-#include "ntptimeclient.h"
-#include "remotecontrol.h"
-#include "ntptimeclient.h"
-
-#if USESTRIP || USEMATRIX
-#include "ledstripgfx.h"
-#endif
-
-#if USEMATRIX
-#include "ledmatrixgfx.h"
-#endif
-
+#include "globals.h"
 #include "effects/matrix/spectrumeffects.h"
 
 CRGB g_SinglePixel = CRGB::Blue;

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -27,9 +27,8 @@
 // History:     Jul-14-2021         Davepl      Split off from main.cpp
 //---------------------------------------------------------------------------
 
-#include "globals.h"                           // CONFIG and global headers
-#include "soundanalyzer.h"                              
-#include "effectmanager.h"                     // manages all of the effects
+#include "globals.h"
+
 #include "effects/strip/fireeffect.h"          // fire effects
 #include "effects/strip/paletteeffect.h"       // palette effects
 #include "effects/strip/doublepaletteeffect.h" // double palette effect
@@ -39,15 +38,14 @@
 #include "effects/strip/tempeffect.h"
 #include "effects/strip/stareffect.h"
 #include "effects/strip/laserline.h"
-
-#include "effects/matrix/PatternClock.h"        // No matrix dependencies
+#include "effects/matrix/PatternClock.h"       // No matrix dependencies
 
 #if ENABLE_AUDIO
-#include "effects/matrix/spectrumeffects.h" // Musis spectrum effects
-#include "effects/strip/musiceffect.h"      // Music based effects
+#include "effects/matrix/spectrumeffects.h"    // Musis spectrum effects
+#include "effects/strip/musiceffect.h"         // Music based effects
 #endif
 
-#ifdef FAN_SIZE
+#if FAN_SIZE
 #include "effects/strip/faneffects.h" // Fan-based effects
 #endif
 
@@ -55,30 +53,27 @@
 // Externals
 //
 
-extern DRAM_ATTR std::unique_ptr<EffectManager<GFXBase>> g_pEffectManager;
-
 #if USEMATRIX
-#include "ledmatrixgfx.h"
-#include "effects/matrix/PatternSerendipity.h"
-#include "effects/matrix/PatternSwirl.h"
-#include "effects/matrix/PatternPulse.h"
-#include "effects/matrix/PatternWave.h"
-#include "effects/matrix/PatternLife.h"
-#include "effects/matrix/PatternSpiro.h"
-#include "effects/matrix/PatternCube.h"
-#include "effects/matrix/PatternCircuit.h"
-#include "effects/matrix/PatternSubscribers.h"
-#include "effects/matrix/PatternAlienText.h"
-#include "effects/matrix/PatternRadar.h"
-#include "effects/matrix/PatternPongClock.h"
-#include "effects/matrix/PatternBounce.h"
-#include "effects/matrix/PatternMandala.h"
-#include "effects/matrix/PatternSpin.h"
-#include "effects/matrix/PatternFlowField.h"
-#include "effects/matrix/PatternMisc.h"
-#include "effects/matrix/PatternNoiseSmearing.h"
-
-#include "effects/matrix/PatternQR.h"
+        #include "ledmatrixgfx.h"
+        #include "effects/matrix/PatternSerendipity.h"
+        #include "effects/matrix/PatternSwirl.h"
+        #include "effects/matrix/PatternPulse.h"
+        #include "effects/matrix/PatternWave.h"
+        #include "effects/matrix/PatternLife.h"
+        #include "effects/matrix/PatternSpiro.h"
+        #include "effects/matrix/PatternCube.h"
+        #include "effects/matrix/PatternCircuit.h"
+        #include "effects/matrix/PatternSubscribers.h"
+        #include "effects/matrix/PatternAlienText.h"
+        #include "effects/matrix/PatternRadar.h"
+        #include "effects/matrix/PatternPongClock.h"
+        #include "effects/matrix/PatternBounce.h"
+        #include "effects/matrix/PatternMandala.h"
+        #include "effects/matrix/PatternSpin.h"
+        #include "effects/matrix/PatternFlowField.h"
+        #include "effects/matrix/PatternMisc.h"
+        #include "effects/matrix/PatternNoiseSmearing.h"
+        #include "effects/matrix/PatternQR.h"
 #endif
 
 #ifdef USESTRIP
@@ -88,8 +83,8 @@ extern DRAM_ATTR std::unique_ptr<EffectManager<GFXBase>> g_pEffectManager;
 extern DRAM_ATTR std::shared_ptr<GFXBase> g_pDevices[NUM_CHANNELS];
 
 #if USEMATRIX
-volatile long PatternSubscribers::cSubscribers;
-volatile long PatternSubscribers::cViews;
+        volatile long PatternSubscribers::cSubscribers;
+        volatile long PatternSubscribers::cViews;
 #endif
 
 // Palettes

--- a/src/ledmatrixgfx.cpp
+++ b/src/ledmatrixgfx.cpp
@@ -28,9 +28,7 @@
 //
 //---------------------------------------------------------------------------
 
-#include "gfxbase.h"
 #include "globals.h"
-#include "effectmanager.h"
 #include "effects/matrix/Boid.h"
 #include "effects/matrix/Vector.h"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,9 +149,19 @@
 //
 //---------------------------------------------------------------------------
 
-#include "globals.h"
 #include <ArduinoOTA.h>                         // For updating the flash over WiFi
 #include <ESPmDNS.h>
+
+#include <SPI.h>
+
+#define HSPI_MISO   27
+#define HSPI_MOSI   26    // This is the only IO pin used in this code (master out, slave in)
+#define HSPI_SCLK   25
+#define HSPI_SS     32
+#define FASTLED_ALL_PINS_HARDWARE_SPI
+#define FASTLED_ESP32_SPI_BUS HSPI
+
+#include "globals.h"
 
 void IRAM_ATTR ScreenUpdateLoopEntry(void *);
 extern volatile double g_FreeDrawTime;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -822,7 +822,7 @@ void loop()
         EVERY_N_SECONDS(5)
         {
             #if ENABLE_AUDIO && ENABLE_WIFI
-                debugI("Wifi: %s, IP: %s, Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, Buffer: %d/%d, LED FPS: %d, LED Watt: %d, LED Brite: %0.0lf%%, Audio FPS: %d, Serial FPS: %d, PeakVU: %0.2lf, MinVU: %0.2lf, VURatio: %0.2lf, CPU: %02.0f%%, %02.0f%%, FreeDraw: %lf",
+                debugI("Wifi: %s, IP: %s, Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, LED FPS: %d, LED Watt: %d, LED Brite: %0.0lf%%, Audio FPS: %d, Serial FPS: %d, PeakVU: %0.2lf, MinVU: %0.2lf, VURatio: %0.2lf, CPU: %02.0f%%, %02.0f%%, FreeDraw: %lf",
                         WLtoString(WiFi.status()), WiFi.localIP().toString().c_str(), // Wifi
                         ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize(), // Mem
                         g_FPS, g_Watts, g_Brite, // LED

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -667,9 +667,8 @@ void setup()
         #if NUM_CHANNELS == 1
             debugI("Adding %d LEDs to FastLED.", g_pDevices[0]->GetLEDCount());
             
-            FastLED.addLeds<WS2812B, LED_PIN0, COLOR_ORDER>(((LEDStripGFX *)g_pDevices[0].get())->leds, 3*144);
-            FastLED[0].setLeds(((LEDStripGFX *)g_pDevices[0].get())->leds, g_pDevices[0]->GetLEDCount());   
-            FastLED.setMaxRefreshRate(0, false);  // turn OFF the refresh rate constraint
+            FastLED.addLeds<WS2812B, LED_PIN0, COLOR_ORDER>(((LEDStripGFX *)g_pDevices[0].get())->leds, g_pDevices[0]->GetLEDCount());
+            FastLED.setMaxRefreshRate(100, false); 
             pinMode(LED_PIN0, OUTPUT);
         #endif
 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -32,15 +32,10 @@
 #include <ArduinoOTA.h>             // Over-the-air helper object so we can be flashed via WiFi
 #include <WiFiClientSecure.h>
 #include <HTTPClient.h>
-
 #include "globals.h"
-#include "soundanalyzer.h"
-#include "network.h"
-#include "ledbuffer.h"
-#include "spiffswebserver.h"
 
-#if ENABLE_REMOTE
-#include "remotecontrol.h"
+#if ENABLE_WEBSERVER
+    extern DRAM_ATTR CSPIFFSWebServer g_WebServer;
 #endif
 
 #if USE_WIFI_MANAGER
@@ -49,7 +44,6 @@ DRAM_ATTR ESP_WiFiManager g_WifiManager("NightDriverWiFi");
 #endif
 
 extern DRAM_ATTR std::unique_ptr<LEDBufferManager> g_apBufferManager[NUM_CHANNELS];
-extern DRAM_ATTR CSPIFFSWebServer g_WebServer;
 
 std::mutex g_buffer_mutex;
 
@@ -129,15 +123,15 @@ extern uint32_t g_FPS;
 //
 // Set up the over-the-air programming info so that we can be flashed over WiFi
 
-void SetupOTA(const String pszHostname)
+void SetupOTA(const String & strHostname)
 {
 #if ENABLE_OTA
     ArduinoOTA.setRebootOnSuccess(true);
 
-    if (nullptr == pszHostname)
+    if (strHostname.isEmpty())
         ArduinoOTA.setMdnsEnabled(false);
     else
-        ArduinoOTA.setHostname(pszHostname.c_str());
+        ArduinoOTA.setHostname(strHostname.c_str());
 
     ArduinoOTA
         .onStart([]() {

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -28,10 +28,10 @@
 //
 //---------------------------------------------------------------------------
 
-#include <mutex>
 #include <ArduinoOTA.h>             // Over-the-air helper object so we can be flashed via WiFi
 #include <WiFiClientSecure.h>
 #include <HTTPClient.h>
+
 #include "globals.h"
 
 #if ENABLE_WEBSERVER

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -28,7 +28,7 @@
 // History:     Jul-14-2021         Davepl      Moved out of main.cpp
 //---------------------------------------------------------------------------
 
-#include <mutex>
+
 #include "globals.h"
 
 extern DRAM_ATTR std::unique_ptr<EffectManager<GFXBase>> g_pEffectManager;

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -28,18 +28,8 @@
 // History:     Jul-14-2021         Davepl      Moved out of main.cpp
 //---------------------------------------------------------------------------
 
-#include "globals.h" // CONFIG and global headers
-#include "soundanalyzer.h"
-#include "effectmanager.h" // So we can display cur effect
-
-#include "gfxbase.h"
-#include "ledbuffer.h"     // For g_apBufferManager type
-#include "Bounce2.h"
-#include "freefonts.h"
-#include "colordata.h"
-
-
 #include <mutex>
+#include "globals.h"
 
 extern DRAM_ATTR std::unique_ptr<EffectManager<GFXBase>> g_pEffectManager;
 
@@ -62,7 +52,7 @@ M5Display *g_pDisplay;
 #if USE_TFTSPI
 #include <TFT_eSPI.h>
 #include <SPI.h>
-TFT_eSPI *g_pDisplay = new TFT_eSPI();
+std::unique_ptr<TFT_eSPI> g_pDisplay = std::make_unique<TFT_eSPI>();
 #endif
 
 //
@@ -122,16 +112,16 @@ void BasicInfoSummary(bool bRedraw)
 
     // Status line 1
 
-    char szBuffer[256];
-    static const char szStatus[] = "|/-\\";
+    static const String szStatus("|/-\\");
     static int cStatus = 0;
-    int c2 = cStatus % strlen(szStatus);
+    int c2 = cStatus % szStatus.length();
     char chStatus = szStatus[c2];
     cStatus++;
 
     Screen::setTextColor(textColor, bkgndColor); // Second color is background color, giving us text overwrite
     Screen::setTextSize(Screen::SMALL);
 
+    char szBuffer[256];
     snprintf(szBuffer, ARRAYSIZE(szBuffer), "%s:%dx%d %c %dK", FLASH_VERSION_NAME, NUM_CHANNELS, NUM_LEDS, chStatus, ESP.getFreeHeap() / 1024);
     Screen::setCursor(xMargin, yMargin);
     Screen::println(szBuffer);
@@ -330,7 +320,7 @@ void CurrentEffectSummary(bool bRedraw)
             Screen::fillRect(0, Screen::screenHeight() - Screen::BottomMargin, Screen::screenWidth(), 1, BLUE16);
             char szBuffer[64];
             yh = Screen::screenHeight() - Screen::fontHeight() - 3;
-            snprintf(szBuffer, sizeof(szBuffer), " LED: %2d  Aud: %2d Ser:%2d ", g_FPS, g_Analyzer._AudioFPS, g_Analyzer._serialFPS);
+            snprintf(szBuffer, ARRAYSIZE(szBuffer), " LED: %2d  Aud: %2d Ser:%2d ", g_FPS, g_Analyzer._AudioFPS, g_Analyzer._serialFPS);
             Screen::setTextColor(YELLOW16, backColor);
             Screen::drawString(szBuffer, yh);
             yh += Screen::fontHeight();

--- a/src/uzlib/src/adler32.c
+++ b/src/uzlib/src/adler32.c
@@ -36,6 +36,8 @@
  * Copyright (C) 1995-1998 Jean-loup Gailly and Mark Adler
  */
 
+// Note: This code might be modfified from teh original, but is based entirely on it.
+
 #include "tinf.h"
 
 #define A32_BASE 65521

--- a/src/uzlib/src/crc32.c
+++ b/src/uzlib/src/crc32.c
@@ -36,6 +36,8 @@
  * Copyright (C) 1995-1998 Jean-loup Gailly and Mark Adler
  */
 
+// Note: This code might be modfified from teh original, but is based entirely on it.
+
 #include "tinf.h"
 
 static const unsigned int tinf_crc32tab[16] = {

--- a/src/uzlib/src/defl_static.c
+++ b/src/uzlib/src/defl_static.c
@@ -30,6 +30,9 @@ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+// Note: This code might be modfified from teh original, but is based entirely on it.
+
+
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>

--- a/src/uzlib/src/tinfgzip.c
+++ b/src/uzlib/src/tinfgzip.c
@@ -33,6 +33,8 @@
  *    any source distribution.
  */
 
+// Note: This code might be modfified from teh original, but is based entirely on it.
+
 #include "tinf.h"
 
 #define FTEXT    1

--- a/src/uzlib/src/tinflate.c
+++ b/src/uzlib/src/tinflate.c
@@ -32,6 +32,8 @@
  *    any source distribution.
  */
 
+// Note: This code might be modfified from teh original tinflate, but is based entirely on it.
+
 #include <assert.h>
 #include "tinf.h"
 

--- a/src/uzlib/src/tinfzlib.c
+++ b/src/uzlib/src/tinfzlib.c
@@ -33,6 +33,8 @@
  *    any source distribution.
  */
 
+// Note: This code might be modfified from teh original, but is based entirely on it.
+
 #include "tinf.h"
 
 


### PR DESCRIPTION
## Description
- This changes our implementation from software SPI to hardware SPI.
- Moves most headers in the right dependency order to globals.h and out of the individual source files
- Uncaps frame rate
- Fixes mismatched printf args in debug logging
- Avoids deprecated FFT calls (but the compiler still warns since the warnings are baked in)
- Gets rid of extra "leds2" copy of the buffer except where specifically needed

## Contributing requirements

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).