### PR TITLE
Make effects movable via the API

### DIFF
--- a/REST_API.md
+++ b/REST_API.md
@@ -10,6 +10,7 @@
   - [Previous effect](#previous-effect)
   - [Disable effect](#disable-effect)
   - [Enable effect](#enable-effect)
+  - [Move effect](#move-effect)
   - [Get effect configuration information](#get-effect-configuration-information)
   - [Device setting specifications](#device-setting-specifications)
   - [Device settings](#device-settings)
@@ -102,6 +103,18 @@ With this endpoint a previously disabled effect can be enabled. From that moment
 | URL | `/enableEffect` |
 | Method | POST | |
 | Parameters | `effectIndex` | The (zero-based) integer index of the effect to enable in the device's effect list. |
+| Response | 200 (OK) | An empty OK response. |
+
+### Move effect
+
+With this endpoint an effect can be moved within the effect list, changing its place in the effect visualisation cycle.
+
+| Property| Value | Explanation |
+|-|-|-|
+| URL | `/moveEffect` |
+| Method | POST | |
+| Parameters | `effectIndex` | The (zero-based) integer index of the effect to move in the device's effect list. |
+| | `newIndex` | The (zero-based) integer index of the place in the device's effect list the effect should be moved to. |
 | Response | 200 (OK) | An empty OK response. |
 
 ### Get effect configuration information

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -482,6 +482,29 @@ public:
         return _vEffects[i]->IsEnabled();
     }
 
+    void MoveEffect(size_t from, size_t to)
+    {
+        if (from >= _vEffects.size() || to >= _vEffects.size())
+        {
+            debugW("Invalid index for MoveEffect");
+            return;
+        }
+
+        if (from == to)
+            return;
+        else if (from > to)
+            std::rotate(_vEffects.rend() - from - 1, _vEffects.rend() - from, _vEffects.rend() - to);
+        else // from < to
+            std::rotate(_vEffects.begin() + from, _vEffects.begin() + from + 1, _vEffects.begin() + to + 1);
+
+        if (_iCurrentEffect == from)
+            _iCurrentEffect = to;
+        else if (from < _iCurrentEffect && to > _iCurrentEffect)
+            _iCurrentEffect--;
+        else if (from > _iCurrentEffect && to <= _iCurrentEffect)
+            _iCurrentEffect++;
+    }
+
     void PlayAll(bool bPlayAll)
     {
         _bPlayAll = bPlayAll;

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -499,7 +499,7 @@ public:
 
         if (_iCurrentEffect == from)
             _iCurrentEffect = to;
-        else if (from < _iCurrentEffect && to > _iCurrentEffect)
+        else if (from < _iCurrentEffect && to >= _iCurrentEffect)
             _iCurrentEffect--;
         else if (from > _iCurrentEffect && to <= _iCurrentEffect)
             _iCurrentEffect++;

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -501,7 +501,7 @@ public:
             _iCurrentEffect = to;
         else if (from < _iCurrentEffect && to >= _iCurrentEffect)
             _iCurrentEffect--;
-        else if (from > _iCurrentEffect && to <= _iCurrentEffect)
+        else if (/*from > _iCurrentEffect &&*/ to <= _iCurrentEffect)
             _iCurrentEffect++;
 
         SaveEffectManagerConfig();

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -503,6 +503,8 @@ public:
             _iCurrentEffect--;
         else if (from > _iCurrentEffect && to <= _iCurrentEffect)
             _iCurrentEffect++;
+
+        SaveEffectManagerConfig();
     }
 
     void PlayAll(bool bPlayAll)

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -501,7 +501,7 @@ public:
             _iCurrentEffect = to;
         else if (from < _iCurrentEffect && to >= _iCurrentEffect)
             _iCurrentEffect--;
-        else if (/*from > _iCurrentEffect &&*/ to <= _iCurrentEffect)
+        else if (from > _iCurrentEffect && to <= _iCurrentEffect)
             _iCurrentEffect++;
 
         SaveEffectManagerConfig();

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -492,12 +492,12 @@ public:
 
         if (from == to)
             return;
-        else if (from > to)
-            std::rotate(_vEffects.rend() - from - 1, _vEffects.rend() - from, _vEffects.rend() - to);
-        else // from < to
+        else if (from < to)
             std::rotate(_vEffects.begin() + from, _vEffects.begin() + from + 1, _vEffects.begin() + to + 1);
+        else // from > to
+            std::rotate(_vEffects.rend() - from - 1, _vEffects.rend() - from, _vEffects.rend() - to);
 
-        if (_iCurrentEffect == from)
+        if (from == _iCurrentEffect)
             _iCurrentEffect = to;
         else if (from < _iCurrentEffect && to >= _iCurrentEffect)
             _iCurrentEffect--;

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -269,8 +269,8 @@ class CWebServer
 };
 
 // Set value in lambda using a forwarding function. Always returns true
-#define SET_VALUE(functionCall) [&](auto value) { functionCall; return true; }
+#define SET_VALUE(functionCall) [=](auto value) { functionCall; return true; }
 
 // Set value in lambda using a forwarding function. Reports success based on function's return value,
 //   which must be implicitly convertable to bool
-#define CONFIRM_VALUE(functionCall) [&](auto value)->bool { return functionCall; }
+#define CONFIRM_VALUE(functionCall) [=](auto value)->bool { return functionCall; }

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -164,6 +164,7 @@ class CWebServer
     static void SetCurrentEffectIndex(AsyncWebServerRequest * pRequest);
     static void EnableEffect(AsyncWebServerRequest * pRequest);
     static void DisableEffect(AsyncWebServerRequest * pRequest);
+    static void MoveEffect(AsyncWebServerRequest * pRequest);
     static void NextEffect(AsyncWebServerRequest * pRequest);
     static void PreviousEffect(AsyncWebServerRequest * pRequest);
 
@@ -222,6 +223,7 @@ class CWebServer
         _server.on("/setCurrentEffectIndex", HTTP_POST, [](AsyncWebServerRequest * pRequest)        { SetCurrentEffectIndex(pRequest); });
         _server.on("/enableEffect",          HTTP_POST, [](AsyncWebServerRequest * pRequest)        { EnableEffect(pRequest); });
         _server.on("/disableEffect",         HTTP_POST, [](AsyncWebServerRequest * pRequest)        { DisableEffect(pRequest); });
+        _server.on("/moveEffect",            HTTP_POST, [](AsyncWebServerRequest * pRequest)        { MoveEffect(pRequest); });
 
         _server.on("/settings/effect/specs", HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { GetEffectSettingSpecs(pRequest); });
         _server.on("/settings/effect",       HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { GetEffectSettings(pRequest); });
@@ -267,8 +269,8 @@ class CWebServer
 };
 
 // Set value in lambda using a forwarding function. Always returns true
-#define SET_VALUE(functionCall) [](auto value) { functionCall; return true; }
+#define SET_VALUE(functionCall) [&](auto value) { functionCall; return true; }
 
 // Set value in lambda using a forwarding function. Reports success based on function's return value,
 //   which must be implicitly convertable to bool
-#define CONFIRM_VALUE(functionCall) [](auto value)->bool { return functionCall; }
+#define CONFIRM_VALUE(functionCall) [&](auto value)->bool { return functionCall; }

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,8 +17,8 @@ default_envs =
 ; Options that are used (or extended) in all device sections (and hence environments) are defined here
 
 [base]
-upload_port     =
-monitor_port    =
+upload_port     = COM10
+monitor_port    = COM10
 upload_speed    = 1500000
 
 build_flags     = -std=gnu++17

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,8 +17,8 @@ default_envs =
 ; Options that are used (or extended) in all device sections (and hence environments) are defined here
 
 [base]
-upload_port     = COM10
-monitor_port    = COM10
+upload_port     =
+monitor_port    = 
 upload_speed    = 1500000
 
 build_flags     = -std=gnu++17

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -192,6 +192,18 @@ void CWebServer::DisableEffect(AsyncWebServerRequest * pRequest)
     AddCORSHeaderAndSendOKResponse(pRequest);
 }
 
+void CWebServer::MoveEffect(AsyncWebServerRequest * pRequest)
+{
+    debugV("MoveEffect");
+
+    auto fromIndex = GetEffectIndexFromParam(pRequest, true);
+    if (fromIndex == -1)
+        return;
+
+    PushPostParamIfPresent<size_t>(pRequest, "newIndex", SET_VALUE(g_ptrEffectManager->MoveEffect(fromIndex, value)));
+    AddCORSHeaderAndSendOKResponse(pRequest);
+}
+
 void CWebServer::NextEffect(AsyncWebServerRequest * pRequest)
 {
     debugV("NextEffect");

--- a/tools/NightDriverStrip.postman_collection.json
+++ b/tools/NightDriverStrip.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "61d9d779-3c0c-4ed6-a14b-94bc94906cea",
+		"_postman_id": "1e0cc474-dcbe-4b92-9b28-4b8a48aa8ef8",
 		"name": "NightDriverStrip endpoints",
 		"description": "Call configurations to use/test some of the endpoints in the NightDriverStrip on-device API - basically those not yet covered by the web UI. These have been confirmed to work with the Mesmerizer board/project and the Spectrum project on the M5StickC Plus.\n\nNotes:\n\n- Before using the call configurations in this collection, make sure to update the value of the \"device_ip\" variable in the Variables tab of this collection. Make sure to Save the collection after doing this, because otherwise your change will not be applied.\n- The parameters for POST call configurations are listed in the Body tab of the respective configurations. As with the collection's \"device_ip\" variable, Save a configuration if you want to persist changes to its parameters.\n- By default, all parameters for all configurations are unchecked, which means nothing will be sent unless at least one parameter is checked.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -312,6 +312,39 @@
 					]
 				},
 				"description": "Change effect-specific settings for one effect.\n\nNotes:\n\n- Only parameters that are sent are actually changed.\n- All parameters are optional.\n- The call will return the current setting values for the effect, after those included in the call have been applied."
+			},
+			"response": []
+		},
+		{
+			"name": "Move effect",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "effectIndex",
+							"value": "7",
+							"type": "text"
+						},
+						{
+							"key": "newIndex",
+							"value": "2",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "{{device_ip}}/moveEffect",
+					"host": [
+						"{{device_ip}}"
+					],
+					"path": [
+						"moveEffect"
+					]
+				},
+				"description": "Moves an effect to another place in the effect list."
 			},
 			"response": []
 		},


### PR DESCRIPTION
## Description

This adds the ability to change the order of the effects in the effects list, and exposes it in an endpoint to which the current and newly desired effect indices can be passed. Any effect order changes made are persisted across reboots.
The API documentation and the Postman collection file have been extended accordingly.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).