### PR TITLE
Tidy

### DIFF
--- a/include/colordata.h
+++ b/include/colordata.h
@@ -36,6 +36,6 @@ extern const CRGBPalette16 vuPaletteBlue;
 extern const CRGBPalette16 spectrumBasicColors;
 extern const CRGBPalette16 bluesky_pal;
 extern const TProgmemRGBGradientPalette_byte vu_gpGreen[];
-extern const  TProgmemRGBPalette16 BlueHeatColors_p;
-extern const  TProgmemRGBPalette16 GreenHeatColors_p;
+extern const TProgmemRGBPalette16 BlueHeatColors_p;
+extern const TProgmemRGBPalette16 GreenHeatColors_p;
 

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -193,4 +193,4 @@ class DeviceConfig : public IJSONSerializable
     }
 };
 
-extern DRAM_ATTR std::unique_ptr<DeviceConfig> g_aptrDeviceConfig;
+extern DRAM_ATTR std::unique_ptr<DeviceConfig> g_ptrDeviceConfig;

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -46,7 +46,7 @@
 #include "effects/strip/fireeffect.h"
 #include "jsonserializer.h"
 
-#define MAX_EFFECTS 32
+#define MAX_EFFECTS 32                  // BUGBUG Not used - needed?  
 #define JSON_FORMAT_VERSION 1
 
 extern uint8_t g_Brightness;

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -46,7 +46,6 @@
 #include "effects/strip/fireeffect.h"
 #include "jsonserializer.h"
 
-#define MAX_EFFECTS 32                  // BUGBUG Not used - needed?  
 #define JSON_FORMAT_VERSION 1
 
 extern uint8_t g_Brightness;
@@ -60,7 +59,7 @@ void SaveEffectManagerConfig();
 void RemoveEffectManagerConfig();
 std::shared_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color);
 std::shared_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color, CRGB color2);
-extern DRAM_ATTR std::shared_ptr<GFXBase> g_ptrDevices[NUM_CHANNELS];
+extern DRAM_ATTR std::shared_ptr<GFXBase> g_aptrDevices[NUM_CHANNELS];
 std::shared_ptr<LEDStripEffect> CreateEffectFromJSON(const JsonObjectConst& jsonObject);
 
 // EffectManager
@@ -156,6 +155,30 @@ public:
         construct(true);
     }
 
+    // DeserializeFromJSON
+    //
+    // This function deserializes LED strip effects from a provided JSON object.
+    //
+    // It first clears any existing effects and then attempts to populate the effects vector from 
+    // the provided JSON object, which should contain an array of effects configurations ("efs").
+    // 
+    // The function also reserves memory for the effects vector based on the size of the JSON array.
+    // For each effect in the JSON array, it attempts to create an effect from its JSON configuration.
+    // If an effect is successfully created, it's added to the effects vector.
+    // 
+    // If no effects are successfully created (i.e., the effects vector is empty), the function returns false.
+    // 
+    // The function also initializes an array to track the enabled state of each effect, defaulting to "enabled".
+    // If the JSON object includes an "eef" array, the function attempts to load each effect's enabled state from it.
+    // If not, or if the index exceeds the "eef" array's size, the effect is enabled by default.
+    // 
+    // The function also sets the effect interval from the "ivl" field in the JSON object, defaulting to a pre-defined value if the field isn't present.
+    // 
+    // If the JSON object includes a "cei" field, the function sets the current effect index to this value. 
+    // If the value is greater than or equal to the number of effects, it defaults to the last effect in the vector.
+    // 
+    // Lastly, the function calls the construct() method, indicating successful deserialization.
+
     virtual bool DeserializeFromJSON(const JsonObjectConst& jsonObject)
     {
         ClearEffects();
@@ -203,6 +226,26 @@ public:
 
         return true;
     }
