### PR TITLE
Subscriber configurability, sensitive and validated settings, documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To use the installer, follow these steps:
 
 1. Connect your device to your computer with a USB cable.
 
-2. Navigate to the following URL in your browser: <https://plummerssoftwarellc.github.io/NightDriverStrip>. It should then show a screen that looks like this:  
+2. Navigate to the following URL in your browser: <https://plummerssoftwarellc.github.io/NightDriverStrip>. It should then show a screen that looks like this:
    ![Installer start screen](assets/installer-start.png)
 
 3. Select your device (like "M5StickC Plus") from the drop-down list. A second drop-down with supported projects on that device will then appear.
@@ -55,6 +55,16 @@ To use the installer, follow these steps:
 9. Now, a dialog will appear that will show the details of the project you flashed. It will also provide options to flash again, visit the device's web application, change the WiFi settings, and show the device's logs & console. Note that if you flashed a device image that includes a web application, it may take a minute or so to come up after the connection to the WiFi network has been made.
 
 The images included in the installer are built using the current state of the source code in this repository. If there's anything you'd like to change in (the configuration of) the project you want to use, then it is time to move to the next stage and start interacting with the source code itself.
+
+## Device web UI and API
+
+On devices with WiFi, NightDriverStrip can start a webserver that hosts the web UI that is part of the project. It can be used to view and change what effect is running, and get live performance statistics of the device.
+
+When the device is started with the webserver enabled, the web UI can be accessed by opening a web browser and typing the IP address of your device in the address bar. Once loaded, the icons at the left of the screen can be used to toggle views within the UI on and off.
+
+More information about the web UI can be found [in its own README.md](site/README.md).
+
+Besides the web UI, the webserver also publishes a REST-like API. More information about it is available in [REST_API.md](./REST_API.md).
 
 ## Getting Started with the Source Code
 
