### PR TITLE
Extend and fix saving of EffectManager config

### DIFF
--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -358,7 +358,7 @@ public:
                 SetGlobalColor(CRGB::Black);
             }
 
-            SaveEffectManagerConfig()
+            SaveEffectManagerConfig();
         }
     }
 

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -335,6 +335,8 @@ public:
                 ClearRemoteColor();
             }
             _cEnabled++;
+
+            SaveEffectManagerConfig();
         }
     }
 
@@ -355,6 +357,8 @@ public:
             {
                 SetGlobalColor(CRGB::Black);
             }
+
+            SaveEffectManagerConfig()
         }
     }
 

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -139,7 +139,7 @@ public:
         _abEffectEnabled = std::make_unique<bool[]>(_vEffects.size());
 
         for (int i = 0; i < _vEffects.size(); i++)
-            EnableEffect(i);
+            EnableEffect(i, true);
 
         construct();
     }
@@ -175,7 +175,7 @@ public:
         int enabledSize = enabledArray.isNull() ? 0 : enabledArray.size();
 
         for (int i = 0; i < _vEffects.size(); i++)
-            EnableEffect(i < enabledSize ? enabledArray[i].as<bool>() : true);
+            EnableEffect(i < enabledSize ? enabledArray[i].as<bool>() : true, true);
 
         construct();
         return true;
@@ -318,7 +318,7 @@ public:
         _effectStartTime = millis();
     }
 
-    void EnableEffect(size_t i)
+    void EnableEffect(size_t i, bool skipSave = false)
     {
         if (i >= _vEffects.size())
         {
@@ -336,11 +336,12 @@ public:
             }
             _cEnabled++;
 
-            SaveEffectManagerConfig();
+            if (!skipSave)
+                SaveEffectManagerConfig();
         }
     }
 
-    void DisableEffect(size_t i)
+    void DisableEffect(size_t i, bool skipSave = false)
     {
         if (i >= _vEffects.size())
         {
@@ -358,7 +359,8 @@ public:
                 SetGlobalColor(CRGB::Black);
             }
 
-            SaveEffectManagerConfig();
+            if (!skipSave)
+                SaveEffectManagerConfig();
         }
     }
 

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -88,8 +88,6 @@ class EffectManager : IJSONSerializable
         _bPlayAll = false;
         _iCurrentEffect = 0;
         _effectStartTime = millis();
-
-        SetInterval(DEFAULT_EFFECT_INTERVAL);
     }
 
     void ClearEffects() 
@@ -141,6 +139,8 @@ public:
         for (int i = 0; i < _vEffects.size(); i++)
             EnableEffect(i, true);
 
+        SetInterval(DEFAULT_EFFECT_INTERVAL, true);
+
         construct();
     }
 
@@ -175,7 +175,12 @@ public:
         int enabledSize = enabledArray.isNull() ? 0 : enabledArray.size();
 
         for (int i = 0; i < _vEffects.size(); i++)
-            EnableEffect(i < enabledSize ? enabledArray[i].as<bool>() : true, true);
+        {
+            if (i >= enabledSize || enabledArray[i] == 1)
+                EnableEffect(i, true);
+        }
+        
+        SetInterval(jsonObject.containsKey("ivl") ? jsonObject["ivl"] : DEFAULT_EFFECT_INTERVAL, true);
 
         construct();
         return true;
@@ -186,11 +191,13 @@ public:
         // Set JSON format version to be able to detect and manage future incompatible structural updates
         jsonObject[PTY_VERSION] = JSON_FORMAT_VERSION;
 
+        jsonObject["ivl"] = _effectInterval;
+
         // Serialize enabled state first. That way we'll still find out if we run out of memory, later
         JsonArray enabledArray = jsonObject.createNestedArray("eef");
 
         for (int i = 0; i < EffectCount(); i++)
-            enabledArray.add(IsEffectEnabled(i));
+            enabledArray.add(IsEffectEnabled(i) ? 1 : 0);
 
         JsonArray effectsArray = jsonObject.createNestedArray("efs");
 
@@ -379,9 +386,12 @@ public:
         _bPlayAll = bPlayAll;
     }
 
-    void SetInterval(uint interval)
+    void SetInterval(uint interval, bool skipSave = false)
     {
         _effectInterval = interval;
+
+        if (!skipSave)
+            SaveEffectManagerConfig();
     }
 
     const LEDStripEffect *const *EffectsList() const

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -806,9 +806,6 @@ void setup()
         CheckHeap();
     #endif
 
-    debugV("Saving effect manager config...");
-    SaveEffectManagerConfig();
-
     debugI("Setup complete - ESP32 Free Memory: %d\n", ESP.getFreeHeap());
     CheckHeap();
 
@@ -816,6 +813,9 @@ void setup()
     debugE("Heap before launch: %s", heap_caps_check_integrity_all(true) ? "PASS" : "FAIL");
     g_TaskManager.StartDrawThread();
     CheckHeap();
+
+    debugV("Saving effect manager config...");
+    SaveEffectManagerConfig();
 
     #if ENABLE_WIFI && WAIT_FOR_WIFI
         debugI("Calling ConnectToWifi()\n");


### PR DESCRIPTION
## Description

This PR improves the JSON (de)serialization of EffectManager. Specifically, it:

- Fixes a bug in the saving of the effect enabled state
- Also saves the effect interval
- Saves the EffectManager config after an update to effect enabled state or effect interval via the respective EffectManager methods

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).