+
+    // SerializeToJSON - Serialize effects to a JSON object.
+    //
+    // This function serializes the current state of the LED strip effects into a JSON object.
+    // It starts by setting the JSON format version ("PTY_VERSION") to a predefined value ("JSON_FORMAT_VERSION") 
+    // that helps in detecting and managing potential future incompatible structural updates.
+    // 
+    // The function then sets the "ivl" and "cei" fields in the JSON object to the current effect interval 
+    // and the current effect index, respectively.
+    // 
+    // The function creates a nested array ("eef") in the JSON object to store the enabled state of each effect.
+    // It iterates through all effects, and for each effect, it adds a value of 1 to the array if the effect 
+    // is enabled, and 0 if it is not.
+    // 
+    // Next, the function creates another nested array ("efs") in the JSON object to store the effects themselves.
+    // It iterates through all effects, and for each effect, it creates a nested object in the effects array 
+    // and attempts to serialize the effect into this object. If serialization of any effect fails, the function 
+    // immediately returns false.
+    // 
+    // If all effects are successfully serialized, the function returns true, indicating successful serialization.
 
     virtual bool SerializeToJSON(JsonObject& jsonObject)
     {

--- a/include/effects/matrix/PatternBounce.h
+++ b/include/effects/matrix/PatternBounce.h
@@ -72,6 +72,11 @@ public:
     {
     }
 
+    virtual bool RequiresDoubleBuffering() const
+    {
+        return false;
+    }
+
     virtual void Start() override
     {
         unsigned int colorWidth = 256 / count;

--- a/include/effects/matrix/PatternClock.h
+++ b/include/effects/matrix/PatternClock.h
@@ -51,6 +51,11 @@ class PatternClock : public LEDStripEffect
     {
     }
 
+    virtual bool RequiresDoubleBuffering() const
+    {
+        return false;
+    }
+
     virtual void Draw() override
     {
         // Get the hours, minutes, and seconds of hte current time

--- a/include/effects/matrix/PatternCube.h
+++ b/include/effects/matrix/PatternCube.h
@@ -187,6 +187,12 @@ class PatternCube : public LEDStripEffect
         return 40;
     }
 
+    virtual bool RequiresDoubleBuffering() const override
+    {
+        return false;
+    }
+
+
     void construct()
     {
       make(cubeWidth);
@@ -201,11 +207,6 @@ class PatternCube : public LEDStripEffect
     PatternCube(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
     {
       construct();
-    }
-
-    virtual bool RequiresDoubleBuffering() const
-    {
-        return false;
     }
 
     virtual void Draw() override

--- a/include/effects/matrix/PatternMandala.h
+++ b/include/effects/matrix/PatternMandala.h
@@ -89,6 +89,10 @@ public:
         return 30;
     }
 
+    virtual bool RequiresDoubleBuffering() const
+    {
+        return false;
+    }
 
     virtual void Start() override
     {

--- a/include/effects/matrix/PatternMisc.h
+++ b/include/effects/matrix/PatternMisc.h
@@ -113,6 +113,11 @@ class PatternRose : public LEDStripEffect
         return 60;
     }
 
+    virtual bool RequiresDoubleBuffering() const
+    {
+        return false;
+    }
+
     virtual void Draw() override
     {
       uint8_t dim = beatsin8(2, 170, 250);
@@ -266,6 +271,11 @@ public:
     virtual size_t DesiredFramesPerSecond() const override
     {
         return 16;
+    }
+
+    virtual bool RequiresDoubleBuffering() const override
+    {
+        return false;
     }
 
     virtual void Draw() override

--- a/include/effects/matrix/PatternPongClock.h
+++ b/include/effects/matrix/PatternPongClock.h
@@ -113,7 +113,7 @@ class PatternPongClock : public LEDStripEffect
         time_t ttime = time(0);
         tm *local_time = localtime(&ttime);
 
-        bool ampm = !g_aptrDeviceConfig->Use24HourClock();
+        bool ampm = !g_ptrDeviceConfig->Use24HourClock();
 
         // update score / time
         mins = local_time->tm_min;
@@ -463,7 +463,7 @@ class PatternPongClock : public LEDStripEffect
             restart = 1;
 
             // update score / time
-            bool ampm = !g_aptrDeviceConfig->Use24HourClock();
+            bool ampm = !g_ptrDeviceConfig->Use24HourClock();
 
             mins = local_time->tm_min;
             hours = local_time->tm_hour;

--- a/include/effects/matrix/PatternPongClock.h
+++ b/include/effects/matrix/PatternPongClock.h
@@ -108,6 +108,11 @@ class PatternPongClock : public LEDStripEffect
         return 35;
     }
 
+    virtual bool RequiresDoubleBuffering() const
+    {
+        return false;
+    }
+
     virtual void Start() override
     {
         time_t ttime = time(0);

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -51,6 +51,11 @@ class PatternSubscribers : public LEDStripEffect
   static const char szChannelID[];
   static const char szChannelName1[];
 
+  virtual bool RequiresDoubleBuffering() const
+  {
+      return false;
+  }
+
   virtual void Draw() override
   {
       LEDMatrixGFX::backgroundLayer.fillScreen(rgb24(0, 16, 64));

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -116,7 +116,7 @@ private:
 
     inline float KelvinToLocal(float K)
     {
-        if (g_aptrDeviceConfig->UseCelsius())
+        if (g_ptrDeviceConfig->UseCelsius())
             return KelvinToCelsius(K);
         else
             return KelvinToFarenheit(K);
@@ -130,14 +130,14 @@ private:
         if (!HasLocationChanged())
             return false;
 
-        const String& configLocation = g_aptrDeviceConfig->GetLocation();
-        const String& configCountryCode = g_aptrDeviceConfig->GetCountryCode();
-        const bool configLocationIsZip = g_aptrDeviceConfig->IsLocationZip();
+        const String& configLocation = g_ptrDeviceConfig->GetLocation();
+        const String& configCountryCode = g_ptrDeviceConfig->GetCountryCode();
+        const bool configLocationIsZip = g_ptrDeviceConfig->IsLocationZip();
 
         if (configLocationIsZip)
-            url = "http://api.openweathermap.org/geo/1.0/zip?zip=" + configLocation + "," + configCountryCode + "&appid=" + g_aptrDeviceConfig->GetOpenWeatherAPIKey();
+            url = "http://api.openweathermap.org/geo/1.0/zip?zip=" + configLocation + "," + configCountryCode + "&appid=" + g_ptrDeviceConfig->GetOpenWeatherAPIKey();
         else
-            url = "http://api.openweathermap.org/geo/1.0/direct?q=" + configLocation + "," + configCountryCode + "&limit=1&appid=" + g_aptrDeviceConfig->GetOpenWeatherAPIKey();
+            url = "http://api.openweathermap.org/geo/1.0/direct?q=" + configLocation + "," + configCountryCode + "&limit=1&appid=" + g_ptrDeviceConfig->GetOpenWeatherAPIKey();
 
         http.begin(url);
         int httpResponseCode = http.GET();
@@ -171,7 +171,7 @@ private:
     bool getTomorrowTemps(float& highTemp, float& lowTemp)
     {
         HTTPClient http;
-        String url = "http://api.openweathermap.org/data/2.5/forecast?lat=" + strLatitude + "&lon=" + strLongitude + "&appid=" + g_aptrDeviceConfig->GetOpenWeatherAPIKey();
+        String url = "http://api.openweathermap.org/data/2.5/forecast?lat=" + strLatitude + "&lon=" + strLongitude + "&appid=" + g_ptrDeviceConfig->GetOpenWeatherAPIKey();
         http.begin(url);
         int httpResponseCode = http.GET();
 
@@ -231,7 +231,7 @@ private:
     {
         HTTPClient http;
 
-        String url = "http://api.openweathermap.org/data/2.5/weather?lat=" + strLatitude + "&lon=" + strLongitude + "&appid=" + g_aptrDeviceConfig->GetOpenWeatherAPIKey();
+        String url = "http://api.openweathermap.org/data/2.5/weather?lat=" + strLatitude + "&lon=" + strLongitude + "&appid=" + g_ptrDeviceConfig->GetOpenWeatherAPIKey();
         http.begin(url);
         int httpResponseCode = http.GET();
         if (httpResponseCode > 0)
@@ -303,8 +303,8 @@ private:
 
     bool HasLocationChanged()
     {
-        String configLocation = g_aptrDeviceConfig->GetLocation();
-        String configCountryCode = g_aptrDeviceConfig->GetCountryCode();
+        String configLocation = g_ptrDeviceConfig->GetLocation();
+        String configCountryCode = g_ptrDeviceConfig->GetCountryCode();
 
         return strLocation != configLocation || strCountryCode != configCountryCode;
     }
@@ -388,7 +388,7 @@ public:
         g()->setTextColor(WHITE16);
         String showLocation = strLocation;
         showLocation.toUpperCase();
-        if (g_aptrDeviceConfig->GetOpenWeatherAPIKey().isEmpty())
+        if (g_ptrDeviceConfig->GetOpenWeatherAPIKey().isEmpty())
             g()->print("No API Key");
         else
             g()->print((strLocationName.isEmpty() ? showLocation : strLocationName).substring(0, (MATRIX_WIDTH - 2 * fontWidth)/fontWidth));

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -104,6 +104,11 @@ private:
         return 25;
     }
 
+    virtual bool RequiresDoubleBuffering() const
+    {
+        return false;
+    }
+
     inline float KelvinToFarenheit(float K)
     {
         return (K - 273.15) * 9.0f/5.0f + 32;

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -278,11 +278,6 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeterEffe
         int yOffset   = pGFXChannel->height() - value;
         int yOffset2  = pGFXChannel->height() - value2;
 
-        if (_fadeRate == 0)
-            for (int y = 1; y < yOffset2; y++)
-                for (int x = xOffset; x < xOffset + barWidth; x++)
-                    g()->setPixel(x, y, CRGB::Black);
-
         for (int y = yOffset2; y < pGFXChannel->height(); y++)
             for (int x = xOffset; x < xOffset + barWidth; x++)
                 g()->setPixel(x, y, baseColor);
@@ -297,8 +292,16 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeterEffe
         float agePercent = (float) msPeakAge / (float) MS_PER_SECOND;
         uint8_t fadeAmount = std::min(255.0f, agePercent * 256);
 
-        colorHighlight = CRGB(CRGB::White).fadeToBlackBy(fadeAmount);
+        // We draw the highlight in white, but if its falling at a different rate than the bar itself,
+        // it indicates a free-floating highlight, and those get faded out based on age
 
+        colorHighlight = CRGB(CRGB::White);
+        if (g_Analyzer.g_peak1Decay != g_Analyzer.g_peak2Decay)
+            colorHighlight = colorHighlight.fadeToBlackBy(fadeAmount);
+
+        // We draw the bottom row in bar color even when only 1 pixel high so as not to have a white
+        // strip as the bottom row (all made up of highlights)
+        
         if (value == 0)
             colorHighlight = baseColor;
 
@@ -395,6 +398,8 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeterEffe
 
         if (_fadeRate)
             fadeAllChannelsToBlackBy(_fadeRate);
+        else
+            pGFXChannel->Clear();
 
         for (int i = 0; i < _numBars; i++)
         {

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -131,7 +131,7 @@ class RainbowTwinkleEffect : public LEDStripEffect
         lastms = millis();
 
         hue += (float) msElapsed / _speedDivisor;
-        hue = fmod(hue, 256.0);
+        hue = fmod(hue, 256.0f);
         fillRainbowAllChannels(0, _cLEDs, hue, _deltaHue);
 
         if (random(0, 1) == 0)
@@ -277,7 +277,7 @@ class SplashLogoEffect : public LEDStripEffect
 
     virtual size_t MaximumEffectTime() const override
     {
-        return 10.0 * MILLIS_PER_SECOND;
+        return 5.0 * MILLIS_PER_SECOND;
     }
 
     virtual bool CanDisplayVUMeter() const override
@@ -291,8 +291,19 @@ class SplashLogoEffect : public LEDStripEffect
         if (JDR_OK != TJpgDec.drawFsJpg(0, 0, pszLogoFile))        // Draw the image
             debugW("Could not display logoo %s", pszLogoFile);
     }
-}
-;
+};
+
+// StatusEffect
+//
+// Effect that shows every 10th LED in a particular color, depending on the state of the system:
+//
+// Color     Meaning
+// -----------------------------------
+// Red       No WiFi
+// Purple    OTA Update in progress
+// Green     WiFi working but no clock yet
+// White     Ready!
+
 class StatusEffect : public LEDStripEffect
 {
   protected:
@@ -450,17 +461,5 @@ class TwinkleEffect : public LEDStripEffect
         {
             fadeToBlackBy(FastLED.leds(), NUM_LEDS, _fadeFactor);
         }
-    }
-};
-
-class PoliceEffect : public LEDStripEffect
-{
-    typedef enum { INNERRED, OUTERRED, INNERBLUE, OUTERBLUE, MIXED, STROBE } lampStates;
-    const lampStates highestState = STROBE;
-
-    virtual void Draw() override
-    {
-
-
     }
 };

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -231,7 +231,10 @@ public:
     //     .----<----<----<----'
     //     |
     //    15 > 16 > 17 > 18 > 19
-
+    //
+    // If your matrix uses a different approach, you can override this function and implement it 
+    // in the xy() function of your class
+    
     virtual uint16_t xy(uint16_t x, uint16_t y) const
     {
         if (x & 0x01)

--- a/include/globals.h
+++ b/include/globals.h
@@ -784,47 +784,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define POWER_LIMIT_MW (3000)                 // 100W transformer for an 8M strip max
     #define DEFAULT_EFFECT_INTERVAL     (1000*60*60*24)
 
-#elif BROOKLYNROOM
-
-    // A decorative strip for a rec room or similar
-
-    #ifndef PROJECT_NAME
-    #define PROJECT_NAME            "Brooklyn Room"
-    #endif
-
-    #define ENABLE_WIFI             1   // Connect to WiFi
-    #define INCOMING_WIFI_ENABLED   1   // Accepting incoming color data and commands
-    #define WAIT_FOR_WIFI           1   // Hold in setup until we have WiFi - for strips without effects
-    #define TIME_BEFORE_LOCAL       5   // How many seconds before the lamp times out and shows local content
-
-    #define NUM_CHANNELS    1
-    #define NUM_LEDS        600
-    #define MATRIX_WIDTH    (NUM_LEDS)
-    #define MATRIX_HEIGHT   1
-    #define ENABLE_REMOTE   1                     // IR Remote Control
-    #define FAN_SIZE        1
-    #define NUM_FANS        1
-    #define ENABLE_AUDIO    1
-    #define LED_FAN_OFFSET_BU  0
-    #define LED_FAN_OFFSET_TD  0
-    #define LED_FAN_OFFSET_LR  0
-    #define LED_FAN_OFFSET_RL  0
-    #define IR_REMOTE_PIN 36
-    #define POWER_LIMIT_MW (1000 * 12 * 8)
-    #define ENABLE_AUDIO    1                     // Listen for audio from the microphone and process it
-    #define NUM_BANDS      16
-
-    #if M5STICKC || M5STICKCPLUS
-        #define LED_PIN0 26
-    #else
-        #define LED_PIN0 5
-    #endif
-
-    #define DEFAULT_EFFECT_INTERVAL     (5*60*24)
-
-    #define NOISE_CUTOFF   75
-    #define NOISE_FLOOR    200.0f
-
 #elif SPECTRUM
 
     // This project is set up as a 48x16 matrix of 16x16 WS2812B panels such as: https://amzn.to/3ABs5DK
@@ -1425,54 +1384,6 @@ extern U8G2_SSD1306_128X64_NONAME_F_HW_I2C g_u8g2;
     extern std::unique_ptr<TFT_eSPI> g_pDisplay;
 #endif
 
-// str_snprintf
-//
-// va-args style printf that returns the formatted string as a reuslt
-
-inline String str_snprintf(const char *fmt, size_t len, ...)
-{
-    std::string str;
-    va_list args;
-
-    // Make the string buffer big enough to hold the stated size
-    str.resize(len);
-
-    va_start(args, len);
-    size_t out_length = vsnprintf(&str[0], len + 1, fmt, args) + 1;
-    va_end(args);
-
-    // If it wound up being smaller than the max buffer size, resize down to actual string length
-    if (out_length < len)
-        str.resize(out_length);
-
-    return String(str.c_str());
-}
-
-// str_snprintf
-//
-// va-args style printf that returns the formatted string as a reuslt
-
-inline String str_sprintf(const char *fmt, ...)
-{
-    std::string str;
-    va_list args, args2;
-    va_start(args, fmt);
-    va_copy(args2, args);
-
-    int requiredLen = vsnprintf(NULL, 0, fmt, args) + 1;
-    if (requiredLen > 1)
-    {
-        str.resize(requiredLen);
-        size_t out_length = vsnprintf(&str[0], requiredLen, fmt, args2) + 1;
-        if (out_length < requiredLen)
-            str.resize(out_length);
-    }
-
-    va_end(args2);
-    va_end(args);
-    return String(str.c_str());
-}
-
 // FPS
 //
 // Given a time value for when the last frame took place and the current timestamp returns the number of
@@ -1608,6 +1519,34 @@ public:
     }
 };
 
+// str_snprintf
+//
+// va-args style printf that returns the formatted string as a reuslt
+
+inline String str_sprintf(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+
+    va_list args_copy;
+    va_copy(args_copy, args);
+
+    int requiredLen = vsnprintf(nullptr, 0, fmt, args) + 1;
+    va_end(args);
+
+    if (requiredLen <= 0) {
+        va_end(args_copy);
+        return {};
+    }
+
+    std::unique_ptr<char []> str = std::make_unique<char []>(requiredLen);
+    vsnprintf(str.get(), requiredLen, fmt, args_copy);
+    va_end(args_copy);
+
+    return String(str.get());
+}
+
+
 // AppTime
 //
 // A class that keeps track of the clock, how long the last frame took, calculating FPS, etc.
@@ -1722,23 +1661,6 @@ inline uint16_t WORDFromMemory(uint8_t * payloadData)
 {
     return  (uint16_t)payloadData[1] << 8   |
             (uint16_t)payloadData[0];
-}
-
-inline bool CheckBlueBuffer(CRGB * prgb, size_t count)
-{
-    bool bOK = true;
-    for (int i = 0; i < count; i++)
-    {
-        if (bOK)
-        {
-            if (prgb[i].r > 0 || prgb[i].g > 0)
-            {
-                Serial.printf("Other color detected at offset %d\n", i);
-                bOK = false;
-            }
-        }
-    }
-    return bOK;
 }
 
 // 16-bit (5:6:5) color definitions for common colors

--- a/include/ledbuffer.h
+++ b/include/ledbuffer.h
@@ -60,9 +60,6 @@ class LEDBuffer
                  _timeStampSeconds(0)
     {
         _leds.reset(psram_allocator<CRGB>().allocate(NUM_LEDS));
-
-        for (int i = 0; i < NUM_LEDS; i++)
-            _leds[i] = CRGB::Yellow;
     }
 
     ~LEDBuffer()
@@ -84,6 +81,10 @@ class LEDBuffer
         
         return false;
     }
+
+    // UpdateFromWire
+    //
+    // Parse and deposit a WiFi packet into a buffer
 
     bool UpdateFromWire(std::unique_ptr<uint8_t []> & payloadData, size_t payloadLength)
     {
@@ -184,7 +185,7 @@ class LEDBufferManager
         }
         else
         {
-            return 0.0;
+            return 0.0f;
         }
     }
 
@@ -197,7 +198,7 @@ class LEDBufferManager
         }
         else
         {
-            return 0.0;
+            return 0.0f;
         }
     }
 

