### PR TITLE
Update SmartMatrix GitHub URL

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -357,7 +357,7 @@ build_flags     = -DMESMERIZER=1
                   ${dev_wrover.build_flags}
 debug_tool      = ftdi
 lib_deps        = ${dev_wrover.lib_deps}
-                  https://github.com/davepl/SmartMatrix.git
+                  https://github.com/PlummersSoftwareLLC/SmartMatrix.git
 
 [env:mesmerizer_lolin]
 extends         = dev_lolin_d32_pro
@@ -368,7 +368,7 @@ build_flags     = -DMESMERIZER=1
                   ${remote_flags.build_flags}
                   ${dev_lolin_d32_pro.build_flags}
 lib_deps        = ${dev_lolin_d32_pro.lib_deps}
-                  https://github.com/davepl/SmartMatrix.git
+                  https://github.com/PlummersSoftwareLLC/SmartMatrix.git
 
 ;==============
 


### PR DESCRIPTION
This updates the GitHub URL used to pull in the SmartMatrix dependency in the Mesmerizer platformIo.ini configurations.