### PR TITLE
added Lilygo T-Display-S3 config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ WebInstaller/assets/**
 WebInstaller/firmware/**
 WebInstaller/manifests/**
 WebInstaller/web_projects.json
+.idea/**

--- a/include/globals.h
+++ b/include/globals.h
@@ -254,6 +254,8 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
     #if M5STICKC || M5STICKCPLUS
         #define LED_PIN0 32
+    #elif LILYGOTDISPLAYS3
+        #define LED_PIN0 16
     #else
         #define LED_PIN0 5
     #endif
@@ -1269,7 +1271,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
         #define USE_M5DISPLAY 1                                     // enable the M5's LCD screen
 
-    #elif ESP32FEATHERTFT || PANLEE
+    #elif ESP32FEATHERTFT || PANLEE || LILYGOTDISPLAYS3
 
         #define USE_TFTSPI 1                                  // Use TFT_eSPI
 

--- a/include/globals.h
+++ b/include/globals.h
@@ -255,7 +255,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #if M5STICKC || M5STICKCPLUS
         #define LED_PIN0 32
     #elif LILYGOTDISPLAYS3
-        #define LED_PIN0 16
+        #define LED_PIN0 21
     #else
         #define LED_PIN0 5
     #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = 
+default_envs = lilygo-tdisplay-s3-demo
 
 ; ==================
 ; Base configuration
@@ -136,10 +136,10 @@ upload_speed    = 1500000
 [dev_lilygo-tdisplay-s3]
 extends         = dev_esp32-s3
 build_flags     = -DLILYGOTDISPLAYS3=1
-                  -DPIN_SDA=16
+                  -DPIN_SDA=21
                   -DTOGGLE_BUTTON_1=0
                   -DTOGGLE_BUTTON_2=14
-                  ${base.build_flags}
+                  ${dev_esp32-s3.build_flags}
 
 ; ===================
 ; Capability sections

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@ monitor_port    =
 upload_speed    = 1500000
 build_flags     = -std=gnu++17
                   -Dregister=                       ; Sinister: redefine 'register' so FastLED can use that keyword under C++17
-                  
+
 lib_deps        = crankyoldgit/IRremoteESP8266  @ ^2.7.20
                   fastled/FastLED               @ ^3.4.0
                   adafruit/Adafruit BusIO       @ ^1.9.1
@@ -133,6 +133,14 @@ board           = esp-wrover-kit
 monitor_speed   = 115200
 upload_speed    = 1500000
 
+[dev_lilygo-tdisplay-s3]
+extends         = dev_esp32-s3
+build_flags     = -DLILYGOTDISPLAYS3=1
+                  -DPIN_SDA=16
+                  -DTOGGLE_BUTTON_1=0
+                  -DTOGGLE_BUTTON_2=14
+                  ${base.build_flags}
+
 ; ===================
 ; Capability sections
 ;
@@ -226,6 +234,15 @@ build_flags     = -DDEMO=1
 extends         = dev_heltec_wifi_v2
 build_flags     = -DDEMO=1
                   ${dev_heltec_wifi_v2.build_flags}
+
+; LILYGO T-Display-S3
+[env:lilygo-tdisplay-s3-demo]
+extends         = dev_lilygo-tdisplay-s3
+build_flags     = -DDEMO=1
+                  -DENABLE_WIFI=1
+                  -DENABLE_WEBSERVER=1
+                  -DUSE_SCREEN=0
+                  ${dev_lilygo-tdisplay-s3.build_flags}
 
 ;=============
 


### PR DESCRIPTION
## Description
Lilygo T-Display-S3 config was added to platform.io to make it easy to compile for this platform.

## Contributing requirements

* [*] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [*] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [*] I selected `main` as the target branch.
* [*] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).