### PR TITLE
Refactor webserver and device config, change WiFi connect (wait) logic

### DIFF
--- a/include/colordata.h
+++ b/include/colordata.h
@@ -2,7 +2,7 @@
 //
 // File:        colordata.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -23,7 +23,7 @@
 //
 // Description:
 //
-//    Palettes and other color table defnitions.  CPP daa in colordata.cpp 
+//    Palettes and other color table defnitions.  CPP daa in colordata.cpp
 //
 // History:     May-11-2021         Davepl      Commented
 //
@@ -32,7 +32,7 @@
 // Palettes defined in colordata.cpp
 
 extern const CRGBPalette16 vuPaletteGreen;
-extern const CRGBPalette16 vuPaletteBlue;    
+extern const CRGBPalette16 vuPaletteBlue;
 extern const CRGBPalette16 spectrumBasicColors;
 extern const CRGBPalette16 bluesky_pal;
 extern const TProgmemRGBGradientPalette_byte vu_gpGreen[];

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -2,7 +2,7 @@
 //
 // File:        deviceconfig.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -46,7 +46,7 @@ class DeviceConfig : public IJSONSerializable
     bool use24HourClock;
     bool useCelsius;
 
-/*    
+/*
     void WriteToNVS(const String& name, const String& value);
     void WriteToNVS(const String& name, bool value);
 */
@@ -66,7 +66,7 @@ class DeviceConfig : public IJSONSerializable
     template <typename T>
     void SetIfPresentIn(const JsonObjectConst& jsonObject, T& target, const char *tag)
     {
-        if (jsonObject.containsKey(tag)) 
+        if (jsonObject.containsKey(tag))
             target = jsonObject[tag].as<T>();
     }
 
@@ -93,7 +93,7 @@ class DeviceConfig : public IJSONSerializable
         jsonDoc[TIME_ZONE_TAG] = timeZone;
         jsonDoc[USE_24_HOUR_CLOCK_TAG] = use24HourClock;
         jsonDoc[USE_CELSIUS_TAG] = useCelsius;
-    
+
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
@@ -111,9 +111,9 @@ class DeviceConfig : public IJSONSerializable
         SetIfPresentIn(jsonObject, use24HourClock, USE_24_HOUR_CLOCK_TAG);
         SetIfPresentIn(jsonObject, useCelsius, USE_CELSIUS_TAG);
 
-        if (jsonObject.containsKey(TIME_ZONE_TAG)) 
+        if (jsonObject.containsKey(TIME_ZONE_TAG))
             return SetTimeZone(jsonObject[TIME_ZONE_TAG], true);
-   
+
         if (!skipWrite)
             SaveToJSON();
 

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -72,13 +72,13 @@ class DeviceConfig : public IJSONSerializable
 
   public:
 
-    static constexpr const char * LOCATION_TAG = NAME_OF(location);
-    static constexpr const char * LOCATION_IS_ZIP_TAG = NAME_OF(locationIsZip);
-    static constexpr const char * COUNTRY_CODE_TAG = NAME_OF(countryCode);
-    static constexpr const char * OPEN_WEATHER_API_KEY_TAG = NAME_OF(openWeatherApiKey);
-    static constexpr const char * TIME_ZONE_TAG = NAME_OF(timeZone);
-    static constexpr const char * USE_24_HOUR_CLOCK_TAG = NAME_OF(use24HourClock);
-    static constexpr const char * USE_CELSIUS_TAG = NAME_OF(useCelsius);
+    static constexpr const char * LocationTag = NAME_OF(location);
+    static constexpr const char * LocationIsZipTag = NAME_OF(locationIsZip);
+    static constexpr const char * CountryCodeTag = NAME_OF(countryCode);
+    static constexpr const char * OpenWeatherApiKeyTag = NAME_OF(openWeatherApiKey);
+    static constexpr const char * TimeZoneTag = NAME_OF(timeZone);
+    static constexpr const char * Use24HourClockTag = NAME_OF(use24HourClock);
+    static constexpr const char * UseCelsiusTag = NAME_OF(useCelsius);
 
     DeviceConfig();
 
