### PR TITLE
Make NTP server configurable & JSON writes parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NightDriverStrip
 
-DEVELOPERS WANTED!  We are searching for talented React and C++ developers to help out on this project.  Check out the code and if you're interest, contact davepl@davepl.com
+DEVELOPERS WANTED!  We are searching for talented React and C++ developers to help out on this project.  Check out the code and if you're interest, contact <davepl@davepl.com>.
 
 ![CI](https://github.com/PlummersSoftwareLLC/NightDriverStrip/actions/workflows/CI.yml/badge.svg)
 

--- a/REST_API.md
+++ b/REST_API.md
@@ -142,6 +142,7 @@ When changing settings:
 | | `countryCode` | The [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code for the country that the device is located in. Used by the Weather effect. |
 | | `location` | The location (city or postal code) where the device is located. Used by the Weather effect. |
 | | `locationIsZip` | A boolean indicating if the value in the `location` setting is a postal code (`true`/1) or not (`false`/0). |
+| | `ntpServer` | The hostname or IP address of the NTP server to be used for time synchronization. Used by effects that require the current time. |
 | | `openWeatherApiKey` | The API key for the [Weather API provided by Open Weather Map](https://openweathermap.org/api). Used by the Weather effect. |
 | | `timeZone` | The timezone the device resides in, in [tz database](https://en.wikipedia.org/wiki/Tz_database) format. The list of available timezone identifiers can be found in the [timezones.json](config/timezones.json) file. Used by effects that show a clock. |
 | | `use24HourClock` | A boolean that indicates if time should be shown in 24-hour format (`true`/1) or 12-hour AM/PM format (`false`/0). Used by effects that show a digital clock. |

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -51,6 +51,7 @@ class DeviceConfig : public IJSONSerializable
     String youtubeChannelName1;
     String ntpServer;
 
+    size_t writerIndex;
 /*
     void WriteToNVS(const String& name, const String& value);
     void WriteToNVS(const String& name, bool value);

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -36,6 +36,7 @@
 #include "jsonserializer.h"
 
 #define DEVICE_CONFIG_FILE "/device.cfg"
+#define DEFAULT_NTP_SERVER "0.pool.ntp.org"
 
 class DeviceConfig : public IJSONSerializable
 {
@@ -48,6 +49,7 @@ class DeviceConfig : public IJSONSerializable
     bool useCelsius;
     String youtubeChannelGuid;
     String youtubeChannelName1;
+    String ntpServer;
 
 /*
     void WriteToNVS(const String& name, const String& value);
@@ -86,6 +88,7 @@ class DeviceConfig : public IJSONSerializable
     static constexpr const char * UseCelsiusTag = NAME_OF(useCelsius);
     static constexpr const char * YouTubeChannelGuidTag = NAME_OF(youtubeChannelGuid);
     static constexpr const char * YouTubeChannelName1Tag = NAME_OF(youtubeChannelName1);
+    static constexpr const char * NTPServerTag = NAME_OF(ntpServer);
 
     DeviceConfig();
 
@@ -106,6 +109,7 @@ class DeviceConfig : public IJSONSerializable
         jsonDoc[UseCelsiusTag] = useCelsius;
         jsonDoc[YouTubeChannelGuidTag] = youtubeChannelGuid;
         jsonDoc[YouTubeChannelName1Tag] = youtubeChannelName1;
+        jsonDoc[NTPServerTag] = ntpServer;
 
         if (includeSensitive)
             jsonDoc[OpenWeatherApiKeyTag] = openWeatherApiKey;
@@ -128,6 +132,10 @@ class DeviceConfig : public IJSONSerializable
         SetIfPresentIn(jsonObject, useCelsius, UseCelsiusTag);
         SetIfPresentIn(jsonObject, youtubeChannelGuid, YouTubeChannelGuidTag);
         SetIfPresentIn(jsonObject, youtubeChannelName1, YouTubeChannelName1Tag);
+        SetIfPresentIn(jsonObject, ntpServer, NTPServerTag);
+
+        if (ntpServer.isEmpty())
+            ntpServer = DEFAULT_NTP_SERVER;
 
         if (jsonObject.containsKey(TimeZoneTag))
             return SetTimeZone(jsonObject[TimeZoneTag], true);
@@ -233,6 +241,17 @@ class DeviceConfig : public IJSONSerializable
         if (!newYouTubeChannelName1.isEmpty())
             SetAndSave(youtubeChannelName1, newYouTubeChannelName1);
     }
+
+    const String &GetNTPServer() const
+    {
+        return ntpServer;
+    }
+
+    void SetNTPServer(const String &newNTPServer)
+    {
+        SetAndSave(ntpServer, newNTPServer);
+    }
+
 };
 
 extern DRAM_ATTR std::unique_ptr<DeviceConfig> g_ptrDeviceConfig;

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -488,10 +488,10 @@ public:
         _iCurrentEffect = i;
         _effectStartTime = millis();
 
+        StartEffect();
+
         if (!skipSave)
             SaveEffectManagerConfig();
-
-        StartEffect();
     }
 
     uint GetTimeUsedByCurrentEffect() const
@@ -557,8 +557,8 @@ public:
             _effectStartTime = millis();
         } while (0 < _cEnabled && false == _bPlayAll && false == IsEffectEnabled(_iCurrentEffect));
 
-        SaveEffectManagerConfig();
         StartEffect();
+        SaveEffectManagerConfig();
     }
 
     // Go back to the previous effect and abort the current one.
@@ -574,8 +574,8 @@ public:
             _effectStartTime = millis();
         } while (0 < _cEnabled && false == _bPlayAll && false == IsEffectEnabled(_iCurrentEffect));
 
-        SaveEffectManagerConfig();
         StartEffect();
+        SaveEffectManagerConfig();
     }
 
     bool Init()

--- a/include/jsonserializer.h
+++ b/include/jsonserializer.h
@@ -207,7 +207,7 @@ class JSONWriter
 
         writers[index].flag = true;
 
-        // Wake up the writer invoker task if it's sleeping
+        // Wake up the writer invoker task if it's sleeping, or request another write cycle if it isn't
         xSemaphoreGive(writerSemaphore);
     }
 };

--- a/include/jsonserializer.h
+++ b/include/jsonserializer.h
@@ -168,8 +168,9 @@ class JSONWriter
             {
                 if (entry.flag)
                 {
-                    entry.writer();
+                    // Unset flag before we do the actual write. This makes that we don't miss another flag raise if it happens while writing.
                     entry.flag = false;
+                    entry.writer();
                 }
             }
         }

--- a/include/jsonserializer.h
+++ b/include/jsonserializer.h
@@ -166,12 +166,9 @@ class JSONWriter
 
             for (auto &entry : pObj->writers)
             {
-                if (entry.flag)
-                {
-                    // Unset flag before we do the actual write. This makes that we don't miss another flag raise if it happens while writing.
-                    entry.flag = false;
+                // Unset flag before we do the actual write. This makes that we don't miss another flag raise if it happens while writing.
+                if (entry.flag.exchange(false))
                     entry.writer();
-                }
             }
         }
     }

--- a/include/ntptimeclient.h
+++ b/include/ntptimeclient.h
@@ -2,7 +2,7 @@
 //
 // File:        NTPTimeClient.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.  
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -10,12 +10,12 @@
 //    it under the terms of the GNU General Public License as published by
 //    the Free Software Foundation, either version 3 of the License, or
 //    (at your option) any later version.
-//   
+//
 //    NightDriver is distributed in the hope that it will be useful,
 //    but WITHOUT ANY WARRANTY; without even the implied warranty of
 //    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 //    GNU General Public License for more details.
-//   
+//
 //    You should have received a copy of the GNU General Public License
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
@@ -36,7 +36,7 @@
 #include <WiFi.h>
 #include <WiFiUdp.h>
 #include <mutex>
-#include "secrets.h"
+#include "deviceconfig.h"
 
 // NTPTimeClient
 //
@@ -46,13 +46,13 @@
 
 class NTPTimeClient
 {
-    static bool        _bClockSet; 
+    static bool        _bClockSet;
     static std::mutex  _clockMutex;
 
   public:
 
     NTPTimeClient()
-    { 
+    {
     }
 
     static inline bool HasClockBeenSet()
@@ -72,14 +72,14 @@ class NTPTimeClient
         std::lock_guard<std::mutex> guard(_clockMutex);
 
         char chNtpPacket[NTP_PACKET_LENGTH];
-        memset(chNtpPacket, 0, NTP_PACKET_LENGTH);      
-        
+        memset(chNtpPacket, 0, NTP_PACKET_LENGTH);
+
         // Send ntp time request.
         // Initialize ntp packet.
 
 
         // Set the ll (leap indicator), vvv (version number) and mmm (mode) bits.
-        //  
+        //
         //  These bits are contained in the first byte of chNtpPacker and are in
         // the following format:  llvvvmmm
         //
@@ -91,9 +91,11 @@ class NTPTimeClient
 
         chNtpPacket[0] = 0b00011011;
 
-        // Send the ntp packet.
-        IPAddress ipNtpServer(cszNTPServer);
+        IPAddress ipNtpServer;
+        if (WiFi.hostByName(g_ptrDeviceConfig->GetNTPServer().c_str(), ipNtpServer) != 1)
+            ipNtpServer.fromString("216.239.35.12"); // Use Google Time as default. The pool.ntp.org servers (IPs) don't necessarily last very long.
 
+        // Send the ntp packet.
         while (pUDP->parsePacket() != 0)
             pUDP->flush();
 
@@ -146,7 +148,7 @@ class NTPTimeClient
         }
 
         debugV("NTP clock: Raw values sec=%u, usec=%u", frac, microsecs);
-        
+
         tvNew.tv_sec = ((unsigned long)chNtpPacket[40] << 24) +       // bits 24 through 31 of ntp time
             ((unsigned long)chNtpPacket[41] << 16) +                        // bits 16 through 23 of ntp time
             ((unsigned long)chNtpPacket[42] << 8) +                         // bits  8 through 15 of ntp time
@@ -182,13 +184,13 @@ class NTPTimeClient
         char chBuffer[64];
         struct tm * tmPointer = localtime(&tvNew.tv_sec);
         strftime(chBuffer, sizeof(chBuffer), "%d %b %y %H:%M:%S", tmPointer);
-        debugV("NTP clock: response received, time written to ESP32 rtc: %ld.%ld, DELTA: %lf\n", 
-                tvNew.tv_sec, 
-                tvNew.tv_usec, 
+        debugV("NTP clock: response received, time written to ESP32 rtc: %ld.%ld, DELTA: %lf\n",
+                tvNew.tv_sec,
+                tvNew.tv_usec,
                 dNew - dOld );
-        
+
         _bClockSet = true;  // Clock has been set at least once
-        
+
         return true;
     }
 };

--- a/include/secrets.example.h
+++ b/include/secrets.example.h
@@ -33,14 +33,8 @@
 #define cszSSID              "Your SSID"
 #define cszPassword          "Your PASS"
 #define cszHostname          "NightDriverStrip"
-#define cszOpenWeatherAPIKey ""                     // Your OpenWeatherMap APIKEY Goes Here
+#define cszOpenWeatherAPIKey ""                     // Your OpenWeatherMap API key goes Here
 #define cszLocation          "98074"
 #define bLocationIsZip       true
 #define cszCountryCode       "us"                   // Look up the Alpha-2 code for your country at https://www.iban.com/country-codes
 #define cszTimeZone          "America/Los_Angeles"
-
-// define the NTP server to connect too (replace . [dots] in IP addresses with , [commas])
-#define cszNTPServer  94, 199, 173, 123     // 0.pool.ntp.org
-//#define cszNTPServer  192, 168, 1, 2
-//#define cszNTPServer 216, 239, 35, 12     // google time
-//#define cszNTPServer 17, 253, 16, 253     // apple time

--- a/src/deviceconfig.cpp
+++ b/src/deviceconfig.cpp
@@ -65,6 +65,7 @@ DeviceConfig::DeviceConfig()
         useCelsius = false;
         youtubeChannelGuid = "";
         youtubeChannelName1 = "";
+        ntpServer = DEFAULT_NTP_SERVER;
 
         SetTimeZone(cszTimeZone, true);
 

--- a/src/deviceconfig.cpp
+++ b/src/deviceconfig.cpp
@@ -40,11 +40,15 @@ DRAM_ATTR size_t g_DeviceConfigJSONBufferSize = 0;
 
 void DeviceConfig::SaveToJSON()
 {
-    SaveToJSONFile(DEVICE_CONFIG_FILE, g_DeviceConfigJSONBufferSize, *this);
+    g_ptrJSONWriter->FlagWriter(writerIndex);
 }
 
 DeviceConfig::DeviceConfig()
 {
+    writerIndex = g_ptrJSONWriter->RegisterWriter(
+        [this]() { SaveToJSONFile(DEVICE_CONFIG_FILE, g_DeviceConfigJSONBufferSize, *this); }
+    );
+
     std::unique_ptr<AllocatedJsonDocument> pJsonDoc(nullptr);
 
     if (LoadJSONFile(DEVICE_CONFIG_FILE, g_DeviceConfigJSONBufferSize, pJsonDoc))

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -527,6 +527,7 @@ const std::vector<std::shared_ptr<LEDStripEffect>> CreateDefaultEffects()
 
 extern DRAM_ATTR std::unique_ptr<EffectManager<GFXBase>> g_ptrEffectManager;
 DRAM_ATTR size_t g_EffectsManagerJSONBufferSize = 0;
+DRAM_ATTR size_t g_EffectsManagerJSONWriterIndex = std::numeric_limits<size_t>::max();
 
 #if USE_MATRIX
 
@@ -546,6 +547,10 @@ DRAM_ATTR size_t g_EffectsManagerJSONBufferSize = 0;
 void InitEffectsManager()
 {
     debugW("InitEffectsManager...");
+
+    g_EffectsManagerJSONWriterIndex = g_ptrJSONWriter->RegisterWriter(
+        []() { SaveToJSONFile(EFFECTS_CONFIG_FILE, g_EffectsManagerJSONBufferSize, *g_ptrEffectManager); }
+    );
 
     std::unique_ptr<AllocatedJsonDocument> pJsonDoc;
 
@@ -583,7 +588,8 @@ void InitEffectsManager()
 
 void SaveEffectManagerConfig()
 {
-    SaveToJSONFile(EFFECTS_CONFIG_FILE, g_EffectsManagerJSONBufferSize, *g_ptrEffectManager);
+    // Default value for writer index is max value for size_t, so nothing will happen if writer has not yet been registered
+    g_ptrJSONWriter->FlagWriter(g_EffectsManagerJSONWriterIndex);
 }
 
 void RemoveEffectManagerConfig()

--- a/src/jsonserializer.cpp
+++ b/src/jsonserializer.cpp
@@ -31,6 +31,8 @@
 #include "SPIFFS.h"
 #include "jsonserializer.h"
 
+DRAM_ATTR std::unique_ptr<JSONWriter> g_ptrJSONWriter = nullptr;
+
 bool LoadJSONFile(const char *fileName, size_t& bufferSize, std::unique_ptr<AllocatedJsonDocument>& pJsonDoc)
 {
     bool jsonReadSuccessful = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -464,7 +464,10 @@ void setup()
     }
     ESP_ERROR_CHECK(err);
 
-    // Create and load device config from NVS if possible
+    // Create the JSON writer
+    g_ptrJSONWriter = std::make_unique<JSONWriter>();
+
+    // Create and load device config from SPIFFS if possible
     g_ptrDeviceConfig = std::make_unique<DeviceConfig>();
 
 #if ENABLE_WIFI

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -45,6 +45,7 @@ const std::vector<const char *> CWebServer::knownSettings
     DeviceConfig::UseCelsiusTag,
     DeviceConfig::YouTubeChannelGuidTag,
     DeviceConfig::YouTubeChannelName1Tag,
+    DeviceConfig::NTPServerTag,
 };
 
 // Maps settings for which a validator is available to the invocation thereof
@@ -242,6 +243,7 @@ void CWebServer::SetSettingsIfPresent(AsyncWebServerRequest * pRequest)
     PushPostParamIfPresent<bool>(pRequest, DeviceConfig::UseCelsiusTag, SET_VALUE(g_ptrDeviceConfig->SetUseCelsius(value)));
     PushPostParamIfPresent<String>(pRequest, DeviceConfig::YouTubeChannelGuidTag, SET_VALUE(g_ptrDeviceConfig->SetYouTubeChannelGuid(value)));
     PushPostParamIfPresent<String>(pRequest, DeviceConfig::YouTubeChannelName1Tag, SET_VALUE(g_ptrDeviceConfig->SetYouTubeChannelName1(value)));
+    PushPostParamIfPresent<String>(pRequest, DeviceConfig::NTPServerTag, SET_VALUE(g_ptrDeviceConfig->SetNTPServer(value)));
 }
 
 // Set settings and return resulting config

--- a/tools/NightDriverStrip.postman_collection.json
+++ b/tools/NightDriverStrip.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "78753837-e8ae-4644-a145-8dab4f6b729d",
+		"_postman_id": "bed322ee-1fb8-4d8c-a6dd-539481594e7a",
 		"name": "NightDriverStrip endpoints",
 		"description": "Call configurations to use/test some of the endpoints in the NightDriverStrip on-device API - basically those not yet covered by the web UI. These have been confirmed to work with the Mesmerizer board/project and the Spectrum project on the M5StickC Plus.\n\nNotes:\n\n- Before using the call configurations in this collection, make sure to update the value of the \"device_ip\" variable in the Variables tab of this collection. Make sure to Save the collection after doing this, because otherwise your change will not be applied.\n- The parameters for POST call configurations are listed in the Body tab of the respective configurations. As with the collection's \"device_ip\" variable, Save a configuration if you want to persist changes to its parameters.\n- By default, all parameters for all configurations are unchecked, which means nothing will be sent unless at least one parameter is checked.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -96,6 +96,12 @@
 						{
 							"key": "nonsense",
 							"value": "gobbledygook",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "ntpServer",
+							"value": "0.pool.ntp.org",
 							"type": "text",
 							"disabled": true
 						}


### PR DESCRIPTION
## Description

This:

- makes the NTP server used for clock synchronization configurable via the /settings endpoint.
- parallelizes JSON writes to SPIFFS

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).