### PR TITLE
Remove SPIFFS flash

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,10 +47,9 @@ jobs:
         grep -v ^default_envs platformio.ini.orig > platformio.ini
         pio run
 
-    - name: Build WebInstaller and dependencies
+    - name: Build WebInstaller
       if: ${{ env.ENABLE_PAGES_PUSH == 'true' }}
       run: | 
-        pio run -t buildfs
         python tools/bake_installer.py
         touch WebInstaller/.nojekyll
 

--- a/README.md
+++ b/README.md
@@ -49,16 +49,6 @@ Please do make sure you set them in include/secrets.h, NOT in include/secrets.ex
 
 This can also be configured in the platformio.ini file, as described in the [Feature Defines](#feature-defines) section below.
 
-## Webserver Setup
-
-To use the built-in webserver, you will need to build and upload the SPIFFS image to your board's flash using platformio. <br/>
-You can do this using the platformio user interface, or using the pio command line tool
-
-```ShellConsole
-pio run --target buildfs --environment <project name>
-pio run --target uploadfs --environment <project name>
-```
-
 ## Tools
 
 This repository includes a number of scrips to perform various tasks during or after building projects. They are included in the [`tools`](tools) directory. Please note that the scripts expect to be started from the project's main directory. So, using:

--- a/config/manifest_template.json
+++ b/config/manifest_template.json
@@ -8,8 +8,7 @@
       [
         { "path": "../firmware/<tag>/bootloader.bin", "offset": 4096  },
         { "path": "../firmware/<tag>/partitions.bin", "offset": 32768 },
-        { "path": "../firmware/<tag>/firmware.bin", "offset": 65536 },
-        { "path": "../firmware/<tag>/spiffs.bin", "offset": 3211264 }
+        { "path": "../firmware/<tag>/firmware.bin", "offset": 65536 }
       ]
     }
   ]


### PR DESCRIPTION
## Description

Now that the SPIFFS partition is no longer used to hold the content for the on-device website, there is no remaining need to build or flash it. This PR removes:

- The SPIFFS image from the web installer manifest template
- The `pio run -t buildfs` step from CI
- The README.md section that discusses how to build and upload the SPIFFS image with the website contents

## Contributing requirements
* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).