@@ -86,13 +86,13 @@ class DeviceConfig : public IJSONSerializable
     {
         StaticJsonDocument<1024> jsonDoc;
 
-        jsonDoc[LOCATION_TAG] = location;
-        jsonDoc[LOCATION_IS_ZIP_TAG] = locationIsZip;
-        jsonDoc[COUNTRY_CODE_TAG] = countryCode;
-        jsonDoc[OPEN_WEATHER_API_KEY_TAG] = openWeatherApiKey;
-        jsonDoc[TIME_ZONE_TAG] = timeZone;
-        jsonDoc[USE_24_HOUR_CLOCK_TAG] = use24HourClock;
-        jsonDoc[USE_CELSIUS_TAG] = useCelsius;
+        jsonDoc[LocationTag] = location;
+        jsonDoc[LocationIsZipTag] = locationIsZip;
+        jsonDoc[CountryCodeTag] = countryCode;
+        jsonDoc[OpenWeatherApiKeyTag] = openWeatherApiKey;
+        jsonDoc[TimeZoneTag] = timeZone;
+        jsonDoc[Use24HourClockTag] = use24HourClock;
+        jsonDoc[UseCelsiusTag] = useCelsius;
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
@@ -104,15 +104,15 @@ class DeviceConfig : public IJSONSerializable
 
     bool DeserializeFromJSON(const JsonObjectConst& jsonObject, bool skipWrite)
     {
-        SetIfPresentIn(jsonObject, location, LOCATION_TAG);
-        SetIfPresentIn(jsonObject, locationIsZip, LOCATION_IS_ZIP_TAG);
-        SetIfPresentIn(jsonObject, countryCode, COUNTRY_CODE_TAG);
-        SetIfPresentIn(jsonObject, openWeatherApiKey, OPEN_WEATHER_API_KEY_TAG);
-        SetIfPresentIn(jsonObject, use24HourClock, USE_24_HOUR_CLOCK_TAG);
-        SetIfPresentIn(jsonObject, useCelsius, USE_CELSIUS_TAG);
+        SetIfPresentIn(jsonObject, location, LocationTag);
+        SetIfPresentIn(jsonObject, locationIsZip, LocationIsZipTag);
+        SetIfPresentIn(jsonObject, countryCode, CountryCodeTag);
+        SetIfPresentIn(jsonObject, openWeatherApiKey, OpenWeatherApiKeyTag);
+        SetIfPresentIn(jsonObject, use24HourClock, Use24HourClockTag);
+        SetIfPresentIn(jsonObject, useCelsius, UseCelsiusTag);
 
-        if (jsonObject.containsKey(TIME_ZONE_TAG))
-            return SetTimeZone(jsonObject[TIME_ZONE_TAG], true);
+        if (jsonObject.containsKey(TimeZoneTag))
+            return SetTimeZone(jsonObject[TimeZoneTag], true);
 
         if (!skipWrite)
             SaveToJSON();

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -71,19 +71,28 @@ class DeviceConfig : public IJSONSerializable
     }
 
   public:
+
+    static constexpr const char * LOCATION_TAG = NAME_OF(location);
+    static constexpr const char * LOCATION_IS_ZIP_TAG = NAME_OF(locationIsZip);
+    static constexpr const char * COUNTRY_CODE_TAG = NAME_OF(countryCode);
+    static constexpr const char * OPEN_WEATHER_API_KEY_TAG = NAME_OF(openWeatherApiKey);
+    static constexpr const char * TIME_ZONE_TAG = NAME_OF(timeZone);
+    static constexpr const char * USE_24_HOUR_CLOCK_TAG = NAME_OF(use24HourClock);
+    static constexpr const char * USE_CELSIUS_TAG = NAME_OF(useCelsius);
+
     DeviceConfig();
 
     virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<1024> jsonDoc;
 
-        jsonDoc[NAME_OF(location)] = location;
-        jsonDoc[NAME_OF(locationIsZip)] = locationIsZip;
-        jsonDoc[NAME_OF(countryCode)] = countryCode;
-        jsonDoc[NAME_OF(openWeatherApiKey)] = openWeatherApiKey;
-        jsonDoc[NAME_OF(timeZone)] = timeZone;
-        jsonDoc[NAME_OF(use24HourClock)] = use24HourClock;
-        jsonDoc[NAME_OF(useCelsius)] = useCelsius;
+        jsonDoc[LOCATION_TAG] = location;
+        jsonDoc[LOCATION_IS_ZIP_TAG] = locationIsZip;
+        jsonDoc[COUNTRY_CODE_TAG] = countryCode;
+        jsonDoc[OPEN_WEATHER_API_KEY_TAG] = openWeatherApiKey;
+        jsonDoc[TIME_ZONE_TAG] = timeZone;
+        jsonDoc[USE_24_HOUR_CLOCK_TAG] = use24HourClock;
+        jsonDoc[USE_CELSIUS_TAG] = useCelsius;
     
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
@@ -95,16 +104,15 @@ class DeviceConfig : public IJSONSerializable
 
     bool DeserializeFromJSON(const JsonObjectConst& jsonObject, bool skipWrite)
     {
-        SetIfPresentIn(jsonObject, location, NAME_OF(location));
-        SetIfPresentIn(jsonObject, locationIsZip, NAME_OF(locationIsZip));
-        SetIfPresentIn(jsonObject, countryCode, NAME_OF(countryCode));
-        SetIfPresentIn(jsonObject, openWeatherApiKey, NAME_OF(openWeatherApiKey));
-        SetIfPresentIn(jsonObject, use24HourClock, NAME_OF(use24HourClock));
-        SetIfPresentIn(jsonObject, useCelsius, NAME_OF(useCelsius));
+        SetIfPresentIn(jsonObject, location, LOCATION_TAG);
+        SetIfPresentIn(jsonObject, locationIsZip, LOCATION_IS_ZIP_TAG);
+        SetIfPresentIn(jsonObject, countryCode, COUNTRY_CODE_TAG);
+        SetIfPresentIn(jsonObject, openWeatherApiKey, OPEN_WEATHER_API_KEY_TAG);
+        SetIfPresentIn(jsonObject, use24HourClock, USE_24_HOUR_CLOCK_TAG);
+        SetIfPresentIn(jsonObject, useCelsius, USE_CELSIUS_TAG);
 
-        const char *tag = NAME_OF(timeZone);
-        if (jsonObject.containsKey(tag)) 
-            return SetTimeZone(jsonObject[tag], true);
+        if (jsonObject.containsKey(TIME_ZONE_TAG)) 
+            return SetTimeZone(jsonObject[TIME_ZONE_TAG], true);
    
         if (!skipWrite)
             SaveToJSON();

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -84,7 +84,7 @@ class DeviceConfig : public IJSONSerializable
 
     virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
-        StaticJsonDocument<1024> jsonDoc;
+        AllocatedJsonDocument jsonDoc(1024);
 
         jsonDoc[LocationTag] = location;
         jsonDoc[LocationIsZipTag] = locationIsZip;

--- a/include/drawing.h
+++ b/include/drawing.h
@@ -2,7 +2,7 @@
 //
 // File:        drawing.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.

--- a/include/effectdependencies.h
+++ b/include/effectdependencies.h
@@ -59,6 +59,7 @@
 
 #if USE_MATRIX
     #include "ledmatrixgfx.h"
+    #include "effects/strip/misceffects.h"
     #include "effects/matrix/PatternSerendipity.h"
     #include "effects/matrix/PatternSwirl.h"
     #include "effects/matrix/PatternPulse.h"

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -83,14 +83,14 @@ class EffectManager : public IJSONSerializable
     std::shared_ptr<GFXTYPE> * _gfx;
     std::shared_ptr<LEDStripEffect> _ptrRemoteEffect = nullptr;
 
-    void construct() 
+    void construct()
     {
         _bPlayAll = false;
         _iCurrentEffect = 0;
         _effectStartTime = millis();
     }
 
-    void ClearEffects() 
+    void ClearEffects()
     {
         for (auto effect : _vEffects)
             delete effect;
@@ -130,7 +130,7 @@ public:
     {
         ClearEffects();
         _vEffects.reserve(cEffects);
-        
+
         for (int i = 0; i < cEffects; i++)
         {
             _vEffects.push_back(pEffects[i]);
@@ -162,14 +162,14 @@ public:
         for (auto effectObject : effectsArray)
         {
             LEDStripEffect *pEffect = CreateEffectFromJSON(effectObject);
-            if (pEffect != nullptr) 
+            if (pEffect != nullptr)
                 _vEffects.push_back(pEffect);
         }
 
         // Check if we have at least one deserialized effect
         if (_vEffects.size() == 0)
             return false;
-        
+
         _abEffectEnabled = std::make_unique<bool[]>(_vEffects.size());
 
         // Try to load effect enabled state from JSON also, default to "enabled" otherwise
@@ -181,7 +181,7 @@ public:
             if (i >= enabledSize || enabledArray[i] == 1)
                 EnableEffect(i, true);
         }
-        
+
         SetInterval(jsonObject.containsKey("ivl") ? jsonObject["ivl"] : DEFAULT_EFFECT_INTERVAL, true);
 
         construct();
@@ -203,7 +203,7 @@ public:
 
         JsonArray effectsArray = jsonObject.createNestedArray("efs");
 
-        for (auto effect : _vEffects) 
+        for (auto effect : _vEffects)
         {
             JsonObject effectObject = effectsArray.createNestedObject();
             if (!(effect->SerializeToJSON(effectObject)))
@@ -318,7 +318,7 @@ public:
 
         // If there's a temporary effect override from the remote control active, we start that, else
         // we start the current regular effect
-        
+
         if (_ptrRemoteEffect)
             _ptrRemoteEffect->Start();
         else
@@ -461,7 +461,7 @@ public:
     uint GetInterval() const
     {
         // This allows you to return a MinimumEffectTime and your effect won't be shown longer than that
-        
+
         if (_effectInterval == 0)
             return std::numeric_limits<uint>::max();
         return min(_effectInterval, GetCurrentEffect()->MaximumEffectTime() - GetTimeUsedByCurrentEffect());

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -90,7 +90,12 @@ class EffectManager : public IJSONSerializable
         _bPlayAll = false;
 
         if (clearRemoteEffect && _ptrRemoteEffect)
+        {
             _clearRemoteEffectWhenExpired = true;
+
+            // This is a hacky way to ensure that we start the correct effect after the temporary one
+            _iCurrentEffect--;
+        }
     }
 
     void ClearEffects()
@@ -113,11 +118,7 @@ public:
         debugV("EffectManager Splash Effect Constructor");
 
         if (pEffect->Init(_gfx))
-        {
             _ptrRemoteEffect = std::shared_ptr<LEDStripEffect>(pEffect);
-            // This is a hacky way to ensure that the first effect in the list is shown after the one we're adopting now
-            _iCurrentEffect = -1;
-        }
 
         construct(false);
     }

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -475,12 +475,12 @@ public:
 
     void CheckEffectTimerExpired()
     {
-        // If interval is zero, the current effect never expires
+        // If interval is zero, the current effect never expires unless it thas a max effect time set
 
-        if (_effectInterval == 0)
+        if (_effectInterval == 0 && !GetCurrentEffect()->HasMaximumEffectTime())
             return;
 
-        if (GetTimeUsedByCurrentEffect() >= GetInterval()) // See if its time for a new effect yet
+        if (GetTimeUsedByCurrentEffect() >= GetInterval()) // See if it's time for a new effect yet
         {
             debugV("%ldms elapsed: Next Effect", millis() - _effectStartTime);
             NextEffect();

--- a/include/effects/matrix/PatternClock.h
+++ b/include/effects/matrix/PatternClock.h
@@ -70,7 +70,7 @@ class PatternClock : public LEDStripEffect
         g->Clear();
         g->drawCircle(MATRIX_WIDTH/2, MATRIX_HEIGHT/2, radius, GREEN16);
         g->drawCircle(MATRIX_WIDTH/2, MATRIX_HEIGHT/2, 1, GREEN16);
-        
+
         // Draw the hour ticks around the outside of the clock every 30 degrees
 
         for (int z = 0; z < 360; z = z + 30)
@@ -92,7 +92,7 @@ class PatternClock : public LEDStripEffect
         int x3 = (MATRIX_CENTER_X + (sin(angle) * (radius)));
         int y3 = (MATRIX_CENTER_Y - (cos(angle) * (radius)));
         g->drawLine(MATRIX_CENTER_X, MATRIX_CENTER_Y, x3, y3, CRGB::White);
-        
+
         // Draw the minute hand
 
         angle = minutes * 6;

--- a/include/effects/matrix/PatternFlowField.h
+++ b/include/effects/matrix/PatternFlowField.h
@@ -93,7 +93,7 @@ public:
     {
         return 16;
     }
-    
+
     virtual void Draw()
     {
         graphics()->DimAll(240);

--- a/include/effects/matrix/PatternLife.h
+++ b/include/effects/matrix/PatternLife.h
@@ -64,23 +64,23 @@
 
 #include <bitset>
 
-extern "C" 
+extern "C"
 {
     #include "uzlib/src/uzlib.h"
 }
 
-class Cell 
+class Cell
 {
 public:
   uint8_t alive : 1;
   uint8_t prev  : 1;
-  uint8_t hue;  
+  uint8_t hue;
   uint8_t brightness;
 };
 
 #define CRC_LENGTH std::max(MATRIX_HEIGHT, MATRIX_WIDTH)                           // Depth of loop check buffer
 
-class PatternLife : public LEDStripEffect 
+class PatternLife : public LEDStripEffect
 {
 private:
     std::unique_ptr<Cell [][MATRIX_HEIGHT]> world;
@@ -92,7 +92,7 @@ private:
     unsigned long seed;
 
 
-    virtual bool Init(std::shared_ptr<GFXBase> gfx[NUM_CHANNELS])               
+    virtual bool Init(std::shared_ptr<GFXBase> gfx[NUM_CHANNELS])
     {
         LEDStripEffect::Init(gfx);
 
@@ -105,7 +105,7 @@ private:
 
         return true;
     }
-    
+
     virtual bool RequiresDoubleBuffering() const
     {
         return false;
@@ -117,7 +117,7 @@ private:
     // Seed: 92465, Generations: 1626
 
     static constexpr long bakedInSeeds[] =
-    { 
+    {
         130908,         // 3253
         1576,           // 3125
         275011,         // 3461
@@ -140,11 +140,11 @@ private:
     };
 
 
-    void randomFillWorld() 
+    void randomFillWorld()
     {
         // Some fraction of the time we pick a pre-baked seed that we know lasts for a lot
         // of generations.  Otherwise we pick a random seed and run with that.
-        
+
         srand(millis());
         if (random(0, 4) == 0)
         {
@@ -152,7 +152,7 @@ private:
             debugI("Prebaked Seed: %lu", seed);
         }
         else
-        {   
+        {
             seed = random();
             debugI("Randomized Seed: %lu", seed);
         }
@@ -210,8 +210,8 @@ public:
     virtual void Draw()
     {
         auto graphics = (GFXBase *) _GFX[0].get();
-        
-        if (cGeneration == 0) 
+
+        if (cGeneration == 0)
             Reset();
 
         // Display current generation
@@ -230,12 +230,12 @@ public:
 
         // We maintain a scrolling window of the last N crcs and if the current crc makes it all
         // the way down to the bototm half we assume we're stuck in a loop and restart.
-        // We have to first extract the alive bits alone because we don't want the hue and brightness 
+        // We have to first extract the alive bits alone because we don't want the hue and brightness
         // data to mess with the CRC.
 
         bool alive[MATRIX_WIDTH][MATRIX_HEIGHT];
-        for (int i = 0; i < MATRIX_WIDTH; i++) 
-            for (int j = 0; j < MATRIX_HEIGHT; j++) 
+        for (int i = 0; i < MATRIX_WIDTH; i++)
+            for (int j = 0; j < MATRIX_HEIGHT; j++)
                 alive[i][j] = world[i][j].alive;
 
         auto crc = uzlib_crc32(alive, sizeof(alive), 0xffffffff);
@@ -245,7 +245,7 @@ public:
 
 
         // Look for any occurance of the current CRC in the first half of the window, which would mean
-        // a loop has occured.  If 
+        // a loop has occured.  If
 
         if (bStuckInLoop)
         {
@@ -260,8 +260,8 @@ public:
             }
             graphics->DimAll(255 - 255*elapsed/resetTime);
 
-            for (int x = 0; x < MATRIX_WIDTH; x++) 
-                for (int y = 0; y < MATRIX_HEIGHT; y++) 
+            for (int x = 0; x < MATRIX_WIDTH; x++)
+                for (int y = 0; y < MATRIX_HEIGHT; y++)
                         world[x][y].brightness *= 0.9;
             if (elapsed > resetTime)
                 Reset();
@@ -286,7 +286,7 @@ public:
                 // Default is for cell to stay the same
                 if (world[x][y].brightness > 0 && world[x][y].prev == 0)
                   world[x][y].brightness *= 0.75;
-                  
+
                 int count = neighbours(x, y);
                 if (count == 3 && world[x][y].prev == 0) {
                     // A new cell is born

--- a/include/effects/matrix/PatternMisc.h
+++ b/include/effects/matrix/PatternMisc.h
@@ -58,7 +58,7 @@
 
 #include "Geometry.h"
 
-class PatternSunburst : public LEDStripEffect 
+class PatternSunburst : public LEDStripEffect
 {
   public:
 
@@ -69,7 +69,7 @@ class PatternSunburst : public LEDStripEffect
     PatternSunburst(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
     {
     }
- 
+
     virtual size_t DesiredFramesPerSecond() const
     {
         return 60;
@@ -78,13 +78,13 @@ class PatternSunburst : public LEDStripEffect
     virtual void Draw()
     {
       uint8_t dim = beatsin8(2, 210, 250);
-      graphics()->DimAll(dim); 
+      graphics()->DimAll(dim);
 
       for (int i = 2; i <= MATRIX_WIDTH / 2; i++)
       {
         CRGB color = graphics()->ColorFromCurrentPalette((i - 2) * (240 / (MATRIX_WIDTH / 2)));
 
-        // The LIB8TION library defines beatsin8, but this needed beatcos8 which did not exist, so I 
+        // The LIB8TION library defines beatsin8, but this needed beatcos8 which did not exist, so I
         // added it to the graphics interface rathe than adding it to a custom version of lib8tion
 
         uint8_t x = graphics()->beatcos8((17 - i) * 2, MATRIX_CENTER_X - i, MATRIX_CENTER_X + i);
@@ -96,10 +96,10 @@ class PatternSunburst : public LEDStripEffect
     }
 };
 
-class PatternRose : public LEDStripEffect 
+class PatternRose : public LEDStripEffect
 {
   public:
-    
+
     PatternRose() : LEDStripEffect(EFFECT_MATRIX_ROSE, "Rose")
     {
     }
@@ -116,8 +116,8 @@ class PatternRose : public LEDStripEffect
     virtual void Draw()
     {
       uint8_t dim = beatsin8(2, 170, 250);
-      graphics()->DimAll(dim); 
-      
+      graphics()->DimAll(dim);
+
 
       for (uint8_t i = 0; i < 32; i++)
       {
@@ -146,7 +146,7 @@ class PatternRose : public LEDStripEffect
 class PatternPinwheel : public LEDStripEffect
 {
   public:
-    
+
     PatternPinwheel() : LEDStripEffect(EFFECT_MATRIX_PINWHEEL, "Pinwheel")
     {
     }
@@ -168,8 +168,8 @@ class PatternPinwheel : public LEDStripEffect
     virtual void Draw()
     {
       uint8_t dim = beatsin8(2, 30, 70);
-      fadeAllChannelsToBlackBy(dim); 
-      
+      fadeAllChannelsToBlackBy(dim);
+
       for (uint8_t i = 0; i < 64; i++)
       {
         CRGB color;
@@ -186,7 +186,7 @@ class PatternPinwheel : public LEDStripEffect
     }
 };
 
-class PatternInfinity : public LEDStripEffect 
+class PatternInfinity : public LEDStripEffect
 {
 public:
 
@@ -208,10 +208,10 @@ public:
 
     virtual void Draw()
     {
-        // dim all pixels on the display slightly 
+        // dim all pixels on the display slightly
         // to 250/255 (98%) of their current brightness
-        graphics()->DimAll(250); 
-        
+        graphics()->DimAll(250);
+
         // the Effects class has some sample oscillators
         // that move from 0 to 255 at different speeds
         graphics()->MoveOscillators();
@@ -241,12 +241,12 @@ public:
         _lastY = y;
 
         //graphics()->setPixel(x, y, graphics()->ColorFromCurrentPalette(hue));
-      
+
     }
 };
 
 
-class PatternMunch : public LEDStripEffect 
+class PatternMunch : public LEDStripEffect
 {
 private:
     uint8_t count = 0;
@@ -270,25 +270,25 @@ public:
 
     virtual void Draw()
     {
-       
+
         for (uint8_t x = 0; x < MATRIX_WIDTH; x++) {
             for (uint8_t y = 0; y < MATRIX_HEIGHT; y++) {
-                graphics()->leds[graphics()->xy(x, y)] = 
-                  (x ^ y ^ flip) < count ? 
-                      graphics()->ColorFromCurrentPalette(((x ^ y) << 2) + generation) 
+                graphics()->leds[graphics()->xy(x, y)] =
+                  (x ^ y ^ flip) < count ?
+                      graphics()->ColorFromCurrentPalette(((x ^ y) << 2) + generation)
                     : CRGB::Black;
 
                 // The below is more pleasant
                // effects.leds[XY(x, y)] = effects.ColorFromCurrentPalette(((x ^ y) << 2) + generation) ;
             }
         }
-        
+
         count += dir;
-        
+
         if (count <= 0 || count >= MATRIX_WIDTH) {
           dir = -dir;
         }
-        
+
         if (count <= 0) {
           if (flip == 0)
             flip = MATRIX_WIDTH-1;

--- a/include/effects/matrix/PatternNoiseSmearing.h
+++ b/include/effects/matrix/PatternNoiseSmearing.h
@@ -58,7 +58,7 @@
 #ifndef PatternNoiseSmearing_H
 #define PatternNoiseSmearing_H
 
-class PatternCurtain : public LEDStripEffect 
+class PatternCurtain : public LEDStripEffect
 {
 public:
   PatternCurtain() : LEDStripEffect(EFFECT_MATRIX_CURTAIN, "Curtain")
@@ -71,7 +71,7 @@ public:
 
   virtual void Draw()
   {
-    graphics()->DimAll(235); 
+    graphics()->DimAll(235);
     graphics()->BlurFrame(50);
 
     // Clear our area potentially drawn by the VU meter last frame; copy Row1 onto Row0 so it usually goes unnoticed
@@ -79,14 +79,14 @@ public:
     for (int x = 0; x < MATRIX_WIDTH; x++)
       graphics()->setPixel(x, 0, graphics()->getPixel(x, 1));
 
-    for (uint8_t i = 3; i < MATRIX_WIDTH - 3; i = i + 3) 
+    for (uint8_t i = 3; i < MATRIX_WIDTH - 3; i = i + 3)
     {
       uint16_t color = graphics()->to16bit(graphics()->ColorFromCurrentPalette(i * 4));
       graphics()->drawCircle(i, 2, 1, color);
       graphics()->setPixel(i, 2, color);
     }
 
-     
+
     // Noise
     graphics()->SetNoise(3000, 3000, 3000, 2000 *(2.0 - g_Analyzer._VURatio), 2000 *(2.0 - g_Analyzer._VURatio));
     graphics()->FillGetNoise();
@@ -111,7 +111,7 @@ public:
 
   virtual void Draw()
   {
-    graphics()->DimAll(230); 
+    graphics()->DimAll(230);
 
     // Clear our area potentially drawn by the VU meter last frame; copy Row1 onto Row0 so it usually goes unnoticed
 
@@ -119,9 +119,9 @@ public:
       graphics()->setPixel(x, 0, graphics()->getPixel(x, 1));
 
     // draw grid of rainbow dots on top of the dimmed image
-    for (uint8_t y = 1; y < MATRIX_HEIGHT - 6; y = y + 6) 
+    for (uint8_t y = 1; y < MATRIX_HEIGHT - 6; y = y + 6)
     {
-      for (uint8_t x = 1; x < MATRIX_WIDTH - 6; x = x + 6) 
+      for (uint8_t x = 1; x < MATRIX_WIDTH - 6; x = x + 6)
       {
         graphics()->leds[graphics()->xy(x, y)] += graphics()->ColorFromCurrentPalette((x * y) / 2);
       }
@@ -139,7 +139,7 @@ public:
   }
 };
 
-class PatternPaletteSmear : public LEDStripEffect 
+class PatternPaletteSmear : public LEDStripEffect
 {
 public:
   PatternPaletteSmear() : LEDStripEffect(EFFECT_MATRIX_PALETTE_SMEAR, "Smear")
@@ -153,26 +153,26 @@ public:
   virtual void Draw()
   {
     graphics()->DimAll(10);
-   
+
     // draw a rainbow color palette
-    for (uint8_t y = 0; y < MATRIX_HEIGHT; y++) 
+    for (uint8_t y = 0; y < MATRIX_HEIGHT; y++)
     {
-      for (uint8_t x = 0; x < MATRIX_CENTER_X; x++) 
+      for (uint8_t x = 0; x < MATRIX_CENTER_X; x++)
       {
         graphics()->leds[graphics()->xy(x, y)] += graphics()->ColorFromCurrentPalette(x * 8, y * 8 + 7);
       }
-      for (uint8_t x = 0; x < MATRIX_CENTER_X; x++) 
+      for (uint8_t x = 0; x < MATRIX_CENTER_X; x++)
       {
         graphics()->leds[graphics()->xy(MATRIX_WIDTH - 1 - x, y)] += graphics()->ColorFromCurrentPalette(x * 8, y * 8 + 7);
       }
 
     }
- 
+
     // Clear our area potentially drawn by the VU meter last frame; copy Row1 onto Row0 so it usually goes unnoticed
 
     // Noise
 graphics()->SetNoise(3000, 3000, 0, 4000, 4000);
- 
+
     graphics()->FillGetNoise();
 
     graphics()->MoveX(6);
@@ -187,7 +187,7 @@ graphics()->SetNoise(3000, 3000, 0, 4000, 4000);
   }
 };
 
-class PatternRainbowFlag : public LEDStripEffect 
+class PatternRainbowFlag : public LEDStripEffect
 {
 public:
   PatternRainbowFlag() : LEDStripEffect(EFFECT_MATRIX_RAINBOW_FLAG, "RainbowFlag")
@@ -200,7 +200,7 @@ public:
 
   virtual void Draw()
   {
-    graphics()->DimAll(10); 
+    graphics()->DimAll(10);
 
     CRGB rainbow[7] = {
       CRGB::Red,
@@ -215,7 +215,7 @@ public:
 
     for (uint8_t c = 0; c < 6; c++) {
       for (uint8_t j = 0; j < 5; j++) {
-        for (uint8_t x = 0; x < MATRIX_WIDTH; x++) 
+        for (uint8_t x = 0; x < MATRIX_WIDTH; x++)
         {
           graphics()->leds[graphics()->xy(x, y)] += rainbow[c];
         }

--- a/include/effects/matrix/PatternPongClock.h
+++ b/include/effects/matrix/PatternPongClock.h
@@ -107,7 +107,7 @@ class PatternPongClock : public LEDStripEffect
     {
         return 35;
     }
-     
+
     virtual void Start()
     {
         time_t ttime = time(0);
@@ -144,7 +144,7 @@ class PatternPongClock : public LEDStripEffect
             g->setPixel(MATRIX_WIDTH / 2, 4, RED16);
             g->setPixel(MATRIX_WIDTH / 2, 6, RED16);
         }
-        
+
         LEDMatrixGFX::backgroundLayer.setFont(gohufont11b);
         char buffer[3];
 
@@ -162,7 +162,7 @@ class PatternPongClock : public LEDStripEffect
             ballpos_x = MATRIX_WIDTH / 2;
             ballpos_y = random(4, MATRIX_HEIGHT-4);
             ballvel_x = 0;
-            
+
             // pick random ball direction
             if (random(0, 2) > 0)
             {
@@ -220,9 +220,9 @@ class PatternPongClock : public LEDStripEffect
         constexpr float leftEdge  = MATRIX_WIDTH / 2 - MAXSPEED * LOOKAHEAD;
         constexpr float rightEdge = MATRIX_WIDTH / 2 + MAXSPEED * LOOKAHEAD;
 
-        // If ball going leftwards towards BAT1, 
+        // If ball going leftwards towards BAT1,
 
-        if (ballvel_x < 0 && ballpos_x > leftEdge  && ballpos_x < rightEdge)   
+        if (ballvel_x < 0 && ballpos_x > leftEdge  && ballpos_x < rightEdge)
         {
 
             uint8_t end_ball_y = pong_get_ball_endpoint(ballpos_x, ballpos_y, ballvel_x, ballvel_y);
@@ -255,10 +255,10 @@ class PatternPongClock : public LEDStripEffect
         // if positive velocity then predict for right bat - first just match ball height
         // when the ball is closer to the right bat, run the ball maths to find out where it will land
 
-        if (ballvel_x > 0 && ballpos_x > leftEdge && ballpos_x < rightEdge) 
+        if (ballvel_x > 0 && ballpos_x > leftEdge && ballpos_x < rightEdge)
         {
             uint8_t end_ball_y = pong_get_ball_endpoint(ballpos_x, ballpos_y, ballvel_x, ballvel_y);
-            
+
             // if flag set to miss, move bat out way of ball
             if (bat2miss == 1)
             {
@@ -334,7 +334,7 @@ class PatternPongClock : public LEDStripEffect
 
         if (ballpos_y >= MATRIX_HEIGHT)
         {
-            ballpos_y = 2 * MATRIX_HEIGHT - ballpos_y; 
+            ballpos_y = 2 * MATRIX_HEIGHT - ballpos_y;
             ballvel_y *= -1;
         }
 
@@ -477,8 +477,8 @@ class PatternPongClock : public LEDStripEffect
     float pong_get_ball_endpoint(float xpos, float ypos, float xspeed, float yspeed)
     {
         // In the following, the fabs() mirrors it over the bottom wall.  The fmod wraps it when it exceeds twice
-        // the top wall.  If the ball ends up in the top half of the double height section, we reflect it back 
-        // 
+        // the top wall.  If the ball ends up in the top half of the double height section, we reflect it back
+        //
         // auto deltaX = (xspeed > 0) ? (BAT2_X - xpos) : -(xpos - BAT1_X);        // How far from ball to opponent bat
         // auto slope = yspeed / xspeed;                                           // Rise over run, ie: deltaY per X
         // float newY = fmod(fabs(ypos + deltaX * slope), (2 * MATRIX_HEIGHT));    // New Y, but wrappped every 2*height

--- a/include/effects/matrix/PatternPulse.h
+++ b/include/effects/matrix/PatternPulse.h
@@ -148,13 +148,13 @@ class PatternPulsar : public BeatEffectBase, public LEDStripEffect
         LEDStripEffect(EFFECT_MATRIX_PULSAR, "Pulsars")
     {
     }
-    
+
     PatternPulsar(const JsonObjectConst& jsonObject) :
         BeatEffectBase(1.5, 0.25 ),
         LEDStripEffect(jsonObject)
     {
     }
-    
+
     virtual size_t DesiredFramesPerSecond() const
     {
         return 30;
@@ -165,7 +165,7 @@ class PatternPulsar : public BeatEffectBase, public LEDStripEffect
         if (span > 1.5)
         {
             for (int i = 0; i < random(2)+2; i ++)
-                _pops.push_back( PulsePop() );            
+                _pops.push_back( PulsePop() );
         }
         else
         {
@@ -173,7 +173,7 @@ class PatternPulsar : public BeatEffectBase, public LEDStripEffect
             small.maxSteps = random(12)+4;
             _pops.push_back( small );
         }
-        
+
     }
 
     virtual void Draw()
@@ -217,7 +217,7 @@ class PatternPulsar : public BeatEffectBase, public LEDStripEffect
                     // secondary pulse
                     if (pop->step > 3)
                         graphics()->drawCircle(pop->centerX, pop->centerY, pop->step - 3, graphics()->to16bit(graphics()->ColorFromCurrentPalette(pop->hue, pow(fadeRate, pop->step - 2) * 255)));
-                    
+
                     // This looks like PDP-11 code to me.  double post-inc for the win!
                     pop++->step++;
                 }

--- a/include/effects/matrix/PatternQR.h
+++ b/include/effects/matrix/PatternQR.h
@@ -59,7 +59,7 @@
 #include "Geometry.h"
 #include "qrcode.h"
 
-class PatternQR : public LEDStripEffect 
+class PatternQR : public LEDStripEffect
 {
     void construct()
     {
@@ -106,7 +106,7 @@ public:
         if (sIP != lastData)
         {
             lastData = sIP;
-            qrcode_initText(&qrcode, qrcodeData, qrVersion, ECC_LOW, sIP.c_str());  
+            qrcode_initText(&qrcode, qrcodeData, qrVersion, ECC_LOW, sIP.c_str());
         }
         graphics()->fillScreen(graphics()->to16bit(CRGB::DarkBlue));
         const int leftMargin = MATRIX_CENTER_X - qrcode.size / 2;
@@ -124,8 +124,8 @@ public:
         graphics()->fillRect(leftMargin - borderSize, topMargin - borderSize, w, h, BLACK16);
         graphics()->drawRect(leftMargin - borderSize, topMargin - borderSize, w, h, borderColor);
 
-        for (uint8_t y = 0; y < qrcode.size; y++) 
-            for (uint8_t x = 0; x < qrcode.size; x++) 
+        for (uint8_t y = 0; y < qrcode.size; y++)
+            for (uint8_t x = 0; x < qrcode.size; x++)
                 graphics()->setPixel(leftMargin + x, topMargin + y, (qrcode_getModule(&qrcode, x, y) ? foregroundColor : BLACK16));
     }
 };

--- a/include/effects/matrix/PatternSerendipity.h
+++ b/include/effects/matrix/PatternSerendipity.h
@@ -102,7 +102,7 @@ public:
     {
     }
 
-    virtual bool Init(std::shared_ptr<GFXBase> gfx[NUM_CHANNELS])   
+    virtual bool Init(std::shared_ptr<GFXBase> gfx[NUM_CHANNELS])
     {
         if (!LEDStripEffect::Init(gfx))
             return false;
@@ -144,7 +144,7 @@ public:
         multiTimer[4].up = MATRIX_HEIGHT - 1;
         multiTimer[4].down = 0;
         multiTimer[4].count = 0;
-    
+
         return true;
     }
 

--- a/include/effects/matrix/PatternSpark.h
+++ b/include/effects/matrix/PatternSpark.h
@@ -57,7 +57,7 @@
 #ifndef PatternSpark_H
 #define PatternSpark_H
 
-class PatternSpark : public LEDStripEffect 
+class PatternSpark : public LEDStripEffect
 {
   private:
 
@@ -89,7 +89,7 @@ class PatternSpark : public LEDStripEffect
       random16_add_entropy( random16());
 
       graphics()->DimAll(235);
-      for (uint8_t x = 0; x < MATRIX_WIDTH; x++) 
+      for (uint8_t x = 0; x < MATRIX_WIDTH; x++)
       {
         // Step 1.  Cool down every cell a little
         for (int y = 0; y < MATRIX_HEIGHT; y++) {
@@ -141,7 +141,7 @@ class PatternSpark : public LEDStripEffect
       effects.MoveFractionalNoiseX(4);
 
       effects.ShowFrame();
-      
+
       return 15;
     }
 };

--- a/include/effects/matrix/PatternSpin.h
+++ b/include/effects/matrix/PatternSpin.h
@@ -76,7 +76,7 @@ public:
     float speed = speedStart;
     float velocity = velocityStart;
 
-    virtual void Start() 
+    virtual void Start()
     {
         speed = speedStart;
         velocity = velocityStart;
@@ -85,8 +85,8 @@ public:
 
     virtual void Draw()
     {
-        graphics()->DimAll(190); 
-        
+        graphics()->DimAll(190);
+
         CRGB color = graphics()->ColorFromCurrentPalette(speed * 8);
 
         // start position

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -37,7 +37,7 @@ class PatternSubscribers : public LEDStripEffect
   private:
 
   public:
-  
+
   PatternSubscribers() : LEDStripEffect(EFFECT_MATRIX_SUBSCRIBERS, "Subs")
   {
   }
@@ -58,7 +58,7 @@ class PatternSubscribers : public LEDStripEffect
 
       // Draw a border around the edge of the panel
       LEDMatrixGFX::backgroundLayer.drawRectangle(0, 1, MATRIX_WIDTH-1, MATRIX_HEIGHT-2, rgb24(160,160,255));
-      
+
       // Draw the channel name
       LEDMatrixGFX::backgroundLayer.drawString(2, 3, rgb24(255,255,255), szChannelName1);
 

--- a/include/effects/matrix/PatternWave.h
+++ b/include/effects/matrix/PatternWave.h
@@ -58,7 +58,7 @@
 #ifndef PatternWave_H
 #define PatternWave_H
 
-class PatternWave : public LEDStripEffect 
+class PatternWave : public LEDStripEffect
 {
 private:
     uint8_t thetaUpdate = 4;

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -151,7 +151,7 @@ private:
             return false;
         }
 
-        DynamicJsonDocument doc(4096);
+        AllocatedJsonDocument doc(4096);
         deserializeJson(doc, http.getStream());
         JsonObject coordinates = configLocationIsZip ? doc.as<JsonObject>() : doc[0].as<JsonObject>();
 
@@ -180,7 +180,7 @@ private:
 
         if (httpResponseCode > 0)
         {
-            DynamicJsonDocument doc(4096);
+            AllocatedJsonDocument doc(4096);
             deserializeJson(doc, http.getStream());
             JsonArray list = doc["list"];
 
@@ -241,7 +241,7 @@ private:
         if (httpResponseCode > 0)
         {
             iconToday = -1;
-            DynamicJsonDocument jsonDoc(4096);
+            AllocatedJsonDocument jsonDoc(4096);
             deserializeJson(jsonDoc, http.getStream());
 
             // Once we have a non-zero temp we can start displaying things

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -325,7 +325,6 @@ public:
     }
 
     // We re-render the entire display every frame
-
     virtual void Draw()
     {
         const int fontHeight = 7;
@@ -378,11 +377,11 @@ public:
         {
             auto filename = pszWeatherIcons[iconTomorrow];
             if (strlen(filename))
-                if (JDR_OK != TJpgDec.drawFsJpg(xHalf+1, 10, filename))        // Draw the image
+                if (JDR_OK != TJpgDec.drawFsJpg(xHalf+1, 10, filename))  // Draw the image
                     debugW("Could not display %s", filename);
         }
 
-        // Print the town/city name, which we looked up via trhe zip code
+        // Print the town/city name
 
         int x = 0;
         int y = fontHeight + 1;

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -140,6 +140,7 @@ private:
         else
             url = "http://api.openweathermap.org/geo/1.0/direct?q=" + configLocation + "," + configCountryCode + "&limit=1&appid=" + g_aptrDeviceConfig->GetOpenWeatherAPIKey();
 
+        http.useHTTP10(true);
         http.begin(url);
         int httpResponseCode = http.GET();
 
@@ -150,9 +151,8 @@ private:
             return false;
         }
 
-        String response = http.getString();
         DynamicJsonDocument doc(4096);
-        deserializeJson(doc, response);
+        deserializeJson(doc, http.getStream());
         JsonObject coordinates = configLocationIsZip ? doc.as<JsonObject>() : doc[0].as<JsonObject>();
 
         strLatitude = coordinates["lat"].as<String>();
@@ -174,14 +174,14 @@ private:
     {
         HTTPClient http;
         String url = "http://api.openweathermap.org/data/2.5/forecast?lat=" + strLatitude + "&lon=" + strLongitude + "&appid=" + g_aptrDeviceConfig->GetOpenWeatherAPIKey();
+        http.useHTTP10(true);
         http.begin(url);
         int httpResponseCode = http.GET();
 
         if (httpResponseCode > 0)
         {
-            String response = http.getString();
             DynamicJsonDocument doc(4096);
-            deserializeJson(doc, response);
+            deserializeJson(doc, http.getStream());
             JsonArray list = doc["list"];
 
             // Get tomorrow's date
@@ -235,14 +235,14 @@ private:
         HTTPClient http;
 
         String url = "http://api.openweathermap.org/data/2.5/weather?lat=" + strLatitude + "&lon=" + strLongitude + "&appid=" + g_aptrDeviceConfig->GetOpenWeatherAPIKey();
+        http.useHTTP10(true);
         http.begin(url);
         int httpResponseCode = http.GET();
         if (httpResponseCode > 0)
         {
             iconToday = -1;
-            String weatherData = http.getString();
             DynamicJsonDocument jsonDoc(4096);
-            deserializeJson(jsonDoc, weatherData);
+            deserializeJson(jsonDoc, http.getStream());
 
             // Once we have a non-zero temp we can start displaying things
             if (0 < jsonDoc["main"]["temp"])

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -114,7 +114,7 @@ private:
     {
         return K - 273.15;
     }
-    
+
     inline float KelvinToLocal(float K)
     {
         if (g_aptrDeviceConfig->UseCelsius())
@@ -123,7 +123,7 @@ private:
             return KelvinToFarenheit(K);
     }
 
-    bool updateCoordinates() 
+    bool updateCoordinates()
     {
         HTTPClient http;
         String url;
@@ -135,7 +135,7 @@ private:
         const String& configCountryCode = g_aptrDeviceConfig->GetCountryCode();
         const bool configLocationIsZip = g_aptrDeviceConfig->IsLocationZip();
 
-        if (configLocationIsZip) 
+        if (configLocationIsZip)
             url = "http://api.openweathermap.org/geo/1.0/zip?zip=" + configLocation + "," + configCountryCode + "&appid=" + g_aptrDeviceConfig->GetOpenWeatherAPIKey();
         else
             url = "http://api.openweathermap.org/geo/1.0/direct?q=" + configLocation + "," + configCountryCode + "&limit=1&appid=" + g_aptrDeviceConfig->GetOpenWeatherAPIKey();
@@ -143,7 +143,7 @@ private:
         http.begin(url);
         int httpResponseCode = http.GET();
 
-        if (httpResponseCode <= 0) 
+        if (httpResponseCode <= 0)
         {
             debugW("Error fetching coordinates for location: %s", configLocation);
             http.end();
@@ -170,14 +170,14 @@ private:
     //
     // Request a forecast and then parse out the high and low temps for tomorrow
 
-    bool getTomorrowTemps(float& highTemp, float& lowTemp) 
+    bool getTomorrowTemps(float& highTemp, float& lowTemp)
     {
         HTTPClient http;
         String url = "http://api.openweathermap.org/data/2.5/forecast?lat=" + strLatitude + "&lon=" + strLongitude + "&appid=" + g_aptrDeviceConfig->GetOpenWeatherAPIKey();
         http.begin(url);
         int httpResponseCode = http.GET();
 
-        if (httpResponseCode > 0) 
+        if (httpResponseCode > 0)
         {
             String response = http.getString();
             DynamicJsonDocument doc(4096);
@@ -191,13 +191,13 @@ private:
             strftime(dateStr, sizeof(dateStr), "%Y-%m-%d", tomorrowTime);
 
             iconTomorrow = -1;
-            
+
             // Look for the temperature data for tomorrow
-            for (size_t i = 0; i < list.size(); ++i) 
+            for (size_t i = 0; i < list.size(); ++i)
             {
                 JsonObject entry = list[i];
                 String dt_txt = entry["dt_txt"];
-                if (dt_txt.startsWith(dateStr)) 
+                if (dt_txt.startsWith(dateStr))
                 {
                     //Serial.printf("Weather: Updating Forecast: %s", response.c_str());
                     JsonObject main = entry["main"];
@@ -205,20 +205,20 @@ private:
                         highTemp        = KelvinToLocal(main["temp_max"]);
                     if (main["temp_min"] > 0)
                         lowTemp         = KelvinToLocal(main["temp_min"]);
-                    
+
                     String iconIdTomorrow = entry["weather"][0]["icon"];
-                    iconTomorrow = iconIdTomorrow.toInt();            
+                    iconTomorrow = iconIdTomorrow.toInt();
                     if (iconTomorrow < 1 || iconTomorrow >= ARRAYSIZE(pszWeatherIcons))
                         iconTomorrow = -1;
 
-                    debugI("Got tomorrow's temps: Lo %d, Hi %d, Icon %d", (int)lowTemp, (int)highTemp, iconTomorrow);                        
+                    debugI("Got tomorrow's temps: Lo %d, Hi %d, Icon %d", (int)lowTemp, (int)highTemp, iconTomorrow);
                     break;
                 }
             }
             http.end();
             return true;
         }
-        else 
+        else
         {
             debugW("Error fetching forecast data for location: %s in country: %s", strLocation.c_str(), strCountryCode.c_str());
             http.end();
@@ -251,7 +251,7 @@ private:
             temperature = KelvinToLocal(jsonDoc["main"]["temp"]);
             highToday   = KelvinToLocal(jsonDoc["main"]["temp_max"]);
             loToday     = KelvinToLocal(jsonDoc["main"]["temp_min"]);
-            
+
             String iconIndex = jsonDoc["weather"][0]["icon"];
             iconToday = iconIndex.toInt();
             debugI("Got today's temps: Now %d Lo %d, Hi %d, Icon %d", (int)temperature, (int)loToday, (int)highToday, iconToday);
@@ -328,7 +328,7 @@ public:
         const int xHalf      = MATRIX_WIDTH / 2 - 1;
 
         graphics()->fillScreen(CRGB(0, 0, 0));
-        graphics()->fillRect(0, 0, MATRIX_WIDTH, 9, graphics()->to16bit(CRGB(0,0,128)));        
+        graphics()->fillRect(0, 0, MATRIX_WIDTH, 9, graphics()->to16bit(CRGB(0,0,128)));
 
         graphics()->setFont(&Apple5x7);
 
@@ -339,15 +339,15 @@ public:
             time_t now;
             time(&now);
 
-            // If location and/or country have changed, trigger an update regardless of timer, but 
+            // If location and/or country have changed, trigger an update regardless of timer, but
             // not more than once every half a minute
             if ((timingObj || HasLocationChanged()) && (now - latestUpdate) >= 30)
             {
                 if (!updateInProgress && nullptr == weatherTask)
-                {   
+                {
                     latestUpdate = now;
                     updateInProgress = true;
-                    
+
                     // Create a thread to update the weather data rather than blocking the draw thread
 
                     debugW("Spawning thread to check weather..");
@@ -368,14 +368,14 @@ public:
             if (strlen(filename))
                 if (JDR_OK != TJpgDec.drawFsJpg(0, 10, filename))        // Draw the image
                     debugW("Could not display %s", filename);
-        }    
+        }
         if (iconTomorrow >= 0)
         {
             auto filename = pszWeatherIcons[iconTomorrow];
             if (strlen(filename))
                 if (JDR_OK != TJpgDec.drawFsJpg(xHalf+1, 10, filename))        // Draw the image
                     debugW("Could not display %s", filename);
-        }    
+        }
 
         // Print the town/city name, which we looked up via trhe zip code
 
@@ -431,7 +431,7 @@ public:
             graphics()->setTextColor(graphics()->to16bit(CRGB(192,192,192)));
             String strHi((int) highToday);
             String strLo((int) loToday);
-        
+
             // Draw today's HI and LO temperatures
 
             x = xHalf - fontWidth * strHi.length();

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -67,7 +67,7 @@ class InsulatorSpectrumEffect : public LEDStripEffect, public BeatEffectBase, pu
 
     virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
-        StaticJsonDocument<512> jsonDoc;
+        AllocatedJsonDocument jsonDoc(512);
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -363,7 +363,7 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeterEffe
 
     virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
-        StaticJsonDocument<512> jsonDoc;
+        AllocatedJsonDocument jsonDoc(512);
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -2,7 +2,7 @@
 //
 // File:        spectrumeffects.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,19 +10,19 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
 //
 // Description:
 //
-//   Classes for moving and fading little render objects over time, 
+//   Classes for moving and fading little render objects over time,
 //   used as a base for the star and insulator effects
 //
 // History:     Jul-7-2021         Davepl      Commented
@@ -46,10 +46,10 @@ class InsulatorSpectrumEffect : public LEDStripEffect, public BeatEffectBase, pu
     int                    _iLastInsulator = 0;
     const CRGBPalette16 & _Palette;
     CRGB _baseColor = CRGB::Black;
-    
+
   public:
 
-    InsulatorSpectrumEffect(const String & strName, const CRGBPalette16 & Palette) : 
+    InsulatorSpectrumEffect(const String & strName, const CRGBPalette16 & Palette) :
         LEDStripEffect(EFFECT_MATRIX_INSULATOR_SPECTRUM, strName),
         BeatEffectBase(1.50, 0.25),
         ParticleSystem<SpinningPaletteRingParticle>(),
@@ -57,7 +57,7 @@ class InsulatorSpectrumEffect : public LEDStripEffect, public BeatEffectBase, pu
     {
     }
 
-    InsulatorSpectrumEffect(const JsonObjectConst& jsonObject) : 
+    InsulatorSpectrumEffect(const JsonObjectConst& jsonObject) :
         LEDStripEffect(jsonObject),
         BeatEffectBase(1.50, 0.25),
         ParticleSystem<SpinningPaletteRingParticle>(),
@@ -65,10 +65,10 @@ class InsulatorSpectrumEffect : public LEDStripEffect, public BeatEffectBase, pu
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<512> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -81,7 +81,7 @@ class InsulatorSpectrumEffect : public LEDStripEffect, public BeatEffectBase, pu
     {
         auto peaks = g_Analyzer.GetPeakData();
 
-        for (int band = 0; band < min(NUM_BANDS, NUM_FANS); band++) 
+        for (int band = 0; band < min(NUM_BANDS, NUM_FANS); band++)
         {
             CRGB color = ColorFromPalette(_Palette, ::map(band, 0, min(NUM_BANDS, NUM_FANS), 0, 255) + beatsin8(1) );
             color = color.fadeToBlackBy(255 - 255 * peaks[band]);
@@ -90,8 +90,8 @@ class InsulatorSpectrumEffect : public LEDStripEffect, public BeatEffectBase, pu
         }
 
         ProcessAudio();
-        ParticleSystem<SpinningPaletteRingParticle>::Render(_GFX);        
-      
+        ParticleSystem<SpinningPaletteRingParticle>::Render(_GFX);
+
         fadeAllChannelsToBlackBy(min(255.0,2000.0 * g_AppTime.DeltaTime()));
     }
 
@@ -103,7 +103,7 @@ class InsulatorSpectrumEffect : public LEDStripEffect, public BeatEffectBase, pu
           iInsulator = random(0, NUM_FANS);
         } while (NUM_FANS > 3 && iInsulator == _iLastInsulator);
         _iLastInsulator = iInsulator;
-        
+
 
         // REVIEW(davepl) This might look interesting if it didn't erase...
         bool bFlash = g_Analyzer._VURatio > 1.99 && span > 1.9 && elapsed > 0.25;
@@ -112,7 +112,7 @@ class InsulatorSpectrumEffect : public LEDStripEffect, public BeatEffectBase, pu
     }
 };
 
-class VUMeterEffect 
+class VUMeterEffect
 {
   protected:
 
@@ -132,12 +132,12 @@ class VUMeterEffect
 
 
     // DrawVUMeter
-    // 
+    //
     // Draws the symmetrical VU meter along with its fading peaks up at the top of the display.
-    
+
     int iPeakVUy = 0;                 // size (in LED pixels) of the VU peak
     unsigned long msPeakVU = 0;       // timestamp in ms when that peak happened so we know how old it is
-    
+
   public:
 
     inline void EraseVUMeter(GFXBase * pGFXChannel, int start, int yVU) const
@@ -234,42 +234,42 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeterEffe
             if (iBar % 4 == 0)
             {
                 value  = g_Analyzer.g_peak1Decay[iBand] * (pGFXChannel->height() - 1);
-                value2 = g_Analyzer.g_peak2Decay[iBand] *  pGFXChannel->height();            
+                value2 = g_Analyzer.g_peak2Decay[iBand] *  pGFXChannel->height();
             }
             else if (iBar % 4 == 1)
             {
                 value  = (g_Analyzer.g_peak1Decay[iBand] * 3 + g_Analyzer.g_peak1Decay[iNextBand] * 1 ) / 4 * (pGFXChannel->height() - 1);
-                value2 = (g_Analyzer.g_peak2Decay[iBand] * 3 + g_Analyzer.g_peak2Decay[iNextBand] * 1 ) / 4 *  pGFXChannel->height();            
+                value2 = (g_Analyzer.g_peak2Decay[iBand] * 3 + g_Analyzer.g_peak2Decay[iNextBand] * 1 ) / 4 *  pGFXChannel->height();
             }
             else if (iBar % 4 == 2)
             {
                 value  = (g_Analyzer.g_peak1Decay[iBand] * 2 + g_Analyzer.g_peak1Decay[iNextBand] * 2 ) / 4 * (pGFXChannel->height() - 1);
-                value2 = (g_Analyzer.g_peak2Decay[iBand] * 2 + g_Analyzer.g_peak2Decay[iNextBand] * 2 ) / 4 *  pGFXChannel->height();            
+                value2 = (g_Analyzer.g_peak2Decay[iBand] * 2 + g_Analyzer.g_peak2Decay[iNextBand] * 2 ) / 4 *  pGFXChannel->height();
             }
             else if (iBar % 4 == 3)
             {
                 value  = (g_Analyzer.g_peak1Decay[iBand] * 1 + g_Analyzer.g_peak1Decay[iNextBand] * 3) / 4 * (pGFXChannel->height() - 1);
-                value2 = (g_Analyzer.g_peak2Decay[iBand] * 1 + g_Analyzer.g_peak2Decay[iNextBand] * 3) / 4 *  pGFXChannel->height();            
+                value2 = (g_Analyzer.g_peak2Decay[iBand] * 1 + g_Analyzer.g_peak2Decay[iNextBand] * 3) / 4 *  pGFXChannel->height();
             }
         }
         else if ((_numBars > NUM_BANDS) && (iBar % 2 == 1))
-        {   
-            // For odd bars, average the bars to the left and right of this one 
+        {
+            // For odd bars, average the bars to the left and right of this one
             value  = ((g_Analyzer.g_peak1Decay[iBand] + g_Analyzer.g_peak1Decay[iNextBand]) / 2) * (pGFXChannel->height() - 1);
-            value2 = ((g_Analyzer.g_peak2Decay[iBand] + g_Analyzer.g_peak2Decay[iNextBand]) / 2) *  pGFXChannel->height();            
+            value2 = ((g_Analyzer.g_peak2Decay[iBand] + g_Analyzer.g_peak2Decay[iNextBand]) / 2) *  pGFXChannel->height();
         }
         else
         {
             // One to one case
             value  = g_Analyzer.g_peak1Decay[iBand] * (pGFXChannel->height() - 1);
-            value2 = g_Analyzer.g_peak2Decay[iBand] *  pGFXChannel->height();            
+            value2 = g_Analyzer.g_peak2Decay[iBand] *  pGFXChannel->height();
         }
 
         debugV("Band: %d, Value: %f\n", iBar, g_Analyzer.g_peak1Decay[iBar] );
 
         if (value > pGFXChannel->height())
             value = pGFXChannel->height();
-    
+
         if (value2 > pGFXChannel->height())
             value2 = pGFXChannel->height();
 
@@ -284,18 +284,18 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeterEffe
                 for (int x = xOffset; x < xOffset + barWidth; x++)
                     graphics()->setPixel(x, y, CRGB::Black);
         }
-        
+
         for (int y = yOffset2; y < pGFXChannel->height(); y++)
             for (int x = xOffset; x < xOffset + barWidth; x++)
                 graphics()->setPixel(x, y, baseColor);
-        
+
         const int PeakFadeTime_ms = 1000;
 
         CRGB colorHighlight = CRGB(CRGB::White);
         unsigned long msPeakAge = millis() - g_Analyzer.g_lastPeak1Time[iBand];
         if (msPeakAge > PeakFadeTime_ms)
             msPeakAge = PeakFadeTime_ms;
-        
+
         float agePercent = (float) msPeakAge / (float) MS_PER_SECOND;
         uint8_t fadeAmount = std::min(255.0f, agePercent * 256);
 
@@ -304,7 +304,7 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeterEffe
         if (value == 0)
             colorHighlight = baseColor;
 
-        // if decay rate is less than zero we interpret that here to mean "don't draw it at all".  
+        // if decay rate is less than zero we interpret that here to mean "don't draw it at all".
 
         if (_peak1DecayRate >= 0.0f)
             pGFXChannel->drawLine(xOffset, max(0, yOffset-1), xOffset + barWidth - 1, max(0, yOffset-1), colorHighlight);
@@ -312,17 +312,17 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeterEffe
 
   public:
 
-    SpectrumAnalyzerEffect(const char   * pszFriendlyName, 
+    SpectrumAnalyzerEffect(const char   * pszFriendlyName,
                            int                    cNumBars = 12,
-                           const CRGBPalette16  & palette = spectrumBasicColors, 
-                           uint16_t           scrollSpeed = 0, 
+                           const CRGBPalette16  & palette = spectrumBasicColors,
+                           uint16_t           scrollSpeed = 0,
                            uint8_t               fadeRate = 0,
                            float           peak1DecayRate = 1.0,
                            float           peak2DecayRate = 1.0)
         : LEDStripEffect(EFFECT_MATRIX_SPECTRUM_ANALYZER, pszFriendlyName),
           _numBars(cNumBars),
           _colorOffset(0),
-          _scrollSpeed(scrollSpeed), 
+          _scrollSpeed(scrollSpeed),
           _fadeRate(fadeRate),
           _palette(palette),
           _peak1DecayRate(peak1DecayRate),
@@ -330,16 +330,16 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeterEffe
     {
     }
 
-    SpectrumAnalyzerEffect(const char   * pszFriendlyName, 
+    SpectrumAnalyzerEffect(const char   * pszFriendlyName,
                            int                    cNumBars = 12,
-                           const CRGB &          baseColor = CRGB::Red, 
+                           const CRGB &          baseColor = CRGB::Red,
                            uint8_t                fadeRate = 0,
                            float            peak1DecayRate = 1.0,
                            float            peak2DecayRate = 1.0)
-        : LEDStripEffect(EFFECT_MATRIX_SPECTRUM_ANALYZER, pszFriendlyName), 
+        : LEDStripEffect(EFFECT_MATRIX_SPECTRUM_ANALYZER, pszFriendlyName),
           _numBars(cNumBars),
           _colorOffset(0),
-          _scrollSpeed(0), 
+          _scrollSpeed(0),
           _fadeRate(fadeRate),
           _palette(baseColor),
           _peak1DecayRate(peak1DecayRate),
@@ -349,10 +349,10 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeterEffe
     }
 
     SpectrumAnalyzerEffect(const JsonObjectConst& jsonObject)
-        : LEDStripEffect(jsonObject), 
+        : LEDStripEffect(jsonObject),
           _numBars(jsonObject["nmb"]),
           _colorOffset(0),
-          _scrollSpeed(jsonObject[PTY_SPEED]), 
+          _scrollSpeed(jsonObject[PTY_SPEED]),
           _fadeRate(jsonObject["frt"]),
           _palette(jsonObject[PTY_PALETTE].as<CRGBPalette16>()),
           _peak1DecayRate(jsonObject["pd1"]),
@@ -361,10 +361,10 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeterEffe
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<512> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -400,7 +400,7 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeterEffe
 
         //if (_bShowVU)
         //    DrawVUMeter(pGFXChannel, 0);
-        
+
         for (int i = 0; i < _numBars; i++)
         {
             // We don't use the auto-cycling palette, but we'll use the paused palette if the user has asked for one
@@ -432,23 +432,23 @@ class WaveformEffect : public LEDStripEffect
     unsigned long                _msPeakVU = 0;
 
   public:
-    
-    WaveformEffect(const String & pszFriendlyName, uint8_t increment = 0) 
+
+    WaveformEffect(const String & pszFriendlyName, uint8_t increment = 0)
         : LEDStripEffect(EFFECT_MATRIX_WAVEFORM, pszFriendlyName),
           _increment(increment)
     {
     }
 
-    WaveformEffect(const JsonObjectConst& jsonObject) 
+    WaveformEffect(const JsonObjectConst& jsonObject)
         : LEDStripEffect(jsonObject),
           _increment(jsonObject["inc"])
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<128> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -457,7 +457,7 @@ class WaveformEffect : public LEDStripEffect
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
-    void DrawSpike(int x, float v, bool bErase = true) 
+    void DrawSpike(int x, float v, bool bErase = true)
     {
         v = std::min(v, 1.0f);
         v = std::max(v, 0.0f);
@@ -485,11 +485,11 @@ class WaveformEffect : public LEDStripEffect
                 if (y < 2 || y > (MATRIX_HEIGHT - 2))
                     color  = CRGB::Red;
                 else
-                    color = g->ColorFromCurrentPalette(255-index + ms / 11, 255, LINEARBLEND); 
+                    color = g->ColorFromCurrentPalette(255-index + ms / 11, 255, LINEARBLEND);
             }
 
             bErase ? g->setPixel(x, y, color) : g->drawPixel(x, y, color);
-            
+
         }
         _iColorOffset = (_iColorOffset + _increment) % 255;
 
@@ -504,7 +504,7 @@ class WaveformEffect : public LEDStripEffect
     virtual void Draw()
     {
         auto g = g_aptrEffectManager->graphics();
-        
+
         int top = g_aptrEffectManager->IsVUVisible() ? 1 : 0;
         g->MoveInwardX(top);                            // Start on Y=1 so we don't shift the VU meter
         DrawSpike(63, g_Analyzer._VURatio/2.0);
@@ -524,7 +524,7 @@ class GhostWave : public WaveformEffect
     }
   public:
 
-    GhostWave(const String & pszFriendlyName, uint8_t increment = 0, uint8_t blur = 0, bool erase = true, int fade = 20) 
+    GhostWave(const String & pszFriendlyName, uint8_t increment = 0, uint8_t blur = 0, bool erase = true, int fade = 20)
         : WaveformEffect(pszFriendlyName, increment),
           _blur(blur),
           _erase(erase),
@@ -533,7 +533,7 @@ class GhostWave : public WaveformEffect
         construct();
     }
 
-    GhostWave(const JsonObjectConst& jsonObject) 
+    GhostWave(const JsonObjectConst& jsonObject)
         : WaveformEffect(jsonObject),
           _blur(jsonObject[PTY_BLUR]),
           _erase(jsonObject[PTY_ERASE]),
@@ -542,10 +542,10 @@ class GhostWave : public WaveformEffect
         construct();
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<128> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -579,7 +579,7 @@ class GhostWave : public WaveformEffect
 
         if (_blur)
             g->blurRows(g->leds, MATRIX_WIDTH, MATRIX_HEIGHT, 0, _blur);
-        
+
         // VURatio is too fast, VURatioFade looks too slow, but averaged is just right
 
         float audioLevel = (g_Analyzer._VURatioFade + g_Analyzer._VURatio) / 2;

--- a/include/effects/strip/bouncingballeffect.h
+++ b/include/effects/strip/bouncingballeffect.h
@@ -2,7 +2,7 @@
 //
 // File:        BouncingBallEffect.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -25,7 +25,7 @@
 //    Draws bouncing balls using a kinematics formula
 //
 // History:     Apr-17-2019         Davepl      Adapted from NightDriver
-//              
+//
 //---------------------------------------------------------------------------
 
 #pragma once
@@ -64,14 +64,14 @@ private:
     float Gravity = -9.81;
     float StartHeight = 1;
     float ImpactVelocityStart = sqrt(-2 * Gravity * StartHeight);
-    
+
     std::vector<float> ClockTimeSinceLastBounce;
     std::vector<float> TimeSinceLastBounce;
     std::vector<float> Height;
     std::vector<float> ImpactVelocity;
     std::vector<float> Dampening;
     std::vector<CRGB>   Colors;
-    
+
   public:
 
     BouncingBallEffect(size_t ballCount = 3, bool bMirrored = true, bool bErase = false, int ballSize = 5)
@@ -83,7 +83,7 @@ private:
     {
     }
 
-    BouncingBallEffect(const JsonObjectConst&  jsonObject) 
+    BouncingBallEffect(const JsonObjectConst&  jsonObject)
         : LEDStripEffect(jsonObject),
           _cBalls(jsonObject["blc"]),
           _cBallSize(jsonObject["bls"]),
@@ -92,10 +92,10 @@ private:
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<128> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -134,14 +134,14 @@ private:
             Dampening[i]                = 1.0 - i / pow(_cBalls, 2);               // Was 0.9
             TimeSinceLastBounce[i]      = 0;
             Colors[i]                   = ballColors[i % ARRAYSIZE(ballColors)];
-        }           
-        return true; 
+        }
+        return true;
     }
 
     // Draw
     //
     // Draw each of the balls.  When any ball gets too little energy it would just sit at the base so it is re-kicked with new energy.#pragma endregion
-    
+
     virtual void Draw()
     {
         // Erase the drawing area
@@ -153,13 +153,13 @@ private:
         {
             for (int j = 0; j<_cLength; j++)                            // fade brightness all LEDs one step
             {
-                if (randomfloat(0, 10)>5) 
+                if (randomfloat(0, 10)>5)
                 {
                     CRGB c = _GFX[0]->getPixel(j);
                     c.fadeToBlackBy(10);
                     setPixelsOnAllChannels(j, 1, c, false);
                 }
-            }            
+            }
         }
 
         // Draw each of the the balls

--- a/include/effects/strip/doublepaletteeffect.h
+++ b/include/effects/strip/doublepaletteeffect.h
@@ -2,7 +2,7 @@
 //
 // File:        DoublePaletteEffect.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -25,7 +25,7 @@
 //    Draws two intersecting palettes
 //
 // History:     Apr-16-2019         Davepl      Created
-//              
+//
 //---------------------------------------------------------------------------
 
 #pragma once
@@ -37,20 +37,20 @@ extern AppTime g_AppTime;
 class DoublePaletteEffect : public LEDStripEffect
 {
   private:
-    
+
     PaletteEffect   _PaletteEffect1;
     PaletteEffect   _PaletteEffect2;
 
   public:
-  
-    DoublePaletteEffect() 
+
+    DoublePaletteEffect()
      :  LEDStripEffect(EFFECT_STRIP_DOUBLE_PALETTE, "Double Palette"),
         _PaletteEffect1(RainbowColors_p, 1.0,  0.03,  4.0, 3, 3, LINEARBLEND, false, 0.5),
         _PaletteEffect2(RainbowColors_p, 1.0, -0.03, -4.0, 3, 3, LINEARBLEND, false, 0.5)
     {
     }
 
-    DoublePaletteEffect(const JsonObjectConst&  jsonObject) 
+    DoublePaletteEffect(const JsonObjectConst&  jsonObject)
       : LEDStripEffect(jsonObject),
         _PaletteEffect1(jsonObject["pt1"].as<JsonObjectConst>()),
         _PaletteEffect2(jsonObject["pt2"].as<JsonObjectConst>())
@@ -72,7 +72,7 @@ class DoublePaletteEffect : public LEDStripEffect
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
-    virtual bool Init(std::shared_ptr<GFXBase> gfx[NUM_CHANNELS])   
+    virtual bool Init(std::shared_ptr<GFXBase> gfx[NUM_CHANNELS])
     {
         LEDStripEffect::Init(gfx);
         if (!_PaletteEffect1.Init(gfx) || !_PaletteEffect2.Init(gfx))
@@ -80,7 +80,7 @@ class DoublePaletteEffect : public LEDStripEffect
         return true;
     }
 
-    virtual void Draw() 
+    virtual void Draw()
     {
         setAllOnAllChannels(0,0,0);
         _PaletteEffect1.Draw();

--- a/include/effects/strip/doublepaletteeffect.h
+++ b/include/effects/strip/doublepaletteeffect.h
@@ -59,7 +59,7 @@ class DoublePaletteEffect : public LEDStripEffect
 
     virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
-        DynamicJsonDocument jsonDoc(896);
+        AllocatedJsonDocument jsonDoc(896);
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -704,7 +704,7 @@ public:
 
   virtual bool SerializeToJSON(JsonObject& jsonObject)
   {
-    StaticJsonDocument<512> jsonDoc;
+    AllocatedJsonDocument jsonDoc(512);
 
     JsonObject root = jsonDoc.to<JsonObject>();
     LEDStripEffect::SerializeToJSON(root);
@@ -1025,7 +1025,7 @@ public:
 
   virtual bool SerializeToJSON(JsonObject& jsonObject)
   {
-    StaticJsonDocument<512> jsonDoc;
+    AllocatedJsonDocument jsonDoc(512);
 
     jsonDoc[PTY_PALETTE] = Palette;
     jsonDoc[PTY_LEDCOUNT] = LEDCount;

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -91,7 +91,7 @@ inline int16_t GetRingPixelPosition(float fPos, int16_t ringSize)
     debugW("GetRingPixelPosition called with negative value %f", fPos);
     return 0;
   }
-  
+
   int pos = fPos;
   if (pos & 1)
     return ringSize - 1 - pos / 2;
@@ -586,11 +586,11 @@ private:
 public:
   PaletteReelEffect(const String & strName) : LEDStripEffect(EFFECT_STRIP_PALETTE_REEL, strName)
   {
-  } 
+  }
 
   PaletteReelEffect(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
   {
-  } 
+  }
 
   virtual void Draw()
   {
@@ -687,25 +687,25 @@ private:
 
 public:
   PaletteSpinEffect(const String &strName, const CRGBPalette16 &palette, bool bReplace, float sparkleChance = 0.0)
-      : LEDStripEffect(EFFECT_STRIP_PALETTE_SPIN, strName), 
-        _Palette(palette), 
-        _bReplaceMagenta(bReplace), 
+      : LEDStripEffect(EFFECT_STRIP_PALETTE_SPIN, strName),
+        _Palette(palette),
+        _bReplaceMagenta(bReplace),
         _sparkleChance(sparkleChance)
   {
   }
 
   PaletteSpinEffect(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject), 
-        _Palette(jsonObject[PTY_PALETTE].as<CRGBPalette16>()), 
-        _bReplaceMagenta(jsonObject["rpm"]), 
+      : LEDStripEffect(jsonObject),
+        _Palette(jsonObject[PTY_PALETTE].as<CRGBPalette16>()),
+        _bReplaceMagenta(jsonObject["rpm"]),
         _sparkleChance(jsonObject["sch"])
   {
   }
 
-  virtual bool SerializeToJSON(JsonObject& jsonObject) 
+  virtual bool SerializeToJSON(JsonObject& jsonObject)
   {
     StaticJsonDocument<512> jsonDoc;
-    
+
     JsonObject root = jsonDoc.to<JsonObject>();
     LEDStripEffect::SerializeToJSON(root);
 
@@ -763,24 +763,24 @@ class ColorCycleEffect : public LEDStripEffect
 public:
   using LEDStripEffect::LEDStripEffect;
 
-  ColorCycleEffect(PixelOrder order = Sequential, int step = 8) 
-    : LEDStripEffect(EFFECT_STRIP_COLOR_CYCLE, "ColorCylceEffect"), 
-      _order(order), 
+  ColorCycleEffect(PixelOrder order = Sequential, int step = 8)
+    : LEDStripEffect(EFFECT_STRIP_COLOR_CYCLE, "ColorCylceEffect"),
+      _order(order),
       _step(step)
   {
   }
 
-  ColorCycleEffect(const JsonObjectConst& jsonObject) 
-    : LEDStripEffect(jsonObject), 
-      _order((PixelOrder)jsonObject[PTY_ORDER]), 
+  ColorCycleEffect(const JsonObjectConst& jsonObject)
+    : LEDStripEffect(jsonObject),
+      _order((PixelOrder)jsonObject[PTY_ORDER]),
       _step(jsonObject["stp"])
   {
   }
 
-  virtual bool SerializeToJSON(JsonObject& jsonObject) 
+  virtual bool SerializeToJSON(JsonObject& jsonObject)
   {
     StaticJsonDocument<128> jsonDoc;
-    
+
     JsonObject root = jsonDoc.to<JsonObject>();
     LEDStripEffect::SerializeToJSON(root);
 
@@ -1023,10 +1023,10 @@ public:
     abHeat = std::make_unique<uint8_t[]>(CellCount());
   }
 
-  virtual bool SerializeToJSON(JsonObject& jsonObject) 
+  virtual bool SerializeToJSON(JsonObject& jsonObject)
   {
     StaticJsonDocument<512> jsonDoc;
-    
+
     jsonDoc[PTY_PALETTE] = Palette;
     jsonDoc[PTY_LEDCOUNT] = LEDCount;
     jsonDoc[PTY_CELLSPERLED] = CellsPerLED;
@@ -1271,21 +1271,21 @@ protected:
 
   // Generate a vector of how bright each of the surrounding 8 LEDs on the unit circle should be
 
-  std::vector<float> led_brightness(float wandering_x, float wandering_y) 
+  std::vector<float> led_brightness(float wandering_x, float wandering_y)
   {
-    constexpr float sqrt2 = std::sqrt(2);  
+    constexpr float sqrt2 = std::sqrt(2);
 
     const std::vector<std::pair<float, float>> unit_circle_coords = {
-        {1, 0},  
+        {1, 0},
         { 1 / sqrt2,  1 / sqrt2},
-        {0, 1},  
+        {0, 1},
         {-1 / sqrt2,  1 / sqrt2},
-        {-1, 0}, 
+        {-1, 0},
         {-1 / sqrt2, -1 / sqrt2},
-        {0, -1}, 
+        {0, -1},
         { 1 / sqrt2, -1 / sqrt2}
     };
-    
+
     std::vector<float> brightness_values;
 
     for (const auto& coord : unit_circle_coords) {
@@ -1363,7 +1363,7 @@ public:
 
       velocityX -= centerX;
       velocityY -= centerY;
-    
+
 
     rotation += 0.0;
 
@@ -1374,7 +1374,7 @@ public:
 
     float xRatio = map(centerX, 0.0f, maxDeviation, -1.0f, 1.0f);
     float yRatio = map(centerY, 0.0f, maxDeviation, -1.0f, 1.0f);
-    
+
     auto brightness = led_brightness(xRatio, yRatio);
     for (int i = 0; i < 8; i++)
     {

--- a/include/effects/strip/fireeffect.h
+++ b/include/effects/strip/fireeffect.h
@@ -248,7 +248,7 @@ public:
 
     virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
-        StaticJsonDocument<512> jsonDoc;
+        AllocatedJsonDocument jsonDoc(512);
 
         JsonObject root = jsonDoc.to<JsonObject>();
         FireEffect::SerializeToJSON(jsonObject);

--- a/include/effects/strip/fireeffect.h
+++ b/include/effects/strip/fireeffect.h
@@ -2,7 +2,7 @@
 //
 // File:        FireEffect.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -37,7 +37,7 @@
 extern AppTime g_AppTime;
 class FireEffect : public LEDStripEffect
 {
-    void construct() 
+    void construct()
     {
         heat = std::make_unique<uint8_t []>(CellCount());
     }
@@ -64,7 +64,7 @@ class FireEffect : public LEDStripEffect
 
     static const uint8_t BlendTotal = (BlendSelf + BlendNeighbor1 + BlendNeighbor2 + BlendNeighbor3);
 
-    int CellCount() const { return LEDCount * CellsPerLED; } 
+    int CellCount() const { return LEDCount * CellsPerLED; }
 
   public:
 
@@ -99,10 +99,10 @@ class FireEffect : public LEDStripEffect
         construct();
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<128> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -126,12 +126,12 @@ class FireEffect : public LEDStripEffect
     {
         return 45;
     }
-    
+
     virtual CRGB GetBlackBodyHeatColor(float temp)
     {
         temp *= 255;
         uint8_t t192 = round((temp/255.0)*191);
- 
+
         // calculate ramp up from
         uint8_t heatramp = t192 & 0x3F; // 0..63
         heatramp <<= 2; // scale up to 0..252
@@ -142,7 +142,7 @@ class FireEffect : public LEDStripEffect
         } else if( t192 > 0x40 ) {             // middle
             return CRGB( 255, heatramp, 0);
         } else {                               // coolest
-            return CRGB( heatramp, 0, 0);     
+            return CRGB( heatramp, 0, 0);
         }
     }
 
@@ -163,7 +163,7 @@ class FireEffect : public LEDStripEffect
             }
         }
     }
-    
+
     virtual void DrawFire()
     {
         // First cool each cell by a little bit
@@ -204,7 +204,7 @@ class FireEffect : public LEDStripEffect
 
             // If we're reversed, we work from the end back.  We don't reverse the bonus pixels
 
-            
+
             int j = (!bReversed) ? i : LEDCount - 1 - i;
             setPixelsOnAllChannels(j, 1, color, false);
             //if (bMirrored)
@@ -217,7 +217,7 @@ class PaletteFlameEffect : public FireEffect
 {
     CRGBPalette16 _palette;
 
-    void construct() 
+    void construct()
     {
         _effectNumber = EFFECT_STRIP_PALETTE_FLAME;
     }
@@ -246,10 +246,10 @@ public:
         construct();
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<512> jsonDoc;
- 
+
         JsonObject root = jsonDoc.to<JsonObject>();
         FireEffect::SerializeToJSON(jsonObject);
 
@@ -291,13 +291,13 @@ class MusicalPaletteFire : public PaletteFlameEffect, protected BeatEffectBase
                        bool mirrored = false)
         :   BeatEffectBase(1.00, 0.01),
             PaletteFlameEffect(strName, palette, ledCount, cellsPerLED, cooling, sparking, sparks, sparkHeight, reversed, mirrored)
-          
+
     {
         construct();
     }
 
-    MusicalPaletteFire(const JsonObjectConst& jsonObject) 
-        : BeatEffectBase(1.00, 0.01), 
+    MusicalPaletteFire(const JsonObjectConst& jsonObject)
+        : BeatEffectBase(1.00, 0.01),
           PaletteFlameEffect(jsonObject)
     {
         construct();
@@ -333,7 +333,7 @@ class ClassicFireEffect : public LEDStripEffect
 
 public:
 
-    ClassicFireEffect(bool mirrored = false, bool reversed = false, int cooling = 5) 
+    ClassicFireEffect(bool mirrored = false, bool reversed = false, int cooling = 5)
         : LEDStripEffect(EFFECT_STRIP_CLASSIC_FIRE, "Classic Fire"),
           _Mirrored(mirrored),
           _Reversed(reversed),
@@ -341,7 +341,7 @@ public:
     {
     }
 
-    ClassicFireEffect(const JsonObjectConst& jsonObject) 
+    ClassicFireEffect(const JsonObjectConst& jsonObject)
         : LEDStripEffect(jsonObject),
           _Mirrored(jsonObject[PTY_MIRORRED]),
           _Reversed(jsonObject[PTY_REVERSED]),
@@ -349,10 +349,10 @@ public:
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<128> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -440,7 +440,7 @@ public:
                 setPixelOnAllChannels(_cLEDs - 1 - Pixel, temperature);
             else
                 setPixelOnAllChannels(Pixel, temperature);
-        } 
+        }
     }
 
     void setPixelHeatColor(int Pixel, uint8_t temperature)
@@ -524,10 +524,10 @@ public:
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<128> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -625,7 +625,7 @@ public:
     {
         if (_Reversed || _Mirrored)
             setPixelOnAllChannels(Pixel, temperature);
-        
+
         if (!_Reversed || _Mirrored)
             setPixelOnAllChannels(_cLEDs - 1 - Pixel, temperature);
     }
@@ -678,7 +678,7 @@ class BaseFireEffect : public LEDStripEffect
         construct();
     }
 
-    BaseFireEffect(const JsonObjectConst& jsonObject) 
+    BaseFireEffect(const JsonObjectConst& jsonObject)
         : LEDStripEffect(jsonObject),
           Cooling(jsonObject[PTY_COOLING]),
           Sparks(jsonObject[PTY_SPARKS]),
@@ -696,10 +696,10 @@ class BaseFireEffect : public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<128> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -718,7 +718,7 @@ class BaseFireEffect : public LEDStripEffect
     virtual CRGB MapHeatToColor(uint8_t temperature)
     {
         uint8_t t192 = round((temperature/255.0)*191);
- 
+
         // calculate ramp up from
         uint8_t heatramp = t192 & 0x3F; // 0..63
         heatramp <<= 2; // scale up to 0..252
@@ -729,7 +729,7 @@ class BaseFireEffect : public LEDStripEffect
         } else if( t192 > 0x40 ) {             // middle
             return CRGB( 255, heatramp, 0);
         } else {                               // coolest
-            return CRGB( heatramp, 0, 0);     
+            return CRGB( heatramp, 0, 0);
         }
     }
 

--- a/include/effects/strip/laserline.h
+++ b/include/effects/strip/laserline.h
@@ -2,7 +2,7 @@
 //
 // File:        LaserLine.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -26,7 +26,7 @@
 //    Sound reactive laser "shot" that travels down a strip
 //
 // History:     Apr-16-2019         Davepl      Created
-//              
+//
 //---------------------------------------------------------------------------
 
 #pragma once
@@ -39,7 +39,7 @@ class LaserShot
     float         _speed    = 10.0;
     float         _size     = 10.0;
     uint8_t       _hue      = 0;
-    
+
 public:
 
     LaserShot(float position, float speed, float size, uint8_t hue)
@@ -75,27 +75,27 @@ class LaserLineEffect : public BeatEffectBase, public LEDStripEffect
     float                      _defaultSpeed;
 
   public:
-  
-    LaserLineEffect(float speed, float size) 
-        : BeatEffectBase(1.50, 0.00), 
-          LEDStripEffect(EFFECT_STRIP_LASER_LINE, "LaserLine"), 
-          _defaultSize(size), 
-          _defaultSpeed(speed) 
+
+    LaserLineEffect(float speed, float size)
+        : BeatEffectBase(1.50, 0.00),
+          LEDStripEffect(EFFECT_STRIP_LASER_LINE, "LaserLine"),
+          _defaultSize(size),
+          _defaultSpeed(speed)
     {
     }
 
-    LaserLineEffect(const JsonObjectConst& jsonObject) 
-        : BeatEffectBase(1.50, 0.00), 
-          LEDStripEffect(jsonObject), 
-          _defaultSize(jsonObject[PTY_SIZE]), 
-          _defaultSpeed(jsonObject[PTY_SPEED]) 
+    LaserLineEffect(const JsonObjectConst& jsonObject)
+        : BeatEffectBase(1.50, 0.00),
+          LEDStripEffect(jsonObject),
+          _defaultSize(jsonObject[PTY_SIZE]),
+          _defaultSpeed(jsonObject[PTY_SPEED])
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<128> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -105,7 +105,7 @@ class LaserLineEffect : public BeatEffectBase, public LEDStripEffect
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
-    virtual bool Init(std::shared_ptr<GFXBase> gfx[NUM_CHANNELS])   
+    virtual bool Init(std::shared_ptr<GFXBase> gfx[NUM_CHANNELS])
     {
         debugW("Initialized LaserLine Effect");
         _gfx = gfx[0];
@@ -114,20 +114,20 @@ class LaserLineEffect : public BeatEffectBase, public LEDStripEffect
         return true;
     }
 
-    virtual void Draw() 
+    virtual void Draw()
     {
         ProcessAudio();
-        
+
         fadeAllChannelsToBlackBy(200);
 
         auto it = _shots.begin();
-        while(it != _shots.end()) 
+        while(it != _shots.end())
         {
             it->Draw(_gfx);
             if (!it->Update(g_AppTime.DeltaTime()))
                 _shots.erase(it);
             else
-                it++;                
+                it++;
         }
     }
 

--- a/include/effects/strip/meteoreffect.h
+++ b/include/effects/strip/meteoreffect.h
@@ -2,7 +2,7 @@
 //
 // File:        MeteorPaletteEffect.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -26,7 +26,7 @@
 //    Draws flying meteors
 //
 // History:     Apr-16-2019         Davepl      Created
-//              
+//
 //---------------------------------------------------------------------------
 
 #pragma once
@@ -51,9 +51,9 @@ public:
     bool          meteorRandomDecay = true;
     const float  minTimeBetweenBeats = 0.6;
 
-    MeteorChannel() 
+    MeteorChannel()
     {
-    
+
     }
 
     virtual void Init(std::shared_ptr<GFXBase> pGFX, size_t meteors = 4, uint size = 4, uint decay = 3, float minSpeed = 0.5, float maxSpeed = 0.5)
@@ -97,7 +97,7 @@ public:
 
         for (int j = 0; j<pGFX->GetLEDCount(); j++)                         // fade brightness all LEDs one step
         {
-            if ((!meteorRandomDecay) || (randomfloat(0, 10)>2))            // BUGBUG Was 5 for everything before atomlight 
+            if ((!meteorRandomDecay) || (randomfloat(0, 10)>2))            // BUGBUG Was 5 for everything before atomlight
             {
                 CRGB c = pGFX->getPixel(j);
                 c.fadeToBlackBy(meteorTrailDecay);
@@ -106,7 +106,7 @@ public:
         }
 
             // If there's a beat to the music in a band, reverse the direction of the meteor indexed by the same number
-        /*          
+        /*
         if (g_Beats.IsBeat[0] && (g_AppTime.FrameStartTime() - lastBeat[0] > minTimeBetweenBeats))
         {
             lastBeat[0] = g_AppTime.FrameStartTime();
@@ -117,7 +117,7 @@ public:
         for (int i = 0; i < meteorCount; i++)
         {
             float spd = speed[i];
-            
+
             #if ENABLE_AUDIO
                 if (g_Analyzer._VURatio > 1.0)
                     spd *= g_Analyzer._VURatio;
@@ -138,7 +138,7 @@ public:
             for (int j = 0; j < meteorSize; j++)                    // Draw the meteor head
             {
                 int x = iPos[i] - j;
-                if ((x <= pGFX->GetLEDCount()) && (x >= 1)) 
+                if ((x <= pGFX->GetLEDCount()) && (x >= 1))
                 {
                     CRGB rgb;
                     hue[i] = hue[i] + 0.025f;
@@ -168,9 +168,9 @@ class MeteorEffect : public LEDStripEffect
     float          _meteorSpeedMax;
 
   public:
-  
-    MeteorEffect(int cMeteors = 4, uint size = 4, uint decay = 3, float minSpeed = 0.2, float maxSpeed = 0.2) 
-        : LEDStripEffect(EFFECT_STRIP_METEOR, "Color Meteors"), 
+
+    MeteorEffect(int cMeteors = 4, uint size = 4, uint decay = 3, float minSpeed = 0.2, float maxSpeed = 0.2)
+        : LEDStripEffect(EFFECT_STRIP_METEOR, "Color Meteors"),
           _Meteors(),
           _cMeteors(cMeteors),
           _meteorSize(size),
@@ -180,8 +180,8 @@ class MeteorEffect : public LEDStripEffect
     {
     }
 
-    MeteorEffect(const JsonObjectConst& jsonObject) 
-        : LEDStripEffect(jsonObject), 
+    MeteorEffect(const JsonObjectConst& jsonObject)
+        : LEDStripEffect(jsonObject),
           _Meteors(),
           _cMeteors(jsonObject["mto"]),
           _meteorSize(jsonObject[PTY_SIZE]),
@@ -191,10 +191,10 @@ class MeteorEffect : public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<128> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -207,7 +207,7 @@ class MeteorEffect : public LEDStripEffect
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
-    virtual bool Init(std::shared_ptr<GFXBase> gfx[NUM_CHANNELS])   
+    virtual bool Init(std::shared_ptr<GFXBase> gfx[NUM_CHANNELS])
     {
         _gfx = gfx;
         if (!LEDStripEffect::Init(gfx))
@@ -217,7 +217,7 @@ class MeteorEffect : public LEDStripEffect
         return true;
     }
 
-    virtual void Draw() 
+    virtual void Draw()
     {
         for (int i = 0; i < ARRAYSIZE(_Meteors); i++)
             _Meteors[i].Draw(_gfx[i]);

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -2,7 +2,7 @@
 //
 // File:        misceffects.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -26,7 +26,7 @@
 //    Draws bouncing balls using a kinematics formula
 //
 // History:     Apr-17-2019         Davepl      Adapted from NightDriver
-//              
+//
 //---------------------------------------------------------------------------
 
 #pragma once
@@ -44,7 +44,7 @@ class SimpleRainbowTestEffect : public LEDStripEffect
     uint8_t     _SpeedDivisor;
 
   public:
-  
+
     SimpleRainbowTestEffect(uint8_t speedDivisor = 8, uint8_t everyNthPixel = 12)
       : LEDStripEffect(EFFECT_STRIP_SIMPLE_RAINBOW_TEST, "Simple Rainbow"),
           _EveryNth(everyNthPixel),
@@ -61,10 +61,10 @@ class SimpleRainbowTestEffect : public LEDStripEffect
         debugV("SimpleRainbowTestEffect JSON constructor");
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<128> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -74,11 +74,11 @@ class SimpleRainbowTestEffect : public LEDStripEffect
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
-    virtual void Draw() 
+    virtual void Draw()
     {
         fillRainbowAllChannels(0, _cLEDs, beatsin16(4, 0, 256), 8, _EveryNth);
         delay(10);
-    }   
+    }
 };
 
 // SimpleRainbowTestEffect
@@ -92,7 +92,7 @@ class RainbowTwinkleEffect : public LEDStripEffect
     int   _deltaHue;
 
   public:
-  
+
     RainbowTwinkleEffect(float speedDivisor = 12.0f, int deltaHue = 14)
       : LEDStripEffect(EFFECT_STRIP_RAINBOW_TWINKLE, "Rainbow Twinkle"),
         _speedDivisor(speedDivisor),
@@ -109,10 +109,10 @@ class RainbowTwinkleEffect : public LEDStripEffect
         debugV("RainbowFill JSON constructor");
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<128> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -155,7 +155,7 @@ protected:
     int   _deltaHue;
 
   public:
-    
+
     RainbowFillEffect(float speedDivisor = 12.0f, int deltaHue = 14)
       : LEDStripEffect(EFFECT_STRIP_RAINBOW_FILL, "RainobwFill Rainbow"),
         _speedDivisor(speedDivisor),
@@ -172,10 +172,10 @@ protected:
         debugV("RainbowFill JSON constructor");
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<128> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -215,7 +215,7 @@ protected:
     CRGB _color;
 
   public:
-    
+
     ColorFillEffect(CRGB color = CRGB(246,200,160), int everyNth = 10)
       : LEDStripEffect(EFFECT_STRIP_COLOR_FILL, "Color Fill"),
         _everyNth(everyNth),
@@ -232,10 +232,10 @@ protected:
         debugV("Color Fill JSON constructor");
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<128> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -248,13 +248,13 @@ protected:
     virtual void Draw()
     {
         if (_everyNth != 1)
-          fillSolidOnAllChannels(CRGB::Black);                    
+          fillSolidOnAllChannels(CRGB::Black);
         fillSolidOnAllChannels(_color);
     }
 };
 
 // SplashLogoEffect
-// 
+//
 // Displays the NightDriver logo on the screen
 
 static const char * pszLogoFile = "/bmp/LowResLogo.jpg";
@@ -262,7 +262,7 @@ static const char * pszLogoFile = "/bmp/LowResLogo.jpg";
 class SplashLogoEffect : public LEDStripEffect
 {
   public:
-    
+
     SplashLogoEffect()
       : LEDStripEffect(EFFECT_STRIP_SPLASH_LOGO, "NightDriver")
     {
@@ -301,7 +301,7 @@ class StatusEffect : public LEDStripEffect
     CRGB _color;
 
   public:
-    
+
     StatusEffect(CRGB color = CRGB(255,255,255), int everyNth = 10)     // Warmer: CRGB(246,200,160)
       : LEDStripEffect(EFFECT_STRIP_STATUS, "Status Fill"),
         _everyNth(everyNth),
@@ -318,10 +318,10 @@ class StatusEffect : public LEDStripEffect
         debugV("Status Fill JSON constructor");
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<128> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -349,7 +349,7 @@ class StatusEffect : public LEDStripEffect
 };
 
 #if CLASSIC_GE_C9
-static const CRGB TwinkleColors[] = 
+static const CRGB TwinkleColors[] =
 {
     CRGB(238, 51, 39),      // Red
     CRGB(0, 172, 87),       // Green
@@ -357,7 +357,7 @@ static const CRGB TwinkleColors[] =
     CRGB(0, 131, 203)       // Blue
 };
 #else
-static const CRGB TwinkleColors[] = 
+static const CRGB TwinkleColors[] =
 {
     CRGB::Red,
     CRGB::Green,
@@ -375,7 +375,7 @@ class TwinkleEffect : public LEDStripEffect
     int  _updateSpeed;
 
   public:
-    
+
     TwinkleEffect(int countToDraw = NUM_LEDS / 2, uint8_t fadeFactor = 10, int updateSpeed = 10)
       : LEDStripEffect(EFFECT_STRIP_TWINKLE, "Twinkle"),
         _countToDraw(countToDraw),
@@ -392,10 +392,10 @@ class TwinkleEffect : public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<128> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -421,7 +421,7 @@ class TwinkleEffect : public LEDStripEffect
                 litPixels.pop_back();
                 _GFX[0]->setPixel(i, CRGB::Black);
             }
-        
+
             // Pick a random pixel and put it in the TOP slot
             int iNew = -1;
             for (int iPass = 0; iPass < NUM_LEDS * 10; iPass++)
@@ -435,12 +435,12 @@ class TwinkleEffect : public LEDStripEffect
                 break;
             }
             if (iNew == -1)             // No empty slot could be found!
-            {   
+            {
                 litPixels.clear();
                 setAllOnAllChannels(0,0,0);
                 return;
             }
-            
+
             assert(litPixels.end() == find(litPixels.begin(), litPixels.end(), iNew));
             setPixelOnAllChannels(iNew, TwinkleColors[random(0, ARRAYSIZE(TwinkleColors))]);
             litPixels.push_front(iNew);
@@ -460,7 +460,7 @@ class PoliceEffect : public LEDStripEffect
 
     virtual void Draw()
     {
-        
+
 
     }
 };

--- a/include/effects/strip/musiceffect.h
+++ b/include/effects/strip/musiceffect.h
@@ -2,7 +2,7 @@
 //
 // File:        MusicEffect.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -37,12 +37,12 @@ extern DRAM_ATTR AppTime g_AppTime;
 
 // BeatEffectBase
 //
-// A specialization of LEDStripEffect, adds a HandleBeat function that allows apps to 
+// A specialization of LEDStripEffect, adds a HandleBeat function that allows apps to
 // draw based on the music beat.  The Draw() function does the audio processing and calls
 // HandleBeat() whenever.  Apps are free to draw in both Draw() and HandleBeat().
 //
 // The constructor allows you to specify the sensitivity by where the latch points are/
-// For a highly sensitive (defaults), keep them both close to 1.0.  For a wider beat 
+// For a highly sensitive (defaults), keep them both close to 1.0.  For a wider beat
 // detection you could use 0.25 and 1.75 for example.
 
 
@@ -56,8 +56,8 @@ class BeatEffectBase
     float _minElapsed = 0;
 
   public:
-   
-    BeatEffectBase(float minRange = 0, float minElapsed = 0)      
+
+    BeatEffectBase(float minRange = 0, float minElapsed = 0)
      :
        _minRange(minRange),
        _minElapsed(minElapsed)
@@ -84,7 +84,7 @@ class BeatEffectBase
     {
         debugV("BeatEffectBase2::Draw");
         double elapsed = SecondsSinceLastBeat();
-    
+
         _samples.push_back(g_Analyzer._VURatio);
         float minimum = *min_element(_samples.begin(), _samples.end());
         float maximum = *max_element(_samples.begin(), _samples.end());
@@ -124,7 +124,7 @@ class SimpleColorBeat : public BeatEffectBase, public LEDStripEffect
   protected:
 
     int _iLastInsulator = -1;
-           
+
     virtual void Draw()
     {
         ProcessAudio();
@@ -177,10 +177,10 @@ class SimpleColorBeat : public BeatEffectBase, public LEDStripEffect
           DrawFanPixels(0, FAN_SIZE, c, Sequential, i);     // Draw twice to float-saturate our color
           DrawFanPixels(0, FAN_SIZE, c, Sequential, i);
         }
-    } 
+    }
 
   public:
-  
+
     SimpleColorBeat(const String & strName)
       : BeatEffectBase(0.5, 0.25), LEDStripEffect(EFFECT_STRIP_SIMPLE_COLOR_BEAT, strName)
     {

--- a/include/effects/strip/paletteeffect.h
+++ b/include/effects/strip/paletteeffect.h
@@ -2,7 +2,7 @@
 //
 // File:        PaletteEffect.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -25,7 +25,7 @@
 //    Fills spokes from a predefined palette
 //
 // History:     Apr-13-2019         Davepl      Adapted from LEDWifiSocket
-//              
+//
 //---------------------------------------------------------------------------
 
 #pragma once
@@ -52,13 +52,13 @@ class PaletteEffect : public LEDStripEffect
 
   public:
 
-    PaletteEffect(const CRGBPalette16 & palette, 
-                  float density = 1.0,                
-                  float paletteSpeed = 1, 
-                  float ledsPerSecond = 0, 
-                  float lightSize = 1, 
+    PaletteEffect(const CRGBPalette16 & palette,
+                  float density = 1.0,
+                  float paletteSpeed = 1,
+                  float ledsPerSecond = 0,
+                  float lightSize = 1,
                   float gapSize = 1,
-                  TBlendType blend = LINEARBLEND, 
+                  TBlendType blend = LINEARBLEND,
                   bool  bErase = true,
                   float brightness = 1.0)
       : LEDStripEffect(EFFECT_STRIP_PALETTE, "Palette Effect"),
@@ -91,10 +91,10 @@ class PaletteEffect : public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<512> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -114,21 +114,21 @@ class PaletteEffect : public LEDStripEffect
     ~PaletteEffect()
     {
     }
-    
-      virtual void Draw() 
+
+      virtual void Draw()
     {
         if (_bErase)
           setAllOnAllChannels(0,0,0);
 
         float deltaTime = g_AppTime.DeltaTime();
-        float increment = (deltaTime * _LEDSPerSecond);      
+        float increment = (deltaTime * _LEDSPerSecond);
         const int totalSize = _gapSize + _lightSize + 1;
         _startIndex   = totalSize > 1 ? fmodf(_startIndex + increment, totalSize) : 0;
-        
+
         // A single color step in a palette is 32 increments.  There are 256 total in a palette, and 144 pixels per meter typical, so this
         // scaling yields a color rotation of "one full palette per meter" by default.  We go backwards (-1) to match pixel scrolling direction.
 
-        _paletteIndex = _paletteIndex - deltaTime * _paletteSpeed * 32 * _density * 256/144.0;    
+        _paletteIndex = _paletteIndex - deltaTime * _paletteSpeed * 32 * _density * 256/144.0;
 
         float iColor = fmodf(_paletteIndex + _startIndex * _density, 256);
 

--- a/include/effects/strip/paletteeffect.h
+++ b/include/effects/strip/paletteeffect.h
@@ -93,7 +93,7 @@ class PaletteEffect : public LEDStripEffect
 
     virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
-        StaticJsonDocument<512> jsonDoc;
+        AllocatedJsonDocument jsonDoc(512);
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);

--- a/include/effects/strip/particles.h
+++ b/include/effects/strip/particles.h
@@ -2,7 +2,7 @@
 //
 // File:        Particles.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -23,7 +23,7 @@
 //
 // Description:
 //
-//   Classes for moving and fading little render objects over time, 
+//   Classes for moving and fading little render objects over time,
 //   used as a base for the star and insulator effects
 //
 // History:     Jul-7-2021         Davepl      Commented
@@ -37,9 +37,9 @@
 extern AppTime g_AppTime;
 
 // Lifespan
-// 
+//
 // Base class that knows only when it was created, so it can later tell you old it is, which is
-// used by the fading classes 
+// used by the fading classes
 
 class Lifespan
 {
@@ -54,12 +54,12 @@ class Lifespan
     }
 
     virtual ~Lifespan()
-    {}    
+    {}
 
     double Age() const
     {
         return g_AppTime.FrameStartTime() - _birthTime;
-    }    
+    }
 
     virtual double TotalLifetime() const = 0;
 };
@@ -68,9 +68,9 @@ class Lifespan
 //
 // Keeps track of a position, velocity, and maximum speed, mo
 // and manage it's velocity (postion drift).  Updates its position
-// automatically based on speed if called every frame.  
+// automatically based on speed if called every frame.
 
-class MovingObject 
+class MovingObject
 {
 protected:
 
@@ -96,7 +96,7 @@ public:
 };
 
 // FadingObject
-// 
+//
 // Based on its age and provided information about how long each life stage lasts, provides a
 // 'FadeoutAmount' function that indicates how much the particle should be dimmed from aging
 
@@ -121,7 +121,7 @@ class FadingObject : public Lifespan
         float age = Age();
         if (age < 0)
             age = 0;
-        
+
         if (age < PreignitionTime() && PreignitionTime() != 0.0f)
             return 1.0 - (age / PreignitionTime());
         age -= PreignitionTime();
@@ -134,7 +134,7 @@ class FadingObject : public Lifespan
             return 1.0f;                                                // Black hole, all faded out
         age -= (HoldTime());
             return (age / FadeTime());                                  // Fading star
-    } 
+    }
 };
 
 class FadingCountDownObject : public FadingObject
@@ -145,7 +145,7 @@ class FadingCountDownObject : public FadingObject
 
   public:
 
-    FadingCountDownObject(unsigned long maxvalue) 
+    FadingCountDownObject(unsigned long maxvalue)
       : _maxValue(maxvalue)
     {
     }
@@ -165,7 +165,7 @@ class FadingColoredObject : public FadingObject
   protected:
 
     CRGB                         _baseColor;
-  
+
   public:
 
     FadingColoredObject(CRGB baseColor)
@@ -184,8 +184,8 @@ class FadingColoredObject : public FadingObject
 
         CRGB c = _baseColor;
         fadeToBlackBy(&c, 1, 255 * FadeoutAmount());
-        return c;        
-    }    
+        return c;
+    }
 };
 
 // FadingPaletteObject
@@ -223,10 +223,10 @@ class FadingPaletteObject : public FadingObject
             fadeToBlackBy(&c, 1, 255 * FadeoutAmount());
             return c;
         }
-        
+
         fadeToBlackBy(&c, 1, 255 * FadeoutAmount());
-        return c;        
-    }    
+        return c;
+    }
 
     virtual void SetColorIndex(uint8_t index)
     {
@@ -249,7 +249,7 @@ class MovingFadingPaletteObject: public FadingPaletteObject, public MovingObject
   public:
 
     MovingFadingPaletteObject(const CRGBPalette16 & palette, TBlendType blendType = NOBLEND, float maxSpeed = 1.0, uint8_t colorIndex = random8())
-      : FadingPaletteObject(palette, blendType, colorIndex), 
+      : FadingPaletteObject(palette, blendType, colorIndex),
         MovingObject(maxSpeed)
     {
     }
@@ -274,7 +274,7 @@ class MovingFadingColoredObject: public FadingColoredObject, public MovingObject
 //
 // Super-simple class which holds a size
 
-class ObjectSize 
+class ObjectSize
 {
     public:
       float _objectSize;
@@ -293,7 +293,7 @@ class DrawableParticle : public Lifespan
      virtual void Render(const std::shared_ptr<GFXBase> _GFX[NUM_CHANNELS]) = 0;
 };
 
-template <typename Type = DrawableParticle> class ParticleSystem 
+template <typename Type = DrawableParticle> class ParticleSystem
 {
   protected:
 
@@ -302,8 +302,8 @@ template <typename Type = DrawableParticle> class ParticleSystem
     // Once per frame we are called to update all particles, which includes aging out old ones
 
   public:
-    
-    ParticleSystem<Type>() 
+
+    ParticleSystem<Type>()
     {
     }
 
@@ -318,12 +318,12 @@ template <typename Type = DrawableParticle> class ParticleSystem
             _allParticles.pop_front();
 
         for(auto i = _allParticles.begin(); i != _allParticles.end(); i++)
-            i->Render(_gfx);            
+            i->Render(_gfx);
     }
 };
 
 class RingParticle : public FadingColoredObject
-{ 
+{
   protected:
 
     int             _iInsulator;
@@ -357,7 +357,7 @@ class RingParticle : public FadingColoredObject
 
           for (int i = 0; i < NUM_FANS; i++)
           {
-            
+
             FillRingPixels(c, i, _iRing);
           }
         }
@@ -418,9 +418,9 @@ class ColorBeatWithFlash : public BeatEffectBase, public ParticleSystem<RingPart
     virtual void Draw()
     {
       // We are inheriting from both the insulator music beat effect and a particle system effect, and both need
-      //  
+      //
       setAllOnAllChannels(0,0,0);
-      
+
       uint8_t v = 16  * g_Analyzer._VURatio;
       _baseColor += CRGB(CHSV(beatsin8(24), 255, v));
       _baseColor.fadeToBlackBy(8 * g_Analyzer._VURatio);
@@ -460,9 +460,9 @@ class ColorBeatOverRed : public LEDStripEffect, public virtual BeatEffectBase, p
         } while (NUM_FANS > 3 && iInsulator == _iLastInsulator);
         _iLastInsulator = iInsulator;
 
-        if (bMajor && span >= 1.999) 
+        if (bMajor && span >= 1.999)
           iInsulator = -1;
-                
+
         float fadetime = min(5.0, elapsed * 1.5);   // Cap it at 5 seconds so we don't get ultra-long beats resulting from delays
         float flashtime = 0;
 
@@ -476,20 +476,20 @@ class ColorBeatOverRed : public LEDStripEffect, public virtual BeatEffectBase, p
       // We are inheriting from both the insulator music beat effect and a particle system effect, and both need a chance
       // to draw.  BeatEffectBase doesn't draw anything directly, but it does call us back at HandleBeat when needed.  We
       // also have to update and render the particle system, which does the actual pixel drawing.  We clear the scene ever
-      // pass and rely on the fade effects of the particles to blend the 
+      // pass and rely on the fade effects of the particles to blend the
 
       float amount = g_Analyzer._VU / MAX_VU;
 
       _baseColor = CRGB(500 * amount, 0, 0);
       setAllOnAllChannels(_baseColor.r, _baseColor.g, _baseColor.b);
       ParticleSystem<RingParticle>::Render(_GFX);
-     
+
     }
 };
 #endif
 
 class SpinningPaletteRingParticle : public FadingObject
-{ 
+{
   protected:
 
           std::shared_ptr<GFXBase> * _pGFX;
@@ -515,15 +515,15 @@ class SpinningPaletteRingParticle : public FadingObject
 
     SpinningPaletteRingParticle(
                   std::shared_ptr<GFXBase> * pGFX,                  // BUGBUG Remove and use what is passed to Render
-                  int                    iInsulator, 
-                  int                    iRing, 
-                  const CRGBPalette16 & palette, 
-                  float                  density = 4.0,                
-                  float                  paletteSpeed = 0.25, 
-                  float                  ledsPerSecond = 0.1, 
-                  float                  lightSize = 1, 
+                  int                    iInsulator,
+                  int                    iRing,
+                  const CRGBPalette16 & palette,
+                  float                  density = 4.0,
+                  float                  paletteSpeed = 0.25,
+                  float                  ledsPerSecond = 0.1,
+                  float                  lightSize = 1,
                   float                  gapSize = 0,
-                  TBlendType             blend = LINEARBLEND, 
+                  TBlendType             blend = LINEARBLEND,
                   bool                   bErase = true,
                   float                  brightness = 1.0f,
                   float                  ignitionTime = 0.0)
@@ -554,7 +554,7 @@ class SpinningPaletteRingParticle : public FadingObject
 
         _start = iInsulator * FAN_SIZE;     // Move to correct insulator
         for (int i = 0; i < iRing; i++)     // Move to ring within the insulator
-          _start += g_aRingSizeTable[i];        
+          _start += g_aRingSizeTable[i];
 
         _length = g_aRingSizeTable[iRing];    // Length is size of this particular ring
     }
@@ -567,14 +567,14 @@ class SpinningPaletteRingParticle : public FadingObject
           _pGFX[0]->setPixelsF(_start, _length, CRGB::Black, false);
 
         float deltaTime = g_AppTime.DeltaTime();
-        float increment = (deltaTime * _LEDSPerSecond);      
+        float increment = (deltaTime * _LEDSPerSecond);
         const int totalSize = _gapSize + _lightSize + 1;
         _startIndex   = totalSize > 1 ? fmodf(_startIndex + increment, totalSize) : 0;
-        
+
         // A single color step in a palette is 32 increments.  There are 256 total in a palette, and 144 pixels per meter typical, so this
         // scaling yields a color rotation of "one full palette per meter" by default.  We go backwards (-1) to match pixel scrolling direction.
 
-        _paletteIndex = _paletteIndex - (deltaTime * _paletteSpeed * _density);    
+        _paletteIndex = _paletteIndex - (deltaTime * _paletteSpeed * _density);
 
         float iColor = 0; // fmodf(_paletteIndex + _startIndex * _density, 256);
 
@@ -619,7 +619,7 @@ class SpinningPaletteRingParticle : public FadingObject
 
 
 class HotWhiteRingParticle : public FadingObject
-{ 
+{
   protected:
 
     std::shared_ptr<GFXBase> * _pGFX;
@@ -669,14 +669,14 @@ class HotWhiteRingParticle : public FadingObject
           else if( t192 > 0x40 )                // middle
               c = CRGB( 255, heatramp, 0);
           else                                  // coolest
-              c = CRGB( heatramp, 0, 0);     
+              c = CRGB( heatramp, 0, 0);
           fadeToBlackBy(&c, 1, 255 * FadeoutAmount());
         }
 
         if (_iInsulator < 0)    // -1 is a major beat, all insulators
         {
             for (int i = 0; i < NUM_FANS; i++)
-            {              
+            {
               FillRingPixels(c, i, _iRing);
             }
         }
@@ -719,10 +719,10 @@ class MoltenGlassOnVioletBkgnd : public LEDStripEffect, public virtual BeatEffec
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<512> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -740,7 +740,7 @@ class MoltenGlassOnVioletBkgnd : public LEDStripEffect, public virtual BeatEffec
           iInsulator = random(0, NUM_FANS);
         } while (NUM_FANS > 3 && iInsulator == _iLastInsulator);
         _iLastInsulator = iInsulator;
-        
+
         switch (random(10))
         {
           case 0:
@@ -761,7 +761,7 @@ class MoltenGlassOnVioletBkgnd : public LEDStripEffect, public virtual BeatEffec
             _allParticles.push_back(SpinningPaletteRingParticle(_GFX, 3, 0, _Palette, 2, 50, -0.5, 1, 0, LINEARBLEND, true, 1.0, 0));
             _allParticles.push_back(SpinningPaletteRingParticle(_GFX, 4, 0, _Palette, 2, 50, -0.5, 1, 0, LINEARBLEND, true, 1.0, 0));
             break;
-        
+
           default:
             _allParticles.push_back(SpinningPaletteRingParticle(_GFX, iInsulator, 0, _Palette, 256.0/FAN_SIZE, 0, -0.5, RING_SIZE_0, 0, LINEARBLEND, true, 1.0, 0));
             break;
@@ -773,10 +773,10 @@ class MoltenGlassOnVioletBkgnd : public LEDStripEffect, public virtual BeatEffec
       // We are inheriting from both the insulator music beat effect and a particle system effect, and both need a chance
       // to draw.  BeatEffectBase doesn't draw anything directly, but it does call us back at HandleBeat when needed.  We
       // also have to update and render the particle system, which does the actual pixel drawing.  We clear the scene ever
-      // pass and rely on the fade effects of the particles to blend the 
+      // pass and rely on the fade effects of the particles to blend the
 
       uint8_t v = 16  * g_Analyzer._VURatio;
-      _baseColor += CRGB(CHSV(200, 255, v));   
+      _baseColor += CRGB(CHSV(200, 255, v));
       _baseColor.fadeToBlackBy((min(255.0, 1000.0 * g_AppTime.DeltaTime())));
       setAllOnAllChannels(_baseColor.r, _baseColor.g, _baseColor.b);
 
@@ -809,10 +809,10 @@ class NewMoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<512> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -829,7 +829,7 @@ class NewMoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase
           iInsulator = random(0, NUM_FANS);
         } while (NUM_FANS > 3 && iInsulator == _iLastInsulator);
         _iLastInsulator = iInsulator;
-        
+
         switch (random(10))
         {
           case 0:
@@ -850,7 +850,7 @@ class NewMoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase
             _allParticles.push_back(SpinningPaletteRingParticle(_GFX, 3, 0, _Palette, 2, 50, -0.5, 1, 0, LINEARBLEND, true, 1.0, 0));
             _allParticles.push_back(SpinningPaletteRingParticle(_GFX, 4, 0, _Palette, 2, 50, -0.5, 1, 0, LINEARBLEND, true, 1.0, 0));
             break;
-        
+
           default:
             _allParticles.push_back(SpinningPaletteRingParticle(_GFX, iInsulator, 0, _Palette, 256.0/FAN_SIZE, 0, -0.5, RING_SIZE_0, 0, LINEARBLEND, true, 1.0, 0));
             break;
@@ -859,14 +859,14 @@ class NewMoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase
 
     virtual void Draw()
     {
-      ProcessAudio();      
+      ProcessAudio();
       // We are inheriting from both the insulator music beat effect and a particle system effect, and both need a chance
       // to draw.  BeatEffectBase doesn't draw anything directly, but it does call us back at HandleBeat when needed.  We
       // also have to update and render the particle system, which does the actual pixel drawing.  We clear the scene ever
-      // pass and rely on the fade effects of the particles to blend the 
+      // pass and rely on the fade effects of the particles to blend the
 
        uint8_t v = 16  * g_Analyzer._VURatio;
-      _baseColor += CRGB(CHSV(200, 255, v));   
+      _baseColor += CRGB(CHSV(200, 255, v));
       _baseColor.fadeToBlackBy((min(255.0, 1000.0 * g_AppTime.DeltaTime())));
       setAllOnAllChannels(_baseColor.r, _baseColor.g, _baseColor.b);
 
@@ -888,17 +888,17 @@ class SparklySpinningMusicEffect : public LEDStripEffect, public BeatEffectBase,
     }
 
     SparklySpinningMusicEffect(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject), 
-        BeatEffectBase(), 
-        ParticleSystem<SpinningPaletteRingParticle>(), 
+      : LEDStripEffect(jsonObject),
+        BeatEffectBase(),
+        ParticleSystem<SpinningPaletteRingParticle>(),
         _Palette(jsonObject[PTY_PALETTE].as<CRGBPalette16>())
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<512> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -913,7 +913,7 @@ class SparklySpinningMusicEffect : public LEDStripEffect, public BeatEffectBase,
         do
         {
           iInsulator = random(0, NUM_FANS);
-        } while (NUM_FANS > 3 && iInsulator == _iLastInsulator);  
+        } while (NUM_FANS > 3 && iInsulator == _iLastInsulator);
         _iLastInsulator = iInsulator;
 
         _allParticles.push_back(SpinningPaletteRingParticle(_GFX, iInsulator, 0, _Palette, 1, 1.0, 1.0, 1, 0, NOBLEND, true, 1.0, min(0.15f, elapsed/2)));
@@ -924,7 +924,7 @@ class SparklySpinningMusicEffect : public LEDStripEffect, public BeatEffectBase,
       // We are inheriting from both the insulator music beat effect and a particle system effect, and both need a chance
       // to draw.  BeatEffectBase doesn't draw anything directly, but it does call us back at HandleBeat when needed.  We
       // also have to update and render the particle system, which does the actual pixel drawing.  We clear the scene ever
-      // pass and rely on the fade effects of the particles to blend the 
+      // pass and rely on the fade effects of the particles to blend the
 
       uint8_t v = 32  * g_Analyzer._VURatio;
       _baseColor += CRGB(CHSV(beatsin8(1), 255, v));
@@ -958,7 +958,7 @@ class MusicalHotWhiteInsulatorEffect : public LEDStripEffect, public BeatEffectB
         do
         {
           iInsulator = random(0, NUM_FANS);
-        } while (NUM_FANS > 3 && iInsulator == _iLastInsulator);  
+        } while (NUM_FANS > 3 && iInsulator == _iLastInsulator);
         _iLastInsulator = iInsulator;
 
         _allParticles.push_back(HotWhiteRingParticle(_GFX, iInsulator, 0, 0.25, 0.75));
@@ -969,7 +969,7 @@ class MusicalHotWhiteInsulatorEffect : public LEDStripEffect, public BeatEffectB
       // We are inheriting from both the insulator music beat effect and a particle system effect, and both need a chance
       // to draw.  BeatEffectBase doesn't draw anything directly, but it does call us back at HandleBeat when needed.  We
       // also have to update and render the particle system, which does the actual pixel drawing.  We clear the scene ever
-      // pass and rely on the fade effects of the particles to blend the 
+      // pass and rely on the fade effects of the particles to blend the
 
       uint8_t v = 32  * g_Analyzer._VURatio;
       _baseColor += CRGB(CHSV(beatsin8(1), 255, v));

--- a/include/effects/strip/particles.h
+++ b/include/effects/strip/particles.h
@@ -721,7 +721,7 @@ class MoltenGlassOnVioletBkgnd : public LEDStripEffect, public virtual BeatEffec
 
     virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
-        StaticJsonDocument<512> jsonDoc;
+        AllocatedJsonDocument jsonDoc(512);
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -811,7 +811,7 @@ class NewMoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase
 
     virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
-        StaticJsonDocument<512> jsonDoc;
+        AllocatedJsonDocument jsonDoc(512);
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -897,7 +897,7 @@ class SparklySpinningMusicEffect : public LEDStripEffect, public BeatEffectBase,
 
     virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
-        StaticJsonDocument<512> jsonDoc;
+        AllocatedJsonDocument jsonDoc(512);
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);

--- a/include/effects/strip/snakeeffect.h
+++ b/include/effects/strip/snakeeffect.h
@@ -2,7 +2,7 @@
 //
 // File:        SnakeEffect.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -51,7 +51,7 @@ class SnakeEffect : public LEDStripEffect
     int     lastEaten;            // Increase the snake-speed as since eaten grows.
     int     direction;            // forward|reverse
     int     apple;                // Spawn location of Apple
-    
+
     int     winMode;              // End of Game Indicator
 
     int     lastLEDIndex;         // One-time init for cleaner code.
@@ -80,10 +80,10 @@ class SnakeEffect : public LEDStripEffect
         construct();
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<512> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -110,18 +110,18 @@ class SnakeEffect : public LEDStripEffect
     virtual void Draw()
     {
         setAllOnAllChannels(0,0,0); // Clear
-        
+
         // Game Loop
         EVERY_N_MILLISECONDS(std::max(SnakeSpeed - (lastEaten * 2), 5)) // 5ms faster cap.
         {
             // Win Reset
             if(snakeSize >= LEDCount)
             {
-                if(winMode < 90) 
+                if(winMode < 90)
                 {
                     winMode++;
                 }
-                else 
+                else
                 {
                     Reset();
                 }
@@ -140,7 +140,7 @@ class SnakeEffect : public LEDStripEffect
             // Move Head && Check for Food
             snakeHead = snakeHead + direction;
             if (snakeHead == apple)
-            { 
+            {
                 lastEaten = 0;
                 apple = getNextApple();
                 snakeSize++;
@@ -161,14 +161,14 @@ class SnakeEffect : public LEDStripEffect
             {
                 setPixelOnAllChannels(i, CRGB::Black);
             }
-            else 
+            else
             {
                 // TODO: Optional Pallete scheme.
                 if (i == apple)
                 {
                     setPixelOnAllChannels(i, CRGB::Yellow);
-                } 
-                else if (i == snakeHead) 
+                }
+                else if (i == snakeHead)
                 {
                     setPixelOnAllChannels(i, CRGB(0x9CB071));
                 }
@@ -181,7 +181,7 @@ class SnakeEffect : public LEDStripEffect
                 }
                 else if (direction == dBackward && ( // Cleaner to keep seperate
                     ((snakeHead+snakeSize) >= lastLEDIndex && (i > snakeHead || i > lastLEDIndex + (lastLEDIndex - (snakeHead+snakeSize)))) || // Wrap-around
-                    ((snakeHead+snakeSize) < lastLEDIndex && i >= snakeHead && i <= (snakeHead+snakeSize)) 
+                    ((snakeHead+snakeSize) < lastLEDIndex && i >= snakeHead && i <= (snakeHead+snakeSize))
                 ))
                 {
                     setPixelOnAllChannels(i, CRGB::Green);
@@ -192,68 +192,68 @@ class SnakeEffect : public LEDStripEffect
                 }
             }
 
-            
+
         }
     }
-    
-    int ifWrapAroundReturnTailIndex() 
+
+    int ifWrapAroundReturnTailIndex()
     {
         if (direction == dForward) {
-            if ((snakeHead-snakeSize) < 0) 
+            if ((snakeHead-snakeSize) < 0)
             {
                 return 0 - (snakeHead-snakeSize);
-            } 
+            }
         } else {
-            if ((snakeHead+snakeSize) > lastLEDIndex) 
+            if ((snakeHead+snakeSize) > lastLEDIndex)
             {
                 return (lastLEDIndex) + ((lastLEDIndex) - (snakeHead+snakeSize));
-            } 
+            }
         }
 
         return -1; // Not Wrap-Around
     }
 
-    int getNextApple() 
+    int getNextApple()
     {
         int wrapIndex = ifWrapAroundReturnTailIndex();
-        if(wrapIndex != -1) 
+        if(wrapIndex != -1)
         {   // Only 1 range in non-wrap-around.
-            if (direction == dForward) 
+            if (direction == dForward)
             {
                 return randomfloat(std::max(snakeHead, wrapIndex), lastLEDIndex);
-            } 
-            else 
+            }
+            else
             {
-                return randomfloat(0, std::min(snakeHead, wrapIndex));    
+                return randomfloat(0, std::min(snakeHead, wrapIndex));
             }
         }
         else
         {
-            if (direction == dForward) 
+            if (direction == dForward)
             {
                 return findRandomInRanges(0, snakeHead-snakeSize, snakeHead, lastLEDIndex);
-            } 
-            else 
+            }
+            else
             {
                 return findRandomInRanges(0, snakeHead, snakeHead+snakeSize, lastLEDIndex);
             }
-            
+
         }
     }
 
     int findRandomInRanges(int r1s, int r1e, int r2s, int r2e) // Easily extended for more ranges.
-    {   
+    {
         // Assume ranges are in bounds.
         // Assume r1s < r1e && r2s < r2e
 
         int r1Diff = (r1e - r1s);
         int random = randomfloat(0, r1Diff + (r2e - r2s));
-        
-        if (random <= r1Diff) 
+
+        if (random <= r1Diff)
         {
             return r1s + random;
-        } 
-        else 
+        }
+        else
         {
             return r2s + (random - r1Diff);
         }

--- a/include/effects/strip/snakeeffect.h
+++ b/include/effects/strip/snakeeffect.h
@@ -82,7 +82,7 @@ class SnakeEffect : public LEDStripEffect
 
     virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
-        StaticJsonDocument<512> jsonDoc;
+        AllocatedJsonDocument jsonDoc(512);
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);

--- a/include/effects/strip/stareffect.h
+++ b/include/effects/strip/stareffect.h
@@ -511,8 +511,6 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
                 }
             #endif
 
-            StarType::GetStarTypeNumber();
-
             if (randomdouble(0, 2.0) < g_AppTime.DeltaTime() * prob)
             {
                 StarType newstar(_palette, _blendType, _maxSpeed * _musicFactor, _starSize);

--- a/include/effects/strip/stareffect.h
+++ b/include/effects/strip/stareffect.h
@@ -469,7 +469,7 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
 
     virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
-        StaticJsonDocument<512> jsonDoc;
+        AllocatedJsonDocument jsonDoc(512);
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);

--- a/include/effects/strip/stareffect.h
+++ b/include/effects/strip/stareffect.h
@@ -2,7 +2,7 @@
 //
 // File:        StarEffect.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -137,7 +137,7 @@ class QuietStar : public RandomPaletteColorStar
     {
         return EFFECT_STAR_QUIET;
     }
-        
+
     QuietStar(const CRGBPalette16 & palette, TBlendType blendType = NOBLEND, float maxSpeed = 10.0, float starSize = 1)
       : RandomPaletteColorStar(palette, blendType, maxSpeed, starSize)
     {}
@@ -146,7 +146,7 @@ class QuietStar : public RandomPaletteColorStar
     virtual float IgnitionTime()    const { return 0.00f; }
     virtual float HoldTime()        const { return 0.00f; }
     virtual float FadeTime()        const { return 2.0f;  }
-    virtual float StarSize()        const { return 1;     }    
+    virtual float StarSize()        const { return 1;     }
 };
 
 #if ENABLE_AUDIO
@@ -156,7 +156,7 @@ class MusicStar : public Star
 
     MusicStar(const CRGBPalette16 & palette, TBlendType blendType = NOBLEND, float maxSpeed = 2.0, float starSize = 1)
       : Star(palette, blendType, maxSpeed, starSize)
-    {        
+    {
     }
 
     static int GetStarTypeNumber()
@@ -193,7 +193,7 @@ class MusicPulseStar : public Star
     virtual float PreignitionTime() const { return 0.00f;  }
     virtual float IgnitionTime()    const { return 0.00f; }
     virtual float HoldTime()        const { return 1.00f;  }
-    virtual float FadeTime()        const { return 2.00f; } 
+    virtual float FadeTime()        const { return 2.00f; }
     virtual float GetStarSize()    const { return 1 + _objectSize * g_Analyzer._VURatio; }
 };
 
@@ -205,7 +205,7 @@ class BubblyStar : public Star
     int         _hue;
 
     public:
-    
+
     BubblyStar(const CRGBPalette16 & palette, TBlendType blendType = LINEARBLEND, float maxSpeed = 2.0, float starSize = 12)
       : Star(palette, blendType, maxSpeed, starSize)
     {
@@ -274,12 +274,12 @@ class ColorCycleStar : public Star
     {
         CRGB c = ColorFromPalette(_palette, millis() / 2048.0f, _brightness, blend);
         fadeToBlackBy(&c, 1, 255 * FadeoutAmount());
-        return c;        
+        return c;
     }
-    
+
     virtual ~ColorCycleStar()
     {}
-    
+
     virtual float PreignitionTime() const { return 2.0f; }
     virtual float IgnitionTime()    const { return 0.0f;}
     virtual float HoldTime()        const { return 2.00f; }
@@ -305,9 +305,9 @@ class MultiColorStar : public Star
     {
         CRGB c = ColorFromPalette(_palette, _hue, _brightness, blend);
         fadeToBlackBy(&c, 1, 255 * FadeoutAmount());
-        return c;        
+        return c;
     }
-    
+
     virtual ~MultiColorStar()
     {}
 
@@ -346,7 +346,7 @@ class ChristmasLightStar : public Star
     virtual float PreignitionTime() const { return 0.20f; }
     virtual float IgnitionTime()    const { return 0.00f; }
     virtual float HoldTime()        const { return 6.0f;  }
-    virtual float FadeTime()        const { return 1.25f; }    
+    virtual float FadeTime()        const { return 1.25f; }
     virtual float StarSize()        const { return 0.00f; }
 };
 
@@ -372,7 +372,7 @@ class HotWhiteStar : public Star
     virtual float PreignitionTime() const { return 0.00f;  }
     virtual float IgnitionTime()    const { return 0.20f;  }
     virtual float HoldTime()        const { return 0.00f;  }
-    virtual float FadeTime()        const { return 2.00f;  }  
+    virtual float FadeTime()        const { return 2.00f;  }
 
     virtual CRGB RenderColor(TBlendType blend)
     {
@@ -380,7 +380,7 @@ class HotWhiteStar : public Star
             return CRGB::White;
         CRGB c = ColorFromPalette(_palette, 130*(1.0f-FadeoutAmount()), 256*(1.0f-FadeoutAmount()), blend);
         return c;
-    }      
+    }
 };
 
 
@@ -413,9 +413,9 @@ template <typename ObjectType> class BeatStarterEffect : public BeatEffectBase
 
 */
 
-// StarryNightEffect template 
+// StarryNightEffect template
 //
-// Generates up to 
+// Generates up to
 
 template <typename StarType> class StarryNightEffect : public LEDStripEffect
 {
@@ -434,10 +434,10 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
 
 
     StarryNightEffect<StarType>(const String & strName,
-                                const CRGBPalette16& palette, 
-                                float probability = 1.0, 
-                                float starSize = 1.0, 
-                                TBlendType blendType = LINEARBLEND, 
+                                const CRGBPalette16& palette,
+                                float probability = 1.0,
+                                float starSize = 1.0,
+                                TBlendType blendType = LINEARBLEND,
                                 float maxSpeed = 100.0,
                                 float blurFactor = 0.0,
                                 float musicFactor = 1.0,
@@ -467,10 +467,10 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<512> jsonDoc;
-        
+
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
@@ -507,7 +507,7 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
             #if ENABLE_AUDIO
                 if (_musicFactor != 1.0)
                 {
-                   prob = prob * (g_Analyzer._VURatio - 1.0) * _musicFactor; 
+                   prob = prob * (g_Analyzer._VURatio - 1.0) * _musicFactor;
                 }
             #endif
 
@@ -555,8 +555,8 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
             i->UpdatePosition();
             float fPos = i->_iPos;
             CRGB c = i->ObjectColor();
-            graphics()->setPixelsF(fPos - i->_objectSize / 2.0, i->_objectSize, c, true);         
-        }        
+            graphics()->setPixelsF(fPos - i->_objectSize / 2.0, i->_objectSize, c, true);
+        }
     }
 
 
@@ -607,8 +607,8 @@ public:
     {
         LEDStripEffect::Init(gfx);
         for (int i = 0; i < NUM_TWINKLES; i++)
-            buffer[i] = -1;      
-        return true;    
+            buffer[i] = -1;
+        return true;
     }
 
     virtual void Draw()

--- a/include/effects/strip/tempeffect.h
+++ b/include/effects/strip/tempeffect.h
@@ -2,7 +2,7 @@
 //
 // File:        TempEffect.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -58,20 +58,20 @@ class SimpleInsulatorBeatEffect : public LEDStripEffect, public BeatEffectBase
             i = random(0, NUM_FANS);
         } while (_lit.end() != std::find(_lit.begin(), _lit.end(), i));
         _lit.push_back(i);
-        
+
         FillRingPixels(RandomSaturatedColor(), i, 0);
     }
 
   public:
 
     using BeatEffectBase::BeatEffectBase;
- 
-    SimpleInsulatorBeatEffect(const String & strName) 
+
+    SimpleInsulatorBeatEffect(const String & strName)
       : LEDStripEffect(EFFECT_STRIP_SIMPLE_INSULATOR_BEAT, strName), BeatEffectBase(0.5, 0.01)
     {
     }
 
-    SimpleInsulatorBeatEffect(const JsonObjectConst& jsonObject) 
+    SimpleInsulatorBeatEffect(const JsonObjectConst& jsonObject)
       : LEDStripEffect(jsonObject), BeatEffectBase(0.5, 0.01)
     {
     }
@@ -102,17 +102,17 @@ class SimpleInsulatorBeatEffect2 : public LEDStripEffect, public BeatEffectBase
         } while (_lit.end() != std::find(_lit.begin(), _lit.end(), i));
         _lit.push_back(i);
 
-      FillRingPixels(CRGB::Red, i, 0);        
+      FillRingPixels(CRGB::Red, i, 0);
     }
 
   public:
- 
-    SimpleInsulatorBeatEffect2(const String & strName) 
+
+    SimpleInsulatorBeatEffect2(const String & strName)
       : LEDStripEffect(EFFECT_STRIP_SIMPLE_INSULATOR_BEAT2, strName), BeatEffectBase()
     {
     }
 
-    SimpleInsulatorBeatEffect2(const JsonObjectConst& jsonObject) 
+    SimpleInsulatorBeatEffect2(const JsonObjectConst& jsonObject)
       : LEDStripEffect(jsonObject), BeatEffectBase()
     {
     }
@@ -136,7 +136,7 @@ class VUInsulatorsEffect : public LEDStripEffect
       static unsigned long msPeakVU = 0;    // Timestamp of when the last big peak was
 
       setAllOnAllChannels(0, 0 , 0);
-      
+
       const int MAX_FADE = 255;
 
       if (iPeakVUy > 0)
@@ -164,7 +164,7 @@ class VUInsulatorsEffect : public LEDStripEffect
 
       for (int i = 0; i < bars; i++)
         DrawVUPixels(i, 0, vuPaletteGreen);
-    }  
+    }
 };
 
 #endif

--- a/include/globals.h
+++ b/include/globals.h
@@ -111,7 +111,7 @@
 #include "RemoteDebug.h"
 
 // The goal here is to get two variables, one numeric and one string, from the *same* version
-// value.  So if version = 020, 
+// value.  So if version = 020,
 //
 // FLASH_VERSION==20
 // FLASH_VERSION_NAME=="v020"
@@ -132,7 +132,7 @@
 #else
     #define STR(x) "v0"#x
 #endif
-#define FLASH_VERSION_NAME_X(x) "v"#x 
+#define FLASH_VERSION_NAME_X(x) "v"#x
 #define FLASH_VERSION_NAME XSTR(FLASH_VERSION)
 
 #define FASTLED_INTERNAL        1   // Silence FastLED build banners
@@ -174,7 +174,7 @@
 // We have a half-dozen workers and these are their relative priorities.  It might survive if all were set equal,
 // but I think drawing should be lower than audio so that a bad or greedy effect doesn't starve the audio system.
 //
-// Idle tasks in taskmgr run at IDLE_PRIORITY+1 so you want to be at least +2 
+// Idle tasks in taskmgr run at IDLE_PRIORITY+1 so you want to be at least +2
 
 #define DRAWING_PRIORITY        tskIDLE_PRIORITY+7
 #define SOCKET_PRIORITY         tskIDLE_PRIORITY+6
@@ -183,10 +183,10 @@
 #define AUDIO_PRIORITY          tskIDLE_PRIORITY+3
 #define SCREEN_PRIORITY         tskIDLE_PRIORITY+2
 
-#define DEBUG_PRIORITY          tskIDLE_PRIORITY+2      
+#define DEBUG_PRIORITY          tskIDLE_PRIORITY+2
 #define REMOTE_PRIORITY         tskIDLE_PRIORITY+2
 
-// If you experiment and mess these up, my go-to solution is to put Drawing on Core 0, and everything else on Core 1. 
+// If you experiment and mess these up, my go-to solution is to put Drawing on Core 0, and everything else on Core 1.
 // My current core layout is as follows, and as of today it's solid as of (7/16/21).
 //
 // #define DRAWING_CORE            0
@@ -200,7 +200,7 @@
 // Some "Reliability Rules"
 // Drawing must be on Core 1 if using SmartMatrix unless you specify SMARTMATRIX_OPTIONS_ESP32_CALC_TASK_CORE_1
 
-#define DRAWING_CORE            1  
+#define DRAWING_CORE            1
 #define NET_CORE                0
 #define AUDIO_CORE              0
 #define AUDIOSERIAL_CORE        1
@@ -217,13 +217,13 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 // Project Configuration
 //
 // One and only one of DEMO, SPECTRUM, ATOMLIGHT, etc should be set to true by the build config for your project
-// 
+//
 // I've used this code to build a dozen different projects, most of which can be created by defining
 // the right built environment (like INSULATORS=1).  The config here defines everything about the
 // LEDs, how many, on how many channels, laid out into how many fang/rings, and so on.  You can also
 // specify the audio system config like how many band channels.
 
-#if DEMO 
+#if DEMO
 
     // This is a simple demo configuration.  To build, simply connect the data lead from a WS2812B
     // strip to pin 5.  This does not use the OLED, LCD, or anything fancy, it simply drives the
@@ -274,7 +274,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
         #define ENABLE_WEBSERVER        0   // Turn on the internal webserver
     #endif
 
-#elif LANTERN 
+#elif LANTERN
 
     // A railway-style lantern with concentric rings of light (16+12+8+1)
 
@@ -306,7 +306,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define ENABLE_NTP              0   // Set the clock from the web
     #define ENABLE_OTA              0   // Accept over the air flash updates
 
-    #if M5STICKC 
+    #if M5STICKC
         #define LED_PIN0 26
     #elif M5STICKCPLUS || M5STACKCORE2
         #define LED_PIN0 32
@@ -346,11 +346,11 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define ENABLE_OTA              1   // Accept over the air flash updates
     #define ENABLE_REMOTE           1   // IR Remote Control
     #define ENABLE_AUDIO            1   // Listen for audio from the microphone and process it
-    
+
     #define LED_PIN0          26
     #define NUM_CHANNELS      1
     #define RING_SIZE_0       24
-    #define BONUS_PIXELS      0                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
+    #define BONUS_PIXELS      0
     #define MATRIX_WIDTH      5
     #define MATRIX_HEIGHT     RING_SIZE_0
     #define NUM_FANS          MATRIX_WIDTH
@@ -359,7 +359,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define NUM_LEDS          (MATRIX_WIDTH*MATRIX_HEIGHT)
     #define ENABLE_REMOTE     1                     // IR Remote Control
     #define ENABLE_AUDIO      1                     // Listen for audio from the microphone and process it
-    #define IR_REMOTE_PIN     25                   
+    #define IR_REMOTE_PIN     25
     #define LED_FAN_OFFSET_BU 12
     #define POWER_LIMIT_MW    20000
 
@@ -412,7 +412,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #endif
 
 
-    #define ENABLE_AUDIOSERIAL      0   // Report peaks at 2400baud on serial port for PETRock consumption   
+    #define ENABLE_AUDIOSERIAL      0   // Report peaks at 2400baud on serial port for PETRock consumption
     #define ENABLE_WIFI             0   // Connect to WiFi
     #define INCOMING_WIFI_ENABLED   0   // Accepting incoming color data and commands
     #define WAIT_FOR_WIFI           0   // Hold in setup until we have WiFi - for strips without effects
@@ -422,11 +422,11 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define ENABLE_OTA              0   // Accept over the air flash updates
     #define ENABLE_REMOTE           0   // IR Remote Control
     #define ENABLE_AUDIO            1   // Listen for audio from the microphone and process it
-    
+
     #define DEFAULT_EFFECT_INTERVAL     (60*60*24*5)
 
     #define NUM_CHANNELS    1
-    #define RING_SIZE_0     24    
+    #define RING_SIZE_0     24
     #define BONUS_PIXELS    0
     #define MATRIX_WIDTH    700
     #define MATRIX_HEIGHT   1
@@ -453,7 +453,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     // This project is set up as a 48x16 matrix of 16x16 WS2812B panels such as: https://amzn.to/3ABs5DK
     // It uses an M5StickCPlus which has a microphone and LCD built in:  https://amzn.to/3CrvCFh
     // It displays a spectrum analyzer and music visualizer
-    
+
     #ifndef PROJECT_NAME
     #define PROJECT_NAME            "Mesmerizer"
     #endif
@@ -473,9 +473,9 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
     #define DEFAULT_EFFECT_INTERVAL     (MILLIS_PER_SECOND * 60 * 2)
     #define MILLIS_PER_FRAME        0
-    
+
     #define NUM_CHANNELS    1
-    #define RING_SIZE_0     24    
+    #define RING_SIZE_0     24
     #define BONUS_PIXELS    0
     #define MATRIX_WIDTH    64
     #define MATRIX_HEIGHT   32
@@ -511,14 +511,14 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define ENABLE_OTA              0  // Accept over the air flash updates
     #define ENABLE_REMOTE           1   // IR Remote Control
     #define ENABLE_AUDIO            1   // Listen for audio from the microphone and process it
-    
+
     #define DEFAULT_EFFECT_INTERVAL     (60*60*24)
 
     #define MAX_BUFFERS     20
 
     #define LED_PIN0        21          // Note that TFT board on TFTGO uses ping 19, 18, 5, 16, 23, and 4
     #define NUM_CHANNELS    1
-    #define RING_SIZE_0     24    
+    #define RING_SIZE_0     24
     #define BONUS_PIXELS    0
     #define MATRIX_WIDTH    48
     #define MATRIX_HEIGHT   16
@@ -526,7 +526,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define FAN_SIZE        MATRIX_HEIGHT
     #define NUM_BANDS       16
     #define NUM_LEDS        (MATRIX_WIDTH*MATRIX_HEIGHT)
-    #define IR_REMOTE_PIN   22                    
+    #define IR_REMOTE_PIN   22
     #define LED_FAN_OFFSET_BU 6
     #define POWER_LIMIT_MW  (1 * 5 * 1000)         // Expects at least a 5V, 1A supply
 
@@ -546,7 +546,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #ifndef PROJECT_NAME
     #define PROJECT_NAME            "X-mas Trees"
     #endif
-    
+
     #define ENABLE_WIFI             1  // Connect to WiFi
     #define INCOMING_WIFI_ENABLED   1   // Accepting incoming color data and commands
     #define WAIT_FOR_WIFI           0   // Hold in setup until we have WiFi - for strips without effects
@@ -556,14 +556,14 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define ENABLE_OTA              0  // Accept over the air flash updates
     #define ENABLE_REMOTE           1   // IR Remote Control
     #define ENABLE_AUDIO            1   // Listen for audio from the microphone and process it
-    
+
     #define DEFAULT_EFFECT_INTERVAL     (60*60*24)
 
     #define MAX_BUFFERS     20
 
     #define LED_PIN0        26
     #define NUM_CHANNELS    1
-    #define RING_SIZE_0     24    
+    #define RING_SIZE_0     24
     #define BONUS_PIXELS    0
     #define MATRIX_WIDTH    24
     #define MATRIX_HEIGHT   5
@@ -571,7 +571,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define NUM_FANS        MATRIX_HEIGHT
     #define NUM_BANDS       16
     #define NUM_LEDS        (MATRIX_WIDTH*MATRIX_HEIGHT)
-    #define IR_REMOTE_PIN   25                    
+    #define IR_REMOTE_PIN   25
     #define LED_FAN_OFFSET_BU 6
     #define POWER_LIMIT_MW  (5 * 5 * 1000)         // Expects at least a 5V, 5A supply
 
@@ -582,7 +582,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define TOGGLE_BUTTON_2         39
     #define NUM_INFO_PAGES 2
 
-#elif ATOMLIGHT 
+#elif ATOMLIGHT
 
     // This is the "Tiki Atomic Fire Lamp" project, which is an LED lamp with 4 arms of 53 LEDs each.
     // Each arm is wired as a separate channel.
@@ -606,7 +606,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define USE_SCREEN      0                       // Normally we use a tiny board inside the lamp with no screen
     #define FAN_SIZE        NUM_LEDS                // Allows us to use fan effects on the spokes
     #define NUM_FANS        1                       // Our fans are on channels, not in sequential order, so only one "fan"
-    #define NUM_RINGS       1   
+    #define NUM_RINGS       1
     #define LED_FAN_OFFSET_BU 0
     #define BONUS_PIXELS      0
 
@@ -647,7 +647,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define ENABLE_REMOTE   1                     // IR Remote Control
     #define IR_REMOTE_PIN   39
     #define ENABLE_AUDIO    1                     // Listen for audio from the microphone and process it
-    #define MAX_BUFFERS     40                    
+    #define MAX_BUFFERS     40
 
     #define POWER_LIMIT_MW (1600 * 1000)                 // 100W transformer for an 8M strip max
     #define DEFAULT_EFFECT_INTERVAL     (1000*30 * 60)
@@ -665,7 +665,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define ONBOARD_LED_B    18
 
     #define TOGGLE_BUTTON_2  0
-    
+
 #elif MAGICMIRROR
 
     // A magic infinity mirror such as: https://amzn.to/3lEZo2D
@@ -686,13 +686,13 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define NUM_CHANNELS    1
     #define BONUS_PIXELS    0
     #define NUM_FANS        1
-    #define FAN_SIZE        100 
-    #define MATRIX_WIDTH    (NUM_FANS * FAN_SIZE + BONUS_PIXELS)    
+    #define FAN_SIZE        100
+    #define MATRIX_WIDTH    (NUM_FANS * FAN_SIZE + BONUS_PIXELS)
     #define NUM_LEDS        (MATRIX_WIDTH*MATRIX_HEIGHT)
     #define MATRIX_HEIGHT   NUM_FANS
     #define ENABLE_REMOTE   1                     // IR Remote Control
     #define ENABLE_AUDIO    1                     // Listen for audio from the microphone and process it
-    #define IR_REMOTE_PIN   15                    
+    #define IR_REMOTE_PIN   15
 
     #define LED_FAN_OFFSET_BU 6
 
@@ -713,7 +713,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define TIME_BEFORE_LOCAL       5   // How many seconds before the lamp times out and shows local content
 
     #define NUM_CHANNELS    1
-    #define MATRIX_WIDTH    (8*144)       // My naximum run, and about all you can do at 30fps  
+    #define MATRIX_WIDTH    (8*144)       // My naximum run, and about all you can do at 30fps
     #define MATRIX_HEIGHT   1
     #define NUM_LEDS        (MATRIX_WIDTH * MATRIX_HEIGHT)
     #define ENABLE_REMOTE   0                     // IR Remote Control
@@ -722,14 +722,14 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
     #define POWER_LIMIT_MW (INT_MAX)              // Unlimited power for long strips, up to you to limit here or supply enough!
 
-    #define DEFAULT_EFFECT_INTERVAL     (1000*20)    
+    #define DEFAULT_EFFECT_INTERVAL     (1000*20)
 
-    #define RING_SIZE_0 1 
+    #define RING_SIZE_0 1
     #define RING_SIZE_1 2
     #define RING_SIZE_2 4
     #define RING_SIZE_3 8
     #define RING_SIZE_4 16
-    
+
 #elif CHIEFTAIN
 
     // The LED strips I use for Christmas lights under my eaves
@@ -744,7 +744,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define TIME_BEFORE_LOCAL       5   // How many seconds before the lamp times out and shows local content
 
     #define NUM_CHANNELS    1
-    #define MATRIX_WIDTH    (12)   
+    #define MATRIX_WIDTH    (12)
     #define MATRIX_HEIGHT   1
     #define NUM_LEDS        (MATRIX_WIDTH * MATRIX_HEIGHT)
     #define ENABLE_REMOTE   0                     // IR Remote Control
@@ -753,14 +753,14 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
     #define POWER_LIMIT_MW (4500)                 // Assumes modern USB3 powered port or supply
 
-    #define DEFAULT_EFFECT_INTERVAL     (1000*20)    
+    #define DEFAULT_EFFECT_INTERVAL     (1000*20)
 
-    #define RING_SIZE_0 1 
+    #define RING_SIZE_0 1
     #define RING_SIZE_1 2
     #define RING_SIZE_2 4
     #define RING_SIZE_3 8
     #define RING_SIZE_4 16
-    
+
 #elif BELT
 
     // I was asked to wear something sparkly once, so I made an LED belt...
@@ -775,7 +775,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define TIME_BEFORE_LOCAL       1   // How many seconds before the lamp times out and shows local content
 
     #define NUM_CHANNELS    1
-    #define MATRIX_WIDTH    (1*144)   
+    #define MATRIX_WIDTH    (1*144)
     #define MATRIX_HEIGHT   1
     #define NUM_LEDS        (MATRIX_WIDTH * MATRIX_HEIGHT)
     #define ENABLE_REMOTE   0                     // IR Remote Control
@@ -799,16 +799,16 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
     #define NUM_CHANNELS    1
     #define NUM_LEDS        600
-    #define MATRIX_WIDTH    (NUM_LEDS)    
+    #define MATRIX_WIDTH    (NUM_LEDS)
     #define MATRIX_HEIGHT   1
     #define ENABLE_REMOTE   1                     // IR Remote Control
     #define FAN_SIZE        1
     #define NUM_FANS        1
     #define ENABLE_AUDIO    1
-    #define LED_FAN_OFFSET_BU  0                    
-    #define LED_FAN_OFFSET_TD  0                   
-    #define LED_FAN_OFFSET_LR  0                     
-    #define LED_FAN_OFFSET_RL  0   
+    #define LED_FAN_OFFSET_BU  0
+    #define LED_FAN_OFFSET_TD  0
+    #define LED_FAN_OFFSET_LR  0
+    #define LED_FAN_OFFSET_RL  0
     #define IR_REMOTE_PIN 36
     #define POWER_LIMIT_MW (1000 * 12 * 8)
     #define ENABLE_AUDIO    1                     // Listen for audio from the microphone and process it
@@ -835,7 +835,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define PROJECT_NAME            "Spectrum"
     #endif
 
-    #define ENABLE_AUDIOSERIAL      0   // Report peaks at 2400baud on serial port for PETRock consumption   
+    #define ENABLE_AUDIOSERIAL      0   // Report peaks at 2400baud on serial port for PETRock consumption
     #define ENABLE_WIFI             1   // Connect to WiFi
     #define INCOMING_WIFI_ENABLED   1   // Accepting incoming color data and commands
     #define WAIT_FOR_WIFI           0   // Hold in setup until we have WiFi - for strips without effects
@@ -851,7 +851,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #else
         #define MAX_BUFFERS         10
     #endif
-        
+
     #define DEFAULT_EFFECT_INTERVAL     (60*60*24*5)
 
     #if SPECTRUM_WROVER_KIT
@@ -861,7 +861,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #endif
 
     #define NUM_CHANNELS    1
-    #define RING_SIZE_0     24    
+    #define RING_SIZE_0     24
     #define BONUS_PIXELS    0
     #define MATRIX_WIDTH    48
     #define MATRIX_HEIGHT   16
@@ -879,7 +879,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define TOGGLE_BUTTON_2 39
 
     #ifdef SPECTRUM_WROVER_KIT
-    #else 
+    #else
         #define NUM_INFO_PAGES          2
         #define ONSCREEN_SPECTRUM_PAGE  1   // Show a little spectrum analyzer on one of the info pages (slower)
     #endif
@@ -892,7 +892,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define PROJECT_NAME            "Fan set"
     #endif
 
-    #define ENABLE_AUDIOSERIAL      1   // Report peaks at 2400baud on serial port for PETRock consumption   
+    #define ENABLE_AUDIOSERIAL      1   // Report peaks at 2400baud on serial port for PETRock consumption
     #define ENABLE_WIFI             1           // Connect to WiFi
     #define INCOMING_WIFI_ENABLED   1           // Accepting incoming color data and commands
     #define WAIT_FOR_WIFI           0           // Hold in setup until we have WiFi - for strips without effects
@@ -915,16 +915,16 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define NUM_RINGS               1           // Fans have a single outer ring of pixels
     #define FAN_SIZE                16          // Each fan's pixel ring has 16 LEDs
     #define FAN_LEN                 (NUM_FANS * FAN_SIZE)
-    #define MATRIX_WIDTH            (NUM_FANS * FAN_SIZE + BONUS_PIXELS)    
+    #define MATRIX_WIDTH            (NUM_FANS * FAN_SIZE + BONUS_PIXELS)
     #define NUM_LEDS                (MATRIX_WIDTH)
-    #define LED_FAN_OFFSET_BU       3                         
+    #define LED_FAN_OFFSET_BU       3
     #define ENABLE_REMOTE           1           // IR Remote Control
     #define ENABLE_AUDIO            1           // Listen for audio from the microphone and process it
     #define POWER_LIMIT_MW          8000
     #define MATRIX_HEIGHT           1
-    
+
     // Being case-mounted normally, the FANSET needs a more sensitive mic so the NOISE_CUTOFF value is are lower than spectrum
-    
+
     #define NOISE_CUTOFF            0
     #define NOISE_FLOOR             0.0f
 
@@ -932,12 +932,12 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define TOGGLE_BUTTON_2         39
 
     #ifdef SPECTRUM_WROVER_KIT
-    #else 
+    #else
         #define NUM_INFO_PAGES          2
         #define ONSCREEN_SPECTRUM_PAGE  1   // Show a little spectrum analyzer on one of the info pages (slower)
     #endif
 
-    
+
 #elif SINGLE_INSULATOR
 
     #ifndef PROJECT_NAME
@@ -955,8 +955,8 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define NUM_CHANNELS    1
     #define BONUS_PIXELS    7
     #define NUM_FANS        1
-    #define FAN_SIZE        12 
-    #define MATRIX_WIDTH    (NUM_FANS * FAN_SIZE + BONUS_PIXELS)    
+    #define FAN_SIZE        12
+    #define MATRIX_WIDTH    (NUM_FANS * FAN_SIZE + BONUS_PIXELS)
     #define NUM_LEDS        (MATRIX_WIDTH*MATRIX_HEIGHT)
     #define MATRIX_HEIGHT   NUM_FANS
 
@@ -973,7 +973,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #else
         #define LED_PIN0 5
     #endif
-    
+
 #elif INSULATORS
 
     // A set of 5 Hemmingray glass insulators that each have a ring of 12 LEDs.  Music reactive to the beat.
@@ -1001,7 +1001,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define NUM_LEDS          (MATRIX_WIDTH*MATRIX_HEIGHT)
     #define ENABLE_REMOTE     0                     // IR Remote Control
     #define ENABLE_AUDIO      1                     // Listen for audio from the microphone and process it
-    #define IR_REMOTE_PIN     26                    
+    #define IR_REMOTE_PIN     26
     #define LED_FAN_OFFSET_BU 6
     #define POWER_LIMIT_MW    50000
 
@@ -1044,7 +1044,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define NUM_LEDS          (MATRIX_WIDTH*MATRIX_HEIGHT)
     #define ENABLE_REMOTE     0                     // IR Remote Control
     #define ENABLE_AUDIO      1                     // Listen for audio from the microphone and process it
-    #define IR_REMOTE_PIN     26                    
+    #define IR_REMOTE_PIN     26
     #define LED_FAN_OFFSET_BU 6
     #define POWER_LIMIT_MW    5000
 
@@ -1109,9 +1109,9 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
 #define STACK_SIZE (ESP_TASK_MAIN_STACK) // Stack size for each new thread
 #define TIME_CHECK_INTERVAL_MS (1000 * 60 * 5)   // How often in ms we resync the clock from NTP
-#define MIN_BRIGHTNESS  4                   
+#define MIN_BRIGHTNESS  4
 #define MAX_BRIGHTNESS  255
-#define BRIGHTNESS_STEP 10          // Amount to step brightness on each remote control repeat 
+#define BRIGHTNESS_STEP 10          // Amount to step brightness on each remote control repeat
 #define MAX_RINGS       5
 
 
@@ -1157,9 +1157,9 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #endif
     #ifndef NOISE_CUTOFF
         #define NOISE_CUTOFF   2000
-    #endif    
+    #endif
     #ifndef AUDIO_PEAK_REMOTE_TIMEOUT
-        #define AUDIO_PEAK_REMOTE_TIMEOUT 1000.0f       // How long after remote PeakData before local microphone is used again   
+        #define AUDIO_PEAK_REMOTE_TIMEOUT 1000.0f       // How long after remote PeakData before local microphone is used again
     #endif
     #ifndef ENABLE_AUDIO_SMOOTHING
         #define ENABLE_AUDIO_SMOOTHING 1
@@ -1259,7 +1259,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 #endif
 
 // Display
-// 
+//
 // Enable USE_OLED or USE_TFT based on selected board definition
 // These board definations are added by platformio
 
@@ -1316,19 +1316,19 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define ONBOARD_PIXEL_DATA      33
 #endif
 
-#ifndef USE_OLED                            
+#ifndef USE_OLED
 #define USE_OLED 0
 #endif
 
-#ifndef USE_M5DISPLAY                            
+#ifndef USE_M5DISPLAY
 #define USE_M5DISPLAY 0
 #endif
 
-#ifndef USE_LCD                            
+#ifndef USE_LCD
 #define USE_LCD 0
 #endif
 
-#ifndef USE_TFTSPI                            
+#ifndef USE_TFTSPI
 #define USE_TFTSPI 0
 #endif
 
@@ -1356,7 +1356,7 @@ extern DRAM_ATTR uint32_t g_FPS;               // Our global framerate (BUGBUG: 
 extern DRAM_ATTR const int g_aRingSizeTable[];
 
 #define MICROS_PER_SECOND   1000000
-#define MILLIS_PER_SECOND   1000 
+#define MILLIS_PER_SECOND   1000
 #define MICROS_PER_MILLI    1000
 
 #ifndef M5STICKC
@@ -1365,7 +1365,7 @@ extern DRAM_ATTR const int g_aRingSizeTable[];
 
 #ifndef M5STICKCPLUS
 #define M5STICKCPLUS 0
-#endif 
+#endif
 
 #ifndef M5STACKCORE2
 #define M5STACKCORE2 0
@@ -1378,23 +1378,23 @@ extern DRAM_ATTR const int g_aRingSizeTable[];
 #if ENABLE_AUDIO
     #ifndef INPUT_PIN
         #if TTGO
-            #define INPUT_PIN (36)   
+            #define INPUT_PIN (36)
         #elif M5STACKCORE2
             #define INPUT_PIN (0)
             #define IO_PIN    (0)
-        #elif M5STICKC || M5STICKCPLUS 
-            #define INPUT_PIN (34)   
+        #elif M5STICKC || M5STICKCPLUS
+            #define INPUT_PIN (34)
             #define IO_PIN (0)
         #else
             #define INPUT_PIN (36)    // Audio line input, ADC #1, input line 0 (GPIO pin 36)
         #endif
     #endif
 #else
-    #define INPUT_PIN 0              
+    #define INPUT_PIN 0
 #endif
 
 #ifndef IR_REMOTE_PIN
-#define IR_REMOTE_PIN   25                    
+#define IR_REMOTE_PIN   25
 #endif
 
 
@@ -1404,11 +1404,11 @@ extern DRAM_ATTR const int g_aRingSizeTable[];
 // a stats request.  Beyond color data these are poorly tested and likely can be removed, though
 // stats and clock are handy for debugging!
 
-#define WIFI_COMMAND_PIXELDATA64 3             // Wifi command with color data and 64-bit clock vals 
+#define WIFI_COMMAND_PIXELDATA64 3             // Wifi command with color data and 64-bit clock vals
 #define WIFI_COMMAND_PEAKDATA    4             // Wifi command that delivers audio peaks
 
 // Final headers
-// 
+//
 // Headers that are only included when certain features are enabled
 
 #if USE_OLED
@@ -1429,11 +1429,11 @@ extern U8G2_SSD1306_128X64_NONAME_F_HW_I2C g_u8g2;
 //
 // va-args style printf that returns the formatted string as a reuslt
 
-inline String str_snprintf(const char *fmt, size_t len, ...) 
+inline String str_snprintf(const char *fmt, size_t len, ...)
 {
     std::string str;
     va_list args;
-    
+
     // Make the string buffer big enough to hold the stated size
     str.resize(len);
 
@@ -1458,7 +1458,7 @@ inline String str_sprintf(const char *fmt, ...)
     va_list args, args2;
     va_start(args, fmt);
     va_copy(args2, args);
-    
+
     int requiredLen = vsnprintf(NULL, 0, fmt, args) + 1;
     if (requiredLen > 1)
     {
@@ -1467,14 +1467,14 @@ inline String str_sprintf(const char *fmt, ...)
         if (out_length < requiredLen)
             str.resize(out_length);
     }
-        
+
     va_end(args2);
     va_end(args);
     return String(str.c_str());
 }
 
 // FPS
-// 
+//
 // Given a time value for when the last frame took place and the current timestamp returns the number of
 // frames per second, as low as 0.  Never exceeds 999 so you can make some width assumptions.
 
@@ -1601,7 +1601,7 @@ public:
     {
         ::new((void *) p ) U(std::forward<Args>(args)...);
     }
-    
+
     void destroy(pointer p)
     {
         p->~T();
@@ -1618,13 +1618,13 @@ class AppTime
 
     double _lastFrame;
     double _deltaTime;
-  
+
   public:
 
     // NewFrame
     //
     // Call this at the start of every frame or udpate, and it'll figure out and keep track of how
-    // long between frames 
+    // long between frames
 
     void NewFrame()
     {
@@ -1694,27 +1694,27 @@ template<typename T> inline float map(T x, T in_min, T in_max, T out_min, T out_
 
 inline uint64_t ULONGFromMemory(uint8_t * payloadData)
 {
-    return  (uint64_t)payloadData[7] << 56  | 
-            (uint64_t)payloadData[6] << 48  | 
-            (uint64_t)payloadData[5] << 40  | 
-            (uint64_t)payloadData[4] << 32  | 
-            (uint64_t)payloadData[3] << 24  | 
-            (uint64_t)payloadData[2] << 16  | 
-            (uint64_t)payloadData[1] << 8   | 
+    return  (uint64_t)payloadData[7] << 56  |
+            (uint64_t)payloadData[6] << 48  |
+            (uint64_t)payloadData[5] << 40  |
+            (uint64_t)payloadData[4] << 32  |
+            (uint64_t)payloadData[3] << 24  |
+            (uint64_t)payloadData[2] << 16  |
+            (uint64_t)payloadData[1] << 8   |
             (uint64_t)payloadData[0];
 }
 
 inline uint32_t DWORDFromMemory(uint8_t * payloadData)
 {
-    return  (uint32_t)payloadData[3] << 24  | 
-            (uint32_t)payloadData[2] << 16  | 
-            (uint32_t)payloadData[1] << 8   | 
+    return  (uint32_t)payloadData[3] << 24  |
+            (uint32_t)payloadData[2] << 16  |
+            (uint32_t)payloadData[1] << 8   |
             (uint32_t)payloadData[0];
 }
 
 inline uint16_t WORDFromMemory(uint8_t * payloadData)
 {
-    return  (uint16_t)payloadData[1] << 8   | 
+    return  (uint16_t)payloadData[1] << 8   |
             (uint16_t)payloadData[0];
 }
 
@@ -1746,7 +1746,7 @@ inline bool CheckBlueBuffer(CRGB * prgb, size_t count)
 #define YELLOW16    0xFFE0
 #define WHITE16     0xFFFF
 
-// Main includes 
+// Main includes
 
 #include <TJpg_Decoder.h>
 #include "improvserial.h"                       // ImprovSerial impl for setting WiFi credentials over the serial port
@@ -1759,7 +1759,7 @@ inline bool CheckBlueBuffer(CRGB * prgb, size_t count)
 #include "ledstripeffect.h"                     // Defines base led effect classes
 #include "ntptimeclient.h"                      // setting the system clock from ntp
 #include "effectmanager.h"                      // For g_EffectManagerf
-#include "network.h"                            // Networking 
+#include "network.h"                            // Networking
 #include "ledbuffer.h"                          // Buffer manager for strip
 #include "Bounce2.h"                            // For Bounce button class
 #include "colordata.h"                          // color palettes

--- a/include/jsonbase.h
+++ b/include/jsonbase.h
@@ -2,7 +2,7 @@
 //
 // File:        jsonbase.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -25,7 +25,7 @@
 //    Declares common requirements for classes involved with JSON processing
 //
 // History:     Mar-29-2023         Rbergen      Created for NightDriverStrip
-//              
+//
 //---------------------------------------------------------------------------
 
 #pragma once

--- a/include/jsonserializer.h
+++ b/include/jsonserializer.h
@@ -2,7 +2,7 @@
 //
 // File:        jsonserializer.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,23 +10,23 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
 //
 // Description:
 //
-//    Declares classes for JSON (de)serialization of selected 
+//    Declares classes for JSON (de)serialization of selected
 //    properties of selected classes
 //
 // History:     Mar-29-2023         Rbergen      Created for NightDriverStrip
-//              
+//
 //---------------------------------------------------------------------------
 
 #pragma once
@@ -47,55 +47,55 @@ constexpr auto to_value(E e) noexcept
 	return static_cast<std::underlying_type_t<E>>(e);
 }
 
-namespace ArduinoJson 
+namespace ArduinoJson
 {
     template <>
-    struct Converter<CRGB> 
+    struct Converter<CRGB>
     {
-        static bool toJson(const CRGB& color, JsonVariant dst) 
+        static bool toJson(const CRGB& color, JsonVariant dst)
         {
             return dst.set((uint32_t)((color.r << 16) | (color.g << 8) | color.b));
         }
 
-        static CRGB fromJson(JsonVariantConst src) 
+        static CRGB fromJson(JsonVariantConst src)
         {
-            return CRGB(src.as<uint32_t>()); 
+            return CRGB(src.as<uint32_t>());
         }
 
-        static bool checkJson(JsonVariantConst src) 
+        static bool checkJson(JsonVariantConst src)
         {
             return src.is<uint32_t>();
         }
     };
 
     template <>
-    struct Converter<CRGBPalette16> 
+    struct Converter<CRGBPalette16>
     {
-        static bool toJson(const CRGBPalette16& palette, JsonVariant dst) 
+        static bool toJson(const CRGBPalette16& palette, JsonVariant dst)
         {
             StaticJsonDocument<384> doc;
-    
+
             JsonArray colors = doc.to<JsonArray>();
 
             for (auto& color: palette.entries)
                 colors.add(color);
-        
+
             return dst.set(doc);
         }
 
-        static CRGBPalette16 fromJson(JsonVariantConst src) 
+        static CRGBPalette16 fromJson(JsonVariantConst src)
         {
             CRGB colors[16];
             int colorIndex = 0;
 
             JsonArrayConst componentsArray = src.as<JsonArrayConst>();
-            for (JsonVariantConst value : componentsArray) 
+            for (JsonVariantConst value : componentsArray)
                 colors[colorIndex++] = value.as<CRGB>();
 
-            return CRGBPalette16(colors); 
+            return CRGBPalette16(colors);
         }
 
-        static bool checkJson(JsonVariantConst src) 
+        static bool checkJson(JsonVariantConst src)
         {
             return src.is<JsonArrayConst>() && src.as<JsonArrayConst>().size() == 16;
         }

--- a/include/ledstripeffect.h
+++ b/include/ledstripeffect.h
@@ -2,7 +2,7 @@
 //
 // File:        LEDStripEffect.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -25,7 +25,7 @@
 //    Defines the base class for effects that run locally on the chip
 //
 // History:     Apr-13-2019         Davepl      Created for NightDriverStrip
-//              
+//
 //---------------------------------------------------------------------------
 
 #pragma once
@@ -69,7 +69,7 @@ class LEDStripEffect : public IJSONSerializable
             _friendlyName = strName;
     }
 
-    LEDStripEffect(const JsonObjectConst&  jsonObject) 
+    LEDStripEffect(const JsonObjectConst&  jsonObject)
         : _effectNumber(jsonObject[PTY_EFFECTNR]),
           _friendlyName(jsonObject["fn"].as<String>())
     {
@@ -80,18 +80,18 @@ class LEDStripEffect : public IJSONSerializable
     }
 
     virtual bool Init(std::shared_ptr<GFXBase> gfx[NUM_CHANNELS])               // There are up to 8 channel in play per effect and when we
-    {           
+    {
         debugV("Init %s", _friendlyName.c_str());                                                    //   start up, we are given copies to their graphics interfaces
         for (int i = 0; i < NUM_CHANNELS; i++)                      //   so that we can call them directly later from other calls
         {
-            _GFX[i] = gfx[i];    
+            _GFX[i] = gfx[i];
         }
         debugV("Get LED Count");
-        _cLEDs = _GFX[0]->GetLEDCount();   
+        _cLEDs = _GFX[0]->GetLEDCount();
         debugV("Init Effect %s with %d LEDs\n", _friendlyName.c_str(), _cLEDs);
-        return true;  
+        return true;
     }
-    
+
     inline std::shared_ptr<GFXBase> graphics() const
     {
         return _GFX[0];
@@ -102,11 +102,11 @@ class LEDStripEffect : public IJSONSerializable
     {
         return ((LEDMatrixGFX *)g_aptrDevices[0].get());
     }
-#endif 
-   
+#endif
+
     virtual void Start() {}                                         // Optional method called when time to clean/init the effect
     virtual void Draw() = 0;                                        // Your effect must implement these
-    
+
     virtual bool CanDisplayVUMeter() const
     {
         return true;
@@ -126,10 +126,15 @@ class LEDStripEffect : public IJSONSerializable
     {
         return 30;
     }
-    
+
     virtual size_t MaximumEffectTime() const
     {
         return SIZE_MAX;
+    }
+
+    virtual bool HasMaximumEffectTime() const
+    {
+        return MaximumEffectTime() != SIZE_MAX;
     }
 
     virtual bool ShouldShowTitle() const
@@ -141,7 +146,7 @@ class LEDStripEffect : public IJSONSerializable
     // If a matrix effect requires the state of the last buffer be preserved, then it requires float buffering.
     // If, on the other hand, it renders from scratch every time, starting witha black fill, etc, then it does not,
     // and it can override this method and return false;
-    
+
     virtual bool RequiresfloatBuffering() const
     {
         return true;
@@ -162,7 +167,7 @@ class LEDStripEffect : public IJSONSerializable
         return colors[randomColorIndex];
     }
 
-    static CRGB GetBlackBodyHeatColor(float temp) 
+    static CRGB GetBlackBodyHeatColor(float temp)
     {
         temp = min(1.0f, temp);
         uint8_t temperature = (uint8_t)(255 * temp);
@@ -178,7 +183,7 @@ class LEDStripEffect : public IJSONSerializable
         else
             return CRGB(heatramp, 0, 0);
     }
-    
+
     static inline CRGB RandomSaturatedColor()
     {
         CRGB c;
@@ -201,10 +206,10 @@ class LEDStripEffect : public IJSONSerializable
         }
 
         for (int n = 0; n < NUM_CHANNELS; n++)
-        {            
+        {
             for (int i = iStart; i < iStart + numToFill; i+= everyN)
                 _GFX[n]->setPixel(i, color);
-               
+
         }
     }
 
@@ -215,20 +220,20 @@ class LEDStripEffect : public IJSONSerializable
             _GFX[i]->Clear();
         }
     }
-    
+
     // ColorFraction
     //
     // Returns a fraction of a color; abstracts the fadeToBlack away so that we can later
     // do better color correction as needed
 
-    static inline CRGB ColorFraction(const CRGB colorIn, float fraction) 
+    static inline CRGB ColorFraction(const CRGB colorIn, float fraction)
     {
         fraction = min(1.0f, fraction);
         fraction = max(0.0f, fraction);
         return CRGB(colorIn).fadeToBlackBy(255 * (1.0f - fraction));
     }
 
-    void fillRainbowAllChannels(int iStart, int numToFill, uint8_t initialhue, uint8_t deltahue, uint8_t everyNth = 1) 
+    void fillRainbowAllChannels(int iStart, int numToFill, uint8_t initialhue, uint8_t deltahue, uint8_t everyNth = 1)
     {
         if (iStart + numToFill > _cLEDs)
         {
@@ -269,27 +274,27 @@ class LEDStripEffect : public IJSONSerializable
 
     inline void setAllOnAllChannels(uint8_t r, uint8_t g, uint8_t b) const
     {
-        for (int n = 0; n < NUM_CHANNELS; n++)    
+        for (int n = 0; n < NUM_CHANNELS; n++)
             for (int i = 0; i < _cLEDs; i++)
                 _GFX[n]->setPixel(i, r, g, b);
     }
 
     inline void setPixelOnAllChannels(int i, CRGB c)
-    {       
-        for (int j = 0; j < NUM_CHANNELS; j++)  
+    {
+        for (int j = 0; j < NUM_CHANNELS; j++)
             _GFX[j]->setPixel(i, c);
     }
 
     inline void setPixelsOnAllChannels(float fPos, float count, CRGB c, bool bMerge = false) const
-    {       
+    {
         for (int i = 0; i < NUM_CHANNELS; i++)
             _GFX[i]->setPixelsF(fPos, count, c, bMerge);
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<128> jsonDoc;
-        
+
         jsonDoc[PTY_EFFECTNR] = _effectNumber;
         jsonDoc["fn"] = _friendlyName;
 

--- a/include/network.h
+++ b/include/network.h
@@ -2,7 +2,7 @@
 //
 // File:        network.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -79,7 +79,7 @@
     //
     // Reads the raw MAC
 
-    inline void get_mac_address_raw(uint8_t *mac) 
+    inline void get_mac_address_raw(uint8_t *mac)
     {
         esp_efuse_mac_get_default(mac);
     }
@@ -88,7 +88,7 @@
     //
     // Returns a packed (non-pretty, without colons) version of the MAC id
 
-    inline String get_mac_address() 
+    inline String get_mac_address()
     {
       uint8_t mac[6];
       WiFi.macAddress(mac);
@@ -99,12 +99,12 @@
     //
     // Returns a packed (non-pretty, without colons) version of the MAC id
 
-    inline String get_mac_address_pretty() 
+    inline String get_mac_address_pretty()
     {
       uint8_t mac[6];
       WiFi.macAddress(mac);
       return str_sprintf("%02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
-    }    
+    }
 
 
 

--- a/include/secrets.example.h
+++ b/include/secrets.example.h
@@ -2,7 +2,7 @@
 //
 // File:        secrets.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,24 +10,24 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
 //
 // Description:
 //
-//    secret definitions, at the moment this is just network secrets, 
+//    secret definitions, at the moment this is just network secrets,
 //    but could be expanded in the future
 //
 //---------------------------------------------------------------------------
 
-// NOTE: do NOT enter your network details in this file (secrets.example.h)! 
+// NOTE: do NOT enter your network details in this file (secrets.example.h)!
 // Instead, copy this file to secrets.h, and set the below defines in that file!
 
 #define cszSSID              "Your SSID"

--- a/include/socketserver.h
+++ b/include/socketserver.h
@@ -2,7 +2,7 @@
 //
 // File:        SocketServer.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -28,18 +28,18 @@
 // History:     Oct-26-2018     Davepl      Created
 //---------------------------------------------------------------------------
 #pragma once
-#include <unistd.h> 
-#include <stdio.h> 
-#include <sys/socket.h> 
-#include <stdlib.h> 
-#include <netinet/in.h> 
-#include <string.h> 
+#include <unistd.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <stdlib.h>
+#include <netinet/in.h>
+#include <string.h>
 #include <memory>
 #include <iostream>
 
 #include "ledbuffer.h"
 
-extern "C" 
+extern "C"
 {
     #include "uzlib/src/uzlib.h"
 }
@@ -54,7 +54,7 @@ extern "C"
 #define MAXIUMUM_PACKET_SIZE \
             (STANDARD_DATA_HEADER_SIZE + LED_DATA_SIZE * NUM_LEDS)                  // Header plus 24 bits per actual LED
 
-#define COMPRESSED_HEADER (0x44415645)                                              // asci "DAVE" as header 
+#define COMPRESSED_HEADER (0x44415645)                                              // asci "DAVE" as header
 bool ProcessIncomingData(uint8_t * payloadData, size_t payloadLength);              // In main file
 
 #if ENABLE_WIFI && INCOMING_WIFI_ENABLED
@@ -73,7 +73,7 @@ struct SocketResponse
     double      wifiSignal;        // 8
     uint32_t    bufferSize;        // 4
     uint32_t    bufferPos;         // 4
-    uint32_t    fpsDrawing;        // 4    
+    uint32_t    fpsDrawing;        // 4
     uint32_t    watts;             // 4
 };
 
@@ -84,17 +84,17 @@ static_assert(sizeof(float)  == 4);             // PeakData on wire uses 4 byte 
 // floats land on byte multiples of 8, otherwise you'll get packing bytes inserted.  Welcome to my world! Once upon
 // a time, I ported about a billion lines of x86 'pragma_pack(1)' code to the MIPS (davepl)!
 
-static_assert( sizeof(SocketResponse) == 64, "SocketResponse struct size is not what is expected - check alignment and float size" );            
+static_assert( sizeof(SocketResponse) == 64, "SocketResponse struct size is not what is expected - check alignment and float size" );
 
 extern AppTime g_AppTime;
 extern std::unique_ptr<LEDBufferManager> g_aptrBufferManager[NUM_CHANNELS];
 extern uint32_t g_FPS;
 extern float g_Brite;
-extern uint32_t g_Watts; 
+extern uint32_t g_Watts;
 
 // SocketServer
 //
-// Handles incoming connections from the server and pass the data that comes in 
+// Handles incoming connections from the server and pass the data that comes in
 
 class SocketServer
 {
@@ -103,7 +103,7 @@ private:
     int                    _port;
     int                    _numLeds;
     int                    _server_fd;
-    struct sockaddr_in     _address; 
+    struct sockaddr_in     _address;
     std::unique_ptr<uint8_t []> _pBuffer;
     std::unique_ptr<uint8_t []> _abOutputBuffer;
 
@@ -138,38 +138,38 @@ public:
         _pBuffer = std::make_unique<uint8_t []>(MAXIUMUM_PACKET_SIZE);
 
         _cbReceived = 0;
-        
-        // Creating socket file descriptor 
 
-        if ((_server_fd = socket(AF_INET, SOCK_STREAM, 0)) == 0) 
-        { 
+        // Creating socket file descriptor
+
+        if ((_server_fd = socket(AF_INET, SOCK_STREAM, 0)) == 0)
+        {
             debugW("socket error\n");
             release();
             return false;
-        } 
+        }
 
         memset(&_address, 0, sizeof(_address));
-        _address.sin_family = AF_INET; 
-        _address.sin_addr.s_addr = INADDR_ANY; 
-        _address.sin_port = htons( _port ); 
-       
-        if (bind(_server_fd, (struct sockaddr *)&_address, sizeof(_address)) < 0)       // Bind socket to port 
-        { 
-            debugW("bind failed\n"); 
+        _address.sin_family = AF_INET;
+        _address.sin_addr.s_addr = INADDR_ANY;
+        _address.sin_port = htons( _port );
+
+        if (bind(_server_fd, (struct sockaddr *)&_address, sizeof(_address)) < 0)       // Bind socket to port
+        {
+            debugW("bind failed\n");
             release();
             return false;
-        } 
+        }
         if (listen(_server_fd, 6) < 0)                                                  // Start listening for connections
-        { 
-            debugW("listen failed\n"); 
+        {
+            debugW("listen failed\n");
             release();
             return false;
-        } 
+        }
         return true;
     }
 
     void ResetReadBuffer()
-    {   
+    {
         _cbReceived = 0;
     }
 
@@ -181,13 +181,13 @@ public:
     {
         if (cbNeeded <= _cbReceived)                            // If we already have that many bytes, we're already done
         {
-            debugV("Already had enough data to satisfy read: requested %d, had %d", cbNeeded, _cbReceived); 
+            debugV("Already had enough data to satisfy read: requested %d, had %d", cbNeeded, _cbReceived);
             return true;
         }
 
         // This test caps maximum packet size as a full buffer read of LED data.  If other packets wind up being longer,
         // the buffer itself and this test might need to change
-        
+
         if (cbNeeded > MAXIUMUM_PACKET_SIZE)
         {
             debugW("Unexpected request for %d bytes in ReadUntilNBytesReceived\n", cbNeeded);
@@ -223,7 +223,7 @@ public:
 
     bool SendResponseToServer(int socket, void * pData, size_t cbSize)
     {
-        // Send a response back to the server 
+        // Send a response back to the server
         if (cbSize != write(socket, pData, cbSize))
         {
             debugW("Could not write to socket\n");
@@ -246,16 +246,16 @@ public:
         }
 
         int new_socket = 0;
-        
+
         // Accept a new incoming connnection
-        int addrlen = sizeof(_address); 
-        if ((new_socket = accept(_server_fd, (struct sockaddr *)&_address, (socklen_t*)&addrlen))<0) 
-        { 
+        int addrlen = sizeof(_address);
+        if ((new_socket = accept(_server_fd, (struct sockaddr *)&_address, (socklen_t*)&addrlen))<0)
+        {
             debugW("Error accepting data!");
             return false;
-        } 
+        }
 
-        // Report where this connection is coming from 
+        // Report where this connection is coming from
 
         struct sockaddr_in addr;
         socklen_t addr_size = sizeof(struct sockaddr_in);
@@ -263,7 +263,7 @@ public:
         debugV("Incoming connection from: %s", inet_ntoa(addr.sin_addr));
 
         // Set a timeout of 3 seconds on the socket so we don't permanently hang on a corrupt or partial packet
-               
+
         struct timeval to;
         to.tv_sec = 3;
         to.tv_usec = 0;
@@ -273,18 +273,18 @@ public:
             close(new_socket);
             return false;
         }
-        
+
         do
         {
             bool bSendResponsePacket = false;
 
-             // Read until we have at least enough for the data header 
+             // Read until we have at least enough for the data header
 
             if (false == ReadUntilNBytesReceived(new_socket, STANDARD_DATA_HEADER_SIZE))
             {
                 debugW("Read error in getting header.\n");
                 close(new_socket);
-                ResetReadBuffer();                    
+                ResetReadBuffer();
                 return false;
             }
 
@@ -314,7 +314,7 @@ public:
                 // If our buffer is in PSRAM it would be expensive to decompress in place, as the SPIRAM doesn't like
                 // non-linear access from what I can tell.  I bet it must send addr+len to request each unique read, so
                 // one big read one time would work best, and we use that to copy it to a regular RAM buffer.
-                
+
                 #if USE_PSRAM
                     std::unique_ptr<uint8_t []> _abTempBuffer = std::make_unique<uint8_t []>(MAXIUMUM_PACKET_SIZE);
                     memcpy(_abTempBuffer.get(), _pBuffer.get(), MAXIUMUM_PACKET_SIZE);
@@ -322,7 +322,7 @@ public:
                 #else
                     auto pSourceBuffer = &_pBuffer[COMPRESSED_HEADER_SIZE];
                 #endif
-                
+
                 if (!DecompressBuffer(pSourceBuffer, compressedSize, _abOutputBuffer.get(), expandedSize))
                 {
                     debugW("Error decompressing data\n");
@@ -354,13 +354,13 @@ public:
                         size_t totalExpected = STANDARD_DATA_HEADER_SIZE + length32;
 
                         debugV("PeakData Header: numbands=%u, length=%u, seconds=%llu, micro=%llu", numbands, length32, seconds, micros);
-                        
+
                         if (numbands != NUM_BANDS)
                         {
                             debugE("Expecting %d bands but received %d", NUM_BANDS, numbands);
                             break;
                         }
-                        
+
                         if (length32 != numbands * sizeof(float))
                         {
                             debugE("Expecting %d bytes for %d audio bands, but received %d.  Ensure float size and endianness matches between sender and receiver systems.", totalExpected, NUM_BANDS, _cbReceived);
@@ -372,16 +372,16 @@ public:
                             debugE("Error in getting peak data from wifi, could not read the %d bytes", totalExpected);
                             break;
                         }
-                        
+
                         if (false == ProcessIncomingData(_pBuffer.get(), totalExpected))
                             break;
 
-                        // Consume the data by resetting the buffer 
+                        // Consume the data by resetting the buffer
                         debugV("Consuming the data as WIFI_COMMAND_PEAKDATA by setting _cbReceived to from %d down 0.", _cbReceived);
-    
+
                     #endif
                     ResetReadBuffer();
-                    
+
                 }
                 else if (command16 == WIFI_COMMAND_PIXELDATA64)
                 {
@@ -407,15 +407,15 @@ public:
                         debugW("Error in getting pixel data from wifi\n");
                         break;
                     }
-                
+
                     // Add it to the buffer ring
-                    
+
                     if (false == ProcessIncomingData(_pBuffer.get(), totalExpected))
                     {
                         break;
                     }
 
-                    // Consume the data by resetting the buffer 
+                    // Consume the data by resetting the buffer
                     debugV("Consuming the data as WIFI_COMMAND_PIXELDATA64 by setting _cbReceived to from %d down 0.", _cbReceived);
                     ResetReadBuffer();
 
@@ -428,14 +428,14 @@ public:
                 }
             }
 
-            // If we make it to this point, it should be success, so we consume 
+            // If we make it to this point, it should be success, so we consume
 
             ResetReadBuffer();
             delay(1);
 
             if (bSendResponsePacket)
             {
-                SocketResponse response = { 
+                SocketResponse response = {
                                             .size = sizeof(SocketResponse),
                                             .flashVersion = FLASH_VERSION,
                                             .currentClock = g_AppTime.CurrentTime(),
@@ -458,7 +458,7 @@ public:
         close(new_socket);
         ResetReadBuffer();
         return false;
-    }    
+    }
 
     // DecompressBuffer
     //
@@ -467,7 +467,7 @@ public:
     bool DecompressBuffer(const uint8_t * pBuffer, size_t cBuffer, uint8_t * pOutput, size_t expectedOutputSize) const
     {
         debugV("Compressed Data: %02X %02X %02X %02X...", pBuffer[0], pBuffer[1], pBuffer[2], pBuffer[3]);
-        
+
         struct uzlib_uncomp d = { 0 };
         uzlib_uncompress_init(&d, NULL, 0);
 
@@ -497,7 +497,7 @@ public:
             debugE("Exepcted it to to decompress to %d but got %d instead\n", expectedOutputSize, d.dest - pOutput);
             return false;
         }
-        
+
         return true;
     }
 };

--- a/include/soundanalyzer.h
+++ b/include/soundanalyzer.h
@@ -646,16 +646,16 @@ public:
         esp_err_t err = ESP_OK;
 
         i2s_driver_uninstall(Speak_I2S_NUMBER);  // Uninstall the I2S driver.  卸载I2S驱动
-        i2s_config_t i2s_config = 
+        i2s_config_t i2s_config =
         {
             .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_PDM),
-            .sample_rate = SAMPLING_FREQUENCY,  // Set the I2S sampling rate. 
+            .sample_rate = SAMPLING_FREQUENCY,  // Set the I2S sampling rate.
             .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,  // Fixed 12-bit stereo MSB.
             .channel_format = I2S_CHANNEL_FMT_ONLY_RIGHT,  // Set the channel format.
             .communication_format = I2S_COMM_FORMAT_STAND_I2S,  // Set the format of the communication.
-            .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,  // Set the interrupt flag.  
-            .dma_buf_count = 2,        // DMA buffer count.  
-            .dma_buf_len = 256,        // DMA buffer length. 
+            .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1,  // Set the interrupt flag.
+            .dma_buf_count = 2,        // DMA buffer count.
+            .dma_buf_len = 256,        // DMA buffer length.
         };
 
         err += i2s_driver_install(Speak_I2S_NUMBER, &i2s_config, 0, NULL);
@@ -663,13 +663,13 @@ public:
         i2s_pin_config_t tx_pin_config;
         tx_pin_config.mck_io_num = I2S_PIN_NO_CHANGE;
         tx_pin_config.bck_io_num = CONFIG_I2S_BCK_PIN;            // Link the BCK to the CONFIG_I2S_BCK_PIN pin.
-        tx_pin_config.ws_io_num = CONFIG_I2S_LRCK_PIN;       
-        tx_pin_config.data_out_num = CONFIG_I2S_DATA_PIN;    
-        tx_pin_config.data_in_num = CONFIG_I2S_DATA_IN_PIN;  
+        tx_pin_config.ws_io_num = CONFIG_I2S_LRCK_PIN;
+        tx_pin_config.data_out_num = CONFIG_I2S_DATA_PIN;
+        tx_pin_config.data_in_num = CONFIG_I2S_DATA_IN_PIN;
         err += i2s_set_pin(Speak_I2S_NUMBER, &tx_pin_config);  // Set the I2S pin number.
         err += i2s_set_clk(Speak_I2S_NUMBER, SAMPLING_FREQUENCY, I2S_BITS_PER_SAMPLE_16BIT, I2S_CHANNEL_MONO);  // Set the clock and bitwidth used by I2S Rx and Tx.
 
-    #elif M5STICKC || M5STICKCPLUS 
+    #elif M5STICKC || M5STICKCPLUS
 
         i2s_config_t i2s_config =
         {

--- a/include/taskmgr.h
+++ b/include/taskmgr.h
@@ -2,7 +2,7 @@
 //
 // File:        taskmgr.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -28,8 +28,8 @@
 //    to not timeslice with them.
 //
 //    Since this totally starves those system idle tasks, the watchdog must
-//    be turned off for them, which we do in begin().  We then turn the 
-//    watchdog on for our own idle tasks, and feed the watchdog in 
+//    be turned off for them, which we do in begin().  We then turn the
+//    watchdog on for our own idle tasks, and feed the watchdog in
 //    ProcessIdleTime as we consume all available idle time.
 //
 //    BUGBUG(davepl): I think this means that vTaskDelete is never called
@@ -46,7 +46,7 @@
 #include <Arduino.h>
 #include <esp_task_wdt.h>
 
-#define IDLE_STACK_SIZE 2048        
+#define IDLE_STACK_SIZE 2048
 // Stack size for the taskmgr's idle threads
 
 class IdleTask
@@ -58,7 +58,7 @@ class IdleTask
 
     const int kMillisPerLoop = 1;
     const int kMillisPerCalc = 1000;
-    
+
     unsigned long counter = 0;
 
   public:
@@ -75,7 +75,7 @@ class IdleTask
             int delta = millis() - _lastMeasurement;
             if (delta >= kMillisPerCalc)
             {
-                //Serial.printf("Core %u Spent %lu in delay during a window of %d for a ratio of %f\n", 
+                //Serial.printf("Core %u Spent %lu in delay during a window of %d for a ratio of %f\n",
                 //  xPortGetCoreID(), counter, delta, (float)counter/delta);
                 _idleRatio = ((float) counter  / delta);
                 _lastMeasurement = millis();
@@ -84,7 +84,7 @@ class IdleTask
             else
             {
                 esp_task_wdt_reset();
-                delayMicroseconds(kMillisPerLoop*1000);        
+                delayMicroseconds(kMillisPerLoop*1000);
                 counter += kMillisPerLoop;
             }
         }
@@ -179,7 +179,7 @@ public:
 };
 
 // NightDriverTaskManager
-// 
+//
 // A superclass of the base TaskManager that knows how to start and track the tasks specific to this project
 
 void IRAM_ATTR ScreenUpdateLoopEntry(void *);
@@ -217,15 +217,15 @@ public:
     {
         #if ENABLE_SERIAL
             debugW(">> Launching Serial Thread");
-            xTaskCreatePinnedToCore(AudioSerialTaskEntry, "Audio Serial Loop", STACK_SIZE, nullptr, AUDIOSERIAL_PRIORITY, &_taskAudio, AUDIOSERIAL_CORE);    
+            xTaskCreatePinnedToCore(AudioSerialTaskEntry, "Audio Serial Loop", STACK_SIZE, nullptr, AUDIOSERIAL_PRIORITY, &_taskAudio, AUDIOSERIAL_CORE);
         #endif
     }
-    
+
 
     void StartDrawThread()
     {
         debugW(">> Launching Draw Thread");
-        xTaskCreatePinnedToCore(DrawLoopTaskEntry, "Draw Loop", STACK_SIZE, nullptr, DRAWING_PRIORITY, &_taskDraw, DRAWING_CORE);    
+        xTaskCreatePinnedToCore(DrawLoopTaskEntry, "Draw Loop", STACK_SIZE, nullptr, DRAWING_PRIORITY, &_taskDraw, DRAWING_CORE);
     }
 
     void StartAudioThread()
@@ -235,12 +235,12 @@ public:
             xTaskCreatePinnedToCore(AudioSamplerTaskEntry, "Audio Sampler Loop", STACK_SIZE, nullptr, AUDIO_PRIORITY, &_taskAudio, AUDIO_CORE);
         #endif
     }
-    
+
     void StartNetworkThread()
     {
         #if ENABLE_WIFI
             debugW(">> Launching Network Thread");
-            xTaskCreatePinnedToCore(NetworkHandlingLoopEntry, "NetworkHandlingLoop", STACK_SIZE, nullptr, NET_PRIORITY, &_taskSync, NET_CORE);    
+            xTaskCreatePinnedToCore(NetworkHandlingLoopEntry, "NetworkHandlingLoop", STACK_SIZE, nullptr, NET_PRIORITY, &_taskSync, NET_CORE);
         #endif
     }
 
@@ -248,10 +248,10 @@ public:
     {
         #if ENABLE_WIFI
             debugW(">> Launching Debug Thread");
-            xTaskCreatePinnedToCore(DebugLoopTaskEntry, "Debug Loop", STACK_SIZE, nullptr, DEBUG_PRIORITY, &_taskDebug, DEBUG_CORE);    
+            xTaskCreatePinnedToCore(DebugLoopTaskEntry, "Debug Loop", STACK_SIZE, nullptr, DEBUG_PRIORITY, &_taskDebug, DEBUG_CORE);
         #endif
     }
-    
+
     void StartSocketThread()
     {
         #if ENABLE_WIFI

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -48,6 +48,7 @@
 #include <ArduinoJson.h>
 #include "deviceconfig.h"
 #include "jsonbase.h"
+#include "effects.h"
 
 class CWebServer
 {
@@ -171,6 +172,7 @@ class CWebServer
 
         _server.on("/settings",              HTTP_GET,  [this](AsyncWebServerRequest * pRequest)    { this->GetSettings(pRequest); });
         _server.on("/settings",              HTTP_POST, [this](AsyncWebServerRequest * pRequest)    { this->SetSettings(pRequest); });
+        _server.on("/effectsConfig",         HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { pRequest->send(SPIFFS, EFFECTS_CONFIG_FILE, "text/json"); });
 
         _server.on("/reset",                 HTTP_POST, [this](AsyncWebServerRequest * pRequest)    { this->Reset(pRequest); });
 

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -34,6 +34,7 @@
 // History:     Jul-12-2018         Davepl      Created
 //              Apr-29-2019         Davepl      Adapted from BigBlueLCD project
 //              Feb-02-2023         LouisRiel   Removed SPIFF served files with statically linked files
+//              Apr-28-2023         Rbergen     Reduce code duplication
 //---------------------------------------------------------------------------
 
 #pragma once

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -54,6 +54,20 @@ class CWebServer
 {
   private:
 
+    struct StaticStatistics
+    {
+        uint32_t HeapSize;
+        size_t DmaHeapSize;
+        uint32_t PsramSize;
+        const char *ChipModel;
+        uint8_t ChipCores;
+        uint32_t CpuFreqMHz;
+        uint32_t SketchSize;
+        uint32_t FreeSketchSpace;
+        uint32_t FlashChipSize;
+    };
+
+
     struct EmbeddedFile
     {
         // Embedded file size in bytes
@@ -71,6 +85,7 @@ class CWebServer
     };
 
     AsyncWebServer _server;
+    StaticStatistics _staticStats;
 
     // Helper functions/templates
     template<typename Tv>

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -205,3 +205,5 @@ class CWebServer
         debugI("HTTP server started");
     }
 };
+
+#define SET_VALUE(method) [](auto value) { method; }

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -2,7 +2,7 @@
 //
 // File:        webserver.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -52,14 +52,14 @@ class CWebServer
 {
   private:
 
-    struct EmbeddedFile 
+    struct EmbeddedFile
     {
         // Embedded file size in bytes
         const size_t length;
         // Contents as bytes
         const uint8_t *const contents;
         // Added to hold the file's MIME type, but could be used for other type types, if desired
-        const char *const type; 
+        const char *const type;
 
         EmbeddedFile(const uint8_t start[], const uint8_t end[], const char type[]) :
             length(end - start),
@@ -100,11 +100,11 @@ class CWebServer
     // AddCORSHeaderAndSend(OK)Response
     //
     // Sends a response with CORS headers
-    template<typename Tr>    
+    template<typename Tr>
     static void AddCORSHeaderAndSendResponse(AsyncWebServerRequest * pRequest, Tr * pResponse)
     {
         pResponse->addHeader("Access-Control-Allow-Origin", "*");
-        pRequest->send(pResponse);      
+        pRequest->send(pResponse);
     }
 
     // Version for empty response, normally used to finish up things that don't return anything, like "NextEffect"
@@ -134,7 +134,7 @@ class CWebServer
     void NextEffect(AsyncWebServerRequest * pRequest);
     void PreviousEffect(AsyncWebServerRequest * pRequest);
 
-    // This registers a handler for GET requests for one of the known files embedded in the firmware. 
+    // This registers a handler for GET requests for one of the known files embedded in the firmware.
     void ServeEmbeddedFile(const char strUri[], EmbeddedFile &file)
     {
         _server.on(strUri, HTTP_GET, [strUri, file](AsyncWebServerRequest *request)
@@ -156,7 +156,7 @@ class CWebServer
         extern const uint8_t ico_end[] asm("_binary_site_favicon_ico_end");
         extern const uint8_t timezones_start[] asm("_binary_config_timezones_json_start");
         extern const uint8_t timezones_end[] asm("_binary_config_timezones_json_end");
-        
+
         debugI("Connecting Web Endpoints");
 
         _server.on("/getEffectList",         HTTP_GET,  [this](AsyncWebServerRequest * pRequest)    { this->GetEffectListText(pRequest); });
@@ -189,7 +189,7 @@ class CWebServer
         ServeEmbeddedFile("/favicon.ico", ico_file);
         ServeEmbeddedFile("/timezones.json", timezones_file);
 
-        _server.onNotFound([](AsyncWebServerRequest *request) 
+        _server.onNotFound([](AsyncWebServerRequest *request)
         {
             if (request->method() == HTTP_OPTIONS) {
                 request->send(200);                                     // Apparently needed for CORS: https://github.com/me-no-dev/ESPAsyncWebServer

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -67,7 +67,6 @@ class CWebServer
         uint32_t FlashChipSize;
     };
 
-
     struct EmbeddedFile
     {
         // Embedded file size in bytes
@@ -173,6 +172,16 @@ class CWebServer
         extern const uint8_t ico_end[] asm("_binary_site_favicon_ico_end");
         extern const uint8_t timezones_start[] asm("_binary_config_timezones_json_start");
         extern const uint8_t timezones_end[] asm("_binary_config_timezones_json_end");
+
+        _staticStats.HeapSize = ESP.getHeapSize();
+        _staticStats.DmaHeapSize = heap_caps_get_total_size(MALLOC_CAP_DMA);
+        _staticStats.PsramSize = ESP.getPsramSize();
+        _staticStats.ChipModel = ESP.getChipModel();
+        _staticStats.ChipCores = ESP.getChipCores();
+        _staticStats.CpuFreqMHz = ESP.getCpuFreqMHz();
+        _staticStats.SketchSize = ESP.getSketchSize();
+        _staticStats.FreeSketchSpace = ESP.getFreeSketchSpace();
+        _staticStats.FlashChipSize = ESP.getFlashChipSize();
 
         debugI("Connecting Web Endpoints");
 

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -206,4 +206,4 @@ class CWebServer
     }
 };
 
-#define SET_VALUE(method) [](auto value) { method; }
+#define SET_VALUE(functionCall) [](auto value) { functionCall; }

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -78,7 +78,7 @@ class CWebServer
     using ValueSetter = std::function<void(Tv)>;
 
     template<typename Tv>
-    static void SetPostParam(AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<Tv> setter, ParamValueGetter<Tv> getter)
+    static void PushPostParamIfPresent(AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<Tv> setter, ParamValueGetter<Tv> getter)
     {
         if (!pRequest->hasParam(paramName, true, false))
             return;
@@ -87,14 +87,14 @@ class CWebServer
 
         AsyncWebParameter *param = pRequest->getParam(paramName, true, false);
 
-        // If found, parse it and pass it off to the setter
+        // Extract the value and pass it off to the setter
         setter(getter(param));
     }
 
     template<typename Tv>
-    static void SetPostParam(AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<Tv> setter)
+    static void PushPostParamIfPresent(AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<Tv> setter)
     {
-        SetPostParam<Tv>(pRequest, paramName, setter, [](AsyncWebParameter *param) { return param->value(); });
+        PushPostParamIfPresent<Tv>(pRequest, paramName, setter, [](AsyncWebParameter * param) constexpr { return param->value(); });
     }
 
     // AddCORSHeaderAndSend(OK)Response

--- a/src/deviceconfig.cpp
+++ b/src/deviceconfig.cpp
@@ -2,7 +2,7 @@
 //
 // File:        deviceconfig.cpp
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -67,14 +67,14 @@ DeviceConfig::DeviceConfig()
     }
 }
 
-bool DeviceConfig::SetTimeZone(const String& newTimeZone, bool skipWrite) 
+bool DeviceConfig::SetTimeZone(const String& newTimeZone, bool skipWrite)
 {
     String quotedTZ = "\n\"" + newTimeZone + '"';
-    
+
     const char *start = strstr(timezones_start, quotedTZ.c_str());
 
     // If we can't find the new timezone as a timezone name, assume it's a literal value
-    if (start == NULL) 
+    if (start == NULL)
         setenv("TZ", newTimeZone.c_str(), 1);
     // We received a timezone name, so we extract and use its timezone value
     else
@@ -85,7 +85,7 @@ bool DeviceConfig::SetTimeZone(const String& newTimeZone, bool skipWrite)
             return false;
 
         start++;
-        const char *end = strchr(start, '"');        
+        const char *end = strchr(start, '"');
         if (end == NULL)        // Can't actually happen unless timezone file is malformed
             return false;
 
@@ -94,7 +94,7 @@ bool DeviceConfig::SetTimeZone(const String& newTimeZone, bool skipWrite)
         std::unique_ptr<char[]> value = std::make_unique<char[]>(length + 1);
         strncpy(value.get(), start, length);
         value[length] = 0;
-        
+
         setenv("TZ", value.get(), 1);
     }
 
@@ -112,11 +112,11 @@ bool DeviceConfig::SetTimeZone(const String& newTimeZone, bool skipWrite)
 void DeviceConfig::WriteToNVS(const String& name, const String& value)
 {
     nvs_handle_t nvsRWHandle;
-    
+
     // The "storage" string must match NVS partition name in partition table
-    
-    esp_err_t err = nvs_open("deviceconfig", NVS_READWRITE, &nvsRWHandle);                       
-    if (err != ESP_OK) 
+
+    esp_err_t err = nvs_open("deviceconfig", NVS_READWRITE, &nvsRWHandle);
+    if (err != ESP_OK)
     {
         debugW("Error (%s) opening NVS handle!\n", esp_err_to_name(err));
         return;
@@ -133,11 +133,11 @@ void DeviceConfig::WriteToNVS(const String& name, const String& value)
 void DeviceConfig::WriteToNVS(const String& name, bool value)
 {
     nvs_handle_t nvsRWHandle;
-    
+
     // The "storage" string must match NVS partition name in partition table
-    
-    esp_err_t err = nvs_open("deviceconfig", NVS_READWRITE, &nvsRWHandle);                       
-    if (err != ESP_OK) 
+
+    esp_err_t err = nvs_open("deviceconfig", NVS_READWRITE, &nvsRWHandle);
+    if (err != ESP_OK)
     {
         debugW("Error (%s) opening NVS handle!\n", esp_err_to_name(err));
         return;
@@ -157,10 +157,10 @@ DeviceConfig::DeviceConfig()
 
     nvs_handle_t nvsROHandle;
     esp_err_t err = nvs_open("deviceconfig", NVS_READONLY, &nvsROHandle);
-    if (err != ESP_OK) 
+    if (err != ESP_OK)
     {
         debugW("Error (%s) opening NVS handle!\n", esp_err_to_name(err));
-        
+
         SetLocation(cszLocation);
         SetLocationIsZip(bLocationIsZip);
         SetCountryCode(cszCountryCode);
@@ -243,8 +243,8 @@ void DeviceConfig::GetTimeZones(std::vector<std::unique_ptr<char[]>>& timeZones)
     std::unique_ptr<char[]> timeZone;
     timeZones.clear();
 
-    while(true) 
-    {  
+    while(true)
+    {
         timeZoneStart = strstr(timeZoneStart, "\n\"");
         if (timeZoneStart == NULL)
             break;
@@ -259,7 +259,7 @@ void DeviceConfig::GetTimeZones(std::vector<std::unique_ptr<char[]>>& timeZones)
         strncpy(timeZone.get(), timeZoneStart, timeZoneLength);
         timeZone[timeZoneLength] = 0;
 
-        timeZones.push_back(timeZone);   
+        timeZones.push_back(timeZone);
     }
 }
 */

--- a/src/deviceconfig.cpp
+++ b/src/deviceconfig.cpp
@@ -43,7 +43,7 @@ void DeviceConfig::SaveToJSON()
 
 DeviceConfig::DeviceConfig()
 {
-    std::unique_ptr<DynamicJsonDocument> pJsonDoc(nullptr);
+    std::unique_ptr<AllocatedJsonDocument> pJsonDoc(nullptr);
 
     if (LoadJSONFile(DEVICE_CONFIG_FILE, g_DeviceConfigJSONBufferSize, pJsonDoc))
     {

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -47,7 +47,7 @@ extern SmartMatrixHub75Calc<COLOR_DEPTH, LEDMatrixGFX::kMatrixWidth, LEDMatrixGF
 #endif
 
 DRAM_ATTR std::unique_ptr<LEDBufferManager> g_aptrBufferManager[NUM_CHANNELS];
-DRAM_ATTR std::unique_ptr<EffectManager<GFXBase>> g_aptrEffectManager;
+DRAM_ATTR std::unique_ptr<EffectManager<GFXBase>> g_aptrEffectManager = nullptr;
 
 double volatile g_FreeDrawTime = 0.0;
 

--- a/src/effectfactories.cpp
+++ b/src/effectfactories.cpp
@@ -22,7 +22,7 @@
 //
 // Description:
 //
-//    Lookup tables for effect factories that create effect instances from 
+//    Lookup tables for effect factories that create effect instances from
 //    JSON objects, and support functions using them.
 //
 // History:     Apr-05-2023         Rbergen      Created for NightDriverStrip
@@ -33,11 +33,11 @@
 
 typedef LEDStripEffect* (*JsonEffectFactory)(const JsonObjectConst&);
 
-std::map<int, JsonEffectFactory> g_JsonStarryNightEffectFactories = 
+std::map<int, JsonEffectFactory> g_JsonStarryNightEffectFactories =
 {
     { EFFECT_STAR,
         [](const JsonObjectConst& jsonObject)->LEDStripEffect* { return new StarryNightEffect<Star>(jsonObject); } },
-    { EFFECT_STAR_BUBBLY, 
+    { EFFECT_STAR_BUBBLY,
         [](const JsonObjectConst& jsonObject)->LEDStripEffect* { return new StarryNightEffect<BubblyStar>(jsonObject); } },
     { EFFECT_STAR_HOT_WHITE,
         [](const JsonObjectConst& jsonObject)->LEDStripEffect* { return new StarryNightEffect<HotWhiteStar>(jsonObject); } },
@@ -57,12 +57,12 @@ LEDStripEffect* CreateStarryNightEffectFromJSON(const JsonObjectConst& jsonObjec
 {
     auto entry = g_JsonStarryNightEffectFactories.find(jsonObject[PTY_STARTYPENR]);
 
-    return entry != g_JsonStarryNightEffectFactories.end() 
+    return entry != g_JsonStarryNightEffectFactories.end()
         ? entry->second(jsonObject)
         : nullptr;
 }
 
-std::map<int, JsonEffectFactory> g_JsonEffectFactories = 
+std::map<int, JsonEffectFactory> g_JsonEffectFactories =
 {
     { EFFECT_STRIP_BOUNCING_BALL,
         [](const JsonObjectConst& jsonObject)->LEDStripEffect* { return new BouncingBallEffect(jsonObject); } },

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -669,7 +669,7 @@ DRAM_ATTR size_t g_EffectsManagerJSONBufferSize = 0;
     {
         debugW("InitSplashEffectManager");
 
-        g_aptrEffectManager = std::make_unique<EffectManager<GFXBase>>(new SplashLogoEffect(), g_aptrDevices);    
+        g_aptrEffectManager = std::make_unique<EffectManager<GFXBase>>(new SplashLogoEffect(), g_aptrDevices);
     }
 
 #endif
@@ -682,7 +682,7 @@ void InitEffectsManager()
 {
     debugW("InitEffectsManager...");
 
-    std::unique_ptr<DynamicJsonDocument> pJsonDoc;
+    std::unique_ptr<AllocatedJsonDocument> pJsonDoc;
 
     if (LoadJSONFile(EFFECTS_CONFIG_FILE, g_EffectsManagerJSONBufferSize, pJsonDoc))
     {

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -41,7 +41,7 @@ extern DRAM_ATTR std::shared_ptr<GFXBase> g_aptrDevices[NUM_CHANNELS];
 // Palettes
 //
 // Palettes that are referenced by effects need to be instantiated first
- 
+
 const CRGBPalette16 BlueColors_p =
 {
     CRGB::DarkBlue,
@@ -264,7 +264,7 @@ std::shared_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color)
 #define STARRYNIGHT_PROBABILITY 1.0
 #define STARRYNIGHT_MUSICFACTOR 1.0
 
-size_t CreateDefaultEffects(std::unique_ptr<EffectPointerArray>& pEffectList) 
+size_t CreateDefaultEffects(std::unique_ptr<EffectPointerArray>& pEffectList)
 {
     // The default effects table
     LEDStripEffect *defaultEffects[] =
@@ -304,10 +304,10 @@ size_t CreateDefaultEffects(std::unique_ptr<EffectPointerArray>& pEffectList)
         new PatternPongClock(),
         new PatternSubscribers(),
         new PatternWeather(),
-        
+
         // Animate a simple rainbow palette by using the palette effect on the built-in rainbow palette
         new GhostWave("GhostWave", 0, 24, false),
-        new WaveformEffect("WaveIn", 8),     
+        new WaveformEffect("WaveIn", 8),
         new GhostWave("WaveOut", 0, 0, true, 0),
 
         new WaveformEffect("WaveForm", 8),
@@ -319,11 +319,11 @@ size_t CreateDefaultEffects(std::unique_ptr<EffectPointerArray>& pEffectList)
         new PatternSunburst(),
 
         new PatternFlowField(),
-        new PatternClock(),        
+        new PatternClock(),
         new PatternAlienText(),
         new PatternCircuit(),
 
-        new StarryNightEffect<MusicStar>("Stars", RainbowColors_p, 2.0, 1, LINEARBLEND, 2.0, 0.5, 10.0),                                                // Rainbow Music Star
+        new StarryNightEffect<MusicStar>("Stars", RainbowColors_p, 2.0, 1, LINEARBLEND, 2.0, 0.5, 10.0), // Rainbow Music Star
 
         new PatternPulsar(),
 
@@ -338,10 +338,10 @@ size_t CreateDefaultEffects(std::unique_ptr<EffectPointerArray>& pEffectList)
         new PatternCurtain(),
         new PatternGridLights(),
         new PatternMunch(),
-        
+
         // new PatternInfinity(),
-        // new PatternQR(),           
-        
+        // new PatternQR(),
+
     #elif UMBRELLA
 
         new FireEffect("Calm Fire", NUM_LEDS, 2, 2, 75, 3, 10, true, false),
@@ -476,7 +476,7 @@ size_t CreateDefaultEffects(std::unique_ptr<EffectPointerArray>& pEffectList)
         new SpectrumAnalyzerEffect("Spectrum Standard", 16, spectrumAltColors, 0, 0, 1.0, 1.0),
 
         new SpectrumAnalyzerEffect("Spectrum Standard", 48, CRGB(0,0,4), 0, 0, 1.25, 1.25),
-        
+
         new GhostWave("GhostWave", 0, 16, false, 40),
         new SpectrumAnalyzerEffect("Spectrum USA", 16, USAColors_p, 0),
         new GhostWave("GhostWave Rainbow", 8),
@@ -642,14 +642,14 @@ size_t CreateDefaultEffects(std::unique_ptr<EffectPointerArray>& pEffectList)
         new PaletteEffect(MagentaColors_p),             // Rainbow palette
         new DoublePaletteEffect(),
 */
-    #else                                                                   
+    #else
 
         new RainbowFillEffect(6, 2),                    // Simple effect if not otherwise defined above
 
     #endif
     };
 
-    // If this assert fires, you have not defined any effects in the table above.  If adding a new config, you need to 
+    // If this assert fires, you have not defined any effects in the table above.  If adding a new config, you need to
     // add the list of effects in this table as shown for the vaious other existing configs.  You MUST have at least
     // one effect even if it's the Status effect.
     static_assert(ARRAYSIZE(defaultEffects) > 0);
@@ -691,7 +691,7 @@ void InitEffectsManager()
     else
     {
         debugI("Creating EffectManager using default effects");
-        
+
         std::unique_ptr<EffectPointerArray> defaultEffects;
         size_t effectCount = CreateDefaultEffects(defaultEffects);
 

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -290,7 +290,7 @@ size_t CreateDefaultEffects(std::unique_ptr<EffectPointerArray>& pEffectList)
 
     #elif MESMERIZER
 
-        new SplashLogoEffect(),
+//        new SplashLogoEffect(),
 
         new SpectrumAnalyzerEffect("Spectrum",   NUM_BANDS,     spectrumBasicColors, 100, 0, 1.0, 1.0),
         new SpectrumAnalyzerEffect("Spectrum 2",   32,            spectrumBasicColors, 100, 0, 1.25, 1.25),
@@ -663,6 +663,17 @@ size_t CreateDefaultEffects(std::unique_ptr<EffectPointerArray>& pEffectList)
 extern DRAM_ATTR std::unique_ptr<EffectManager<GFXBase>> g_aptrEffectManager;
 DRAM_ATTR size_t g_EffectsManagerJSONBufferSize = 0;
 
+#if USE_MATRIX
+
+    void InitSplashEffectManager()
+    {
+        debugW("InitSplashEffectManager");
+
+        g_aptrEffectManager = std::make_unique<EffectManager<GFXBase>>(new SplashLogoEffect(), g_aptrDevices);    
+    }
+
+#endif
+
 // InitEffectsManager
 //
 // Initializes the effect manager.  Reboots on failure, since it's not optional
@@ -677,7 +688,10 @@ void InitEffectsManager()
     {
         debugI("Creating EffectManager from JSON config");
 
-        g_aptrEffectManager = std::make_unique<EffectManager<GFXBase>>(pJsonDoc->as<JsonObjectConst>(), g_aptrDevices);
+        if (g_aptrEffectManager == nullptr)
+            g_aptrEffectManager = std::make_unique<EffectManager<GFXBase>>(pJsonDoc->as<JsonObjectConst>(), g_aptrDevices);
+        else
+            g_aptrEffectManager->DeserializeFromJSON(pJsonDoc->as<JsonObjectConst>());
 
         if (g_aptrEffectManager->EffectCount() == 0)
         {
@@ -695,7 +709,10 @@ void InitEffectsManager()
         std::unique_ptr<EffectPointerArray> defaultEffects;
         size_t effectCount = CreateDefaultEffects(defaultEffects);
 
-        g_aptrEffectManager = std::make_unique<EffectManager<GFXBase>>(defaultEffects, effectCount, g_aptrDevices);
+        if (g_aptrEffectManager == nullptr)
+            g_aptrEffectManager = std::make_unique<EffectManager<GFXBase>>(defaultEffects, effectCount, g_aptrDevices);
+        else
+            g_aptrEffectManager->LoadEffectArray(defaultEffects, effectCount);
     }
 
     if (false == g_aptrEffectManager->Init())

--- a/src/jsonserializer.cpp
+++ b/src/jsonserializer.cpp
@@ -2,7 +2,7 @@
 //
 // File:        jsonserializer.cpp
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -36,7 +36,7 @@ bool LoadJSONFile(const char *fileName, size_t& bufferSize, std::unique_ptr<Dyna
     bool jsonReadSuccessful = false;
 
     File file = SPIFFS.open(fileName);
-    
+
     if (file)
     {
         if (file.size() > 0)
@@ -50,7 +50,7 @@ bool LoadJSONFile(const char *fileName, size_t& bufferSize, std::unique_ptr<Dyna
             while(true)
             {
                 pJsonDoc.reset(new DynamicJsonDocument(bufferSize));
-                
+
                 DeserializationError error = deserializeJson(*pJsonDoc, file);
 
                 if (error == DeserializationError::NoMemory)
@@ -66,7 +66,7 @@ bool LoadJSONFile(const char *fileName, size_t& bufferSize, std::unique_ptr<Dyna
                     jsonReadSuccessful = true;
                     break;
                 }
-                else 
+                else
                 {
                     debugW("Error with code %d occurred while deserializing JSON from file %s", to_value(error.code()), fileName);
                     break;
@@ -105,7 +105,7 @@ bool SaveToJSONFile(const char *fileName, size_t& bufferSize, IJSONSerializable&
     SPIFFS.remove(fileName);
 
     File file = SPIFFS.open(fileName, FILE_WRITE);
-    
+
     if (!file)
     {
         debugE("Unable to open file %s to write JSON!", fileName);
@@ -114,7 +114,7 @@ bool SaveToJSONFile(const char *fileName, size_t& bufferSize, IJSONSerializable&
 
     size_t bytesWritten = serializeJson(*pJsonDoc, file);
     debugI("Number of bytes written to JSON file %s: %d", fileName, bytesWritten);
-    
+
     file.flush();
     file.close();
 
@@ -131,7 +131,7 @@ bool SaveToJSONFile(const char *fileName, size_t& bufferSize, IJSONSerializable&
     {
         while (file.available())
             Serial.write(file.read());
-        
+
         file.close();
     }
 */

--- a/src/jsonserializer.cpp
+++ b/src/jsonserializer.cpp
@@ -31,7 +31,7 @@
 #include "SPIFFS.h"
 #include "jsonserializer.h"
 
-bool LoadJSONFile(const char *fileName, size_t& bufferSize, std::unique_ptr<DynamicJsonDocument>& pJsonDoc)
+bool LoadJSONFile(const char *fileName, size_t& bufferSize, std::unique_ptr<AllocatedJsonDocument>& pJsonDoc)
 {
     bool jsonReadSuccessful = false;
 
@@ -49,7 +49,7 @@ bool LoadJSONFile(const char *fileName, size_t& bufferSize, std::unique_ptr<Dyna
             // Loop is here to deal with out of memory conditions
             while(true)
             {
-                pJsonDoc.reset(new DynamicJsonDocument(bufferSize));
+                pJsonDoc.reset(new AllocatedJsonDocument(bufferSize));
 
                 DeserializationError error = deserializeJson(*pJsonDoc, file);
 
@@ -85,12 +85,12 @@ bool SaveToJSONFile(const char *fileName, size_t& bufferSize, IJSONSerializable&
     if (bufferSize == 0)
         bufferSize = JSON_BUFFER_BASE_SIZE;
 
-    std::unique_ptr<DynamicJsonDocument> pJsonDoc(nullptr);
+    std::unique_ptr<AllocatedJsonDocument> pJsonDoc(nullptr);
 
     // Loop is here to deal with out of memory conditions
     while(true)
     {
-        pJsonDoc.reset(new DynamicJsonDocument(bufferSize));
+        pJsonDoc.reset(new AllocatedJsonDocument(bufferSize));
         JsonObject jsonObject = pJsonDoc->to<JsonObject>();
 
         if (object.SerializeToJSON(jsonObject))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,8 @@
 //+--------------------------------------------------------------------------
 //
-// File:        main.cpp  
+// File:        main.cpp
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -27,7 +27,7 @@
 //    external dependencies.
 //
 //    NightDriver is an LED display project composed of a client app
-//    that runs on the ESP32 and an optional server that can run on 
+//    that runs on the ESP32 and an optional server that can run on
 //    a variety of platforms (anywhere .Net CORE works, like the Pi).
 //    The app controls WS2812B style LEDs.  The number of LEDs in a
 //    row is unbounded but realistically limited to about 1000 which
@@ -35,7 +35,7 @@
 //    can be 8 such channels connected to 8 different pins.
 //    By default NightDriver draws client effects, and there many
 //    built in, from marquees to fire.  But it can also receive color
-//    data from a server.  So it firsts checks to see if there is 
+//    data from a server.  So it firsts checks to see if there is
 //    data coming in, and if so, draws that.  If not it falls back
 //    to internal drawing.  The server sends a simple packet with
 //    an LED count, timestamp, and then the color data for the LEDs.
@@ -47,7 +47,7 @@
 //
 //    Both client and server require reliable access to an SNTP server
 //    to keep their clocks in sync.  The client sets its time every
-//    few hours to combat clock drifts on the ESP32.  Since all the 
+//    few hours to combat clock drifts on the ESP32.  Since all the
 //    clients (and the server) have the same clock, they can sync
 //    shows across multiple clients.  Imagine a setup where a dozen
 //    LED matrixes are arranged to form a small "jumbotron".  This
@@ -59,12 +59,12 @@
 //    of sound-reactive and beat-driven effects built in.
 //
 //    In addition to simple trips, the app handles matrixes as well.
-//    It also handles groups of rings.  In one incarnation, 10 RGB 
+//    It also handles groups of rings.  In one incarnation, 10 RGB
 //    LED PC fans are connected in a LianLi case plus the 32 or so
 //    on the front of the case.  The fans are grouped into NUM_FANS
 //    fans.  It also suports concentrically nested rings of varying
 //    size, which I use for a Christmas-tree project where each tree
-//    is made up of a "stack" of rings - 32 leds, 18, 10, 4, 1.  
+//    is made up of a "stack" of rings - 32 leds, 18, 10, 4, 1.
 //    It's up to individual effects to take advantage of them but
 //    the drawing code provides APIs for "draw to LED x of RING q on
 //    FAZN number z" and so on for convenience.
@@ -88,8 +88,8 @@
 //    code (optionally) receives color data over Wifi.  If it hasn't had
 //    any for a bit of time, it falls back to rotating through a table
 //    of internal effects.
-//    
-//    A number of worker threads are created which:  
+//
+//    A number of worker threads are created which:
 //
 //      1) Draw the TFT and display stats like framerate and IP addr
 //      2) Sync the clock periodically
@@ -105,42 +105,42 @@
 //
 // License:
 //
-// NightDriver is an open source embedded application governed by the terms 
-// of the General Public License (GPL). This requires that anyone modifying 
-// the NightDriver code (for anything other than personal use) or building 
-// applications based on NightDriver code must also make their derived 
-// product available under the same open source GPL terms. By purchasing 
-// a license for NightDriver, you would not then be bound by the GPL and 
-// you would gain an extended feature set and various levels of support.  
-// Think commas, not zeros, when discussing product volumes and license 
-// pricing.  
+// NightDriver is an open source embedded application governed by the terms
+// of the General Public License (GPL). This requires that anyone modifying
+// the NightDriver code (for anything other than personal use) or building
+// applications based on NightDriver code must also make their derived
+// product available under the same open source GPL terms. By purchasing
+// a license for NightDriver, you would not then be bound by the GPL and
+// you would gain an extended feature set and various levels of support.
+// Think commas, not zeros, when discussing product volumes and license
+// pricing.
 //
-// Without restricting the author protections found in the GPL, Plummer's 
+// Without restricting the author protections found in the GPL, Plummer's
 // Software LLC, its programmers, representatives and agents, etc.,
-// specifically disclaim any liability related to safety or suitability 
+// specifically disclaim any liability related to safety or suitability
 // for any purpose whatsoever.  Hypothetical example so we all know what
 // I mean:  If the code that limits LED power consumption has a horribly
 // negligent bug that burns down your village, you have my sympathy but
 // not my liability. It's not that I don't care, there's just no world
-// where I'd casually release code that I was responsible for in that 
+// where I'd casually release code that I was responsible for in that
 // manner without suitable engineering and testing, none of which this
 // code has had.  Not sure?  Turn and flee.  By proceeding, you agree.
 //
 // License Purchases
 //
-// NightDriver is an open source embedded application governed by the 
-// terms of the General Public License (GPL).  If you follow that license 
+// NightDriver is an open source embedded application governed by the
+// terms of the General Public License (GPL).  If you follow that license
 // it's yours at the amazing price of 'completely free'.
 //
-// If, on the other hand, you are building a commercial application for 
+// If, on the other hand, you are building a commercial application for
 // internal use or resale:
 //
-// Anyone building applications based on NightDriver code, or modifying 
-// the NightDriver code, must also make their derived product available 
-// under the same open source GPL terms. Commercial licenses may be 
-// purchased from Plummer's Software LLC if you do not wish to be bound 
+// Anyone building applications based on NightDriver code, or modifying
+// the NightDriver code, must also make their derived product available
+// under the same open source GPL terms. Commercial licenses may be
+// purchased from Plummer's Software LLC if you do not wish to be bound
 // by the GPL terms. These licenses are valid for a specified term.
-// 
+//
 // Contact Plummer's Software LLC for volume pricing and support questions.
 //
 // History:     Jul-12-2018         Davepl      Created
@@ -171,11 +171,11 @@ extern float g_Brite;
 
 NightDriverTaskManager g_TaskManager;
 
-// The one and only instance of ImprovSerial.  We instantiate is as the type needed 
+// The one and only instance of ImprovSerial.  We instantiate is as the type needed
 // for the serial port on this module.  That's usually HardwareSerial but can be
 // other types on the S2, etc... which is why it's a template class.
 
-ImprovSerial<typeof(Serial)> g_ImprovSerial; 
+ImprovSerial<typeof(Serial)> g_ImprovSerial;
 
 //
 // Global Variables
@@ -183,9 +183,9 @@ ImprovSerial<typeof(Serial)> g_ImprovSerial;
 
 #if NUM_INFO_PAGES > 0
 DRAM_ATTR uint8_t giInfoPage = NUM_INFO_PAGES - 1;                                  // Default to last page
-#else                               
+#else
 DRAM_ATTR uint8_t giInfoPage = 0;                                                   // Default to first page
-#endif                              
+#endif
 
 DRAM_ATTR WiFiUDP g_Udp;                                                            // UDP object used for NNTP, etc
 DRAM_ATTR uint32_t g_FPS = 0;                                                       // Our global framerate
@@ -203,17 +203,17 @@ extern bool bitmap_output(int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t
 
 // If an insulator or tree or fan has multiple rings, this table defines how those rings are laid out such
 // that they add up to FAN_SIZE pixels total per ring.
-// 
+//
 // Imagine a setup of 5 christmas trees, where each tree was made up of 4 concentric rings of descreasing
 // size, like 16, 12, 8, 4.  You would have NUM_FANS of 5 and MAX_RINGS of 4 and your ring table would be 16, 12, 8 4.
 
-DRAM_ATTR const int g_aRingSizeTable[MAX_RINGS] = 
-{ 
-    RING_SIZE_0, 
-    RING_SIZE_1, 
-    RING_SIZE_2, 
-    RING_SIZE_3, 
-    RING_SIZE_4 
+DRAM_ATTR const int g_aRingSizeTable[MAX_RINGS] =
+{
+    RING_SIZE_0,
+    RING_SIZE_1,
+    RING_SIZE_2,
+    RING_SIZE_3,
+    RING_SIZE_4
 };
 
 //
@@ -245,7 +245,7 @@ extern DRAM_ATTR std::unique_ptr<LEDBufferManager> g_aptrBufferManager[NUM_CHANN
 
 #if ENABLE_WIFI
 void IRAM_ATTR DebugLoopTaskEntry(void *)
-{    
+{
     //debugI(">> DebugLoopTaskEntry\n");
 
    // Initialize RemoteDebug
@@ -268,9 +268,9 @@ void IRAM_ATTR DebugLoopTaskEntry(void *)
         {
             Debug.handle();
         }
-        
-        delay(10);        
-    }    
+
+        delay(10);
+    }
 }
 #endif
 
@@ -287,14 +287,14 @@ void IRAM_ATTR DebugLoopTaskEntry(void *)
 
     #define SUB_CHECK_INTERVAL 60000
     #define SUB_CHECK_ERROR_INTERVAL 10000
-    #define CHANNEL_GUID "9558daa1-eae8-482f-8066-17fa787bc0e4" 
+    #define CHANNEL_GUID "9558daa1-eae8-482f-8066-17fa787bc0e4"
 
     WiFiClient http;
     YouTubeSight sight(CHANNEL_GUID, http);
 #endif
 
 void IRAM_ATTR NetworkHandlingLoopEntry(void *)
-{    
+{
     //debugI(">> NetworkHandlingLoopEntry\n");
 
 #if ENABLE_WIFI
@@ -361,10 +361,10 @@ void IRAM_ATTR NetworkHandlingLoopEntry(void *)
                 {
                     debugV("Refreshing Time from Server...");
                     NTPTimeClient::UpdateClockFromWeb(&g_Udp);
-                    
+
                 }
             }
-        #endif     
+        #endif
 
         delay(50);
     }
@@ -420,7 +420,7 @@ void PrintOutputHeader()
         debugI("ESP32 PSRAM Init: %s", psramInit() ? "OK" : "FAIL");
     #endif
 
-    debugI("Version %u: Wifi SSID: %s - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u", 
+    debugI("Version %u: Wifi SSID: %s - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u",
             FLASH_VERSION, cszSSID, ESP.getFreeHeap(), ESP.getPsramSize(), ESP.getFreePsram());
     debugI("ESP32 Clock Freq : %d MHz", ESP.getCpuFreqMHz());
 }
@@ -434,7 +434,7 @@ void TerminateHandler()
     debugE("-------------------------------------------------------------------------------------");
     debugE("- NightDriverStrip Guru Meditation                              Unhandled Exception -");
     debugE("-------------------------------------------------------------------------------------");
-    
+
     PrintOutputHeader();
 
     try {
@@ -459,7 +459,7 @@ Bounce2::Button Button2;
 //
 // Invoked once at boot, does initial chip setup and application initial init, then spins off worker tasks and returns
 // control to the system so it can invoke the main loop() function.
-// 
+//
 // Threads (tasks) created here can include:
 //
 // DebugLoopTaskEntry           - Run a little debug console accessible via telnet and serial
@@ -473,11 +473,11 @@ Bounce2::Button Button2;
 void setup()
 {
     // Initialize Serial output
-    Serial.begin(115200);      
+    Serial.begin(115200);
 
     uzlib_init();
 
-    if (!SPIFFS.begin(true)) 
+    if (!SPIFFS.begin(true))
         Serial.println("WARNING: SPIFFs could not be intialized!");
 
     // Star the Task Manager which takes over the watchdog role and measures CPU usage
@@ -485,7 +485,7 @@ void setup()
 
     esp_log_level_set("*", ESP_LOG_WARN);        // set all components to an appropriate logging level
 
-    // Set the unhandled exception handler to be our own special exit function                 
+    // Set the unhandled exception handler to be our own special exit function
     std::set_terminate(TerminateHandler);
 
     // Display a simple statup header on the serial port
@@ -540,14 +540,14 @@ void setup()
     // If we have a remote control enabled, set the direction on its input pin accordingly
 
     #if ENABLE_REMOTE
-        pinMode(IR_REMOTE_PIN, INPUT);             
+        pinMode(IR_REMOTE_PIN, INPUT);
     #endif
 
     #if ENABLE_AUDIO
         #if INPUT_PIN
             pinMode(INPUT_PIN, INPUT);
         #endif
-        #if TTGO                                    
+        #if TTGO
             pinMode(37, OUTPUT);            // This pin layout allows for mounting a MAX4466 to the backside
             digitalWrite(37, LOW);          //   of a TTGO with the OUT pin on 36, GND on 37, and Vcc on 38
             pinMode(38, OUTPUT);
@@ -610,7 +610,7 @@ void setup()
     // Set up bitmap drawing for those that need it
 
     // Without these two magic lines, you get no picture, which is pretty annoying...
-    
+
     #ifndef TFT_BL
       #define TFT_BL 5 // LED back-light
     #endif
@@ -627,15 +627,15 @@ void setup()
     g_pDisplay->setRotation(1);
 
     uint8_t x = g_pDisplay->readcommand8(ILI9341_RDMODE);
-    debugI("Display Power Mode: %x", x); 
+    debugI("Display Power Mode: %x", x);
     x = g_pDisplay->readcommand8(ILI9341_RDMADCTL);
-    debugI("MADCTL Mode: %x", x); 
+    debugI("MADCTL Mode: %x", x);
     x = g_pDisplay->readcommand8(ILI9341_RDPIXFMT);
-    debugI("Pixel Format: %x", x); 
+    debugI("Pixel Format: %x", x);
     x = g_pDisplay->readcommand8(ILI9341_RDIMGFMT);
-    debugI("Image Format: %x", x); 
+    debugI("Image Format: %x", x);
     x = g_pDisplay->readcommand8(ILI9341_RDSELFDIAG);
-    debugI("Self Diagnostic: %x", x); 
+    debugI("Self Diagnostic: %x", x);
 
 #endif
 
@@ -659,7 +659,7 @@ void setup()
     #endif
 
     TJpgDec.setJpgScale(1);
-    TJpgDec.setCallback(bitmap_output);        
+    TJpgDec.setCallback(bitmap_output);
 
     #if USE_PSRAM
         uint32_t memtouse = ESP.getFreePsram() - RESERVE_MEMORY;
@@ -692,7 +692,7 @@ void setup()
     CheckHeap();
 
     // Due to the nature of how FastLED compiles, the LED_PINx must be passed as a literal, not a variable (template stuff)
-    // Onboard PWM LED 
+    // Onboard PWM LED
 
     #if ONBOARD_LED_R
         ledcAttachPin(ONBOARD_LED_R,  1);   // assign RGB led pins to PWM channels
@@ -707,9 +707,9 @@ void setup()
 
         #if NUM_CHANNELS == 1
             debugI("Adding %d LEDs to FastLED.", g_aptrDevices[0]->GetLEDCount());
-            
+
             FastLED.addLeds<WS2812B, LED_PIN0, COLOR_ORDER>(((LEDStripGFX *)g_aptrDevices[0].get())->leds, g_aptrDevices[0]->GetLEDCount());
-            //FastLED.setMaxRefreshRate(100, false); 
+            //FastLED.setMaxRefreshRate(100, false);
             pinMode(LED_PIN0, OUTPUT);
         #endif
 
@@ -750,13 +750,13 @@ void setup()
             pinMode(LED_PIN7, OUTPUT);
             FastLED.addLeds<WS2812B, LED_PIN0, COLOR_ORDER>(g_aptrDevices[7].get()->leds,g_aptrDevices[7].get()->GetLEDCount());
         #endif
-           
+
         #ifdef POWER_LIMIT_MW
             set_max_power_in_milliwatts(POWER_LIMIT_MW);                // Set brightness limit
         #endif
 
             g_Brightness = 255;
-            
+
         #if ATOMLIGHT
             pinMode(4, INPUT);
             pinMode(12, INPUT);
@@ -770,7 +770,7 @@ void setup()
     InitEffectsManager();
 
     // Microphone stuff
-    #if ENABLE_AUDIO    
+    #if ENABLE_AUDIO
         pinMode(INPUT_PIN, INPUT);
         // The audio sampler task might as well be on a different core from the LED stuff
         g_TaskManager.StartAudioThread();
@@ -889,10 +889,10 @@ void loop()
             #endif
 
             strOutput += str_sprintf("CPU: %03.0f%%, %03.0f%%, FreeDraw: %4.3lf", g_TaskManager.GetCPUUsagePercent(0), g_TaskManager.GetCPUUsagePercent(1), g_FreeDrawTime);
-            
+
             Serial.println(strOutput);
         }
 
-        delay(1);        
+        delay(1);
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -766,8 +766,14 @@ void setup()
         #endif
     #endif
 
-    debugI("Initializing effects manager...");
-    InitEffectsManager();
+    // Show splash effect on matrix
+    #if USE_MATRIX
+        debugI("Initializing splash effect manager...");
+        InitSplashEffectManager();
+    #else
+        debugI("Initializing effects manager...");
+        InitEffectsManager();
+    #endif
 
     // Microphone stuff
     #if ENABLE_AUDIO
@@ -814,6 +820,12 @@ void setup()
     debugE("Heap before launch: %s", heap_caps_check_integrity_all(true) ? "PASS" : "FAIL");
     g_TaskManager.StartDrawThread();
     CheckHeap();
+
+    // Do proper effects manager initialization now that splash effect is running
+    #if USE_MATRIX
+        debugI("Initializing regular effects manager...");
+        InitEffectsManager();
+    #endif
 
     debugV("Saving effect manager config...");
     SaveEffectManagerConfig();

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -2,7 +2,7 @@
 //
 // File:        network.cpp
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -49,7 +49,7 @@ std::mutex g_buffer_mutex;
 String WiFi_ssid;
 String WiFi_password;
 
-// processRemoteDebugCmd() 
+// processRemoteDebugCmd()
 //
 // This is where we can add our own custom debugger commands
 
@@ -57,12 +57,12 @@ extern AppTime  g_AppTime;
 extern uint32_t g_FPS;
 
 // processRemoteDebugCmd
-// 
+//
 // Callback function that the debug library (which exposes a little console over telnet and serial) calls
 // in order to allow us to add custom commands.  I've added a clock reset and stats command, for example.
 
 #if ENABLE_WIFI
-    void processRemoteDebugCmd() 
+    void processRemoteDebugCmd()
     {
         String str = Debug.getLastCommand();
         if (str.equalsIgnoreCase("clock"))
@@ -87,8 +87,8 @@ extern uint32_t g_FPS;
                 debugI("Socket Buffer _cbReceived: %d", g_SocketServer._cbReceived);
             #endif
 
-            // Print out a buffer log with timestamps and deltas 
-            
+            // Print out a buffer log with timestamps and deltas
+
             for (size_t i = 0; i < g_aptrBufferManager[0]->Depth(); i++)
             {
                 auto pBufferManager = g_aptrBufferManager[0].get();
@@ -126,17 +126,17 @@ void SetupOTA(const String & strHostname)
                 type = "filesystem";
 
             debugI("Stopping IR remote");
-            #if ENABLE_REMOTE            
+            #if ENABLE_REMOTE
             g_RemoteControl.end();
-            #endif        
-            
+            #endif
+
             debugI("Start updating from OTA ");
             debugI("%s", type.c_str());
         })
         .onEnd([]() {
             debugI("\nEnd OTA");
         })
-        .onProgress([](unsigned int progress, unsigned int total) 
+        .onProgress([](unsigned int progress, unsigned int total)
         {
             static uint last_time = millis();
             if (millis() - last_time > 1000)
@@ -148,7 +148,7 @@ void SetupOTA(const String & strHostname)
             {
                 debugV("Progress: %u%%\r", (progress / (total / 100)));
             }
-            
+
         })
         .onError([](ota_error_t error) {
             debugW("Error[%u]: ", error);
@@ -196,14 +196,14 @@ void IRAM_ATTR RemoteLoopEntry(void *)
     while (true)
     {
         g_RemoteControl.handle();
-        delay(20);        
+        delay(20);
     }
 }
 #endif
 
 // ConnectToWiFi
 //
-// Connect to the pre-configured WiFi network.  
+// Connect to the pre-configured WiFi network.
 
 #if ENABLE_WIFI
 
@@ -254,7 +254,6 @@ void IRAM_ATTR RemoteLoopEntry(void *)
             }
         }
 
-
         if (false == bPreviousConnection)
         {
             debugW("Received IP: %s", WiFi.localIP().toString().c_str());
@@ -292,7 +291,7 @@ void IRAM_ATTR RemoteLoopEntry(void *)
         }
         return true;
     }
-    
+
 #endif
 
 // ProcessIncomingData
@@ -317,7 +316,7 @@ bool ProcessIncomingData(uint8_t *payloadData, size_t payloadLength)
     switch (command16)
     {
         // WIFI_COMMAND_PEAKDATA has a header plus NUM_BANDS floats that will be used to set the audio peaks
-        
+
         case WIFI_COMMAND_PEAKDATA:
         {
             #if ENABLE_AUDIO
@@ -325,22 +324,22 @@ bool ProcessIncomingData(uint8_t *payloadData, size_t payloadLength)
                 uint32_t length32  = DWORDFromMemory(&payloadData[4]);
                 uint64_t seconds   = ULONGFromMemory(&payloadData[8]);
                 uint64_t micros    = ULONGFromMemory(&payloadData[16]);
-            
-                debugV("ProcessIncomingData -- Bands: %u, Length: %u, Seconds: %llu, Micros: %llu ... ", 
-                    numbands, 
-                    length32, 
-                    seconds, 
+
+                debugV("ProcessIncomingData -- Bands: %u, Length: %u, Seconds: %llu, Micros: %llu ... ",
+                    numbands,
+                    length32,
+                    seconds,
                     micros);
-                    
+
                 PeakData peaks((double *)(payloadData + STANDARD_DATA_HEADER_SIZE));
                 peaks.ApplyScalars(PeakData::PCREMOTE);
                 g_Analyzer.SetPeakData(peaks);
             #endif
             return true;
         }
-        
+
         // WIFI_COMMAND_PIXELDATA64 has a header plus length32 CRGBs
-        
+
         case WIFI_COMMAND_PIXELDATA64:
         {
             uint16_t channel16 = WORDFromMemory(&payloadData[2]);
@@ -349,14 +348,14 @@ bool ProcessIncomingData(uint8_t *payloadData, size_t payloadLength)
             uint64_t micros    = ULONGFromMemory(&payloadData[16]);
 
 
-            debugV("ProcessIncomingData -- Channel: %u, Length: %u, Seconds: %llu, Micros: %llu ... ", 
-                   channel16, 
-                   length32, 
-                   seconds, 
+            debugV("ProcessIncomingData -- Channel: %u, Length: %u, Seconds: %llu, Micros: %llu ... ",
+                   channel16,
+                   length32,
+                   seconds,
                    micros);
 
             // Another option here would be to draw on all channels (0xff) instead of just one (0x01) if 0 is specified
-            
+
             if (channel16 == 0)
                 channel16 = 1;
 
@@ -373,7 +372,7 @@ bool ProcessIncomingData(uint8_t *payloadData, size_t payloadLength)
                 if ((channelMask & channel16) != 0)
                 {
                     debugV("Processing for Channel %d", iChannel);
-                    
+
                     bool bDone = false;
                     if (!g_aptrBufferManager[iChannel]->IsEmpty())
                     {
@@ -422,12 +421,12 @@ bool ReadWiFiConfig()
 
     nvs_handle_t nvsROHandle;
     esp_err_t err = nvs_open("storage", NVS_READONLY, &nvsROHandle);
-    if (err != ESP_OK) 
+    if (err != ESP_OK)
     {
         debugW("Error (%s) opening NVS handle!\n", esp_err_to_name(err));
         return false;
     }
-    else 
+    else
     {
         // Read the SSID and Password from the NVS partition name/value keypair set
 
@@ -463,7 +462,7 @@ bool ReadWiFiConfig()
 //
 // Attempts to write the WiFi ssid and password to NVS storage strings.  The keys
 // for those name-value pairs are made from the variable names (WiFi_ssid, WiFi_Password)
-// directly.  It's not transactional, so it could conceivably succeed at writing 
+// directly.  It's not transactional, so it could conceivably succeed at writing
 // the ssid and not the password (but will still report failure).  Does not
 // enforce length limits on values given, so conceivable you could write longer
 // pairs than you could read, but they wouldn't work on WiFi anyway.
@@ -471,11 +470,11 @@ bool ReadWiFiConfig()
 bool WriteWiFiConfig()
 {
     nvs_handle_t nvsRWHandle;
-    
+
     // The "storage" string must match NVS partition name in partition table
-    
-    esp_err_t err = nvs_open("storage", NVS_READWRITE, &nvsRWHandle);                       
-    if (err != ESP_OK) 
+
+    esp_err_t err = nvs_open("storage", NVS_READWRITE, &nvsRWHandle);
+    if (err != ESP_OK)
     {
         debugW("Error (%s) opening NVS handle!\n", esp_err_to_name(err));
         return false;

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -241,16 +241,18 @@ void IRAM_ATTR RemoteLoopEntry(void *)
                     Serial.printf("Connected to AP with BSSID: %s\n", WiFi.BSSIDstr().c_str());
                     break;
                 }
-                else
-                {
-                    delay(3000);
-                }
             }
             // Additional Services onwwards reliant on network so close if not up.
             if (false == WiFi.isConnected())
             {
-                debugW("Giving up on WiFi\n");
-                return false;
+                debugW("Giving WiFi a few more seconds to connect");
+                delay(4000);
+
+                if (!WiFi.isConnected())
+                {
+                    debugW("Giving up on WiFi\n");
+                    return false;
+                }
             }
         }
 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -224,7 +224,7 @@ void IRAM_ATTR RemoteLoopEntry(void *)
                 return false;
             }
 
-            for (uint iPass = 0; iPass < cRetries; iPass++)
+            for (uint iPass = 1; iPass <= cRetries; iPass++)
             {
                 Serial.printf("Pass %u of %u: Connecting to Wifi SSID: %s - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u\n",
                     iPass, cRetries, WiFi_ssid, ESP.getFreeHeap(), ESP.getPsramSize(), ESP.getFreePsram());
@@ -233,8 +233,8 @@ void IRAM_ATTR RemoteLoopEntry(void *)
                 WiFi.mode(WIFI_STA);
                 WiFi.begin(WiFi_ssid.c_str(), WiFi_password.c_str());
 
-                // Give the module a couple of seconds to connect
-                delay(2000);
+                // Give the module a few seconds to connect
+                delay(4000);
 
                 if (WiFi.isConnected())
                 {

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -166,7 +166,7 @@ void CWebServer::SetCurrentEffectIndex(AsyncWebServerRequest * pRequest)
     }
     */
 
-    PushPostParamIfPresent<size_t>(pRequest, "currentEffectIndex", [](auto value) { g_aptrEffectManager->SetCurrentEffectIndex(value); });
+    PushPostParamIfPresent<size_t>(pRequest, "currentEffectIndex", SET_VALUE(g_aptrEffectManager->SetCurrentEffectIndex(value)));
 
     // Complete the response so the client knows it can happily proceed now
     AddCORSHeaderAndSendOKResponse(pRequest);
@@ -176,7 +176,7 @@ void CWebServer::EnableEffect(AsyncWebServerRequest * pRequest)
 {
     debugV("EnableEffect");
 
-    PushPostParamIfPresent<size_t>(pRequest, "effectIndex", [](auto value) { g_aptrEffectManager->EnableEffect(value); });
+    PushPostParamIfPresent<size_t>(pRequest, "effectIndex", SET_VALUE(g_aptrEffectManager->EnableEffect(value)));
 
     // Complete the response so the client knows it can happily proceed now
     AddCORSHeaderAndSendOKResponse(pRequest);
@@ -186,7 +186,7 @@ void CWebServer::DisableEffect(AsyncWebServerRequest * pRequest)
 {
     debugV("DisableEffect");
 
-    PushPostParamIfPresent<size_t>(pRequest, "effectIndex", [](auto value) { g_aptrEffectManager->DisableEffect(value); });
+    PushPostParamIfPresent<size_t>(pRequest, "effectIndex", SET_VALUE(g_aptrEffectManager->DisableEffect(value)));
 
     // Complete the response so the client knows it can happily proceed now
     AddCORSHeaderAndSendOKResponse(pRequest);
@@ -236,13 +236,13 @@ void CWebServer::SetSettings(AsyncWebServerRequest * pRequest)
         g_aptrEffectManager->SetInterval(effectInterval);
     }
 
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::LOCATION_TAG, [](auto value) { g_aptrDeviceConfig->SetLocation(value); });
-    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::LOCATION_IS_ZIP_TAG, [](auto value) { g_aptrDeviceConfig->SetLocationIsZip(value); });
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::COUNTRY_CODE_TAG, [](auto value) { g_aptrDeviceConfig->SetCountryCode(value); });
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::OPEN_WEATHER_API_KEY_TAG, [](auto value) { g_aptrDeviceConfig->SetOpenWeatherAPIKey(value); });
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::TIME_ZONE_TAG, [](auto value) { g_aptrDeviceConfig->SetTimeZone(value); });
-    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::USE_24_HOUR_CLOCK_TAG, [](auto value) { g_aptrDeviceConfig->Set24HourClock(value); });
-    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::USE_CELSIUS_TAG, [](auto value) { g_aptrDeviceConfig->SetUseCelsius(value); });
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::LOCATION_TAG, SET_VALUE(g_aptrDeviceConfig->SetLocation(value)));
+    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::LOCATION_IS_ZIP_TAG, SET_VALUE(g_aptrDeviceConfig->SetLocationIsZip(value)));
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::COUNTRY_CODE_TAG, SET_VALUE(g_aptrDeviceConfig->SetCountryCode(value)));
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::OPEN_WEATHER_API_KEY_TAG, SET_VALUE(g_aptrDeviceConfig->SetOpenWeatherAPIKey(value)));
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::TIME_ZONE_TAG, SET_VALUE(g_aptrDeviceConfig->SetTimeZone(value)));
+    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::USE_24_HOUR_CLOCK_TAG, SET_VALUE(g_aptrDeviceConfig->Set24HourClock(value)));
+    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::USE_CELSIUS_TAG, SET_VALUE(g_aptrDeviceConfig->SetUseCelsius(value)));
 
     // We return the current config in response
     GetSettings(pRequest);

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -212,13 +212,13 @@ void CWebServer::SetSettings(AsyncWebServerRequest * pRequest)
         g_aptrEffectManager->SetInterval(effectInterval);
     }
 
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::LOCATION_TAG, SET_VALUE(g_aptrDeviceConfig->SetLocation(value)));
-    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::LOCATION_IS_ZIP_TAG, SET_VALUE(g_aptrDeviceConfig->SetLocationIsZip(value)));
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::COUNTRY_CODE_TAG, SET_VALUE(g_aptrDeviceConfig->SetCountryCode(value)));
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::OPEN_WEATHER_API_KEY_TAG, SET_VALUE(g_aptrDeviceConfig->SetOpenWeatherAPIKey(value)));
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::TIME_ZONE_TAG, SET_VALUE(g_aptrDeviceConfig->SetTimeZone(value)));
-    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::USE_24_HOUR_CLOCK_TAG, SET_VALUE(g_aptrDeviceConfig->Set24HourClock(value)));
-    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::USE_CELSIUS_TAG, SET_VALUE(g_aptrDeviceConfig->SetUseCelsius(value)));
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::LocationTag, SET_VALUE(g_aptrDeviceConfig->SetLocation(value)));
+    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::LocationIsZipTag, SET_VALUE(g_aptrDeviceConfig->SetLocationIsZip(value)));
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::CountryCodeTag, SET_VALUE(g_aptrDeviceConfig->SetCountryCode(value)));
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::OpenWeatherApiKeyTag, SET_VALUE(g_aptrDeviceConfig->SetOpenWeatherAPIKey(value)));
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::TimeZoneTag, SET_VALUE(g_aptrDeviceConfig->SetTimeZone(value)));
+    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::Use24HourClockTag, SET_VALUE(g_aptrDeviceConfig->Set24HourClock(value)));
+    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::UseCelsiusTag, SET_VALUE(g_aptrDeviceConfig->SetUseCelsius(value)));
 
     // We return the current config in response
     GetSettings(pRequest);

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -119,26 +119,26 @@ void CWebServer::GetStatistics(AsyncWebServerRequest * pRequest)
     j["SERIAL_FPS"]            = g_Analyzer._serialFPS;
     j["AUDIO_FPS"]             = g_Analyzer._AudioFPS;
 
-    j["HEAP_SIZE"]             = ESP.getHeapSize();
+    j["HEAP_SIZE"]             = _staticStats.HeapSize;
     j["HEAP_FREE"]             = ESP.getFreeHeap();
     j["HEAP_MIN"]              = ESP.getMinFreeHeap();
 
-    j["DMA_SIZE"]              = heap_caps_get_total_size(MALLOC_CAP_DMA);
+    j["DMA_SIZE"]              = _staticStats.DmaHeapSize;
     j["DMA_FREE"]              = heap_caps_get_free_size(MALLOC_CAP_DMA);
     j["DMA_MIN"]               = heap_caps_get_largest_free_block(MALLOC_CAP_DMA);
 
-    j["PSRAM_SIZE"]            = ESP.getPsramSize();
+    j["PSRAM_SIZE"]            = _staticStats.PsramSize;
     j["PSRAM_FREE"]            = ESP.getFreePsram();
     j["PSRAM_MIN"]             = ESP.getMinFreePsram();
 
-    j["CHIP_MODEL"]            = ESP.getChipModel();
-    j["CHIP_CORES"]            = ESP.getChipCores();
-    j["CHIP_SPEED"]            = ESP.getCpuFreqMHz();
-    j["PROG_SIZE"]             = ESP.getSketchSize();
+    j["CHIP_MODEL"]            = _staticStats.ChipModel;
+    j["CHIP_CORES"]            = _staticStats.ChipCores;
+    j["CHIP_SPEED"]            = _staticStats.CpuFreqMHz;
+    j["PROG_SIZE"]             = _staticStats.SketchSize;
 
-    j["CODE_SIZE"]             = ESP.getSketchSize();
-    j["CODE_FREE"]             = ESP.getFreeSketchSpace();
-    j["FLASH_SIZE"]            = ESP.getFlashChipSize();
+    j["CODE_SIZE"]             = _staticStats.SketchSize;
+    j["CODE_FREE"]             = _staticStats.FreeSketchSpace;
+    j["FLASH_SIZE"]            = _staticStats.FlashChipSize;
 
     j["CPU_USED"]              = g_TaskManager.GetCPUUsagePercent();
     j["CPU_USED_CORE0"]        = g_TaskManager.GetCPUUsagePercent(0);

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -2,7 +2,7 @@
 //
 // File:        webserver.cpp
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -35,8 +35,8 @@
 template<>
 void CWebServer::SetPostParam<bool>(AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<bool> setter)
 {
-    SetPostParam<bool>(pRequest, paramName, setter, [](AsyncWebParameter *param) 
-        { 
+    SetPostParam<bool>(pRequest, paramName, setter, [](AsyncWebParameter *param)
+        {
             const String& value = param->value();
             return value == "true" || strtol(value.c_str(), NULL, 10);
         }
@@ -49,7 +49,7 @@ void CWebServer::SetPostParam<size_t>(AsyncWebServerRequest * pRequest, const St
     SetPostParam<size_t>(pRequest, paramName, setter, [](AsyncWebParameter *param) { return strtoul(param->value().c_str(), NULL, 10); });
 }
 
-template<>    
+template<>
 void CWebServer::AddCORSHeaderAndSendResponse<AsyncJsonResponse>(AsyncWebServerRequest * pRequest, AsyncJsonResponse * pResponse)
 {
     pResponse->setLength();
@@ -73,7 +73,7 @@ void CWebServer::GetEffectListText(AsyncWebServerRequest * pRequest)
     bool bufferOverflow;
     debugV("GetEffectListText");
 
-    do 
+    do
     {
         bufferOverflow = false;
         std::unique_ptr<AsyncJsonResponse> response(new AsyncJsonResponse(false, jsonBufferSize));
@@ -85,13 +85,13 @@ void CWebServer::GetEffectListText(AsyncWebServerRequest * pRequest)
         j["effectInterval"]        = g_aptrEffectManager->GetInterval();
         j["enabledCount"]          = g_aptrEffectManager->EnabledCount();
 
-        for (int i = 0; i < g_aptrEffectManager->EffectCount(); i++) 
+        for (int i = 0; i < g_aptrEffectManager->EffectCount(); i++)
         {
             DynamicJsonDocument effectDoc(256);
             effectDoc["name"]    = g_aptrEffectManager->EffectsList()[i]->FriendlyName();
             effectDoc["enabled"] = g_aptrEffectManager->IsEffectEnabled(i);
 
-            if (!j["Effects"].add(effectDoc)) 
+            if (!j["Effects"].add(effectDoc))
             {
                 bufferOverflow = true;
                 jsonBufferSize += JSON_BUFFER_INCREMENT;
@@ -100,7 +100,7 @@ void CWebServer::GetEffectListText(AsyncWebServerRequest * pRequest)
             }
         }
 
-        if (!bufferOverflow) 
+        if (!bufferOverflow)
             AddCORSHeaderAndSendResponse(pRequest, response.release());
 
     } while (bufferOverflow);
@@ -133,7 +133,7 @@ void CWebServer::GetStatistics(AsyncWebServerRequest * pRequest)
     j["CHIP_MODEL"]            = ESP.getChipModel();
     j["CHIP_CORES"]            = ESP.getChipCores();
     j["CHIP_SPEED"]            = ESP.getCpuFreqMHz();
-    j["PROG_SIZE"]             = ESP.getSketchSize();         
+    j["PROG_SIZE"]             = ESP.getSketchSize();
 
     j["CODE_SIZE"]             = ESP.getSketchSize();
     j["CODE_FREE"]             = ESP.getFreeSketchSpace();
@@ -144,7 +144,7 @@ void CWebServer::GetStatistics(AsyncWebServerRequest * pRequest)
     j["CPU_USED_CORE1"]        = g_TaskManager.GetCPUUsagePercent(1);
 
     AddCORSHeaderAndSendResponse(pRequest, response);
-}    
+}
 
 void CWebServer::SetCurrentEffectIndex(AsyncWebServerRequest * pRequest)
 {
@@ -162,13 +162,13 @@ void CWebServer::SetCurrentEffectIndex(AsyncWebServerRequest * pRequest)
     else
     {
         debugV("No args!");
-    }   
+    }
     */
 
     SetPostParam<size_t>(pRequest, "currentEffectIndex", [](size_t value) { g_aptrEffectManager->SetCurrentEffectIndex(value); });
 
     // Complete the response so the client knows it can happily proceed now
-    AddCORSHeaderAndSendOKResponse(pRequest);   
+    AddCORSHeaderAndSendOKResponse(pRequest);
 }
 
 void CWebServer::EnableEffect(AsyncWebServerRequest * pRequest)
@@ -178,7 +178,7 @@ void CWebServer::EnableEffect(AsyncWebServerRequest * pRequest)
     SetPostParam<size_t>(pRequest, "effectIndex", [](size_t value) { g_aptrEffectManager->EnableEffect(value); });
 
     // Complete the response so the client knows it can happily proceed now
-    AddCORSHeaderAndSendOKResponse(pRequest);   
+    AddCORSHeaderAndSendOKResponse(pRequest);
 }
 
 void CWebServer::DisableEffect(AsyncWebServerRequest * pRequest)
@@ -188,7 +188,7 @@ void CWebServer::DisableEffect(AsyncWebServerRequest * pRequest)
     SetPostParam<size_t>(pRequest, "effectIndex", [](size_t value) { g_aptrEffectManager->DisableEffect(value); });
 
     // Complete the response so the client knows it can happily proceed now
-    AddCORSHeaderAndSendOKResponse(pRequest);   
+    AddCORSHeaderAndSendOKResponse(pRequest);
 }
 
 void CWebServer::NextEffect(AsyncWebServerRequest * pRequest)
@@ -213,7 +213,7 @@ void CWebServer::GetSettings(AsyncWebServerRequest * pRequest)
     response->addHeader("Server","NightDriverStrip");
     auto root = response->getRoot();
     JsonObject jsonObject = root.to<JsonObject>();
-    
+
     g_aptrDeviceConfig->SerializeToJSON(jsonObject);
     jsonObject["effectInterval"] = g_aptrEffectManager->GetInterval();
 
@@ -231,9 +231,9 @@ void CWebServer::SetSettings(AsyncWebServerRequest * pRequest)
         debugV("found EffectInterval");
         // If found, parse it and pass it off to the EffectManager, who will validate it
         AsyncWebParameter * param = pRequest->getParam(strEffectInterval, true, false);
-        size_t effectInterval = strtoul(param->value().c_str(), NULL, 10);  
+        size_t effectInterval = strtoul(param->value().c_str(), NULL, 10);
         g_aptrEffectManager->SetInterval(effectInterval);
-    }       
+    }
 
     SetPostParam<const String&>(pRequest, DeviceConfig::LOCATION_TAG, [](const String& value) { g_aptrDeviceConfig->SetLocation(value); });
     SetPostParam<bool>(pRequest, DeviceConfig::LOCATION_IS_ZIP_TAG, [](bool value) { g_aptrDeviceConfig->SetLocationIsZip(value); });
@@ -262,10 +262,10 @@ void CWebServer::Reset(AsyncWebServerRequest * pRequest)
     }
 
     bool boardResetRequested = IsPostParamTrue(pRequest, "board");
-    
+
     AddCORSHeaderAndSendOKResponse(pRequest);
-    
-    if (boardResetRequested) 
+
+    if (boardResetRequested)
     {
         delay(1000);    // Give the response a second to be sent
         throw new std::runtime_error("Resetting device at API request");

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -33,9 +33,9 @@
 // Member function template specialzations
 
 template<>
-void CWebServer::SetPostParam<bool>(AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<bool> setter)
+void CWebServer::PushPostParamIfPresent<bool>(AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<bool> setter)
 {
-    SetPostParam<bool>(pRequest, paramName, setter, [](AsyncWebParameter *param)
+    PushPostParamIfPresent<bool>(pRequest, paramName, setter, [](AsyncWebParameter * param) constexpr
         {
             const String& value = param->value();
             return value == "true" || strtol(value.c_str(), NULL, 10);
@@ -44,9 +44,9 @@ void CWebServer::SetPostParam<bool>(AsyncWebServerRequest * pRequest, const Stri
 }
 
 template<>
-void CWebServer::SetPostParam<size_t>(AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<size_t> setter)
+void CWebServer::PushPostParamIfPresent<size_t>(AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<size_t> setter)
 {
-    SetPostParam<size_t>(pRequest, paramName, setter, [](AsyncWebParameter *param) { return strtoul(param->value().c_str(), NULL, 10); });
+    PushPostParamIfPresent<size_t>(pRequest, paramName, setter, [](AsyncWebParameter * param) constexpr { return strtoul(param->value().c_str(), NULL, 10); });
 }
 
 template<>
@@ -60,9 +60,9 @@ void CWebServer::AddCORSHeaderAndSendResponse<AsyncJsonResponse>(AsyncWebServerR
 
 bool CWebServer::IsPostParamTrue(AsyncWebServerRequest * pRequest, const String &paramName)
 {
-    bool returnValue;
+    bool returnValue = false;
 
-    SetPostParam<bool>(pRequest, paramName, [returnValue](bool value) mutable { returnValue = value; });
+    PushPostParamIfPresent<bool>(pRequest, paramName, [&returnValue](auto value) { returnValue = value; });
 
     return returnValue;
 }
@@ -165,7 +165,7 @@ void CWebServer::SetCurrentEffectIndex(AsyncWebServerRequest * pRequest)
     }
     */
 
-    SetPostParam<size_t>(pRequest, "currentEffectIndex", [](size_t value) { g_aptrEffectManager->SetCurrentEffectIndex(value); });
+    PushPostParamIfPresent<size_t>(pRequest, "currentEffectIndex", [](auto value) { g_aptrEffectManager->SetCurrentEffectIndex(value); });
 
     // Complete the response so the client knows it can happily proceed now
     AddCORSHeaderAndSendOKResponse(pRequest);
@@ -175,7 +175,7 @@ void CWebServer::EnableEffect(AsyncWebServerRequest * pRequest)
 {
     debugV("EnableEffect");
 
-    SetPostParam<size_t>(pRequest, "effectIndex", [](size_t value) { g_aptrEffectManager->EnableEffect(value); });
+    PushPostParamIfPresent<size_t>(pRequest, "effectIndex", [](auto value) { g_aptrEffectManager->EnableEffect(value); });
 
     // Complete the response so the client knows it can happily proceed now
     AddCORSHeaderAndSendOKResponse(pRequest);
@@ -185,7 +185,7 @@ void CWebServer::DisableEffect(AsyncWebServerRequest * pRequest)
 {
     debugV("DisableEffect");
 
-    SetPostParam<size_t>(pRequest, "effectIndex", [](size_t value) { g_aptrEffectManager->DisableEffect(value); });
+    PushPostParamIfPresent<size_t>(pRequest, "effectIndex", [](auto value) { g_aptrEffectManager->DisableEffect(value); });
 
     // Complete the response so the client knows it can happily proceed now
     AddCORSHeaderAndSendOKResponse(pRequest);
@@ -235,13 +235,13 @@ void CWebServer::SetSettings(AsyncWebServerRequest * pRequest)
         g_aptrEffectManager->SetInterval(effectInterval);
     }
 
-    SetPostParam<const String&>(pRequest, DeviceConfig::LOCATION_TAG, [](const String& value) { g_aptrDeviceConfig->SetLocation(value); });
-    SetPostParam<bool>(pRequest, DeviceConfig::LOCATION_IS_ZIP_TAG, [](bool value) { g_aptrDeviceConfig->SetLocationIsZip(value); });
-    SetPostParam<const String&>(pRequest, DeviceConfig::COUNTRY_CODE_TAG, [](const String& value) { g_aptrDeviceConfig->SetCountryCode(value); });
-    SetPostParam<const String&>(pRequest, DeviceConfig::OPEN_WEATHER_API_KEY_TAG, [](const String& value) { g_aptrDeviceConfig->SetOpenWeatherAPIKey(value); });
-    SetPostParam<const String&>(pRequest, DeviceConfig::TIME_ZONE_TAG, [](const String& value) { g_aptrDeviceConfig->SetTimeZone(value); });
-    SetPostParam<bool>(pRequest, DeviceConfig::USE_24_HOUR_CLOCK_TAG, [](bool value) { g_aptrDeviceConfig->Set24HourClock(value); });
-    SetPostParam<bool>(pRequest, DeviceConfig::USE_CELSIUS_TAG, [](bool value) { g_aptrDeviceConfig->SetUseCelsius(value); });
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::LOCATION_TAG, [](auto value) { g_aptrDeviceConfig->SetLocation(value); });
+    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::LOCATION_IS_ZIP_TAG, [](auto value) { g_aptrDeviceConfig->SetLocationIsZip(value); });
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::COUNTRY_CODE_TAG, [](auto value) { g_aptrDeviceConfig->SetCountryCode(value); });
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::OPEN_WEATHER_API_KEY_TAG, [](auto value) { g_aptrDeviceConfig->SetOpenWeatherAPIKey(value); });
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::TIME_ZONE_TAG, [](auto value) { g_aptrDeviceConfig->SetTimeZone(value); });
+    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::USE_24_HOUR_CLOCK_TAG, [](auto value) { g_aptrDeviceConfig->Set24HourClock(value); });
+    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::USE_CELSIUS_TAG, [](auto value) { g_aptrDeviceConfig->SetUseCelsius(value); });
 
     // We return the current config in response
     GetSettings(pRequest);

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -88,7 +88,7 @@ void CWebServer::GetEffectListText(AsyncWebServerRequest * pRequest)
 
         for (int i = 0; i < g_aptrEffectManager->EffectCount(); i++)
         {
-            DynamicJsonDocument effectDoc(256);
+            StaticJsonDocument<256> effectDoc;
             effectDoc["name"]    = g_aptrEffectManager->EffectsList()[i]->FriendlyName();
             effectDoc["enabled"] = g_aptrEffectManager->IsEffectEnabled(i);
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -150,45 +150,21 @@ void CWebServer::GetStatistics(AsyncWebServerRequest * pRequest)
 void CWebServer::SetCurrentEffectIndex(AsyncWebServerRequest * pRequest)
 {
     debugV("SetCurrentEffectIndex");
-
-    /*
-    AsyncWebParameter * param = pRequest->getParam(0);
-    if (param != nullptr)
-    {
-        debugV("ParamName: [%s]", param->name().c_str());
-        debugV("ParamVal : [%s]", param->value().c_str());
-        debugV("IsPost: [%d]", param->isPost());
-        debugV("IsFile: [%d]", param->isFile());
-    }
-    else
-    {
-        debugV("No args!");
-    }
-    */
-
     PushPostParamIfPresent<size_t>(pRequest, "currentEffectIndex", SET_VALUE(g_aptrEffectManager->SetCurrentEffectIndex(value)));
-
-    // Complete the response so the client knows it can happily proceed now
     AddCORSHeaderAndSendOKResponse(pRequest);
 }
 
 void CWebServer::EnableEffect(AsyncWebServerRequest * pRequest)
 {
     debugV("EnableEffect");
-
     PushPostParamIfPresent<size_t>(pRequest, "effectIndex", SET_VALUE(g_aptrEffectManager->EnableEffect(value)));
-
-    // Complete the response so the client knows it can happily proceed now
     AddCORSHeaderAndSendOKResponse(pRequest);
 }
 
 void CWebServer::DisableEffect(AsyncWebServerRequest * pRequest)
 {
     debugV("DisableEffect");
-
     PushPostParamIfPresent<size_t>(pRequest, "effectIndex", SET_VALUE(g_aptrEffectManager->DisableEffect(value)));
-
-    // Complete the response so the client knows it can happily proceed now
     AddCORSHeaderAndSendOKResponse(pRequest);
 }
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -201,17 +201,7 @@ void CWebServer::SetSettings(AsyncWebServerRequest * pRequest)
 {
     debugV("SetSettings");
 
-    // Look for the parameter by name
-    const String strEffectInterval = "effectInterval";
-    if (pRequest->hasParam(strEffectInterval, true, false))
-    {
-        debugV("found EffectInterval");
-        // If found, parse it and pass it off to the EffectManager, who will validate it
-        AsyncWebParameter * param = pRequest->getParam(strEffectInterval, true, false);
-        size_t effectInterval = strtoul(param->value().c_str(), NULL, 10);
-        g_aptrEffectManager->SetInterval(effectInterval);
-    }
-
+    PushPostParamIfPresent<size_t>(pRequest,"effectInterval", SET_VALUE(g_aptrEffectManager->SetInterval(value)));
     PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::LocationTag, SET_VALUE(g_aptrDeviceConfig->SetLocation(value)));
     PushPostParamIfPresent<bool>(pRequest, DeviceConfig::LocationIsZipTag, SET_VALUE(g_aptrDeviceConfig->SetLocationIsZip(value)));
     PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::CountryCodeTag, SET_VALUE(g_aptrDeviceConfig->SetCountryCode(value)));

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -25,6 +25,7 @@
 //   Implementations for some of the web server methods declared in webserver.h
 //
 // History:     Apr-18-2023         Rbergen     Created
+//              Apr-28-2023         Rbergen     Reduce code duplication
 //---------------------------------------------------------------------------
 
 #include "globals.h"


### PR DESCRIPTION
## Description

This:

- Refactors the webserver and device config class to reduce duplication of code
- Modifies the WiFi connect (wait) logic, to allow for connections taking longer to settle
- Shows the splash screen effect at startup, regardless of the effect list loaded from JSON or by default
- Incorporates the changes of #257, and thus also fixes #255
- Made the Weather effect update task persistent, which fixes a memory leak
- Uses PSRAM for JsonDocument instances
- Preloads static device stats in the webserver, preventing freezes when the web interface stats view is enabled

Note: while reviewing this PR, one might want to ignore whitespace changes. In one commit, trailing whitespace was removed for most files in the `include` and `src` directories.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).