--- a/include/ledmatrixgfx.h
+++ b/include/ledmatrixgfx.h
@@ -85,10 +85,14 @@ public:
         matrix.setBrightness(percent);
     }
     
-    virtual uint16_t xy(uint16_t x, uint16_t y) const
+    virtual uint16_t xy(uint16_t x, uint16_t y) const override
     {
         return y * MATRIX_WIDTH + x;    
     }
+
+    // Whereas an LEDStripGFX would track it's own memory for the CRGB array, we simply point to the buffer already used for
+    // the matrix display memory.  That also eliminated having a local draw buffer that is then copied, because the effects
+    // can render directly to the right back buffer automatically.  
 
     void setLeds(CRGB *pLeds)
     {
@@ -127,7 +131,7 @@ public:
         captionStartTime = millis();
     }
 
-    virtual void MoveInwardX(int startY = 0, int endY = MATRIX_HEIGHT - 1)
+    virtual void MoveInwardX(int startY = 0, int endY = MATRIX_HEIGHT - 1) override
     {
         // Optimized for Smartmatrix matrix - uses knowledge of how the pixels are laid
         // out in order to do the scroll with memmove rather than row by column pixel
@@ -141,7 +145,7 @@ public:
         }
     }
 
-    virtual void MoveOutwardsX(int startY = 0, int endY = MATRIX_HEIGHT - 1)
+    virtual void MoveOutwardsX(int startY = 0, int endY = MATRIX_HEIGHT - 1) override
     {
         // Optimized for Smartmatrix matrix - uses knowledge of how the pixels are laid
         // out in order to do the scroll with memmove rather than row by column pixel
@@ -155,12 +159,12 @@ public:
         }
     }
 
