### PR TITLE
Fix #255

### DIFF
--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -470,11 +470,8 @@ public:
 
     uint GetInterval() const
     {
-        // This allows you to return a MinimumEffectTime and your effect won't be shown longer than that
-
-        if (_effectInterval == 0)
-            return std::numeric_limits<uint>::max();
-        return min(_effectInterval, GetCurrentEffect()->MaximumEffectTime() - GetTimeUsedByCurrentEffect());
+        // This allows you to return a MaximumEffectTime and your effect won't be shown longer than that
+        return min((_effectInterval == 0 ? std::numeric_limits<uint>::max() : _effectInterval), GetCurrentEffect()->MaximumEffectTime());
     }
 
     void CheckEffectTimerExpired()

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -461,11 +461,10 @@ public:
     uint GetTimeRemainingForCurrentEffect() const
     {
         // If the Interval is set to zero, we treat that as an infinite interval and don't even look at the time used so far
+        uint timeUsedByCurrentEffect = GetTimeUsedByCurrentEffect();
+        uint interval = GetInterval();
 
-        if (GetTimeUsedByCurrentEffect() > GetInterval())
-            return 0;
-
-        return GetInterval() - GetTimeUsedByCurrentEffect();
+        return timeUsedByCurrentEffect > interval ? 0 : (interval - timeUsedByCurrentEffect);
     }
 
     uint GetInterval() const
@@ -481,7 +480,7 @@ public:
         if (_effectInterval == 0)
             return;
 