@@ -84,7 +94,7 @@ This can also be configured in the platformio.ini file, as described in the [Fea
 
 ## File system
 
-To build and upload the file system that is used by some effects (currently the [Weather effect](include/effects/matrix/PatternWeather.h) to be specific), you will need to build and upload the SPIFFS image to your board's flash using platformio.  
+To build and upload the file system that is used by some effects (currently the [Weather effect](include/effects/matrix/PatternWeather.h) to be specific), you will need to build and upload the SPIFFS image to your board's flash using platformio.
 You can do this using the platformio user interface, or using the pio command line tool:
 
 ```ShellConsole

--- a/REST_API.md
+++ b/REST_API.md
@@ -1,0 +1,163 @@
+# On-board REST-like API
+
+## Introduction
+
+On devices with WiFi and the webserver enabled, NightDriverStrip publishes a REST-like API. The API includes a number of endpoints to:
+
+- Restrieve information about the device and the effects it runs
+- Changing the effect that's running
+- Disable and enable effects
+- Retrieve and change settings
+
+A subset of the endpoints is used by the NightDriverStrip [web UI](site/README.md).
+
+In the sections below:
+
+- Parameters for GET requests are query parameters
+- Parameters for POST requests are HTTP POST body key/value pairs
+- Boolean parameters are considered to be true if their value is the text `true` (lower-case only) or any whole number other than 0 (zero).
+
+## Endpoints
+
+### Get effect list information
+
+This endpoint returns a JSON document with basic information about the effects on the device.
+
+| Property| Value | Explanation |
+|-|-|-|
+| URL | `/effects` |
+| Method | GET | |
+| Parameters | | |
+| Response | 200 (OK) | A JSON blob with information about the device's effect list. The zero-based effect indexes used in other endpoints correspond with the indexes in this list. |
+
+### Set current effect
+
+This endpoint can be used to set the effect that the device is currently showing.
+
+| Property| Value | Explanation |
+|-|-|-|
+| URL | `/currentEffect` | |
+| Method | POST | |
+| Parameters | `currentEffectIndex` | The (zero-based) integer index of the effect to activate in the device's effect list. |
+| Response | 200 (OK) | An empty OK response. |
+
+### Next effect
+
+This endpoint can be used to activate the next effect.
+
+| Property| Value | Explanation |
+|-|-|-|
+| URL | `/nextEffect` | |
+| Method | POST | |
+| Parameters | | |
+| Response | 200 (OK) | An empty OK response. |
+
+### Previous effect
+
+This endpoint can be used to activate the previous effect.
+
+| Property| Value | Explanation |
+|-|-|-|
+| URL | `/previousEffect` | |
+| Method | POST | |
+| Parameters | | |
+| Response | 200 (OK) | An empty OK response. |
+
+### Disable effect
+
+With this endpoint an effect can be disabled. This means it will no longer be activated, and skipped when it's its turn to be shown.
+
+| Property| Value | Explanation |
+|-|-|-|
+| URL | `/disableEffect` | |
+| Method | POST | |
+| Parameters | `effectIndex` | The (zero-based) integer index of the effect to disable in the device's effect list. |
+| Response | 200 (OK) | An empty OK response. |
+
+### Enable effect
+
+With this endpoint a previously disabled effect can be enabled. From that moment on, it will once again be shown.
+
+| Property| Value | Explanation |
+|-|-|-|
+| URL | `/enableEffect` |
+| Method | POST | |
+| Parameters | `effectIndex` | the (zero-based) integer index of the effect to enable in the device's effect list. |
+| Response | 200 (OK) | An empty OK response. |
+
+### Get effect configuration information
+
+This endpoint returns a JSON document with information about the detailed configuration of the effects on the device. Note that this document currently has an internal purpose, and is as such not optimized for human inspection.
+
+| Property| Value | Explanation |
+|-|-|-|
+| URL | `/effectsConfig` |
+| Method | GET | |
+| Parameters | | |
+| Response | 200 (OK) | A JSON blob with detailed configuration information about the device's effects. |
+
+### Settings
+
+This endpoint can be used to retrieve and change device configuration settings.
+
+When retrieving settings, sensitive properties (like API keys) are not returned.
+
+When changing settings:
+
+- All parameters are optional. Only settings that are sent in the POST parameters are modified. All other settings are unchanged.
+- No validation of values provided takes place. There is a [separate endpoint with which an individual setting can be changed after validation](#set-setting-with-validation).
+
+#### Retrieve
+
+| Property| Value | Explanation |
+|-|-|-|
+| URL | `/settings` |
+| Method | GET | |
+| Parameters | | |
+| Response | 200 (OK) | A JSON blob with the current values for the device's configuration settings. |
+
+#### Change
+
+| Property| Value | Explanation |
+|-|-|-|
+| URL | `/settings` |
+| Method | POST | |
+| Parameters | `countryCode` | The [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code for the country that the device is located. Used by the Weather effect. |
+| | `location` | The location (city or postal code) where the device is located. Used by the Weather effect. |
+| | `locationIsZip` | A boolean indicating if the value in the `location` setting is a postal code (`true`/1) or not (`false`/0). |
+| | `openWeatherApiKey` | The API key for the [Weather API provided by Open Weather Map](https://openweathermap.org/api). Used by the Weather effect. |
+| | `timeZone` | The timezone the device resides in, in [tz database](https://en.wikipedia.org/wiki/Tz_database) format. The list of available timezone identifiers can be found in the [timezones.json](config/timezones.json) file. Used by effects that show a clock. |
+| | `use24HourClock` | A boolean that indicates if time should be shown in 24-hour format (`true`/1) or 12-hour AM/PM format (`false`/0). Used by effects that show a digital clock. |
+| | `useCelsius` | A boolean that indicates if temperatures should be shown in degrees Celsius (`true`/1) or degrees Fahrenheit ( `false`/0). Used by the Weather effect. |
+| | `youtubeChannelGuid` | The [YouTube Sight](http://tools.tastethecode.com/youtube-sight) GUID of the channel for which the Subscriber effect should show subscriber information. |
+| | `youtubeChannelName1` | The name of the channel for which the Subscriber effect should show subscriber information. |
+| Response | 200 (OK) | A JSON blob with the current values for the device's configuration settings, after applying the values in the request's POST parameters. |
+
+### Set setting with validation
+
+This endpoint can be used to validate the value for one device configuration setting, and set it if validation succeeds. Note that this endpoint will accept only one of the known configuration settings (listed as the parameters of [the Settings endpoint](#settings).)
+
+Note that validation is not implemented for all settings; the validation step is skipped for settings for which validation is not available.
+
+| Property| Value | Explanation |
+|-|-|-|
+| URL | `/settings/validated` |
+| Method | POST | |
+| Parameters | | Exactly one of the known settings may be provided. The known settings are listed as the parameters of [the Settings endpoint](#settings). |
+| Response | 200 (OK) | Validation succeeded and the provided value has been set. |
+| | 400 (Bad Request) | More than one known setting was provided, or validation failed. The applicable message is returned in a JSON blob. |
+
+### Reset configuration and/or device
+
+This endpoint can be used to reset effect configuration (see [Get effect configuration information](#get-effect-configuration-information)), device settings (see [Settings](#settings)), and/or the board itself - i.e. restart it.
+
+Any parameters that are not provided are considered to be `false`.
+
+| Property| Value | Explanation |
+|-|-|-|
+| URL | `/settings/validated` |
+| Method | POST | |
+| Parameters | `deviceConfig` | A boolean value indicating if device settings should be reset to defaults (`true`/1) or not (`false`/0). |
+| | `effectsConfig` | A boolean value indicating if effect configuration information should be reset to defaults (`true`/1) or not (`false`/0). |
+| | `board` | A boolean value indicating if the device should be restarted (`true`/1) or not (`false`/0). |
+| Response | 200 (OK) | An empty OK response. |

--- a/REST_API.md
+++ b/REST_API.md
@@ -155,7 +155,7 @@ Any parameters that are not provided are considered to be `false`.
 
 | Property| Value | Explanation |
 |-|-|-|
-| URL | `/settings/validated` |
+| URL | `/reset` |
 | Method | POST | |
 | Parameters | `deviceConfig` | A boolean value indicating if device settings should be reset to defaults (`true`/1) or not (`false`/0). |
 | | `effectsConfig` | A boolean value indicating if effect configuration information should be reset to defaults (`true`/1) or not (`false`/0). |

--- a/REST_API.md
+++ b/REST_API.md
@@ -4,7 +4,7 @@
 
 On devices with WiFi and the webserver enabled, NightDriverStrip publishes a REST-like API. The API includes a number of endpoints to:
 
-- Restrieve information about the device and the effects it runs
+- Retrieve information about the device and the effects it runs
 - Changing the effect that's running
 - Disable and enable effects
 - Retrieve and change settings
@@ -122,7 +122,7 @@ When changing settings:
 |-|-|-|
 | URL | `/settings` |
 | Method | POST | |
-| Parameters | `countryCode` | The [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code for the country that the device is located. Used by the Weather effect. |
+| Parameters | `countryCode` | The [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code for the country that the device is located in. Used by the Weather effect. |
 | | `location` | The location (city or postal code) where the device is located. Used by the Weather effect. |
 | | `locationIsZip` | A boolean indicating if the value in the `location` setting is a postal code (`true`/1) or not (`false`/0). |
 | | `openWeatherApiKey` | The API key for the [Weather API provided by Open Weather Map](https://openweathermap.org/api). Used by the Weather effect. |

--- a/REST_API.md
+++ b/REST_API.md
@@ -14,7 +14,7 @@
   - [Settings](#settings)
   - [Set setting with validation](#set-setting-with-validation)
   - [Reset configuration and/or device](#reset-configuration-andor-device)
-
+- [Postman collection](#postman-collection)
 
 ## Introduction
 
@@ -138,7 +138,8 @@ When changing settings:
 |-|-|-|
 | URL | `/settings` |
 | Method | POST | |
-| Parameters | `countryCode` | The [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code for the country that the device is located in. Used by the Weather effect. |
+| Parameters | `effectInterval` | The duration in milliseconds that an individual effect runs, before NightDriverStrip activates the next effect. |
+| | `countryCode` | The [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code for the country that the device is located in. Used by the Weather effect. |
 | | `location` | The location (city or postal code) where the device is located. Used by the Weather effect. |
 | | `locationIsZip` | A boolean indicating if the value in the `location` setting is a postal code (`true`/1) or not (`false`/0). |
 | | `openWeatherApiKey` | The API key for the [Weather API provided by Open Weather Map](https://openweathermap.org/api). Used by the Weather effect. |
@@ -177,3 +178,9 @@ Any parameters that are not provided are considered to be `false`.
 | | `effectsConfig` | A boolean value indicating if effect configuration information should be reset to defaults (`true`/1) or not (`false`/0). |
 | | `board` | A boolean value indicating if the device should be restarted (`true`/1) or not (`false`/0). |
 | Response | 200 (OK) | An empty OK response. |
+
+## Postman collection
+
+To aid in the use and testing of the endpoints discussed in this document - and particularly those not used by the NightDriverStrip web UI - a [Postman collection file](tools/NightDriverStrip.postman_collection.json) has been provided.
+
+It can be used with the Postman API Client, a free version of which can be [downloaded from the Postman website](https://www.postman.com/downloads/).

--- a/REST_API.md
+++ b/REST_API.md
@@ -1,4 +1,20 @@
-# On-board REST-like API
+# On-board REST-like API <!-- omit in toc -->
+
+## Table of Contents <!-- omit in toc -->
+
+- [Introduction](#introduction)
+- [Endpoints](#endpoints)
+  - [Get effect list information](#get-effect-list-information)
+  - [Set current effect](#set-current-effect)
+  - [Next effect](#next-effect)
+  - [Previous effect](#previous-effect)
+  - [Disable effect](#disable-effect)
+  - [Enable effect](#enable-effect)
+  - [Get effect configuration information](#get-effect-configuration-information)
+  - [Settings](#settings)
+  - [Set setting with validation](#set-setting-with-validation)
+  - [Reset configuration and/or device](#reset-configuration-andor-device)
+
 
 ## Introduction
 

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -45,6 +45,8 @@ class DeviceConfig : public IJSONSerializable
     String openWeatherApiKey;
     bool use24HourClock;
     bool useCelsius;
+    String youtubeChannelGuid;
+    String youtubeChannelName1;
 
 /*
     void WriteToNVS(const String& name, const String& value);
@@ -79,10 +81,12 @@ class DeviceConfig : public IJSONSerializable
     static constexpr const char * TimeZoneTag = NAME_OF(timeZone);
     static constexpr const char * Use24HourClockTag = NAME_OF(use24HourClock);
     static constexpr const char * UseCelsiusTag = NAME_OF(useCelsius);
+    static constexpr const char * YouTubeChannelGuidTag = NAME_OF(youtubeChannelGuid);
+    static constexpr const char * YouTubeChannelName1Tag = NAME_OF(youtubeChannelName1);
 
     DeviceConfig();
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         AllocatedJsonDocument jsonDoc(1024);
 
@@ -93,11 +97,13 @@ class DeviceConfig : public IJSONSerializable
         jsonDoc[TimeZoneTag] = timeZone;
         jsonDoc[Use24HourClockTag] = use24HourClock;
         jsonDoc[UseCelsiusTag] = useCelsius;
+        jsonDoc[YouTubeChannelGuidTag] = youtubeChannelGuid;
+        jsonDoc[YouTubeChannelName1Tag] = youtubeChannelName1;
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
-    virtual bool DeserializeFromJSON(const JsonObjectConst& jsonObject)
+    virtual bool DeserializeFromJSON(const JsonObjectConst& jsonObject) override
     {
         return DeserializeFromJSON(jsonObject, false);
     }
@@ -110,6 +116,8 @@ class DeviceConfig : public IJSONSerializable
         SetIfPresentIn(jsonObject, openWeatherApiKey, OpenWeatherApiKeyTag);
         SetIfPresentIn(jsonObject, use24HourClock, Use24HourClockTag);
         SetIfPresentIn(jsonObject, useCelsius, UseCelsiusTag);
+        SetIfPresentIn(jsonObject, youtubeChannelGuid, YouTubeChannelGuidTag);
+        SetIfPresentIn(jsonObject, youtubeChannelName1, YouTubeChannelName1Tag);
 
         if (jsonObject.containsKey(TimeZoneTag))
             return SetTimeZone(jsonObject[TimeZoneTag], true);
@@ -191,6 +199,28 @@ class DeviceConfig : public IJSONSerializable
     {
         SetAndSave(useCelsius, newUseCelsius);
     }
+
+    const String &GetYouTubeChannelGuid() const
+    {
+        return youtubeChannelGuid;
+    }
+
+    void SetYouTubeChannelGuid(const String &newYouTubeChannelGuid)
+    {
+        if (!newYouTubeChannelGuid.isEmpty())
+            SetAndSave(youtubeChannelGuid, newYouTubeChannelGuid);
+    }
+
+    const String &GetYouTubeChannelName1() const
+    {
+        return youtubeChannelName1;
+    }
+
+    void SetYouTubeChannelName1(const String &newYouTubeChannelName1)
+    {
+        if (!newYouTubeChannelName1.isEmpty())
+            SetAndSave(youtubeChannelName1, newYouTubeChannelName1);
+    }
 };
 
-extern DRAM_ATTR std::unique_ptr<DeviceConfig> g_aptrDeviceConfig;
+extern DRAM_ATTR std::unique_ptr<DeviceConfig> g_ptrDeviceConfig;

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -32,6 +32,7 @@
 
 #include <memory>
 #include <vector>
+#include <tuple>
 #include "jsonserializer.h"
 
 #define DEVICE_CONFIG_FILE "/device.cfg"
@@ -74,6 +75,8 @@ class DeviceConfig : public IJSONSerializable
 
   public:
 
+    using ValidateResponse = std::pair<bool, String>;
+
     static constexpr const char * LocationTag = NAME_OF(location);
     static constexpr const char * LocationIsZipTag = NAME_OF(locationIsZip);
     static constexpr const char * CountryCodeTag = NAME_OF(countryCode);
@@ -88,17 +91,24 @@ class DeviceConfig : public IJSONSerializable
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
+        return SerializeToJSON(jsonObject, true);
+    }
+
+    bool SerializeToJSON(JsonObject& jsonObject, bool includeSensitive)
+    {
         AllocatedJsonDocument jsonDoc(1024);
 
         jsonDoc[LocationTag] = location;
         jsonDoc[LocationIsZipTag] = locationIsZip;
         jsonDoc[CountryCodeTag] = countryCode;
-        jsonDoc[OpenWeatherApiKeyTag] = openWeatherApiKey;
         jsonDoc[TimeZoneTag] = timeZone;
         jsonDoc[Use24HourClockTag] = use24HourClock;
         jsonDoc[UseCelsiusTag] = useCelsius;
         jsonDoc[YouTubeChannelGuidTag] = youtubeChannelGuid;
         jsonDoc[YouTubeChannelName1Tag] = youtubeChannelName1;
+
+        if (includeSensitive)
+            jsonDoc[OpenWeatherApiKeyTag] = openWeatherApiKey;
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
@@ -184,6 +194,8 @@ class DeviceConfig : public IJSONSerializable
     {
         return openWeatherApiKey;
     }
+
+    ValidateResponse ValidateOpenWeatherAPIKey(const String &newOpenWeatherAPIKey);
 
     void SetOpenWeatherAPIKey(const String &newOpenWeatherAPIKey)
     {

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -156,7 +156,7 @@ public:
         construct(true);
     }
 
-    virtual bool DeserializeFromJSON(const JsonObjectConst& jsonObject)
+    virtual bool DeserializeFromJSON(const JsonObjectConst& jsonObject) override
     {
         ClearEffects();
 
@@ -204,7 +204,7 @@ public:
         return true;
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         // Set JSON format version to be able to detect and manage future incompatible structural updates
         jsonObject[PTY_VERSION] = JSON_FORMAT_VERSION;

--- a/include/effects/matrix/PatternPongClock.h
+++ b/include/effects/matrix/PatternPongClock.h
@@ -113,7 +113,7 @@ class PatternPongClock : public LEDStripEffect
         time_t ttime = time(0);
         tm *local_time = localtime(&ttime);
 
-        bool ampm = !g_aptrDeviceConfig->Use24HourClock();
+        bool ampm = !g_ptrDeviceConfig->Use24HourClock();
 
         // update score / time
         mins = local_time->tm_min;
@@ -463,7 +463,7 @@ class PatternPongClock : public LEDStripEffect
             restart = 1;
 
             // update score / time
-            bool ampm = !g_aptrDeviceConfig->Use24HourClock();
+            bool ampm = !g_ptrDeviceConfig->Use24HourClock();
 
             mins = local_time->tm_min;
             hours = local_time->tm_hour;

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -68,7 +68,7 @@ class PatternSubscribers : public LEDStripEffect
             bool guidUpdated = pObj->UpdateGuid();
             unsigned long millisSinceLastCheck = millis() - pObj->millisLastCheck;
 
-            if (guidUpdated || (!pObj->succeededBefore && millisSinceLastCheck > SUB_CHECK_ERROR_INTERVAL) || millisSinceLastCheck > SUBCHECK_INTERVAL)
+            if (guidUpdated || pObj->millisLastCheck == 0 || (!pObj->succeededBefore && millisSinceLastCheck > SUB_CHECK_ERROR_INTERVAL) || millisSinceLastCheck > SUBCHECK_INTERVAL)
                 pObj->UpdateSubscribers(guidUpdated);
 
             // Sleep for a few seconds before we recheck if the GUID has changed
@@ -142,8 +142,6 @@ class PatternSubscribers : public LEDStripEffect
 
     virtual bool Init(std::shared_ptr<GFXBase> gfx[NUM_CHANNELS]) override
     {
-        millisLastCheck = millis();
-
         debugW("Spawning thread to get subscriber data...");
         xTaskCreatePinnedToCore(SightTaskEntryPoint, "Subs", 4096, (void *) this, NET_PRIORITY, &sightTask, NET_CORE);
 

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -68,8 +68,12 @@ class PatternSubscribers : public LEDStripEffect
             bool guidUpdated = pObj->UpdateGuid();
             unsigned long millisSinceLastCheck = millis() - pObj->millisLastCheck;
 
-            if (guidUpdated || pObj->millisLastCheck == 0 || (!pObj->succeededBefore && millisSinceLastCheck > SUB_CHECK_ERROR_INTERVAL) || millisSinceLastCheck > SUBCHECK_INTERVAL)
+            if (guidUpdated || !pObj->millisLastCheck
+                || (!pObj->succeededBefore && millisSinceLastCheck > SUB_CHECK_ERROR_INTERVAL)
+                || millisSinceLastCheck > SUBCHECK_INTERVAL)
+            {
                 pObj->UpdateSubscribers(guidUpdated);
+            }
 
             // Sleep for a few seconds before we recheck if the GUID has changed
             vTaskDelay(SUB_CHECK_GUID_INTERVAL / portTICK_PERIOD_MS);

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -84,6 +84,7 @@ class PatternSubscribers : public LEDStripEffect
             return false;
 
         strChannelGuid = configChannelGuid;
+        succeededBefore = false;
         return true;
     }
 

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -32,59 +32,150 @@
 #ifndef PatternSub_H
 #define PatternSub_H
 
+#include "deviceconfig.h"
+
+#define SUB_CHECK_INTERVAL 60000
+#define SUB_CHECK_ERROR_INTERVAL 20000
+
+#define DEFAULT_CHANNEL_GUID "9558daa1-eae8-482f-8066-17fa787bc0e4"
+#define DEFAULT_CHANNEL_NAME1 "Daves Garage"
+
 class PatternSubscribers : public LEDStripEffect
 {
   private:
+    long subscribers        = 0;
+    long views              = 0;
+    String strChannelGuid;
+
+    unsigned long millisLastCheck  = 0;
+    bool succeededBefore    = false;
+
+    TaskHandle_t sightTask   = nullptr;
+    time_t latestUpdate      = 0;
+
+    WiFiClient http;
+    std::unique_ptr<YouTubeSight> sight = nullptr;
+
+    // Thread entry point so we can update the subscriber data asynchronously
+    static void SightTaskEntryPoint(void * pv)
+    {
+        PatternSubscribers * pObj = (PatternSubscribers *) pv;
+
+        for(;;)
+        {
+            pObj->UpdateSubscribers();
+
+            // Suspend ourself until Draw() wakes us up
+            vTaskSuspend(NULL);
+        }
+    }
+
+    bool UpdateGuid()
+    {
+        const String &configChannelGuid = g_ptrDeviceConfig->GetYouTubeChannelGuid();
+
+        if (strChannelGuid == configChannelGuid)
+            return false;
+
+        strChannelGuid = configChannelGuid;
+        return true;
+    }
+
+    void UpdateSubscribers()
+    {
+        if (!sight || UpdateGuid())
+            sight = std::make_unique<YouTubeSight>(strChannelGuid, http);
+
+        // Use the YouTubeSight API call to get the current channel stats
+        if (sight->getData())
+        {
+            subscribers = atol(sight->channelStats.subscribers_count.c_str());
+            views       = atol(sight->channelStats.views.c_str());
+            succeededBefore = true;
+        }
+        else
+        {
+            debugW("YouTubeSight Subscriber API failed\n");
+        }
+    }
+
+    void SetConfigIfUnset()
+    {
+        if (g_ptrDeviceConfig->GetYouTubeChannelGuid().isEmpty())
+            g_ptrDeviceConfig->SetYouTubeChannelGuid(DEFAULT_CHANNEL_GUID);
+
+        if (g_ptrDeviceConfig->GetYouTubeChannelName1().isEmpty())
+            g_ptrDeviceConfig->SetYouTubeChannelName1(DEFAULT_CHANNEL_NAME1);
+    }
 
   public:
 
-  PatternSubscribers() : LEDStripEffect(EFFECT_MATRIX_SUBSCRIBERS, "Subs")
-  {
-  }
+    PatternSubscribers() : LEDStripEffect(EFFECT_MATRIX_SUBSCRIBERS, "Subs")
+    {
+    }
 
-  PatternSubscribers(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
-  {
-  }
+    PatternSubscribers(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
+    {
+    }
 
-  static volatile long cSubscribers;
-  static volatile long cViews;
-  static const char szChannelID[];
-  static const char szChannelName1[];
+    virtual void Draw() override
+    {
+        if (WiFi.isConnected())
+        {
+            unsigned long millisSinceLastCheck = millis() - millisLastCheck;
+            // If we've never succeeded, we try every 20 seconds, but then we settle down to the SUBCHECK_INTERVAL
+            if (millisLastCheck == 0 || (!succeededBefore && millisSinceLastCheck > SUB_CHECK_ERROR_INTERVAL) || (millisSinceLastCheck > SUBCHECK_INTERVAL))
+            {
+                millisLastCheck = millis();
 
-  virtual void Draw() override
-  {
-      LEDMatrixGFX::backgroundLayer.fillScreen(rgb24(0, 16, 64));
-      LEDMatrixGFX::backgroundLayer.setFont(font5x7);
+                // Lazily create the subscriber update task the first time we need it
+                if (sightTask == nullptr)
+                {
+                    debugW("Spawning thread to get subscriber data...");
+                    xTaskCreatePinnedToCore(SightTaskEntryPoint, "Weather", 4096, (void *) this, NET_PRIORITY, &sightTask, NET_CORE);
+                }
+                else
+                {
+                    debugW("Triggering thread to get subscriber data now...");
+                    // Resume the subscriber task. If it's not suspended then there's an update running and this will do nothing,
+                    //   so we'll silently skip the update this would otherwise trigger.
+                    vTaskResume(sightTask);
+                }
+            }
+        }
 
-      // Draw a border around the edge of the panel
-      LEDMatrixGFX::backgroundLayer.drawRectangle(0, 1, MATRIX_WIDTH-1, MATRIX_HEIGHT-2, rgb24(160,160,255));
+        LEDMatrixGFX::backgroundLayer.fillScreen(rgb24(0, 16, 64));
+        LEDMatrixGFX::backgroundLayer.setFont(font5x7);
 
-      // Draw the channel name
-      LEDMatrixGFX::backgroundLayer.drawString(2, 3, rgb24(255,255,255), szChannelName1);
+        // Draw a border around the edge of the panel
+        LEDMatrixGFX::backgroundLayer.drawRectangle(0, 1, MATRIX_WIDTH-1, MATRIX_HEIGHT-2, rgb24(160,160,255));
 
-      // Start in the middle of the panel and then back up a half a row to center vertically,
-      // then back up left one half a char for every 10s digit in the subscriber count.  This
-      // shoud center the number on the screen
+        // Draw the channel name
+        LEDMatrixGFX::backgroundLayer.drawString(2, 3, rgb24(255,255,255), g_ptrDeviceConfig->GetYouTubeChannelName1().c_str());
 
-      const int CHAR_WIDTH = 6;
-      const int CHAR_HEIGHT = 7;
-      int x = MATRIX_WIDTH / 2 - CHAR_WIDTH / 2;
-      int y = MATRIX_HEIGHT / 2 - CHAR_HEIGHT / 2 - 3;        // -3 to put it above the caption
-      long z = cSubscribers;                                  // Use a long in case of Mr Beast
+        // Start in the middle of the panel and then back up a half a row to center vertically,
+        // then back up left one half a char for every 10s digit in the subscriber count.  This
+        // shoud center the number on the screen
 
-      while (z/=10)
-        x-= CHAR_WIDTH / 2;
+        const int CHAR_WIDTH = 6;
+        const int CHAR_HEIGHT = 7;
+        int x = MATRIX_WIDTH / 2 - CHAR_WIDTH / 2;
+        int y = MATRIX_HEIGHT / 2 - CHAR_HEIGHT / 2 - 3;        // -3 to put it above the caption
+        long z = subscribers;                                  // Use a long in case of Mr Beast
 
-      String result = str_sprintf("%ld", cSubscribers);
-      const char * pszText = result.c_str();
+        while (z/=10)
+          x-= CHAR_WIDTH / 2;
 
-      LEDMatrixGFX::backgroundLayer.setFont(gohufont11b);
-      LEDMatrixGFX::backgroundLayer.drawString(x-1, y,   rgb24(0,0,0),          pszText);
-      LEDMatrixGFX::backgroundLayer.drawString(x+1, y,   rgb24(0,0,0),          pszText);
-      LEDMatrixGFX::backgroundLayer.drawString(x,   y-1, rgb24(0,0,0),          pszText);
-      LEDMatrixGFX::backgroundLayer.drawString(x,   y+1, rgb24(0,0,0),          pszText);
-      LEDMatrixGFX::backgroundLayer.drawString(x,   y,   rgb24(255,255,255),    pszText);
-  }
+        String result = str_sprintf("%ld", subscribers);
+        const char * pszText = result.c_str();
+
+        LEDMatrixGFX::backgroundLayer.setFont(gohufont11b);
+        LEDMatrixGFX::backgroundLayer.drawString(x-1, y,   rgb24(0,0,0),          pszText);
+        LEDMatrixGFX::backgroundLayer.drawString(x+1, y,   rgb24(0,0,0),          pszText);
+        LEDMatrixGFX::backgroundLayer.drawString(x,   y-1, rgb24(0,0,0),          pszText);
+        LEDMatrixGFX::backgroundLayer.drawString(x,   y+1, rgb24(0,0,0),          pszText);
+        LEDMatrixGFX::backgroundLayer.drawString(x,   y,   rgb24(255,255,255),    pszText);
+    }
 };
 
 #endif

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -32,6 +32,7 @@
 #ifndef PatternSub_H
 #define PatternSub_H
 
+#include <UrlEncode.h>
 #include "deviceconfig.h"
 
 #define SUB_CHECK_WIFI_WAIT 5000
@@ -103,7 +104,7 @@ class PatternSubscribers : public LEDStripEffect
         millisLastCheck = millis();
 
         if (!sight || useNewSight)
-            sight = std::make_unique<YouTubeSight>(strChannelGuid, http);
+            sight = std::make_unique<YouTubeSight>(urlEncode(strChannelGuid), http);
 
         // Use the YouTubeSight API call to get the current channel stats
         if (sight->getData())

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -116,7 +116,7 @@ private:
 
     inline float KelvinToLocal(float K)
     {
-        if (g_aptrDeviceConfig->UseCelsius())
+        if (g_ptrDeviceConfig->UseCelsius())
             return KelvinToCelsius(K);
         else
             return KelvinToFarenheit(K);
@@ -130,14 +130,14 @@ private:
         if (!HasLocationChanged())
             return false;
 
-        const String& configLocation = g_aptrDeviceConfig->GetLocation();
-        const String& configCountryCode = g_aptrDeviceConfig->GetCountryCode();
-        const bool configLocationIsZip = g_aptrDeviceConfig->IsLocationZip();
+        const String& configLocation = g_ptrDeviceConfig->GetLocation();
+        const String& configCountryCode = g_ptrDeviceConfig->GetCountryCode();
+        const bool configLocationIsZip = g_ptrDeviceConfig->IsLocationZip();
 
         if (configLocationIsZip)
-            url = "http://api.openweathermap.org/geo/1.0/zip?zip=" + configLocation + "," + configCountryCode + "&appid=" + g_aptrDeviceConfig->GetOpenWeatherAPIKey();
+            url = "http://api.openweathermap.org/geo/1.0/zip?zip=" + configLocation + "," + configCountryCode + "&appid=" + g_ptrDeviceConfig->GetOpenWeatherAPIKey();
         else
-            url = "http://api.openweathermap.org/geo/1.0/direct?q=" + configLocation + "," + configCountryCode + "&limit=1&appid=" + g_aptrDeviceConfig->GetOpenWeatherAPIKey();
+            url = "http://api.openweathermap.org/geo/1.0/direct?q=" + configLocation + "," + configCountryCode + "&limit=1&appid=" + g_ptrDeviceConfig->GetOpenWeatherAPIKey();
 
         http.begin(url);
         int httpResponseCode = http.GET();
@@ -171,7 +171,7 @@ private:
     bool getTomorrowTemps(float& highTemp, float& lowTemp)
     {
         HTTPClient http;
-        String url = "http://api.openweathermap.org/data/2.5/forecast?lat=" + strLatitude + "&lon=" + strLongitude + "&appid=" + g_aptrDeviceConfig->GetOpenWeatherAPIKey();
+        String url = "http://api.openweathermap.org/data/2.5/forecast?lat=" + strLatitude + "&lon=" + strLongitude + "&appid=" + g_ptrDeviceConfig->GetOpenWeatherAPIKey();
         http.begin(url);
         int httpResponseCode = http.GET();
 
@@ -231,7 +231,7 @@ private:
     {
         HTTPClient http;
 
-        String url = "http://api.openweathermap.org/data/2.5/weather?lat=" + strLatitude + "&lon=" + strLongitude + "&appid=" + g_aptrDeviceConfig->GetOpenWeatherAPIKey();
+        String url = "http://api.openweathermap.org/data/2.5/weather?lat=" + strLatitude + "&lon=" + strLongitude + "&appid=" + g_ptrDeviceConfig->GetOpenWeatherAPIKey();
         http.begin(url);
         int httpResponseCode = http.GET();
         if (httpResponseCode > 0)
@@ -303,8 +303,8 @@ private:
 
     bool HasLocationChanged()
     {
-        String configLocation = g_aptrDeviceConfig->GetLocation();
-        String configCountryCode = g_aptrDeviceConfig->GetCountryCode();
+        String configLocation = g_ptrDeviceConfig->GetLocation();
+        String configCountryCode = g_ptrDeviceConfig->GetCountryCode();
 
         return strLocation != configLocation || strCountryCode != configCountryCode;
     }
@@ -388,7 +388,7 @@ public:
         g()->setTextColor(WHITE16);
         String showLocation = strLocation;
         showLocation.toUpperCase();
-        if (g_aptrDeviceConfig->GetOpenWeatherAPIKey().isEmpty())
+        if (g_ptrDeviceConfig->GetOpenWeatherAPIKey().isEmpty())
             g()->print("No API Key");
         else
             g()->print((strLocationName.isEmpty() ? showLocation : strLocationName).substring(0, (MATRIX_WIDTH - 2 * fontWidth)/fontWidth));

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -35,6 +35,7 @@
 #include <Arduino.h>
 #include <string.h>
 #include <HTTPClient.h>
+#include <UrlEncode.h>
 #include <ledstripeffect.h>
 #include <ledmatrixgfx.h>
 #include <secrets.h>
@@ -135,9 +136,11 @@ private:
         const bool configLocationIsZip = g_ptrDeviceConfig->IsLocationZip();
 
         if (configLocationIsZip)
-            url = "http://api.openweathermap.org/geo/1.0/zip?zip=" + configLocation + "," + configCountryCode + "&appid=" + g_ptrDeviceConfig->GetOpenWeatherAPIKey();
+            url = "http://api.openweathermap.org/geo/1.0/zip"
+                "?zip=" + urlEncode(configLocation) + "," + urlEncode(configCountryCode) + "&appid=" + urlEncode(g_ptrDeviceConfig->GetOpenWeatherAPIKey());
         else
-            url = "http://api.openweathermap.org/geo/1.0/direct?q=" + configLocation + "," + configCountryCode + "&limit=1&appid=" + g_ptrDeviceConfig->GetOpenWeatherAPIKey();
+            url = "http://api.openweathermap.org/geo/1.0/direct"
+                "?q=" + urlEncode(configLocation) + "," + urlEncode(configCountryCode) + "&limit=1&appid=" + urlEncode(g_ptrDeviceConfig->GetOpenWeatherAPIKey());
 
         http.begin(url);
         int httpResponseCode = http.GET();
@@ -171,7 +174,8 @@ private:
     bool getTomorrowTemps(float& highTemp, float& lowTemp)
     {
         HTTPClient http;
-        String url = "http://api.openweathermap.org/data/2.5/forecast?lat=" + strLatitude + "&lon=" + strLongitude + "&appid=" + g_ptrDeviceConfig->GetOpenWeatherAPIKey();
+        String url = "http://api.openweathermap.org/data/2.5/forecast"
+            "?lat=" + strLatitude + "&lon=" + strLongitude + "&appid=" + urlEncode(g_ptrDeviceConfig->GetOpenWeatherAPIKey());
         http.begin(url);
         int httpResponseCode = http.GET();
 
@@ -231,7 +235,8 @@ private:
     {
         HTTPClient http;
 
-        String url = "http://api.openweathermap.org/data/2.5/weather?lat=" + strLatitude + "&lon=" + strLongitude + "&appid=" + g_ptrDeviceConfig->GetOpenWeatherAPIKey();
+        String url = "http://api.openweathermap.org/data/2.5/weather"
+            "?lat=" + strLatitude + "&lon=" + strLongitude + "&appid=" + urlEncode(g_ptrDeviceConfig->GetOpenWeatherAPIKey());
         http.begin(url);
         int httpResponseCode = http.GET();
         if (httpResponseCode > 0)

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -65,7 +65,7 @@ class InsulatorSpectrumEffect : public LEDStripEffect, public BeatEffectBase, pu
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         AllocatedJsonDocument jsonDoc(512);
 
@@ -359,7 +359,7 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeterEffe
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         AllocatedJsonDocument jsonDoc(512);
 
@@ -440,7 +440,7 @@ class WaveformEffect : public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 
@@ -537,7 +537,7 @@ class GhostWave : public WaveformEffect
         construct();
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 

--- a/include/effects/strip/bouncingballeffect.h
+++ b/include/effects/strip/bouncingballeffect.h
@@ -92,7 +92,7 @@ private:
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 

--- a/include/effects/strip/doublepaletteeffect.h
+++ b/include/effects/strip/doublepaletteeffect.h
@@ -57,7 +57,7 @@ class DoublePaletteEffect : public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         AllocatedJsonDocument jsonDoc(896);
 

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -702,7 +702,7 @@ public:
   {
   }
 
-  virtual bool SerializeToJSON(JsonObject& jsonObject)
+  virtual bool SerializeToJSON(JsonObject& jsonObject) override
   {
     AllocatedJsonDocument jsonDoc(512);
 
@@ -777,7 +777,7 @@ public:
   {
   }
 
-  virtual bool SerializeToJSON(JsonObject& jsonObject)
+  virtual bool SerializeToJSON(JsonObject& jsonObject) override
   {
     StaticJsonDocument<128> jsonDoc;
 
@@ -1023,7 +1023,7 @@ public:
     abHeat = std::make_unique<uint8_t[]>(CellCount());
   }
 
-  virtual bool SerializeToJSON(JsonObject& jsonObject)
+  virtual bool SerializeToJSON(JsonObject& jsonObject) override
   {
     AllocatedJsonDocument jsonDoc(512);
 

--- a/include/effects/strip/fireeffect.h
+++ b/include/effects/strip/fireeffect.h
@@ -99,7 +99,7 @@ class FireEffect : public LEDStripEffect
         construct();
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 
@@ -246,7 +246,7 @@ public:
         construct();
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         AllocatedJsonDocument jsonDoc(512);
 
@@ -349,7 +349,7 @@ public:
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 
@@ -524,7 +524,7 @@ public:
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 
@@ -696,7 +696,7 @@ class BaseFireEffect : public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 

--- a/include/effects/strip/laserline.h
+++ b/include/effects/strip/laserline.h
@@ -92,7 +92,7 @@ class LaserLineEffect : public BeatEffectBase, public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 

--- a/include/effects/strip/meteoreffect.h
+++ b/include/effects/strip/meteoreffect.h
@@ -191,7 +191,7 @@ class MeteorEffect : public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -61,7 +61,7 @@ class SimpleRainbowTestEffect : public LEDStripEffect
         debugV("SimpleRainbowTestEffect JSON constructor");
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 
@@ -109,7 +109,7 @@ class RainbowTwinkleEffect : public LEDStripEffect
         debugV("RainbowFill JSON constructor");
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 
@@ -172,7 +172,7 @@ protected:
         debugV("RainbowFill JSON constructor");
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 
@@ -392,7 +392,7 @@ class TwinkleEffect : public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 

--- a/include/effects/strip/paletteeffect.h
+++ b/include/effects/strip/paletteeffect.h
@@ -91,7 +91,7 @@ class PaletteEffect : public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         AllocatedJsonDocument jsonDoc(512);
 

--- a/include/effects/strip/particles.h
+++ b/include/effects/strip/particles.h
@@ -719,7 +719,7 @@ class MoltenGlassOnVioletBkgnd : public LEDStripEffect, public virtual BeatEffec
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         AllocatedJsonDocument jsonDoc(512);
 
@@ -809,7 +809,7 @@ class NewMoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         AllocatedJsonDocument jsonDoc(512);
 
@@ -895,7 +895,7 @@ class SparklySpinningMusicEffect : public LEDStripEffect, public BeatEffectBase,
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         AllocatedJsonDocument jsonDoc(512);
 

--- a/include/effects/strip/snakeeffect.h
+++ b/include/effects/strip/snakeeffect.h
@@ -80,7 +80,7 @@ class SnakeEffect : public LEDStripEffect
         construct();
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         AllocatedJsonDocument jsonDoc(512);
 

--- a/include/effects/strip/stareffect.h
+++ b/include/effects/strip/stareffect.h
@@ -467,7 +467,7 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         AllocatedJsonDocument jsonDoc(512);
 

--- a/include/globals.h
+++ b/include/globals.h
@@ -1047,6 +1047,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define IR_REMOTE_PIN     26
     #define LED_FAN_OFFSET_BU 6
     #define POWER_LIMIT_MW    5000
+    #define ENABLE_OTA        0
 
     #define NOISE_CUTOFF   75
     #define NOISE_FLOOR    200.0f

--- a/include/ledstripeffect.h
+++ b/include/ledstripeffect.h
@@ -326,7 +326,7 @@ class LEDStripEffect : public IJSONSerializable
     //
     // Serialize this effects paramters to a JSON document
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -99,7 +99,7 @@ class CWebServer
         if (!pRequest->hasParam(paramName, true, false))
             return;
 
-        debugW("found %s", paramName.c_str());
+        debugV("found %s", paramName.c_str());
 
         AsyncWebParameter *param = pRequest->getParam(paramName, true, false);
 

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -47,6 +47,7 @@
 #include <Arduino.h>
 #include <AsyncJson.h>
 #include <ArduinoJson.h>
+#include <HTTPClient.h>
 #include "deviceconfig.h"
 #include "jsonbase.h"
 #include "effects.h"
@@ -140,7 +141,7 @@ class CWebServer
     // Version for empty response, normally used to finish up things that don't return anything, like "NextEffect"
     static void AddCORSHeaderAndSendOKResponse(AsyncWebServerRequest * pRequest)
     {
-        AddCORSHeaderAndSendResponse(pRequest, pRequest->beginResponse(200));
+        AddCORSHeaderAndSendResponse(pRequest, pRequest->beginResponse(HTTP_CODE_OK));
     }
 
     // Straightforward support functions
@@ -241,10 +242,10 @@ class CWebServer
         _server.onNotFound([](AsyncWebServerRequest *request)
         {
             if (request->method() == HTTP_OPTIONS) {
-                request->send(200);                                     // Apparently needed for CORS: https://github.com/me-no-dev/ESPAsyncWebServer
+                request->send(HTTP_CODE_OK);                                     // Apparently needed for CORS: https://github.com/me-no-dev/ESPAsyncWebServer
             } else {
                    debugW("Failed GET for %s\n", request->url().c_str() );
-                request->send(404);
+                request->send(HTTP_CODE_NOT_FOUND);
             }
         });
 

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -99,7 +99,7 @@ class CWebServer
         if (!pRequest->hasParam(paramName, true, false))
             return;
 
-        debugV("found %s", paramName.c_str());
+        debugW("found %s", paramName.c_str());
 
         AsyncWebParameter *param = pRequest->getParam(paramName, true, false);
 
@@ -110,7 +110,7 @@ class CWebServer
     template<typename Tv>
     static void PushPostParamIfPresent(AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<Tv> setter)
     {
-        PushPostParamIfPresent<Tv>(pRequest, paramName, setter, [](AsyncWebParameter * param) constexpr { return param->value(); });
+        PushPostParamIfPresent<Tv>(pRequest, paramName, setter, [](AsyncWebParameter * param) { return param->value(); });
     }
 
     // AddCORSHeaderAndSend(OK)Response

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -207,11 +207,14 @@ class CWebServer
 
         debugI("Connecting Web Endpoints");
 
+        _server.on("/effects",               HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { GetEffectListText(pRequest); });
         _server.on("/getEffectList",         HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { GetEffectListText(pRequest); });
+        _server.on("/statistics",            HTTP_GET,  [this](AsyncWebServerRequest * pRequest)    { this->GetStatistics(pRequest); });
         _server.on("/getStatistics",         HTTP_GET,  [this](AsyncWebServerRequest * pRequest)    { this->GetStatistics(pRequest); });
         _server.on("/nextEffect",            HTTP_POST, [](AsyncWebServerRequest * pRequest)        { NextEffect(pRequest); });
         _server.on("/previousEffect",        HTTP_POST, [](AsyncWebServerRequest * pRequest)        { PreviousEffect(pRequest); });
 
+        _server.on("/currentEffect",         HTTP_POST, [](AsyncWebServerRequest * pRequest)        { SetCurrentEffectIndex(pRequest); });
         _server.on("/setCurrentEffectIndex", HTTP_POST, [](AsyncWebServerRequest * pRequest)        { SetCurrentEffectIndex(pRequest); });
         _server.on("/enableEffect",          HTTP_POST, [](AsyncWebServerRequest * pRequest)        { EnableEffect(pRequest); });
         _server.on("/disableEffect",         HTTP_POST, [](AsyncWebServerRequest * pRequest)        { DisableEffect(pRequest); });

--- a/platformio.ini
+++ b/platformio.ini
@@ -37,7 +37,8 @@ lib_deps        = crankyoldgit/IRremoteESP8266  @ ^2.7.20
                   thomasfredericks/Bounce2      @ ^2.7.0
                   https://github.com/PlummersSoftwareLLC/RemoteDebug
                   QRCode                        @ ^0.0.1
-                  Bodmer/TJpg_Decoder
+                  Bodmer/TJpg_Decoder           @ ^1.0.8
+                  plageoj/UrlEncode             @ ^1.0.1
 
 ; This partition table attempts to fit everything in 4M of flash.
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = 
+default_envs =
 
 ; ==================
 ; Base configuration
@@ -17,8 +17,8 @@ default_envs =
 ; Options that are used (or extended) in all device sections (and hence environments) are defined here
 
 [base]
-upload_port     = 
-monitor_port    = 
+upload_port     =
+monitor_port    =
 upload_speed    = 1500000
 
 build_flags     = -std=gnu++17
@@ -28,16 +28,16 @@ lib_deps        = crankyoldgit/IRremoteESP8266  @ ^2.7.20
                   fastled/FastLED               @ ^3.4.0
                   adafruit/Adafruit BusIO       @ ^1.9.1
                   adafruit/Adafruit GFX Library @ ^1.10.12
-                  adafruit/Adafruit ILI9341     @ ^1.5.10                  
+                  adafruit/Adafruit ILI9341     @ ^1.5.10
                   olikraus/U8g2                 @ ^2.28.8
-                  kosme/arduinoFFT              @ ^1.5.6                                                     
+                  kosme/arduinoFFT              @ ^1.5.6
                   me-no-dev/AsyncTCP            @ ^1.1.1
                   https://github.com/PlummersSoftwareLLC/ESPAsyncWebServer.git
                   bblanchon/ArduinoJson         @ ^6.8.14
                   thomasfredericks/Bounce2      @ ^2.7.0
                   https://github.com/PlummersSoftwareLLC/RemoteDebug
                   QRCode                        @ ^0.0.1
-                  Bodmer/TJpg_Decoder                  
+                  Bodmer/TJpg_Decoder
 
 ; This partition table attempts to fit everything in 4M of flash.
 
@@ -47,12 +47,12 @@ board_build.partitions = config/partitions_custom.csv
 ; =================================
 ; Build flags for enabling a remote
 ;
-; You can set these here once to match your setup; they are then included in all environments 
+; You can set these here once to match your setup; they are then included in all environments
 ; that are configured to be used with a remote.
 
 [remote_flags]
 build_flags     = -D_IR_ENABLE_DEFAULT_=false       ; Don't automatically include every remote control decoder
-                  -DDECODE_NEC=true                 ; Enable whichever you need for your remote.  Try not disabling 
+                  -DDECODE_NEC=true                 ; Enable whichever you need for your remote.  Try not disabling
                                                     ; above to figure out which it is.
 
 ; ===============
@@ -91,7 +91,7 @@ monitor_speed   = 115200
 upload_speed    = 921600
 build_flags     = -DUSE_SCREEN=1
                   -DARDUINO_HELTEC_WIFI_KIT_32=1
-                  -Ofast 
+                  -Ofast
                   ${base.build_flags}
 
 [dev_heltec_wifi_v2]
@@ -111,10 +111,10 @@ monitor_speed   = 115200
 upload_speed    = 1500000
 build_flags     = -DUSE_SCREEN=1
                   -DM5STICKC=1
-                  -Ofast 
+                  -Ofast
                   ${base.build_flags}
 lib_deps        = ${base.lib_deps}
-                  m5stack/M5StickC     @ ^0.2.3 
+                  m5stack/M5StickC     @ ^0.2.3
 
 [dev_m5stick-c-plus]
 extends         = base
@@ -123,7 +123,7 @@ monitor_speed   = 115200
 upload_speed    = 1500000
 build_flags     = -DUSE_SCREEN=1
                   -DM5STICKCPLUS=1
-                  -Ofast 
+                  -Ofast
                   ${base.build_flags}
 lib_deps        = ${base.lib_deps}
                   m5stack/M5StickCPlus @ ^0.0.2
@@ -135,7 +135,7 @@ monitor_speed   = 115200
 upload_speed    = 1500000
 build_flags     = -DUSE_SCREEN=1
                   -DM5STACKCORE2=1
-                  -Ofast 
+                  -Ofast
                   ${base.build_flags}
 lib_deps        = ${base.lib_deps}
                   https://github.com/m5stack/M5Core2.git
@@ -170,7 +170,7 @@ build_flags     = -DLILYGOTDISPLAYS3=1
 ; Capability sections
 ;
 ; The following sections contain build flags and/or dependencies to enable a particular capability
-; or module in specific environments. They applicable option(s) - build_flags, lib_deps or both - 
+; or module in specific environments. They applicable option(s) - build_flags, lib_deps or both -
 ; are included in the environments in question.
 ;
 ; Note that these sections do not extend "base", as they are basically feature toggles.
@@ -213,11 +213,11 @@ board_build.embed_txtfiles = config/timezones.json
 ; Project environments
 ;
 ; These are the actual environments defined in this file. Each configures one project for one
-; specific device. They extend the "dev_" config for the device in question, both in general 
+; specific device. They extend the "dev_" config for the device in question, both in general
 ; and in terms of build flags and dependencies, where applicable.
 ;
-; Note: when adding a new environment to the list, don't forget to explicitly add the device 
-; section's build_flags and lib_deps options (using ${dev_<device>.<option>}) if you define 
+; Note: when adding a new environment to the list, don't forget to explicitly add the device
+; section's build_flags and lib_deps options (using ${dev_<device>.<option>}) if you define
 ; either or both in the environment you add. PlatformIO does not merge them automatically.
 ; In addition to the build_flags and lib_deps of the device, capability flags and/or dependencies
 ; can be included where appropriate.
@@ -227,10 +227,10 @@ board_build.embed_txtfiles = config/timezones.json
 [env:demo]
 extends         = dev_esp32
 build_flags     = -DDEMO=1
-                  -Ofast 
+                  -Ofast
                   ${dev_esp32.build_flags}
 
-; This is the basic DEMO project again, but expanded to work on the M5, which means it can draw to 
+; This is the basic DEMO project again, but expanded to work on the M5, which means it can draw to
 ; the built in LCD.  It's made so that you can connect to the small 4-pin connector on the M5,
 ; so it sends power and ground as well as data on PIN 32.
 [env:m5demo]
@@ -345,6 +345,7 @@ build_flags     = -DSPECTRUM=1
                   -DSHOW_VU_METER=1
                   ${remote_flags.build_flags}
                   ${dev_m5stick-c-plus.build_flags}
+board_build.partitions = config/partitions_custom_noota.csv
 
 [env:spectrumstack]
 extends         = dev_m5stack
@@ -353,6 +354,7 @@ build_flags     = -DSPECTRUM=1
                   ${psram_flags.build_flags}
                   ${remote_flags.build_flags}
                   ${dev_m5stack.build_flags}
+board_build.partitions = config/partitions_custom_noota.csv
 
 ; Same as Spectrum but using a non-Plus M5 Stick (older version with smaller screen)
 [env:spectrumlite]
@@ -360,16 +362,18 @@ extends         = dev_m5stick-c
 build_flags     = -DSPECTRUM=1
                   ${remote_flags.build_flags}
                   ${dev_m5stick-c.build_flags}
+board_build.partitions = config/partitions_custom_noota.csv
 
 ; And again, for the Wrover
 [env:spectrum_wrover_kit]
 extends         = dev_wrover
 build_flags     = -DSPECTRUM=1
                   -DSPECTRUM_WROVER_KIT=1
-                  -Ofast 
+                  -Ofast
                   ${remote_flags.build_flags}
                   ${dev_wrover.build_flags}
 debug_init_break = tbreak setup
+board_build.partitions = config/partitions_custom_noota.csv
 
 ;===============
 
@@ -391,7 +395,7 @@ debug_tool      = esp-prog
 extends         = dev_lolin_d32_pro
 build_flags     = -DMESMERIZER=1
                   -DUSE_MATRIX=1
-                  -Ofast 
+                  -Ofast
                   ${psram_flags.build_flags}
                   ${remote_flags.build_flags}
                   ${dev_lolin_d32_pro.build_flags}
@@ -416,7 +420,7 @@ build_flags     = -DLANTERN=1
 [env:chieftain]
 extends         = dev_tinypico
 build_flags     = -DCHIEFTAIN=1
-                  -Ofast 
+                  -Ofast
                   ${unity_double_flags.build_flags}
                   ${dev_tinypico.build_flags}
 
@@ -432,7 +436,7 @@ build_flags     = -DUMBRELLA=1
 [env:generic]
 extends         = dev_esp32
 build_flags     = -DLEDSTRIP=1
-                  -Ofast 
+                  -Ofast
                   ${dev_esp32.build_flags}
 
 [env:panlee]
@@ -455,9 +459,9 @@ build_flags     = -DLEDSTRIP=1
                   -DTFT_RST=22
                   -DTFT_BL=48
                   -DLOAD_GLCD
-                  -DLOAD_FONT2  
+                  -DLOAD_FONT2
                   -DLOAD_FONT4
-                  -DLOAD_FONT6 
+                  -DLOAD_FONT6
                   -DLOAD_FONT7
                   -DLOAD_FONT8
                   -DLOAD_GFXFF
@@ -472,13 +476,13 @@ build_flags     = -DLEDSTRIP=1
                   ${remote_flags.build_flags}
                   ${dev_esp32-s3.build_flags}
 lib_deps        = ${dev_esp32-s3.lib_deps}
-                  TFT_eSPI                 
+                  TFT_eSPI
 
 [env:ttgo]
 extends         = dev_esp32
 build_flags     = -DTTGO=1
                   -DUSE_SCREEN=1
-                  -Ofast 
+                  -Ofast
                   ${remote_flags.build_flags}
                   ${dev_esp32.build_flags}
 lib_deps        = ${dev_esp32.lib_deps}
@@ -489,6 +493,7 @@ extends         = dev_m5stick-c-plus
 build_flags     = -DXMASTREES=1
                   ${remote_flags.build_flags}
                   ${dev_m5stick-c-plus.build_flags}
+board_build.partitions = config/partitions_custom_noota.csv
 
 [env:insulators]
 extends         = dev_m5stick-c-plus
@@ -519,9 +524,11 @@ build_flags     = -DFANSET=1
                   ${remote_flags.build_flags}
                   ${dev_m5stick-c-plus.build_flags}
 monitor_filters = esp32_exception_decoder
+board_build.partitions = config/partitions_custom_noota.csv
 
 [env:cube]
 extends         = dev_m5stick-c-plus
 build_flags     = -DCUBE=1
                   ${dev_m5stick-c-plus.build_flags}
+board_build.partitions = config/partitions_custom_noota.csv
 

--- a/site/src/components/home/designer/designer.jsx
+++ b/site/src/components/home/designer/designer.jsx
@@ -19,13 +19,13 @@ const DesignerPanel = withStyles(designStyle)(props => {
             const timer = setTimeout(()=>{
                 setNextRefreshDate(Date.now());
             },3000);
-    
-            chipRequest(`${httpPrefix !== undefined ? httpPrefix : ""}/getEffectList`,{signal:aborter.signal})
+
+            chipRequest(`${httpPrefix !== undefined ? httpPrefix : ""}/effects`,{signal:aborter.signal})
                 .then(resp => resp.json())
                 .then(setEffects)
                 .then(()=>clearTimeout(timer))
                 .catch(err => addNotification("Error","Service","Get Effect List",err));
-    
+
             return () => {
                 abortControler && abortControler.abort();
                 clearTimeout(timer);
@@ -35,8 +35,8 @@ const DesignerPanel = withStyles(designStyle)(props => {
 
     const requestRefresh = () => setTimeout(()=>setNextRefreshDate(Date.now()),50);
 
-    const chipRequest = (url,options,operation) => 
-        new Promise((resolve,reject) => 
+    const chipRequest = (url,options,operation) =>
+        new Promise((resolve,reject) =>
             fetch(url,options)
                 .then(resolve)
                 .catch(err => {addNotification("Error",operation,err);reject(err)}));
@@ -44,11 +44,11 @@ const DesignerPanel = withStyles(designStyle)(props => {
     const navigateTo = (idx)=>{
         return new Promise((resolve,reject)=>{
             setRequestRunning(true);
-            chipRequest(`${httpPrefix !== undefined ? httpPrefix : ""}/setCurrentEffectIndex?`,{method:"POST", body: new URLSearchParams({currentEffectIndex:idx})}, "navigateTo")
+            chipRequest(`${httpPrefix !== undefined ? httpPrefix : ""}/currentEffect`,{method:"POST", body: new URLSearchParams({currentEffectIndex:idx})}, "navigateTo")
                 .then(resolve)
                 .then(requestRefresh)
                 .catch(reject)
-                .finally(()=>setRequestRunning(false));    
+                .finally(()=>setRequestRunning(false));
         });
     };
 
@@ -59,7 +59,7 @@ const DesignerPanel = withStyles(designStyle)(props => {
                 .then(resolve)
                 .then(requestRefresh)
                 .catch(reject)
-                .finally(()=>setRequestRunning(false));    
+                .finally(()=>setRequestRunning(false));
         });
     };
 
@@ -70,7 +70,7 @@ const DesignerPanel = withStyles(designStyle)(props => {
                 .then(resolve)
                 .then(requestRefresh)
                 .catch(reject)
-                .finally(()=>setRequestRunning(false));    
+                .finally(()=>setRequestRunning(false));
         });
     };
 
@@ -84,7 +84,7 @@ const DesignerPanel = withStyles(designStyle)(props => {
             },"updateEventInterval").then(resolve)
               .then(requestRefresh)
               .catch(reject)
-              .finally(()=>setRequestRunning(false));    
+              .finally(()=>setRequestRunning(false));
         });
     };
 
@@ -112,10 +112,10 @@ const DesignerPanel = withStyles(designStyle)(props => {
 
     return effects && <Box className={`${classes.root} ${!open && classes.hidden}`}>
         <Box className={classes.effectsHeader}>
-            {editing ? 
+            {editing ?
             editingHeader():
             displayHeader()}
-            <Countdown 
+            <Countdown
                 label="Time Remaining"
                 requestRefresh={requestRefresh}
                 millisecondsRemaining={effects.millisecondsRemaining}/>
@@ -126,10 +126,10 @@ const DesignerPanel = withStyles(designStyle)(props => {
             </Box>}
         </Box>
         <Box className={classes.effects}>
-            {effects.Effects.map((effect,idx) => <Effect 
+            {effects.Effects.map((effect,idx) => <Effect
                                                     key={`effect-${idx}`}
-                                                    effect={effect} 
-                                                    effectIndex={idx} 
+                                                    effect={effect}
+                                                    effectIndex={idx}
                                                     navigateTo={navigateTo}
                                                     requestRunning={requestRunning}
                                                     effectEnable={effectEnable}

--- a/site/src/components/home/statistics/stats.jsx
+++ b/site/src/components/home/statistics/stats.jsx
@@ -12,10 +12,10 @@ const StatsPanel = withStyles(statsStyle)(props => {
         NightDriver: false
     });
 
-    const getStats = (aborter) => fetch(`${httpPrefix !== undefined ? httpPrefix : ""}/getStatistics`,{signal:aborter.signal})
+    const getStats = (aborter) => fetch(`${httpPrefix !== undefined ? httpPrefix : ""}/statistics`,{signal:aborter.signal})
                             .then(resp => resp.json())
                             .then(stats => {
-                                setAbortControler(undefined); 
+                                setAbortControler(undefined);
                                 return {
                                     CPU:{
                                         CPU: {
@@ -106,20 +106,20 @@ const StatsPanel = withStyles(statsStyle)(props => {
         if (open) {
             const aborter = new AbortController();
             setAbortControler(aborter);
-    
+
             getStats(aborter)
                 .then(setStatistics)
                 .catch(err => addNotification("Error","Service","Get Statistics",err));
-    
+
             if (timer) {
                 clearTimeout(timer);
                 setTimer(undefined);
             }
-    
+
             if (statsRefreshRate.value && open) {
                 setTimer(setTimeout(() => setLastRefreshDate(Date.now()),statsRefreshRate.value*1000));
             }
-    
+
             return () => {
                 timer && clearTimeout(timer);
                 abortControler && abortControler.abort();
@@ -131,11 +131,11 @@ const StatsPanel = withStyles(statsStyle)(props => {
         return <Box>Loading...</Box>
     }
 
-    return statistics && 
+    return statistics &&
     <Box className={`${classes.root} ${!open && classes.hidden}`}>
-        {Object.entries(statistics).map(category => 
+        {Object.entries(statistics).map(category =>
         <Box key={category[0]} className={`${classes.category} ${!openedCategories[category[0]] && classes.detailedStats}`}>
-            {openedCategories[category[0]] ? 
+            {openedCategories[category[0]] ?
             <Box className={classes.statCatergoryHeader} key="header">
                 <Typography variant="h5">{category[0]}</Typography>
                 <IconButton onClick={()=>setOpenedCategories(prev => {return {...prev,[category[0]]:!openedCategories[category[0]]}})}><Icon>minimize</Icon></IconButton>
@@ -145,25 +145,25 @@ const StatsPanel = withStyles(statsStyle)(props => {
             </Box>}
             <Box className={classes.categoryStats}>
             {Object.entries(category[1])
-               .filter(entry=> entry[1].static) 
+               .filter(entry=> entry[1].static)
                .map(entry=>
-                <Box 
+                <Box
                   key={`entry-${entry[0]}`}
-                  className={!openedCategories[category[0]] && classes.summaryStats }  
+                  className={!openedCategories[category[0]] && classes.summaryStats }
                   onClick={()=>!openedCategories[category[0]] && setOpenedCategories(prev => {return {...prev,[category[0]]:!openedCategories[category[0]]}})}>
                     <StaticStatsPanel
                         key={`static-${entry[0]}`}
                         detail={openedCategories[category[0]]}
                         name={entry[0]}
-                        stat={entry[1]}/>                
+                        stat={entry[1]}/>
                 </Box>)}
                 <Box className={classes.categoryStats} key="charts">
                     {Object.entries(category[1])
-                        .filter(entry=> !entry[1].static) 
-                        .map((entry)=>  
+                        .filter(entry=> !entry[1].static)
+                        .map((entry)=>
                             <Box key={`chart-${entry[0]}`}
                                  sx={{cursor:"pointer"}}
-                                 onClick={()=>!openedCategories[category[0]] && setOpenedCategories(prev => {return {...prev,[category[0]]:!openedCategories[category[0]]}})} 
+                                 onClick={()=>!openedCategories[category[0]] && setOpenedCategories(prev => {return {...prev,[category[0]]:!openedCategories[category[0]]}})}
                                  className={`${classes.chartArea} ${!openedCategories[category[0]] && classes.summaryStats}`}>
                                     {category[1][entry[0]].idleField && <BarStat
                                         key={`Bar-${entry[0]}`}

--- a/src/deviceconfig.cpp
+++ b/src/deviceconfig.cpp
@@ -31,7 +31,7 @@
 #include "globals.h"
 #include "deviceconfig.h"
 
-DRAM_ATTR std::unique_ptr<DeviceConfig> g_aptrDeviceConfig;
+DRAM_ATTR std::unique_ptr<DeviceConfig> g_ptrDeviceConfig;
 extern const char timezones_start[] asm("_binary_config_timezones_json_start");
 
 DRAM_ATTR size_t g_DeviceConfigJSONBufferSize = 0;
@@ -61,6 +61,9 @@ DeviceConfig::DeviceConfig()
         openWeatherApiKey = cszOpenWeatherAPIKey;
         use24HourClock = false;
         useCelsius = false;
+        youtubeChannelGuid = "";
+        youtubeChannelName1 = "";
+
         SetTimeZone(cszTimeZone, true);
 
         SaveToJSON();

--- a/src/deviceconfig.cpp
+++ b/src/deviceconfig.cpp
@@ -121,15 +121,13 @@ DeviceConfig::ValidateResponse DeviceConfig::ValidateOpenWeatherAPIKey(const Str
 
     switch (http.GET())
     {
-        // OK
-        case 200:
+        case HTTP_CODE_OK:
         {
             http.end();
             return { true, "" };
         }
 
-        // Unauthorized
-        case 401:
+        case HTTP_CODE_UNAUTHORIZED:
         {
             AllocatedJsonDocument jsonDoc(1024);
             deserializeJson(jsonDoc, http.getString());

--- a/src/deviceconfig.cpp
+++ b/src/deviceconfig.cpp
@@ -29,6 +29,7 @@
 //---------------------------------------------------------------------------
 
 #include <HTTPClient.h>
+#include <UrlEncode.h>
 #include "globals.h"
 #include "deviceconfig.h"
 
@@ -115,7 +116,7 @@ DeviceConfig::ValidateResponse DeviceConfig::ValidateOpenWeatherAPIKey(const Str
 {
     HTTPClient http;
 
-    String url = "http://api.openweathermap.org/data/2.5/weather?lat=0&lon=0&appid=" + newOpenWeatherAPIKey;
+    String url = "http://api.openweathermap.org/data/2.5/weather?lat=0&lon=0&appid=" + urlEncode(newOpenWeatherAPIKey);
 
     http.begin(url);
 

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -33,11 +33,6 @@
 
 extern DRAM_ATTR std::shared_ptr<GFXBase> g_aptrDevices[NUM_CHANNELS];
 
-#if USE_MATRIX
-    volatile long PatternSubscribers::cSubscribers;
-    volatile long PatternSubscribers::cViews;
-#endif
-
 // Palettes
 //
 // Palettes that are referenced by effects need to be instantiated first

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -281,17 +281,6 @@ void IRAM_ATTR DebugLoopTaskEntry(void *)
 
 // Data for Dave's Garage as an example,
 
-#if USE_MATRIX
-    const char PatternSubscribers::szChannelID[] = "UCNzszbnvQeFzObW0ghk0Ckw";
-    const char PatternSubscribers::szChannelName1[] = "Daves Garage";
-
-    #define SUB_CHECK_INTERVAL 60000
-    #define SUB_CHECK_ERROR_INTERVAL 10000
-    #define CHANNEL_GUID "9558daa1-eae8-482f-8066-17fa787bc0e4"
-
-    WiFiClient http;
-    YouTubeSight sight(CHANNEL_GUID, http);
-#endif
 
 void IRAM_ATTR NetworkHandlingLoopEntry(void *)
 {
@@ -321,38 +310,7 @@ void IRAM_ATTR NetworkHandlingLoopEntry(void *)
                     #endif
                 }
             }
-
-            // Get Subscriber Count when wifi first connects, then every 60 seconds (or whatever the interval is set to)
-
-            #if (SUB_CHECK_INTERVAL > 0)
-                if (WiFi.isConnected())
-                {
-                    static int millisLastCheck = 0;
-                    static bool succeededBefore = false;
-
-                    // If we've never succeeded, we try every 20 seconds, but then we settle down to the SUBCHECK_INTERVAL
-                    if (millisLastCheck == 0 || (!succeededBefore && (millis() - millisLastCheck > 60000)) || (millis() - millisLastCheck > SUBCHECK_INTERVAL))
-                    {
-                        millisLastCheck = millis();
-                        sight._debug = false;
-
-                        // Use the YouTubeSight API call to get the current channel stats
-
-                        if (sight.getData())
-                        {
-                            PatternSubscribers::cSubscribers = atol(sight.channelStats.subscribers_count.c_str());
-                            PatternSubscribers::cViews       = atol(sight.channelStats.views.c_str());
-                            succeededBefore = true;
-                        }
-                        else
-                        {
-                            debugW("YouTubeSight Subscriber API failed\n");
-                        }
-                    }
-                }
-            #endif
         #endif
-
 
         #if ENABLE_WIFI && ENABLE_NTP
             EVERY_N_MILLIS(TIME_CHECK_INTERVAL_MS)
@@ -509,7 +467,7 @@ void setup()
     ESP_ERROR_CHECK(err);
 
     // Create and load device config from NVS if possible
-    g_aptrDeviceConfig = std::make_unique<DeviceConfig>();
+    g_ptrDeviceConfig = std::make_unique<DeviceConfig>();
 
 #if ENABLE_WIFI
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -204,15 +204,15 @@ void CWebServer::SetSettings(AsyncWebServerRequest * pRequest)
     debugV("SetSettings");
 
     PushPostParamIfPresent<size_t>(pRequest,"effectInterval", SET_VALUE(g_ptrEffectManager->SetInterval(value)));
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::LocationTag, SET_VALUE(g_ptrDeviceConfig->SetLocation(value)));
+    PushPostParamIfPresent<String>(pRequest, DeviceConfig::LocationTag, SET_VALUE(g_ptrDeviceConfig->SetLocation(value)));
     PushPostParamIfPresent<bool>(pRequest, DeviceConfig::LocationIsZipTag, SET_VALUE(g_ptrDeviceConfig->SetLocationIsZip(value)));
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::CountryCodeTag, SET_VALUE(g_ptrDeviceConfig->SetCountryCode(value)));
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::OpenWeatherApiKeyTag, SET_VALUE(g_ptrDeviceConfig->SetOpenWeatherAPIKey(value)));
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::TimeZoneTag, SET_VALUE(g_ptrDeviceConfig->SetTimeZone(value)));
+    PushPostParamIfPresent<String>(pRequest, DeviceConfig::CountryCodeTag, SET_VALUE(g_ptrDeviceConfig->SetCountryCode(value)));
+    PushPostParamIfPresent<String>(pRequest, DeviceConfig::OpenWeatherApiKeyTag, SET_VALUE(g_ptrDeviceConfig->SetOpenWeatherAPIKey(value)));
+    PushPostParamIfPresent<String>(pRequest, DeviceConfig::TimeZoneTag, SET_VALUE(g_ptrDeviceConfig->SetTimeZone(value)));
     PushPostParamIfPresent<bool>(pRequest, DeviceConfig::Use24HourClockTag, SET_VALUE(g_ptrDeviceConfig->Set24HourClock(value)));
     PushPostParamIfPresent<bool>(pRequest, DeviceConfig::UseCelsiusTag, SET_VALUE(g_ptrDeviceConfig->SetUseCelsius(value)));
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::YouTubeChannelGuidTag, SET_VALUE(g_ptrDeviceConfig->SetYouTubeChannelGuid(value)));
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::YouTubeChannelName1Tag, SET_VALUE(g_ptrDeviceConfig->SetYouTubeChannelName1(value)));
+    PushPostParamIfPresent<String>(pRequest, DeviceConfig::YouTubeChannelGuidTag, SET_VALUE(g_ptrDeviceConfig->SetYouTubeChannelGuid(value)));
+    PushPostParamIfPresent<String>(pRequest, DeviceConfig::YouTubeChannelName1Tag, SET_VALUE(g_ptrDeviceConfig->SetYouTubeChannelName1(value)));
 
     // We return the current config in response
     GetSettings(pRequest);

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -271,7 +271,7 @@ void CWebServer::ValidateAndSetSetting(AsyncWebServerRequest * pRequest)
             // We found multiple known settings in the request, which we don't allow
             {
                 String responseText = "{\"message\": \"Malformed request\"}";
-                auto pResponse = pRequest->beginResponse(400, "text/json", responseText);
+                auto pResponse = pRequest->beginResponse(HTTP_CODE_BAD_REQUEST, "text/json", responseText);
                 AddCORSHeaderAndSendResponse(pRequest, pResponse);
                 return;
             }
@@ -297,7 +297,7 @@ void CWebServer::ValidateAndSetSetting(AsyncWebServerRequest * pRequest)
         if (!isValid)
         {
             String responseText = "{\"message\": \"" + validationMessage + "\"}";
-            auto pResponse = pRequest->beginResponse(400, "text/json", responseText);
+            auto pResponse = pRequest->beginResponse(HTTP_CODE_BAD_REQUEST, "text/json", responseText);
             AddCORSHeaderAndSendResponse(pRequest, pResponse);
             return;
         }

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -193,7 +193,7 @@ void CWebServer::GetSettings(AsyncWebServerRequest * pRequest)
     auto root = response->getRoot();
     JsonObject jsonObject = root.to<JsonObject>();
 
-    g_aptrDeviceConfig->SerializeToJSON(jsonObject);
+    g_ptrDeviceConfig->SerializeToJSON(jsonObject);
     jsonObject["effectInterval"] = g_ptrEffectManager->GetInterval();
 
     AddCORSHeaderAndSendResponse(pRequest, response);
@@ -204,13 +204,15 @@ void CWebServer::SetSettings(AsyncWebServerRequest * pRequest)
     debugV("SetSettings");
 
     PushPostParamIfPresent<size_t>(pRequest,"effectInterval", SET_VALUE(g_ptrEffectManager->SetInterval(value)));
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::LocationTag, SET_VALUE(g_aptrDeviceConfig->SetLocation(value)));
-    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::LocationIsZipTag, SET_VALUE(g_aptrDeviceConfig->SetLocationIsZip(value)));
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::CountryCodeTag, SET_VALUE(g_aptrDeviceConfig->SetCountryCode(value)));
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::OpenWeatherApiKeyTag, SET_VALUE(g_aptrDeviceConfig->SetOpenWeatherAPIKey(value)));
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::TimeZoneTag, SET_VALUE(g_aptrDeviceConfig->SetTimeZone(value)));
-    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::Use24HourClockTag, SET_VALUE(g_aptrDeviceConfig->Set24HourClock(value)));
-    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::UseCelsiusTag, SET_VALUE(g_aptrDeviceConfig->SetUseCelsius(value)));
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::LocationTag, SET_VALUE(g_ptrDeviceConfig->SetLocation(value)));
+    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::LocationIsZipTag, SET_VALUE(g_ptrDeviceConfig->SetLocationIsZip(value)));
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::CountryCodeTag, SET_VALUE(g_ptrDeviceConfig->SetCountryCode(value)));
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::OpenWeatherApiKeyTag, SET_VALUE(g_ptrDeviceConfig->SetOpenWeatherAPIKey(value)));
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::TimeZoneTag, SET_VALUE(g_ptrDeviceConfig->SetTimeZone(value)));
+    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::Use24HourClockTag, SET_VALUE(g_ptrDeviceConfig->Set24HourClock(value)));
+    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::UseCelsiusTag, SET_VALUE(g_ptrDeviceConfig->SetUseCelsius(value)));
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::YouTubeChannelGuidTag, SET_VALUE(g_ptrDeviceConfig->SetYouTubeChannelGuid(value)));
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::YouTubeChannelName1Tag, SET_VALUE(g_ptrDeviceConfig->SetYouTubeChannelName1(value)));
 
     // We return the current config in response
     GetSettings(pRequest);
@@ -221,7 +223,7 @@ void CWebServer::Reset(AsyncWebServerRequest * pRequest)
     if (IsPostParamTrue(pRequest, "deviceConfig"))
     {
         debugI("Removing DeviceConfig");
-        g_aptrDeviceConfig->RemovePersisted();
+        g_ptrDeviceConfig->RemovePersisted();
     }
 
     if (IsPostParamTrue(pRequest, "effectsConfig"))

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -31,25 +31,52 @@
 #include "globals.h"
 #include "webserver.h"
 
+// Static member initializers
+
+const std::vector<const char *> CWebServer::knownSettings
+{
+    "effectInterval",
+    DeviceConfig::LocationTag,
+    DeviceConfig::LocationIsZipTag,
+    DeviceConfig::CountryCodeTag,
+    DeviceConfig::OpenWeatherApiKeyTag,
+    DeviceConfig::TimeZoneTag,
+    DeviceConfig::Use24HourClockTag,
+    DeviceConfig::UseCelsiusTag,
+    DeviceConfig::YouTubeChannelGuidTag,
+    DeviceConfig::YouTubeChannelName1Tag,
+};
+
+// Maps settings for which a validator is available to the invocation thereof
+const std::map<const char *, CWebServer::ValueValidator> CWebServer::settingValidators
+{
+    { DeviceConfig::OpenWeatherApiKeyTag, [](const String& value) { return g_ptrDeviceConfig->ValidateOpenWeatherAPIKey(value); } }
+};
+
 // Member function template specialzations
 
+// Push param that represents a bool. Values considered true are text "true" and any whole number not equal to 0
 template<>
-void CWebServer::PushPostParamIfPresent<bool>(AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<bool> setter)
+bool CWebServer::PushPostParamIfPresent<bool>(AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<bool> setter)
 {
-    PushPostParamIfPresent<bool>(pRequest, paramName, setter, [](AsyncWebParameter * param) constexpr
-        {
-            const String& value = param->value();
-            return value == "true" || strtol(value.c_str(), NULL, 10);
-        }
-    );
+    return PushPostParamIfPresent<bool>(pRequest, paramName, setter, [](AsyncWebParameter * param) constexpr
+    {
+        const String& value = param->value();
+        return value == "true" || strtol(value.c_str(), NULL, 10);
+    });
 }
 
+// Push param that represents a size_t
 template<>
-void CWebServer::PushPostParamIfPresent<size_t>(AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<size_t> setter)
+bool CWebServer::PushPostParamIfPresent<size_t>(AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<size_t> setter)
 {
-    PushPostParamIfPresent<size_t>(pRequest, paramName, setter, [](AsyncWebParameter * param) constexpr { return strtoul(param->value().c_str(), NULL, 10); });
+    return PushPostParamIfPresent<size_t>(pRequest, paramName, setter, [](AsyncWebParameter * param) constexpr
+    {
+        return strtoul(param->value().c_str(), NULL, 10);
+    });
 }
 
+// Add CORS header to and send JSON response
 template<>
 void CWebServer::AddCORSHeaderAndSendResponse<AsyncJsonResponse>(AsyncWebServerRequest * pRequest, AsyncJsonResponse * pResponse)
 {
@@ -63,7 +90,7 @@ bool CWebServer::IsPostParamTrue(AsyncWebServerRequest * pRequest, const String 
 {
     bool returnValue = false;
 
-    PushPostParamIfPresent<bool>(pRequest, paramName, [&returnValue](auto value) { returnValue = value; });
+    PushPostParamIfPresent<bool>(pRequest, paramName, [&returnValue](auto value) { returnValue = value; return true; });
 
     return returnValue;
 }
@@ -184,6 +211,7 @@ void CWebServer::PreviousEffect(AsyncWebServerRequest * pRequest)
     AddCORSHeaderAndSendOKResponse(pRequest);
 }
 
+// Responds with current config, excluding any sensitive values
 void CWebServer::GetSettings(AsyncWebServerRequest * pRequest)
 {
     debugV("GetSettings");
@@ -193,16 +221,17 @@ void CWebServer::GetSettings(AsyncWebServerRequest * pRequest)
     auto root = response->getRoot();
     JsonObject jsonObject = root.to<JsonObject>();
 
-    g_ptrDeviceConfig->SerializeToJSON(jsonObject);
+    // We get the serialized JSON for the device config, without any sensitive values
+    g_ptrDeviceConfig->SerializeToJSON(jsonObject, false);
     jsonObject["effectInterval"] = g_ptrEffectManager->GetInterval();
 
     AddCORSHeaderAndSendResponse(pRequest, response);
 }
 
-void CWebServer::SetSettings(AsyncWebServerRequest * pRequest)
+// Support function that silently sets whatever settings are included in the request passed.
+//   Composing a response is left to the invoker!
+void CWebServer::SetSettingsIfPresent(AsyncWebServerRequest * pRequest)
 {
-    debugV("SetSettings");
-
     PushPostParamIfPresent<size_t>(pRequest,"effectInterval", SET_VALUE(g_ptrEffectManager->SetInterval(value)));
     PushPostParamIfPresent<String>(pRequest, DeviceConfig::LocationTag, SET_VALUE(g_ptrDeviceConfig->SetLocation(value)));
     PushPostParamIfPresent<bool>(pRequest, DeviceConfig::LocationIsZipTag, SET_VALUE(g_ptrDeviceConfig->SetLocationIsZip(value)));
@@ -213,11 +242,73 @@ void CWebServer::SetSettings(AsyncWebServerRequest * pRequest)
     PushPostParamIfPresent<bool>(pRequest, DeviceConfig::UseCelsiusTag, SET_VALUE(g_ptrDeviceConfig->SetUseCelsius(value)));
     PushPostParamIfPresent<String>(pRequest, DeviceConfig::YouTubeChannelGuidTag, SET_VALUE(g_ptrDeviceConfig->SetYouTubeChannelGuid(value)));
     PushPostParamIfPresent<String>(pRequest, DeviceConfig::YouTubeChannelName1Tag, SET_VALUE(g_ptrDeviceConfig->SetYouTubeChannelName1(value)));
+}
+
+// Set settings and return resulting config
+void CWebServer::SetSettings(AsyncWebServerRequest * pRequest)
+{
+    debugV("SetSettings");
+
+    SetSettingsIfPresent(pRequest);
 
     // We return the current config in response
     GetSettings(pRequest);
 }
 
+// Validate and set one setting. If no validator is available in settingValidators for the setting, validation is skipped.
+//   Requests containing more than one known setting are malformed and rejected.
+void CWebServer::ValidateAndSetSetting(AsyncWebServerRequest * pRequest)
+{
+    const char *paramName = nullptr;
+
+    for (auto knownSetting : knownSettings)
+    {
+        if (pRequest->hasParam(knownSetting, true))
+        {
+            if (!paramName)
+                paramName = knownSetting;
+            else
+            // We found multiple known settings in the request, which we don't allow
+            {
+                String responseText = "{\"message\": \"Malformed request\"}";
+                auto pResponse = pRequest->beginResponse(400, "text/json", responseText);
+                AddCORSHeaderAndSendResponse(pRequest, pResponse);
+                return;
+            }
+        }
+    }
+
+    // No known setting in the request, so we can stop processing and go on with our business
+    if (!paramName)
+    {
+        AddCORSHeaderAndSendOKResponse(pRequest);
+        return;
+    }
+
+    auto validator = settingValidators.find(paramName);
+    if (validator != settingValidators.end())
+    {
+        const String &paramValue = pRequest->getParam(paramName, true)->value();
+        bool isValid;
+        String validationMessage;
+
+        std::tie(isValid, validationMessage) = validator->second(paramValue);
+
+        if (!isValid)
+        {
+            String responseText = "{\"message\": \"" + validationMessage + "\"}";
+            auto pResponse = pRequest->beginResponse(400, "text/json", responseText);
+            AddCORSHeaderAndSendResponse(pRequest, pResponse);
+            return;
+        }
+    }
+
+    // Process the setting as per usual
+    SetSettingsIfPresent(pRequest);
+    AddCORSHeaderAndSendOKResponse(pRequest);
+}
+
+// Reset effect config, device config and/or the board itself
 void CWebServer::Reset(AsyncWebServerRequest * pRequest)
 {
     if (IsPostParamTrue(pRequest, "deviceConfig"))
@@ -238,6 +329,7 @@ void CWebServer::Reset(AsyncWebServerRequest * pRequest)
 
     if (boardResetRequested)
     {
+        debugW("Resetting device at API request!");
         delay(1000);    // Give the response a second to be sent
         throw new std::runtime_error("Resetting device at API request");
     }

--- a/tools/NightDriverStrip.postman_collection.json
+++ b/tools/NightDriverStrip.postman_collection.json
@@ -1,0 +1,239 @@
+{
+	"info": {
+		"_postman_id": "78753837-e8ae-4644-a145-8dab4f6b729d",
+		"name": "NightDriverStrip endpoints",
+		"description": "Call configurations to use/test some of the endpoints in the NightDriverStrip on-device API - basically those not yet covered by the web UI. These have been confirmed to work with the Mesmerizer board/project and the Spectrum project on the M5StickC Plus.\n\nNotes:\n\n- Before using the call configurations in this collection, make sure to update the value of the \"device_ip\" variable in the Variables tab of this collection. Make sure to Save the collection after doing this, because otherwise your change will not be applied.\n- The parameters for POST call configurations are listed in the Body tab of the respective configurations. As with the collection's \"device_ip\" variable, Save a configuration if you want to persist changes to its parameters.\n- By default, all parameters for all configurations are unchecked, which means nothing will be sent unless at least one parameter is checked.",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "26965397"
+	},
+	"item": [
+		{
+			"name": "Get config",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{device_ip}}/settings",
+					"host": [
+						"{{device_ip}}"
+					],
+					"path": [
+						"settings"
+					]
+				},
+				"description": "Retrieve device settings used by NightDriverStrip effects."
+			},
+			"response": []
+		},
+		{
+			"name": "Set config",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "location",
+							"value": "Utrecht",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "locationIsZip",
+							"value": "false",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "countryCode",
+							"value": "nl",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "openWeatherApiKey",
+							"value": "<your-API-key>",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "timeZone",
+							"value": "Europe/Amsterdam",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "use24HourClock",
+							"value": "1",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "useCelsius",
+							"value": "true",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "effectInterval",
+							"value": "60000",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "youtubeChannelGuid",
+							"value": "9558daa1-eae8-482f-8066-17fa787bc0e4",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "youtubeChannelName1",
+							"value": "Daves Garage",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "nonsense",
+							"value": "gobbledygook",
+							"type": "text",
+							"disabled": true
+						}
+					]
+				},
+				"url": {
+					"raw": "{{device_ip}}/settings",
+					"host": [
+						"{{device_ip}}"
+					],
+					"path": [
+						"settings"
+					]
+				},
+				"description": "Change device settings used by NightDriverStrip effects.\n\nNotes:\n\n- Only parameters that are sent are actually changed.\n- All parameters are optional.\n- The call will return the current setting values, after those included in the call have been applied."
+			},
+			"response": []
+		},
+		{
+			"name": "Set config with validation",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "location",
+							"value": "Utrecht",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "locationIsZip",
+							"value": "false",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "countryCode",
+							"value": "nl",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "openWeatherApiKey",
+							"value": "<your-API-key>",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "nonsense",
+							"value": "gobbledygook",
+							"type": "text",
+							"disabled": true
+						}
+					]
+				},
+				"url": {
+					"raw": "{{device_ip}}/settings/validated",
+					"host": [
+						"{{device_ip}}"
+					],
+					"path": [
+						"settings",
+						"validated"
+					]
+				},
+				"description": "Validates and changes exactly one known setting. The new setting value is only applied if validation succeeds.\n\nNotes:\n\n- Providing more than one known setting (i.e. sending more than one known parameter) is an error.\n- If a validation error occurs, the call will return a message indicating the nature of the problem.\n- Validation is not implemented for all settings. The validation step is skipped for settings for which no validation is available."
+			},
+			"response": []
+		},
+		{
+			"name": "Reset config and/or device",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "effectsConfig",
+							"value": "true",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "deviceConfig",
+							"value": "1",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "board",
+							"value": "true",
+							"type": "text",
+							"disabled": true
+						}
+					]
+				},
+				"url": {
+					"raw": "{{device_ip}}/reset",
+					"host": [
+						"{{device_ip}}"
+					],
+					"path": [
+						"reset"
+					]
+				},
+				"description": "Reset the device settings, effect configuration information, and/or the device (i.e. restart it).\n\nThe parameters included in the call with a value representing a boolean \"true\" indicate which reset(s) should be applied. Absent parameters are considered to be \"false\"."
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "device_ip",
+			"value": "192.168.1.1"
+		}
+	]
+}


### PR DESCRIPTION
## Description

This:

- Makes the YouTube channel GUID and name, as used by the Subscriber effect, configurable using DeviceConfig
- Adds the ability to have individual settings validated by POSTing them to the /settings/validated sub-endpoint
- Hides sensitive settings when returning the configuration on the /settings endpoint
- Adds the `override` specifier to JSON-related functions
- Documents the API published by the built-in webserver
- Provides a Postman collection file to facilitate the use of the on-device API

Because of the first point, this fixes #261.

## Contributing requirements

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).