-    virtual void fillLeds(const CRGB *pLEDs)
+    virtual void fillLeds(std::unique_ptr<CRGB[]> &pLEDs) override
     {
         // A mesmerizer panel has the same layout as in memory, so we can memcpy.  Others may require transposition,
         // so we do it the "slow" way for other matrices
 
-        memcpy(leds, pLEDs, sizeof(CRGB) * _width * _height);
+        memcpy(leds, pLEDs.get(), sizeof(CRGB) * _width * _height);
     }
 
     // Matrix interop

--- a/include/ledstripeffect.h
+++ b/include/ledstripeffect.h
@@ -137,7 +137,7 @@ class LEDStripEffect : public IJSONSerializable
 
     // RequiresDoubleBuffering
     //
-    // If a matrix effect requires the state of the last buffer be preserved, then it requires float buffering.
+    // If a matrix effect requires the state of the last buffer be preserved, then it requires double buffering.
     // If, on the other hand, it renders from scratch every time, starting witha black fill, etc, then it does not,
     // and it can override this method and return false;
 

--- a/include/ledstripeffect.h
+++ b/include/ledstripeffect.h
@@ -83,6 +83,9 @@ class LEDStripEffect : public IJSONSerializable
         return true;
     }
 
+    virtual void Start() {}                                         // Optional method called when time to clean/init the effect
+    virtual void Draw() = 0;                                        // Your effect must implement these
+
     inline std::shared_ptr<GFXBase> g() const
     {
         return _GFX[0];
@@ -91,14 +94,11 @@ class LEDStripEffect : public IJSONSerializable
     // mg is a shortcut for MATRIX projects to retrieve a pointer to the specialized LEDMatrixGFX type
 
     #if USE_MATRIX
-    static std::shared_ptr<LEDMatrixGFX> mg()
-    {
+      static std::shared_ptr<LEDMatrixGFX> mg()
+      {
         return std::static_pointer_cast<LEDMatrixGFX>(g_aptrDevices[0]);
-    }
-#endif
-
-    virtual void Start() {}                                         // Optional method called when time to clean/init the effect
-    virtual void Draw() = 0;                                        // Your effect must implement these
+      }
+    #endif
 
     virtual bool CanDisplayVUMeter() const
     {
@@ -150,7 +150,6 @@ class LEDStripEffect : public IJSONSerializable
     //
     // Returns a random color of the rainbow
     // BUGBUG Should likely be in GFXBase, not in LEDStripEffect
-
 
     static CRGB RandomRainbowColor()
     {
@@ -326,7 +325,7 @@ class LEDStripEffect : public IJSONSerializable
     //
     // Serialize this effects paramters to a JSON document
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject)
+    virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 

--- a/include/ledstripgfx.h
+++ b/include/ledstripgfx.h
@@ -46,9 +46,7 @@ public:
     {
         leds = static_cast<CRGB *>(calloc(w * h, sizeof(CRGB)));
         if(!leds)
-        {
             throw std::runtime_error("Unable to allocate LEDs in LEDStripGFX");
-        }
     }
 
     CRGB * GetLEDBuffer() const

--- a/include/network.h
+++ b/include/network.h
@@ -61,7 +61,8 @@
     #define WL_DISCONNECTED     "WL_DISCONNECTED"
     #define WL_UNKNOWN_STATUS   "WL_UNKNOWN_STATUS"
 
-    inline static const char* WLtoString(wl_status_t status) {
+    inline static const char* WLtoString(wl_status_t status) 
+    {
       switch (status) {
         case 255: return WL_NO_SHIELD;
         case 0: return   WL_IDLE_STATUS;

--- a/include/remotecontrol.h
+++ b/include/remotecontrol.h
@@ -180,9 +180,7 @@ class RemoteControl
         static uint lastResult = 0;
 
         if (!_IR_Receive.decode(&results))
-        {
             return;
-        }
 
         uint result = results.value;
         _IR_Receive.resume();
@@ -223,7 +221,6 @@ class RemoteControl
         {
             g_ptrEffectManager->ClearRemoteColor();
             g_ptrEffectManager->NextEffect();
-            
             return;
         }
         else if (IR_BMINUS == result)

--- a/include/soundanalyzer.h
+++ b/include/soundanalyzer.h
@@ -615,9 +615,9 @@ public:
         _SamplingFrequency = SAMPLING_FREQUENCY;
         _MaxSamples = MAX_SAMPLES;
 
-        _vReal = (double *)malloc(_MaxSamples * sizeof(_vReal[0]));
-        _vImaginary = (double *)malloc(_MaxSamples * sizeof(_vImaginary[0]));
-        _vPeaks = (double *)malloc(_BandCount * sizeof(_vPeaks[0]));
+        _vReal = (double *)PreferPSRAMAlloc(_MaxSamples * sizeof(_vReal[0]));
+        _vImaginary = (double *)PreferPSRAMAlloc(_MaxSamples * sizeof(_vImaginary[0]));
+        _vPeaks = (double *)PreferPSRAMAlloc(_BandCount * sizeof(_vPeaks[0]));
 
         _oldVU = 0.0f;
         _oldPeakVU = 0.0f;

--- a/include/taskmgr.h
+++ b/include/taskmgr.h
@@ -206,7 +206,7 @@ private:
     TaskHandle_t _taskSerial = nullptr;
 
 public:
-
+  
     void StartScreenThread()
     {
         debugW(">> Launching Screen Thread");

--- a/include/taskmgr.h
+++ b/include/taskmgr.h
@@ -110,10 +110,10 @@ class IdleTask
         // If the measurement failed to even get a chance to run, this core is maxed and there was no idle time
 
         if (millis() - _lastMeasurement > kMillisPerCalc)
-            return 100.0;
+            return 100.0f;
 
         // Otherwise, whatever cycles we were able to burn in the idle loop counts as "would have been idle" time
-        return 100.0-100*_idleRatio;
+        return 100.0f-100*_idleRatio;
     }
 
     // Stub entry point for calling into it without a THIS pointer

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = 
+default_envs = mesmerizer
 
 ; ==================
 ; Base configuration

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = mesmerizer
+default_envs = 
 
 ; ==================
 ; Base configuration
@@ -507,11 +507,6 @@ build_flags     = -DATOMLIGHT=1
                   ${dev_heltec_wifi.build_flags}
                   -UUSE_SCREEN                      ; Unset USE_SCREEN that is set in the device build flags.
                                                     ; The ATOMLIGHT project really prefers not to use it.
-
-[env:brooklynroom]
-extends         = dev_heltec_wifi
-build_flags     = -DBROOKLYNROOM=1
-                  ${dev_heltec_wifi.build_flags}
 
 [env:fanset]
 extends         = dev_m5stick-c-plus

--- a/src/deviceconfig.cpp
+++ b/src/deviceconfig.cpp
@@ -31,7 +31,7 @@
 #include "globals.h"
 #include "deviceconfig.h"
 
-DRAM_ATTR std::unique_ptr<DeviceConfig> g_aptrDeviceConfig;
+DRAM_ATTR std::unique_ptr<DeviceConfig> g_ptrDeviceConfig;
 extern const char timezones_start[] asm("_binary_config_timezones_json_start");
 
 DRAM_ATTR size_t g_DeviceConfigJSONBufferSize = 0;

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -93,7 +93,7 @@ void MatrixPreDraw()
 
         auto graphics = (*g_ptrEffectManager)[0];
 
-        LEDMatrixGFX::matrix.setRefreshRate(95);
+        LEDMatrixGFX::matrix.setRefreshRate(200);
 
         auto pMatrix = std::static_pointer_cast<LEDMatrixGFX>(graphics);
         pMatrix->setLeds(LEDMatrixGFX::GetMatrixBackBuffer());

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -290,8 +290,6 @@ const std::vector<std::shared_ptr<LEDStripEffect>> CreateDefaultEffects()
 
     #elif MESMERIZER
 
-//        new SplashLogoEffect(),
-
         std::make_shared<SpectrumAnalyzerEffect>("Spectrum",   NUM_BANDS,     spectrumBasicColors, 100, 0, 1.0, 1.0),
         std::make_shared<SpectrumAnalyzerEffect>("Spectrum 2",   32,            spectrumBasicColors, 100, 0, 1.25, 1.25),
         std::make_shared<SpectrumAnalyzerEffect>("Spectrum 3",   32,            spectrumBasicColors, 100, 0, 0.25, 1.25),
@@ -305,7 +303,6 @@ const std::vector<std::shared_ptr<LEDStripEffect>> CreateDefaultEffects()
         std::make_shared<PatternSubscribers>(),
         std::make_shared<PatternWeather>(),
 
-        // Animate a simple rainbow palette by using the palette effect on the built-in rainbow palette
         std::make_shared<GhostWave>("GhostWave", 0, 24, false),
         std::make_shared<WaveformEffect>("WaveIn", 8),
         std::make_shared<GhostWave>("WaveOut", 0, 0, true, 0),
@@ -395,9 +392,6 @@ const std::vector<std::shared_ptr<LEDStripEffect>> CreateDefaultEffects()
 
         std::make_shared<ColorBeatOverRed>("ColorBeatOverRed"),
 
-        //        std::make_shared<HueFireFanEffect>(NUM_LEDS, 1, 12, 200, 2, NUM_LEDS / 2, Sequential, false, true, false, HUE_GREEN),
-        //        std::make_shared<HueFireFanEffect>(NUM_LEDS, 2, 10, 200, 2, NUM_LEDS / 2, Sequential, false, true, false, HUE_BLUE),
-
         std::make_shared<ColorCycleEffect>(BottomUp, 6),
         std::make_shared<ColorCycleEffect>(BottomUp, 2),
 
@@ -410,29 +404,10 @@ const std::vector<std::shared_ptr<LEDStripEffect>> CreateDefaultEffects()
         std::make_shared<StarryNightEffect<LongLifeSparkleStar>>("Red Sparkle Stars", GreenColors_p, 2.0, 1, LINEARBLEND, 2.0, 0.0, 0.0, CRGB::Red),         // Blue Sparkle
         std::make_shared<StarryNightEffect<LongLifeSparkleStar>>("Blue Sparkle Stars", GreenColors_p, 2.0, 1, LINEARBLEND, 2.0, 0.0, 0.0, CRGB::Blue),       // Blue Sparkle
 
-        //        std::make_shared<VUFlameEffect>("Multicolor Sound Flame", VUFlameEffect::GREENX, 50, true),
-        //        std::make_shared<VUFlameEffect>("Multicolor Sound Flame", VUFlameEffect::BLUEX, 50, true),
-        //        std::make_shared<VUFlameEffect>("Multicolor Sound Flame", VUFlameEffect::REDX, 50, true),
-        //       std::make_shared<VUFlameEffect>("Multicolor Sound Flame", VUFlameEffect::MULTICOLOR, 50, true),
-
-        // std::make_shared<StarryNightEffect<LongLifeSparkleStar>>("Blue Sparkle Stars", BlueColors_p, 10.0, 1, LINEARBLEND, 2.0, 0.0, 0.0),        // Blue Sparkle
-
-        // std::make_shared<StarryNightEffect<Star>>()
-        /*
-        std::make_shared<SparklySpinningMusicEffect>("SparklySpinningMusical", RainbowColors_p),
-        std::make_shared<ColorBeatOverRed>("ColorBeatOnRedBkgnd"),
-        std::make_shared<MoltenGlassOnVioletBkgnd>("MoltenGlassOnViolet", RainbowColors_p),
-        std::make_shared<ColorBeatWithFlash>("ColorBeatWithFlash"),
-        std::make_shared<MusicalHotWhiteInsulatorEffect>("MusicalHotWhite"),
-
-        std::make_shared<SimpleInsulatorBeatEffect2>("SimpleInsulatorColorBeat"),
-        std::make_shared<InsulatorSpectrumEffect>("InsulatorSpectrumEffect"),
-        */
         std::make_shared<PaletteEffect>(rainbowPalette, 256 / 16, .2, 0)
 
     #elif INSULATORS
 
-        //        std::make_shared<MusicFireEffect>(NUM_LEDS, 1, 10, 100, 0, NUM_LEDS),
         std::make_shared<InsulatorSpectrumEffect>("Spectrum Effect", RainbowColors_p),
         std::make_shared<NewMoltenGlassOnVioletBkgnd>("Molten Glass", RainbowColors_p),
         std::make_shared<StarryNightEffect<MusicStar>>("RGB Music Blend Stars", RGBColors_p, 0.8, 1, NOBLEND, 15.0, 0.1, 10.0),      // RGB Music Blur - Can You Hear Me Knockin'
@@ -440,14 +415,6 @@ const std::vector<std::shared_ptr<LEDStripEffect>> CreateDefaultEffects()
         std::make_shared<PaletteReelEffect>("PaletteReelEffect"),
         std::make_shared<ColorBeatOverRed>("ColorBeatOverRed"),
         std::make_shared<TapeReelEffect>("TapeReelEffect"),
-
-    // std::make_shared<SparklySpinningMusicEffect>(RainbowColors_p),
-    // std::make_shared<SparklySpinningMusicEffect>("Blu Sprkl Spin", BlueColors_p),
-    // std::make_shared<ColorBeatOverRed>("ColorBeatOverRed"),
-    // std::make_shared<ColorBeatWithFlash>("ColorBeatFlash"),
-    // std::make_shared<MusicalHotWhiteInsulatorEffect>("Hot White"),
-    // std::make_shared<SimpleInsulatorBeatEffect2>("Simple Beat 2"),
-    // std::make_shared<SparklySpinningMusicEffect>("Sparkle Spin", RainbowColors_p),
 
     #elif CUBE
         // Simple rainbow pallette
@@ -508,63 +475,6 @@ const std::vector<std::shared_ptr<LEDStripEffect>> CreateDefaultEffects()
         std::make_shared<MeteorEffect>(1, 1, 5, .15, .25),
         std::make_shared<MeteorEffect>(), // Rainbow palette
 
-/* Commented out because no project definition sets the defines, and some sections refer to non-existent effects.
-   Effect instantiations will have to be reviewed if this section is uncommented.
-
-    #elif FIRESTICK
-
-        std::make_shared<BouncingBallEffect>(),
-        std::make_shared<VUFlameEffect>("Multicolor Sound Flame", VUFlameEffect::MULTICOLOR),
-        std::make_shared<PaletteFlameEffect>("Smooth Red Fire", heatmap_pal),
-        // std::make_shared<ClassicFireEffect>(),
-
-        std::make_shared<StarryNightEffect<MusicStar>>("RGB Music Bubbles", RGBColors_p, 0.5, 1, NOBLEND, 15.0, 0.0, 75.0), // RGB Music Bubbles
-        // std::make_shared<StarryNightEffect<MusicPulseStar>>("RGB Pulse", RainbowColors_p, 0.02, 20, NOBLEND, 5.0, 0.0, 75.0), // RGB Music Bubbles
-
-        std::make_shared<PaletteFlameEffect>("Smooth Purple Fire", purpleflame_pal),
-
-        std::make_shared<MeteorEffect>(),                                                                                                                                           // Our overlapping color meteors
-        std::make_shared<StarryNightEffect<BubblyStar>>("Little Blooming Rainbow Stars", BlueColors_p, STARRYNIGHT_PROBABILITY, 4, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR), // Blooming Little Rainbow Stars
-        std::make_shared<StarryNightEffect<BubblyStar>>("Big Blooming Rainbow Stars", RainbowColors_p, 2, 12, LINEARBLEND, 1.0),                                                    // Blooming Rainbow Stars
-        std::make_shared<StarryNightEffect<BubblyStar>>("Neon Bars", RainbowColors_p, 0.5, 64, NOBLEND, 0),                                                                         // Neon Bars
-
-        std::make_shared<StarryNightEffect<MusicStar>>("RGB Music Blend Stars", RGBColors_p, 0.8, 1, NOBLEND, 15.0, 0.1, 10.0),      // RGB Music Blur - Can You Hear Me Knockin'
-        std::make_shared<StarryNightEffect<MusicStar>>("Rainbow Music Stars", RainbowColors_p, 2.0, 2, LINEARBLEND, 5.0, 0.0, 10.0), // Rainbow Music Star
-
-        //        std::make_shared<VUFlameEffect("Sound Flame >(Green)",    VUFlameEffect::GREEN),
-        //       std::make_shared<VUFlameEffect("Sound Flame >(Blue)",     VUFlameEffect::BLUE),
-
-        std::make_shared<SimpleRainbowTestEffect>(8, 4),                                                                                                                  // Rainbow palette simple test of walking pixels
-        std::make_shared<PaletteEffect>(RainbowColors_p),                                                                                                                 // Rainbow palette
-        std::make_shared<StarryNightEffect<QuietStar>>("Green Twinkle Stars", GreenColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR), // Green Twinkle
-        std::make_shared<StarryNightEffect<Star>>("Blue Sparkle Stars", BlueColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),        // Blue Sparkle
-
-        std::make_shared<StarryNightEffect<QuietStar>>("Red Twinkle Stars", RedColors_p, 1.0, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),                             // Red Twinkle
-        std::make_shared<StarryNightEffect<Star>>("Lava Stars", LavaColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),                    // Lava Stars
-        std::make_shared<StarryNightEffect<QuietStar>>("Rainbow Twinkle Stars", RainbowColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR), // Rainbow Twinkle
-        std::make_shared<DoublePaletteEffect>(),
-        std::make_shared<VUEffect>()
-
-    #elif FLAMEBULB
-        std::make_shared<PaletteFlameEffect>("Smooth Red Fire", heatmap_pal, true, 4.5, 1, 1, 255, 4, false),
-    #elif BIGMATRIX
-        std::make_shared<SimpleRainbowTestEffect>(8, 1),  // Rainbow palette simple test of walking pixels
-        std::make_shared<PaletteEffect>(RainbowColors_p), // Rainbow palette
-        std::make_shared<RainbowFillEffect>(24, 0),
-        std::make_shared<RainbowFillEffect>(),
-
-        std::make_shared<StarryNightEffect<MusicStar>>("RGB Music Bubbles", RGBColors_p, 0.25, 1, NOBLEND, 3.0, 0.0, 75.0),                                                         // RGB Music Bubbles
-        std::make_shared<StarryNightEffect<HotWhiteStar>>("Lava Stars", HeatColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),                  // Lava Stars
-        std::make_shared<StarryNightEffect<BubblyStar>>("Little Blooming Rainbow Stars", BlueColors_p, STARRYNIGHT_PROBABILITY, 4, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR), // Blooming Little Rainbow Stars
-        std::make_shared<StarryNightEffect<QuietStar>>("Green Twinkle Stars", GreenColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),           // Green Twinkle
-        std::make_shared<StarryNightEffect<QuietStar>>("Red Twinkle Stars", RedColors_p, 1.0, 1, LINEARBLEND, 2.0),                                                                 // Red Twinkle
-        std::make_shared<StarryNightEffect<QuietStar>>("Rainbow Twinkle Stars", RainbowColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),       // Rainbow Twinkle
-        std::make_shared<BouncingBallEffect>(),
-        std::make_shared<VUEffect>()
-
-    #elif RINGSET
-        std::make_shared<MusicalInsulatorEffect2>("Musical Effect 2"),
-*/
     #elif FANSET
 
         std::make_shared<RainbowFillEffect>(24, 0),
@@ -602,46 +512,10 @@ const std::vector<std::shared_ptr<LEDStripEffect>> CreateDefaultEffects()
         std::make_shared<FireFanEffect>(HeatColors_p, NUM_LEDS, 2, 10, 800, 2, NUM_LEDS / 2, Sequential, false, true),
         std::make_shared<FireFanEffect>(HeatColors_p, NUM_LEDS, 1, 12, 1000, 2, NUM_LEDS / 2, Sequential, false, true),
 
-
-    #elif BROOKLYNROOM
-
-        std::make_shared<RainbowFillEffect>(24, 0),
-        std::make_shared<RainbowFillEffect>(32, 1),
-        std::make_shared<SimpleRainbowTestEffect>(8, 1),  // Rainbow palette simple test of walking pixels
-        std::make_shared<SimpleRainbowTestEffect>(8, 4),  // Rainbow palette simple test of walking pixels
-        std::make_shared<PaletteEffect>(MagentaColors_p), // Rainbow palette
-        std::make_shared<DoublePaletteEffect>(),
-
-        std::make_shared<MeteorEffect>(), // Our overlapping color meteors
-
-        std::make_shared<StarryNightEffect<QuietStar>>("Magenta Twinkle Stars", GreenColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR), // Green Twinkle
-        std::make_shared<StarryNightEffect<Star>>("Blue Sparkle Stars", BlueColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),          // Blue Sparkle
-
-        std::make_shared<StarryNightEffect<QuietStar>>("Red Twinkle Stars", MagentaColors_p, 1.0, 1, LINEARBLEND, 2.0),                                                       // Red Twinkle
-        std::make_shared<StarryNightEffect<Star>>("Lava Stars", MagentaColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),                 // Lava Stars
-        std::make_shared<StarryNightEffect<QuietStar>>("Rainbow Twinkle Stars", RainbowColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR), // Rainbow Twinkle
-
-        std::make_shared<StarryNightEffect<BubblyStar>>("Little Blooming Rainbow Stars", MagentaColors_p, STARRYNIGHT_PROBABILITY, 4, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR), // Blooming Little Rainbow Stars
-        std::make_shared<StarryNightEffect<BubblyStar>>("Big Blooming Rainbow Stars", MagentaColors_p, 2, 12, LINEARBLEND, 1.0),                                                       // Blooming Rainbow Stars
-        std::make_shared<StarryNightEffect<BubblyStar>>("Neon Bars", MagentaColors_p, 0.5, 64, NOBLEND, 0),                                                                            // Neon Bars
-
-        std::make_shared<ClassicFireEffect>(true),
-
     #elif LEDSTRIP
 
         std::make_shared<StatusEffect>(CRGB::White)
 
-/* Commented out because no project definition sets the define. Effect instantiations may need to be reviewed if
-   this section is uncommented.
-
-    #elif HOODORNAMENT
-
-        std::make_shared<RainbowFillEffect>(24, 0),
-        std::make_shared<RainbowFillEffect>(32, 1),
-        std::make_shared<SimpleRainbowTestEffect>(8, 1),              // Rainbow palette simple test of walking pixels
-        std::make_shared<PaletteEffect>(MagentaColors_p),             // Rainbow palette
-        std::make_shared<DoublePaletteEffect>(),
-*/
     #else
 
         std::make_shared<RainbowFillEffect>(6, 2),                    // Simple effect if not otherwise defined above

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -31,7 +31,7 @@
 #include "SPIFFS.h"
 #include "effectdependencies.h"
 
-extern DRAM_ATTR std::shared_ptr<GFXBase> g_aptrDevices[NUM_CHANNELS];
+extern std::shared_ptr<GFXBase> g_aptrDevices[NUM_CHANNELS];
 
 #if USE_MATRIX
     volatile long PatternSubscribers::cSubscribers;
@@ -264,7 +264,7 @@ std::shared_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color)
 #define STARRYNIGHT_PROBABILITY 1.0
 #define STARRYNIGHT_MUSICFACTOR 1.0
 
-std::vector<std::shared_ptr<LEDStripEffect>> CreateDefaultEffects()
+const std::vector<std::shared_ptr<LEDStripEffect>> CreateDefaultEffects()
 {
     // The default effects table
     static const std::vector<std::shared_ptr<LEDStripEffect>> defaultEffects =

--- a/src/ledmatrixgfx.cpp
+++ b/src/ledmatrixgfx.cpp
@@ -55,10 +55,11 @@ void LEDMatrixGFX::StartMatrix()
   matrix.addLayer(&titleLayer);
 
   // When the matrix starts, you can ask it to leave N bytes of memory free, and this amount must be tuned.  Too much free 
-  // will cause a dim panel with a low refresh, too little will starve other things.  100K seems a good starting point.
+  // will cause a dim panel with a low refresh, too little will starve other things.  We currently have enough RAM for
+  // use so begin() is not being called with a reserve paramter, but it can be if memory becomes scarce.
   
   matrix.setRefreshRate(200);
-  matrix.begin(50000);
+  matrix.begin();
 
   Serial.printf("Matrix Refresh Rate: %d\n", matrix.getRefreshRate());
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -476,9 +476,11 @@ void setup()
 {
     // Initialize Serial output
     Serial.begin(115200);
+    // Re-route debug output to the serial port
+    Debug.setSerialEnabled(true);
 
+    heap_caps_malloc_extmem_enable(128);
     uzlib_init();
-    heap_caps_malloc_extmem_enable(1024);
 
     if (!SPIFFS.begin(true))
         Serial.println("WARNING: SPIFFs could not be intialized!");
@@ -536,9 +538,6 @@ void setup()
     }
 
 #endif
-
-    // Re-route debug output to the serial port
-    Debug.setSerialEnabled(true);
 
     // If we have a remote control enabled, set the direction on its input pin accordingly
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -171,7 +171,7 @@ extern float g_Brite;
 
 NightDriverTaskManager g_TaskManager;
 
-// The one and only instance of ImprovSerial.  We instantiate is as the type needed
+// The one and only instance of ImprovSerial.  We instantiate it as the type needed
 // for the serial port on this module.  That's usually HardwareSerial but can be
 // other types on the S2, etc... which is why it's a template class.
 
@@ -220,7 +220,6 @@ DRAM_ATTR const int g_aRingSizeTable[MAX_RINGS] =
 // External Variables
 //
 
-extern DRAM_ATTR LEDStripEffect * g_apEffects[];      // Main table of internal events in effects.cpp
 extern DRAM_ATTR std::unique_ptr<LEDBufferManager> g_aptrBufferManager[NUM_CHANNELS];
 
 //
@@ -282,7 +281,7 @@ void IRAM_ATTR DebugLoopTaskEntry(void *)
 // Data for Dave's Garage as an example,
 
 #if USE_MATRIX
-    const char PatternSubscribers::szChannelID[] = "UCNzszbnvQeFzObW0ghk0Ckw";
+    const char PatternSubscribers::szChannelID[]    = "UCNzszbnvQeFzObW0ghk0Ckw";
     const char PatternSubscribers::szChannelName1[] = "Daves Garage";
 
     #define SUB_CHECK_INTERVAL 60000
@@ -292,6 +291,10 @@ void IRAM_ATTR DebugLoopTaskEntry(void *)
     WiFiClient http;
     YouTubeSight sight(CHANNEL_GUID, http);
 #endif
+
+// NetworkHandlingLoopEntry
+//
+// Thead entry point for the Networking task
 
 void IRAM_ATTR NetworkHandlingLoopEntry(void *)
 {
@@ -391,7 +394,6 @@ void IRAM_ATTR NetworkHandlingLoopEntry(void *)
     }
 #endif
 
-
 // CheckHeap
 //
 // Quick and dirty debug test to make sure the heap has not been corrupted
@@ -431,9 +433,9 @@ void PrintOutputHeader()
 
 void TerminateHandler()
 {
-    debugE("-------------------------------------------------------------------------------------");
-    debugE("- NightDriverStrip Guru Meditation                              Unhandled Exception -");
-    debugE("-------------------------------------------------------------------------------------");
+    Serial.println("-------------------------------------------------------------------------------------");
+    Serial.println("- NightDriverStrip Guru Meditation                              Unhandled Exception -");
+    Serial.println("-------------------------------------------------------------------------------------");
 
     PrintOutputHeader();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -509,7 +509,7 @@ void setup()
     ESP_ERROR_CHECK(err);
 
     // Create and load device config from NVS if possible
-    g_aptrDeviceConfig = std::make_unique<DeviceConfig>();
+    g_ptrDeviceConfig = std::make_unique<DeviceConfig>();
 
 #if ENABLE_WIFI
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -193,7 +193,7 @@ void CWebServer::GetSettings(AsyncWebServerRequest * pRequest)
     auto root = response->getRoot();
     JsonObject jsonObject = root.to<JsonObject>();
 
-    g_aptrDeviceConfig->SerializeToJSON(jsonObject);
+    g_ptrDeviceConfig->SerializeToJSON(jsonObject);
     jsonObject["effectInterval"] = g_ptrEffectManager->GetInterval();
 
     AddCORSHeaderAndSendResponse(pRequest, response);
@@ -204,13 +204,13 @@ void CWebServer::SetSettings(AsyncWebServerRequest * pRequest)
     debugV("SetSettings");
 
     PushPostParamIfPresent<size_t>(pRequest,"effectInterval", SET_VALUE(g_ptrEffectManager->SetInterval(value)));
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::LocationTag, SET_VALUE(g_aptrDeviceConfig->SetLocation(value)));
-    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::LocationIsZipTag, SET_VALUE(g_aptrDeviceConfig->SetLocationIsZip(value)));
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::CountryCodeTag, SET_VALUE(g_aptrDeviceConfig->SetCountryCode(value)));
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::OpenWeatherApiKeyTag, SET_VALUE(g_aptrDeviceConfig->SetOpenWeatherAPIKey(value)));
-    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::TimeZoneTag, SET_VALUE(g_aptrDeviceConfig->SetTimeZone(value)));
-    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::Use24HourClockTag, SET_VALUE(g_aptrDeviceConfig->Set24HourClock(value)));
-    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::UseCelsiusTag, SET_VALUE(g_aptrDeviceConfig->SetUseCelsius(value)));
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::LocationTag, SET_VALUE(g_ptrDeviceConfig->SetLocation(value)));
+    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::LocationIsZipTag, SET_VALUE(g_ptrDeviceConfig->SetLocationIsZip(value)));
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::CountryCodeTag, SET_VALUE(g_ptrDeviceConfig->SetCountryCode(value)));
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::OpenWeatherApiKeyTag, SET_VALUE(g_ptrDeviceConfig->SetOpenWeatherAPIKey(value)));
+    PushPostParamIfPresent<const String&>(pRequest, DeviceConfig::TimeZoneTag, SET_VALUE(g_ptrDeviceConfig->SetTimeZone(value)));
+    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::Use24HourClockTag, SET_VALUE(g_ptrDeviceConfig->Set24HourClock(value)));
+    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::UseCelsiusTag, SET_VALUE(g_ptrDeviceConfig->SetUseCelsius(value)));
 
     // We return the current config in response
     GetSettings(pRequest);
@@ -221,7 +221,7 @@ void CWebServer::Reset(AsyncWebServerRequest * pRequest)
     if (IsPostParamTrue(pRequest, "deviceConfig"))
     {
         debugI("Removing DeviceConfig");
-        g_aptrDeviceConfig->RemovePersisted();
+        g_ptrDeviceConfig->RemovePersisted();
     }
 
     if (IsPostParamTrue(pRequest, "effectsConfig"))


### PR DESCRIPTION
## Description
Various cleanups
Pointer naming (aptr is for arrays of pointers)
Add comments to JSON serializers
Refine which effects need double buffering
Change spectrum to clear rather than erase
Shorten splash time
Remove dead effects
Remove BROOKLYNROOM project and config
Remote str_snprintf
Improve str_sprintf with unique_ptr instead of std::string
Remove unused utility functions like CheckBlueBuffer
Change memmove to memcpy in scroll functions
Change audio to prefer PSRAM
Use AppTime for timing peak decay in audio engine
Request 200Hz for refresh (to get 100 after divider)
Remove dead sections in effects.cpp
Reduce DMA RAM preservation in matrix.begin

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).