-        if (millis() - _effectStartTime >= GetInterval()) // See if its time for a new effect yet
+        if (GetTimeUsedByCurrentEffect() >= GetInterval()) // See if its time for a new effect yet
         {
             debugV("%ldms elapsed: Next Effect", millis() - _effectStartTime);
             NextEffect();

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -475,12 +475,12 @@ public:
 
     void CheckEffectTimerExpired()
     {
-        // If interval is zero, the current effect never expires
+        // If interval is zero, the current effect never expires unless it thas a max effect time set
 
-        if (_effectInterval == 0)
+        if (_effectInterval == 0 && !GetCurrentEffect()->HasMaximumEffectTime())
             return;
 
-        if (GetTimeUsedByCurrentEffect() >= GetInterval()) // See if its time for a new effect yet
+        if (GetTimeUsedByCurrentEffect() >= GetInterval()) // See if it's time for a new effect yet
         {
             debugV("%ldms elapsed: Next Effect", millis() - _effectStartTime);
             NextEffect();

--- a/include/ledstripeffect.h
+++ b/include/ledstripeffect.h
@@ -2,7 +2,7 @@
 //
 // File:        LEDStripEffect.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -25,7 +25,7 @@
 //    Defines the base class for effects that run locally on the chip
 //
 // History:     Apr-13-2019         Davepl      Created for NightDriverStrip
-//              
+//
 //---------------------------------------------------------------------------
 
 #pragma once
@@ -69,7 +69,7 @@ class LEDStripEffect : public IJSONSerializable
             _friendlyName = strName;
     }
 
-    LEDStripEffect(const JsonObjectConst&  jsonObject) 
+    LEDStripEffect(const JsonObjectConst&  jsonObject)
         : _effectNumber(jsonObject[PTY_EFFECTNR]),
           _friendlyName(jsonObject["fn"].as<String>())
     {
@@ -80,18 +80,18 @@ class LEDStripEffect : public IJSONSerializable
     }
 
     virtual bool Init(std::shared_ptr<GFXBase> gfx[NUM_CHANNELS])               // There are up to 8 channel in play per effect and when we
-    {           
+    {
         debugV("Init %s", _friendlyName.c_str());                                                    //   start up, we are given copies to their graphics interfaces
         for (int i = 0; i < NUM_CHANNELS; i++)                      //   so that we can call them directly later from other calls
         {
-            _GFX[i] = gfx[i];    
+            _GFX[i] = gfx[i];
         }
         debugV("Get LED Count");
-        _cLEDs = _GFX[0]->GetLEDCount();   
+        _cLEDs = _GFX[0]->GetLEDCount();
         debugV("Init Effect %s with %d LEDs\n", _friendlyName.c_str(), _cLEDs);
-        return true;  
+        return true;
     }
-    
+
     inline std::shared_ptr<GFXBase> graphics() const
     {
         return _GFX[0];
@@ -102,11 +102,11 @@ class LEDStripEffect : public IJSONSerializable
     {
         return ((LEDMatrixGFX *)g_aptrDevices[0].get());
     }
-#endif 
-   
+#endif
+
     virtual void Start() {}                                         // Optional method called when time to clean/init the effect
     virtual void Draw() = 0;                                        // Your effect must implement these
-    
+
     virtual bool CanDisplayVUMeter() const
     {
         return true;
@@ -126,10 +126,15 @@ class LEDStripEffect : public IJSONSerializable
     {
         return 30;
     }
-    
+
     virtual size_t MaximumEffectTime() const
     {
         return SIZE_MAX;
+    }
+
+    virtual bool HasMaximumEffectTime() const
+    {
+        return MaximumEffectTime() != SIZE_MAX;
     }
 
     virtual bool ShouldShowTitle() const
@@ -141,7 +146,7 @@ class LEDStripEffect : public IJSONSerializable
     // If a matrix effect requires the state of the last buffer be preserved, then it requires float buffering.
     // If, on the other hand, it renders from scratch every time, starting witha black fill, etc, then it does not,
     // and it can override this method and return false;
-    
+
     virtual bool RequiresfloatBuffering() const
     {
         return true;
@@ -162,7 +167,7 @@ class LEDStripEffect : public IJSONSerializable
         return colors[randomColorIndex];
     }
 
-    static CRGB GetBlackBodyHeatColor(float temp) 
+    static CRGB GetBlackBodyHeatColor(float temp)
     {
         temp = min(1.0f, temp);
         uint8_t temperature = (uint8_t)(255 * temp);
@@ -178,7 +183,7 @@ class LEDStripEffect : public IJSONSerializable
         else
             return CRGB(heatramp, 0, 0);
     }
-    
+
     static inline CRGB RandomSaturatedColor()
     {
         CRGB c;
@@ -201,10 +206,10 @@ class LEDStripEffect : public IJSONSerializable
         }
 
         for (int n = 0; n < NUM_CHANNELS; n++)
-        {            
+        {
             for (int i = iStart; i < iStart + numToFill; i+= everyN)
                 _GFX[n]->setPixel(i, color);
-               
+
         }
     }
 
@@ -215,20 +220,20 @@ class LEDStripEffect : public IJSONSerializable
             _GFX[i]->Clear();
         }
     }
-    
+
     // ColorFraction
     //
     // Returns a fraction of a color; abstracts the fadeToBlack away so that we can later
     // do better color correction as needed
 
-    static inline CRGB ColorFraction(const CRGB colorIn, float fraction) 
+    static inline CRGB ColorFraction(const CRGB colorIn, float fraction)
     {
         fraction = min(1.0f, fraction);
         fraction = max(0.0f, fraction);
         return CRGB(colorIn).fadeToBlackBy(255 * (1.0f - fraction));
     }
 
-    void fillRainbowAllChannels(int iStart, int numToFill, uint8_t initialhue, uint8_t deltahue, uint8_t everyNth = 1) 
+    void fillRainbowAllChannels(int iStart, int numToFill, uint8_t initialhue, uint8_t deltahue, uint8_t everyNth = 1)
     {
         if (iStart + numToFill > _cLEDs)
         {
@@ -269,27 +274,27 @@ class LEDStripEffect : public IJSONSerializable
 
     inline void setAllOnAllChannels(uint8_t r, uint8_t g, uint8_t b) const
     {
-        for (int n = 0; n < NUM_CHANNELS; n++)    
+        for (int n = 0; n < NUM_CHANNELS; n++)
             for (int i = 0; i < _cLEDs; i++)
                 _GFX[n]->setPixel(i, r, g, b);
     }
 
     inline void setPixelOnAllChannels(int i, CRGB c)
-    {       
-        for (int j = 0; j < NUM_CHANNELS; j++)  
+    {
+        for (int j = 0; j < NUM_CHANNELS; j++)
             _GFX[j]->setPixel(i, c);
     }
 
     inline void setPixelsOnAllChannels(float fPos, float count, CRGB c, bool bMerge = false) const
-    {       
+    {
         for (int i = 0; i < NUM_CHANNELS; i++)
             _GFX[i]->setPixelsF(fPos, count, c, bMerge);
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) 
+    virtual bool SerializeToJSON(JsonObject& jsonObject)
     {
         StaticJsonDocument<128> jsonDoc;
-        
+
         jsonDoc[PTY_EFFECTNR] = _effectNumber;
         jsonDoc["fn"] = _friendlyName;
 

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -300,9 +300,9 @@ class CWebServer
 
         _server.on("/settings",              HTTP_GET,  [this](AsyncWebServerRequest * pRequest)    { this->GetSettings(pRequest); });
         _server.on("/settings",              HTTP_POST, [this](AsyncWebServerRequest * pRequest)    { this->SetSettings(pRequest); });
+        _server.on("/effectsConfig",         HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { pRequest->send(SPIFFS, EFFECTS_CONFIG_FILE); });
 
         _server.on("/reset",                 HTTP_POST, [this](AsyncWebServerRequest * pRequest)    { this->Reset(pRequest); });
-        _server.on("/effectsConfig",         HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { pRequest->send(SPIFFS, EFFECTS_CONFIG_FILE); });
 
         EmbeddedFile html_file(html_start, html_end, "text/html");
         EmbeddedFile jsx_file(jsx_start, jsx_end, "application/javascript");

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -2,7 +2,7 @@
 //
 // File:        webserver.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -47,19 +47,20 @@
 #include <ArduinoJson.h>
 #include "deviceconfig.h"
 #include "jsonbase.h"
+#include "effects.h"
 
 class CWebServer
 {
   private:
 
-    struct EmbeddedFile 
+    struct EmbeddedFile
     {
         // Embedded file size in bytes
         const size_t length;
         // Contents as bytes
         const uint8_t *const contents;
         // Added to hold the file's MIME type, but could be used for other type types, if desired
-        const char *const type; 
+        const char *const type;
 
         EmbeddedFile(const uint8_t start[], const uint8_t end[], const char type[]) :
             length(end - start),
@@ -83,11 +84,11 @@ class CWebServer
 
     void AddCORSHeaderAndSendOKResponse(AsyncWebServerRequest * pRequest, const char * strText = nullptr)
     {
-        AsyncWebServerResponse * pResponse = (strText == nullptr) ? 
+        AsyncWebServerResponse * pResponse = (strText == nullptr) ?
                                                     pRequest->beginResponse(200) :
-                                                    pRequest->beginResponse(200, "text/json",  strText);    
+                                                    pRequest->beginResponse(200, "text/json",  strText);
         pResponse->addHeader("Access-Control-Allow-Origin", "*");
-        pRequest->send(pResponse);      
+        pRequest->send(pResponse);
     }
 
     void GetEffectListText(AsyncWebServerRequest * pRequest)
@@ -96,7 +97,7 @@ class CWebServer
         bool bufferOverflow;
         debugV("GetEffectListText");
 
-        do 
+        do
         {
             bufferOverflow = false;
             std::unique_ptr<AsyncJsonResponse> response(new AsyncJsonResponse(false, jsonBufferSize));
@@ -108,13 +109,13 @@ class CWebServer
             j["effectInterval"]        = g_aptrEffectManager->GetInterval();
             j["enabledCount"]          = g_aptrEffectManager->EnabledCount();
 
-            for (int i = 0; i < g_aptrEffectManager->EffectCount(); i++) 
+            for (int i = 0; i < g_aptrEffectManager->EffectCount(); i++)
             {
                 DynamicJsonDocument effectDoc(256);
                 effectDoc["name"]    = g_aptrEffectManager->EffectsList()[i]->FriendlyName();
                 effectDoc["enabled"] = g_aptrEffectManager->IsEffectEnabled(i);
 
-                if (!j["Effects"].add(effectDoc)) 
+                if (!j["Effects"].add(effectDoc))
                 {
                     bufferOverflow = true;
                     jsonBufferSize += JSON_BUFFER_INCREMENT;
@@ -123,12 +124,12 @@ class CWebServer
                 }
             }
 
-            if (!bufferOverflow) 
+            if (!bufferOverflow)
             {
                 response->addHeader("Access-Control-Allow-Origin", "*");
                 response->setLength();
                 // The 'send' call will take ownership of the response, so we need to release it here
-                pRequest->send(response.release()); 
+                pRequest->send(response.release());
             }
         } while (bufferOverflow);
     }
@@ -160,7 +161,7 @@ class CWebServer
         j["CHIP_MODEL"]            = ESP.getChipModel();
         j["CHIP_CORES"]            = ESP.getChipCores();
         j["CHIP_SPEED"]            = ESP.getCpuFreqMHz();
-        j["PROG_SIZE"]             = ESP.getSketchSize();         
+        j["PROG_SIZE"]             = ESP.getSketchSize();
 
         j["CODE_SIZE"]             = ESP.getSketchSize();
         j["CODE_FREE"]             = ESP.getFreeSketchSpace();
@@ -173,7 +174,7 @@ class CWebServer
         response->setLength();
         response->addHeader("Access-Control-Allow-Origin", "*");
         pRequest->send(response);
-    }    
+    }
 
     void GetSettings(AsyncWebServerRequest * pRequest);
 
@@ -197,7 +198,7 @@ class CWebServer
         else
         {
             debugV("No args!");
-        }   
+        }
         */
 
         const String strCurrentEffectIndex = "currentEffectIndex";
@@ -206,11 +207,11 @@ class CWebServer
             debugV("currentEffectIndex param found");
             // If found, parse it and pass it off to the EffectManager, who will validate it
             AsyncWebParameter * param = pRequest->getParam(strCurrentEffectIndex, true);
-            size_t currentEffectIndex = strtoul(param->value().c_str(), NULL, 10);  
+            size_t currentEffectIndex = strtoul(param->value().c_str(), NULL, 10);
             g_aptrEffectManager->SetCurrentEffectIndex(currentEffectIndex);
         }
         // Complete the response so the client knows it can happily proceed now
-        AddCORSHeaderAndSendOKResponse(pRequest);   
+        AddCORSHeaderAndSendOKResponse(pRequest);
     }
 
     void EnableEffect(AsyncWebServerRequest * pRequest)
@@ -223,11 +224,11 @@ class CWebServer
         {
             // If found, parse it and pass it off to the EffectManager, who will validate it
             AsyncWebParameter * param = pRequest->getParam(strEffectIndex, true);
-            size_t effectIndex = strtoul(param->value().c_str(), NULL, 10); 
+            size_t effectIndex = strtoul(param->value().c_str(), NULL, 10);
             g_aptrEffectManager->EnableEffect(effectIndex);
         }
         // Complete the response so the client knows it can happily proceed now
-        AddCORSHeaderAndSendOKResponse(pRequest);   
+        AddCORSHeaderAndSendOKResponse(pRequest);
     }
 
     void DisableEffect(AsyncWebServerRequest * pRequest)
@@ -240,12 +241,12 @@ class CWebServer
         {
             // If found, parse it and pass it off to the EffectManager, who will validate it
             AsyncWebParameter * param = pRequest->getParam(strEffectIndex, true);
-            size_t effectIndex = strtoul(param->value().c_str(), NULL, 10); 
+            size_t effectIndex = strtoul(param->value().c_str(), NULL, 10);
             g_aptrEffectManager->DisableEffect(effectIndex);
             debugV("Disabled Effect %d", effectIndex);
         }
         // Complete the response so the client knows it can happily proceed now
-        AddCORSHeaderAndSendOKResponse(pRequest);   
+        AddCORSHeaderAndSendOKResponse(pRequest);
     }
 
     void NextEffect(AsyncWebServerRequest * pRequest)
@@ -262,7 +263,7 @@ class CWebServer
         AddCORSHeaderAndSendOKResponse(pRequest);
     }
 
-    // This registers a handler for GET requests for one of the known files embedded in the firmware. 
+    // This registers a handler for GET requests for one of the known files embedded in the firmware.
     void ServeEmbeddedFile(const char strUri[], EmbeddedFile &file)
     {
         _server.on(strUri, HTTP_GET, [strUri, file](AsyncWebServerRequest *request)
@@ -285,7 +286,7 @@ class CWebServer
         extern const uint8_t timezones_start[] asm("_binary_config_timezones_json_start");
         extern const uint8_t timezones_end[] asm("_binary_config_timezones_json_end");
 
-        
+
         debugI("Connecting Web Endpoints");
 
         _server.on("/getEffectList",         HTTP_GET,  [this](AsyncWebServerRequest * pRequest)    { this->GetEffectListText(pRequest); });
@@ -301,6 +302,7 @@ class CWebServer
         _server.on("/settings",              HTTP_POST, [this](AsyncWebServerRequest * pRequest)    { this->SetSettings(pRequest); });
 
         _server.on("/reset",                 HTTP_POST, [this](AsyncWebServerRequest * pRequest)    { this->Reset(pRequest); });
+        _server.on("/effectsConfig",         HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { pRequest->send(SPIFFS, EFFECTS_CONFIG_FILE); });
 
         EmbeddedFile html_file(html_start, html_end, "text/html");
         EmbeddedFile jsx_file(jsx_start, jsx_end, "application/javascript");
@@ -318,7 +320,7 @@ class CWebServer
         ServeEmbeddedFile("/favicon.ico", ico_file);
         ServeEmbeddedFile("/timezones.json", timezones_file);
 
-        _server.onNotFound([](AsyncWebServerRequest *request) 
+        _server.onNotFound([](AsyncWebServerRequest *request)
         {
             if (request->method() == HTTP_OPTIONS) {
                 request->send(200);                                     // Apparently needed for CORS: https://github.com/me-no-dev/ESPAsyncWebServer

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -300,7 +300,7 @@ class CWebServer
 
         _server.on("/settings",              HTTP_GET,  [this](AsyncWebServerRequest * pRequest)    { this->GetSettings(pRequest); });
         _server.on("/settings",              HTTP_POST, [this](AsyncWebServerRequest * pRequest)    { this->SetSettings(pRequest); });
-        _server.on("/effectsConfig",         HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { pRequest->send(SPIFFS, EFFECTS_CONFIG_FILE); });
+        _server.on("/effectsConfig",         HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { pRequest->send(SPIFFS, EFFECTS_CONFIG_FILE, "text/json"); });
 
         _server.on("/reset",                 HTTP_POST, [this](AsyncWebServerRequest * pRequest)    { this->Reset(pRequest); });
 


### PR DESCRIPTION
## Description

This fixes #255, by:

- Not ignoring an effect's MaximumEffectTime() when the default effect interval is 0
- Persisting and restoring the current effect index

It also adds an /effectsConfig webserver endpoint that returns the contents of the effects config JSON file.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).