### PR TITLE
Expose LEDStripEffect settings, copy effects and remove copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Each channel of LEDs has an `LEDStripGfx` instance associated with it. `_GFX[0]`
 
 The simplest configuration, `DEMO`, assumes you have a single meter strip of 144 LEDs and a power supply connected to your ESP32. It boots up, finds a single `RainbowFillEffect` in the `LoadEffectFactories()` function, and repeatedly calls its `Draw()` method to update the CRGB array before sending it out to the LEDs. If working correctly it should draw a scrolling rainbow palette on your LED strip.
 
-Concerning JSON peristence: the effects table is persisted to a JSON file on SPIFFS at regular intervals, to retain the state of effects (and in fact the whole effect list) across reboots. This is largely in preparation for future updates to NightDriverStrip, where the configuration of individual effects can be changed using the device API, and eventually the device web application (see [Device web UI and API](#device-web-ui-and-api), below.)
+Concerning JSON peristence: the effects table is persisted to a JSON file on SPIFFS at regular intervals, to retain the state of effects (and in fact the whole effect list) across reboots. This is largely in preparation for future updates to NightDriverStrip, where the composition of the effect list configuration of individual effects can be changed using the device web application. The API endpoints to facilitate this are already available and ready for use (see [Device web UI and API](#device-web-ui-and-api), below.)
 
 This makes that an override of `SerializeToJSON()` and a corresponding deserializing constructor must be provided for effects that need (or want) to persist more than the friendly name and effect number. Those two properties are (de)serialized from/to JSON by `LEDStripEffect` by default.
 

--- a/REST_API.md
+++ b/REST_API.md
@@ -11,6 +11,8 @@
   - [Disable effect](#disable-effect)
   - [Enable effect](#enable-effect)
   - [Move effect](#move-effect)
+  - [Copy effect](#copy-effect)
+  - [Delete effect](#delete-effect)
   - [Get effect configuration information](#get-effect-configuration-information)
   - [Device setting specifications](#device-setting-specifications)
   - [Device settings](#device-settings)
@@ -117,6 +119,30 @@ With this endpoint an effect can be moved within the effect list, changing its p
 | | `newIndex` | The (zero-based) integer index of the place in the device's effect list the effect should be moved to. |
 | Response | 200 (OK) | An empty OK response. |
 
+### Copy effect
+
+With this endpoint an effect in the effect list can be copied. The created copy will be added to the end of the effect list. While copying the effect, supported effect settings on the copy can be set within the same call.
+
+| Property| Value | Explanation |
+|-|-|-|
+| URL | `/copyEffect` |
+| Method | POST | |
+| Parameters | `effectIndex` | The (zero-based) integer index of the effect of which a copy should be made. |
+| | | Zero, one or more settings that have been returned by the [Effect setting specifications endpoint](#effect-setting-specifications); also refer to the [Change effect settings endpoint](#change-effect-settings) for more information. |
+| Response | 200 (OK) | A JSON blob with the values for the copied effect's configuration settings, after applying the values in the request's POST parameters. |
+
+### Delete effect
+
+With this endpoint an effect from the effect list can be deleted. Only effects that are copies of the default set (see [Copy effect](#copy-effect)) can be deleted.
+
+| Property| Value | Explanation |
+|-|-|-|
+| URL | `/deleteEffect` |
+| Method | POST | |
+| Parameters | `effectIndex` | The (zero-based) integer index of the effect that should be deleted from the effect list. |
+| Response | 200 (OK) | An empty OK response if the effect was successfully deleted or the `effectIndex` was out of bounds. |
+| | 400 (Bad Request) | `effectIndex` points to an effect in the default set, that being an effect marked as `"core": true` in the output of the [Get effect list endpoint](#get-effect-list-information). |
+
 ### Get effect configuration information
 
 This endpoint returns a JSON document with information about the detailed configuration of the effects on the device. Note that this document currently has an internal purpose, and is as such not optimized for human inspection.
@@ -213,7 +239,7 @@ When changing settings:
 | URL | `/settings/effect` |
 | Method | GET | |
 | Parameters | `effectIndex` | The (zero-based) integer index in the device's effect list of the effect to retrieve the settings for. |
-| Response | 200 (OK) | A JSON blob with the current values for the effect's configuration settings. The response is empty if the effect does not have any configurable settings. |
+| Response | 200 (OK) | A JSON blob with the current values for the effect's configuration settings. |
 
 #### Change effect settings
 
@@ -223,7 +249,7 @@ When changing settings:
 | Method | POST | |
 | Parameters | `effectIndex` | The (zero-based) integer index in the device's effect list of the effect to change settings for. |
 | | | One or more settings that have been returned by the [Effect setting specifications endpoint](#effect-setting-specifications). |
-| Response | 200 (OK) | A JSON blob with the current values for the effect's configuration settings, after applying the values in the request's POST parameters. The response is empty if the effect does not have any configurable settings. |
+| Response | 200 (OK) | A JSON blob with the current values for the effect's configuration settings, after applying the values in the request's POST parameters. |
 
 ### Reset configuration and/or device
 

--- a/REST_API.md
+++ b/REST_API.md
@@ -192,7 +192,7 @@ This endpoint can be used to retrieve the list of known effect-specific configur
 | URL | `/settings/effect/specs` |
 | Method | GET | |
 | Parameters | `effectIndex` | The (zero-based) integer index in the device's effect list of the effect to retrieve the setting specifications for. |
-| Response | 200 (OK) | A JSON array with the known effect-specific configuration settings for the effect with index `effectIndex`. The specifications include the name, description, type identifier and type name for each setting. The response is empty if the effect does not have any configurable settings. |
+| Response | 200 (OK) | A JSON array with the known effect-specific configuration settings for the effect with index `effectIndex`. The specifications include the name, description, type identifier and type name for each setting. |
 
 ### Effect settings
 

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -571,10 +571,10 @@ public:
         if (_vEffects[index]->IsCoreEffect())
             return false;
 
+        DisableEffect(index, true);
+
         if (index == _iCurrentEffect)
             NextEffect();
-
-        DisableEffect(index, true);
 
         _vEffects.erase(_vEffects.begin() + index);
 

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -110,8 +110,7 @@ class EffectManager : public IJSONSerializable
                 continue;
 
             auto pEffect = factoryEntry->second(effectObject);
-
-            if (pEffect != nullptr)
+            if (pEffect)
             {
                 if (effectObject[PTY_COREEFFECT].as<int>())
                     pEffect->MarkAsCoreEffect();
@@ -142,7 +141,7 @@ class EffectManager : public IJSONSerializable
                         return;
 
                     auto pEffect = numberedFactory.Factory();
-                    if (pEffect != nullptr)
+                    if (pEffect)
                     {
                         // Effects in the default list are core effects. These can be disabled but not deleted.
                         pEffect->MarkAsCoreEffect();
@@ -203,7 +202,7 @@ public:
         for (auto &numberedFactory : g_EffectFactories.GetDefaultFactories())
         {
             auto pEffect = numberedFactory.Factory();
-            if (pEffect != nullptr)
+            if (pEffect)
             {
                 // Effects in the default list are core effects. These can be disabled but not deleted.
                 pEffect->MarkAsCoreEffect();

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -537,7 +537,7 @@ public:
 
         auto copiedEffect = factoryEntry->second(ptrJsonDoc->as<JsonObjectConst>());
 
-        if (copiedEffect == nullptr)
+        if (!copiedEffect)
             return nullptr;
 
         copiedEffect->SetEnabled(false);
@@ -553,7 +553,9 @@ public:
             return false;
 
         _vEffects.push_back(effect);
-        EnableEffect(_vEffects.size() - 1);     // This will also trigger a JSON save
+        EnableEffect(_vEffects.size() - 1, true);
+
+        SaveEffectManagerConfig();
 
         return true;
     }

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -443,12 +443,10 @@ public:
 
         if (!effect->IsEnabled())
         {
-            effect->SetEnabled(true);
-
-            if (EnabledCount() < 1)
-            {
+            if (!AreEffectsEnabled())
                 ClearRemoteColor(true);
-            }
+
+            effect->SetEnabled(true);
 
             if (!skipSave)
                 SaveEffectManagerConfig();
@@ -469,10 +467,8 @@ public:
         {
             effect->SetEnabled(false);
 
-            if (EnabledCount() < 1)
-            {
+            if (!AreEffectsEnabled())
                 SetGlobalColor(CRGB::Black);
-            }
 
             if (!skipSave)
                 SaveEffectManagerConfig();
@@ -612,15 +608,13 @@ public:
         return _vEffects.size();
     }
 
-    const size_t EnabledCount() const
+    const bool AreEffectsEnabled() const
     {
-        size_t enabledCount = 0;
-
         for (auto& pEffect : _vEffects)
             if (pEffect->IsEnabled())
-                enabledCount++;
+                return true;
 
-        return enabledCount;
+        return false;
     }
 
     const size_t GetCurrentEffectIndex() const
@@ -715,14 +709,14 @@ public:
 
     void NextEffect(bool skipSave = false)
     {
-        auto enabledCount = EnabledCount();
+        auto enabled = AreEffectsEnabled();
 
         do
         {
             _iCurrentEffect++; //   ... if so advance to next effect
             _iCurrentEffect %= EffectCount();
             _effectStartTime = millis();
-        } while (0 < enabledCount && false == _bPlayAll && false == IsEffectEnabled(_iCurrentEffect));
+        } while (enabled && false == _bPlayAll && false == IsEffectEnabled(_iCurrentEffect));
 
         StartEffect();
         if (!skipSave)
@@ -733,7 +727,7 @@ public:
 
     void PreviousEffect()
     {
-        auto enabledCount = EnabledCount();
+        auto enabled = AreEffectsEnabled();
 
         do
         {
@@ -742,7 +736,7 @@ public:
 
             _iCurrentEffect--;
             _effectStartTime = millis();
-        } while (0 < enabledCount && false == _bPlayAll && false == IsEffectEnabled(_iCurrentEffect));
+        } while (enabled && false == _bPlayAll && false == IsEffectEnabled(_iCurrentEffect));
 
         StartEffect();
         SaveEffectManagerConfig();

--- a/include/effects.h
+++ b/include/effects.h
@@ -123,6 +123,7 @@
 
 // Some common JSON properties to prevent typos
 #define PTY_EFFECTNR        "en"
+#define PTY_COREEFFECT      "ce"
 #define PTY_REVERSED        "rvr"
 #define PTY_MIRORRED        "mir"
 #define PTY_ERASE           "ers"

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -212,14 +212,12 @@ class PatternSubscribers : public LEDStripEffect
         LEDMatrixGFX::backgroundLayer.drawString(x,   y,   rgb24(255,255,255),    pszText);
     }
 
-    virtual bool HasSettings() const override
-    {
-        return true;
-    }
-
     virtual bool SerializeSettingsToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<384> jsonDoc;
+        auto rootObject = jsonDoc.to<JsonObject>();
+
+        LEDStripEffect::SerializeSettingsToJSON(jsonObject);
 
         jsonDoc[NAME_OF(youtubeChannelGuid)] = youtubeChannelGuid;
         jsonDoc[NAME_OF(youtubeChannelName)] = youtubeChannelName;
@@ -230,7 +228,9 @@ class PatternSubscribers : public LEDStripEffect
     virtual bool SetSetting(const String& name, const String& value) override
     {
         RETURN_IF_SET(name, NAME_OF(youtubeChannelGuid), youtubeChannelGuid, value);
-        return SetIfSelected(name, NAME_OF(youtubeChannelName), youtubeChannelName, value);
+        RETURN_IF_SET(name, NAME_OF(youtubeChannelName), youtubeChannelName, value);
+
+        return LEDStripEffect::SetSetting(name, value);
     }
 };
 

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -219,7 +219,7 @@ class PatternSubscribers : public LEDStripEffect
 
     virtual bool SerializeSettingsToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<256> jsonDoc;
+        StaticJsonDocument<384> jsonDoc;
 
         jsonDoc[NAME_OF(youtubeChannelGuid)] = youtubeChannelGuid;
         jsonDoc[NAME_OF(youtubeChannelName)] = youtubeChannelName;

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -365,7 +365,7 @@ public:
         const int fontWidth  = 5;
         const int xHalf      = MATRIX_WIDTH / 2 - 1;
 
-        g()->fillScreen(CRGB(0, 0, 0));
+        g()->fillScreen(BLACK16);
         g()->fillRect(0, 0, MATRIX_WIDTH, 9, g()->to16bit(CRGB(0,0,128)));
 
         g()->setFont(&Apple5x7);

--- a/include/effects/strip/bouncingballeffect.h
+++ b/include/effects/strip/bouncingballeffect.h
@@ -94,7 +94,7 @@ private:
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<256> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -1027,6 +1027,9 @@ public:
   {
     AllocatedJsonDocument jsonDoc(512);
 
+    JsonObject root = jsonDoc.to<JsonObject>();
+    LEDStripEffect::SerializeToJSON(root);
+
     jsonDoc[PTY_PALETTE] = Palette;
     jsonDoc[PTY_LEDCOUNT] = LEDCount;
     jsonDoc[PTY_CELLSPERLED] = CellsPerLED;
@@ -1037,9 +1040,6 @@ public:
     jsonDoc[PTY_REVERSED] = bReversed;
     jsonDoc[PTY_MIRORRED] = bMirrored;
     jsonDoc[PTY_ORDER] = to_value(Order);
-
-    JsonObject root = jsonDoc.as<JsonObject>();
-    LEDStripEffect::SerializeToJSON(root);
 
     return jsonObject.set(jsonDoc.as<JsonObjectConst>());
   }

--- a/include/effects/strip/fireeffect.h
+++ b/include/effects/strip/fireeffect.h
@@ -101,7 +101,7 @@ class FireEffect : public LEDStripEffect
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<256> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -351,7 +351,7 @@ public:
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<256> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -698,7 +698,7 @@ class BaseFireEffect : public LEDStripEffect
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<256> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);

--- a/include/effects/strip/meteoreffect.h
+++ b/include/effects/strip/meteoreffect.h
@@ -193,7 +193,7 @@ class MeteorEffect : public LEDStripEffect
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<256> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -415,7 +415,7 @@ class TwinkleEffect : public LEDStripEffect
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<256> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);

--- a/include/globals.h
+++ b/include/globals.h
@@ -143,6 +143,7 @@
 // C Helpers and Macros
 
 #define NAME_OF(x)          #x
+#define ACTUAL_NAME_OF(x)   ((#x) + 1)
 #define ARRAYSIZE(a)        (sizeof(a)/sizeof(a[0]))        // Returns the number of elements in an array
 #define PERIOD_FROM_FREQ(f) (round(1000000 * (1.0 / f)))    // Calculate period in microseconds (us) from frequency in Hz
 #define FREQ_FROM_PERIOD(p) (1.0 / p * 1000000)             // Calculate frequency in Hz given the period in microseconds (us)

--- a/include/globals.h
+++ b/include/globals.h
@@ -143,7 +143,10 @@
 // C Helpers and Macros
 
 #define NAME_OF(x)          #x
+
+// NAME_OF with first character cut off - addresses underscore-prefixed (member) variables
 #define ACTUAL_NAME_OF(x)   ((#x) + 1)
+
 #define ARRAYSIZE(a)        (sizeof(a)/sizeof(a[0]))        // Returns the number of elements in an array
 #define PERIOD_FROM_FREQ(f) (round(1000000 * (1.0 / f)))    // Calculate period in microseconds (us) from frequency in Hz
 #define FREQ_FROM_PERIOD(p) (1.0 / p * 1000000)             // Calculate frequency in Hz given the period in microseconds (us)

--- a/include/jsonserializer.h
+++ b/include/jsonserializer.h
@@ -48,11 +48,6 @@ constexpr auto to_value(E e) noexcept
 	return static_cast<std::underlying_type_t<E>>(e);
 }
 
-bool BoolFromJSON(const String& text)
-{
-    return text == "true" || strtol(text.c_str(), NULL, 10);
-}
-
 #if USE_PSRAM
     struct JsonPsramAllocator
     {
@@ -130,6 +125,8 @@ namespace ArduinoJson
     };
 }
 
+bool BoolFromText(const String& text);
+void SerializeWithBufferSize(std::unique_ptr<AllocatedJsonDocument>& pJsonDoc, size_t& bufferSize, std::function<bool(JsonObject&)> serializationFunction);
 bool LoadJSONFile(const char *fileName, size_t& bufferSize, std::unique_ptr<AllocatedJsonDocument>& pJsonDoc);
 bool SaveToJSONFile(const char *fileName, size_t& bufferSize, IJSONSerializable& object);
 bool RemoveJSONFile(const char *fileName);

--- a/include/jsonserializer.h
+++ b/include/jsonserializer.h
@@ -48,6 +48,11 @@ constexpr auto to_value(E e) noexcept
 	return static_cast<std::underlying_type_t<E>>(e);
 }
 
+bool BoolFromJSON(const String& text)
+{
+    return text == "true" || strtol(text.c_str(), NULL, 10);
+}
+
 #if USE_PSRAM
     struct JsonPsramAllocator
     {

--- a/include/types.h
+++ b/include/types.h
@@ -57,7 +57,8 @@ struct SettingSpec
         Float,
         Boolean,
         String,
-        Palette
+        Palette,
+        Color
     };
 
     String Name;
@@ -80,7 +81,7 @@ struct SettingSpec
 
     String static ToName(SettingType type)
     {
-        String names[] = { "Integer", "PositiveBigInteger", "Float", "Boolean", "String", "Palette" };
+        String names[] = { "Integer", "PositiveBigInteger", "Float", "Boolean", "String", "Palette", "Color" };
         return names[(int)type];
     }
 };

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -140,6 +140,12 @@ class CWebServer
         AddCORSHeaderAndSendResponse(pRequest, pRequest->beginResponse(HTTP_CODE_OK));
     }
 
+    static void AddCORSHeaderAndSendBadRequest(AsyncWebServerRequest * pRequest, const String& message)
+    {
+        AddCORSHeaderAndSendResponse(pRequest, pRequest->beginResponse(HTTP_CODE_BAD_REQUEST, "text/json",
+            "{\"message\": \"" + message + "\"}"));
+    }
+
     // Straightforward support functions
 
     static bool IsPostParamTrue(AsyncWebServerRequest * pRequest, const String & paramName);
@@ -149,6 +155,7 @@ class CWebServer
     static long GetEffectIndexFromParam(AsyncWebServerRequest * pRequest, bool post = false);
     static bool CheckAndGetSettingsEffect(AsyncWebServerRequest * pRequest, std::shared_ptr<LEDStripEffect> & effect, bool post = false);
     static void SendEffectSettingsResponse(AsyncWebServerRequest * pRequest, std::shared_ptr<LEDStripEffect> & effect);
+    static bool ApplyEffectSettings(AsyncWebServerRequest * pRequest, std::shared_ptr<LEDStripEffect> & effect);
 
     // Endpoint member functions
 
@@ -165,6 +172,8 @@ class CWebServer
     static void EnableEffect(AsyncWebServerRequest * pRequest);
     static void DisableEffect(AsyncWebServerRequest * pRequest);
     static void MoveEffect(AsyncWebServerRequest * pRequest);
+    static void CopyEffect(AsyncWebServerRequest * pRequest);
+    static void DeleteEffect(AsyncWebServerRequest * pRequest);
     static void NextEffect(AsyncWebServerRequest * pRequest);
     static void PreviousEffect(AsyncWebServerRequest * pRequest);
 
@@ -224,6 +233,8 @@ class CWebServer
         _server.on("/enableEffect",          HTTP_POST, [](AsyncWebServerRequest * pRequest)        { EnableEffect(pRequest); });
         _server.on("/disableEffect",         HTTP_POST, [](AsyncWebServerRequest * pRequest)        { DisableEffect(pRequest); });
         _server.on("/moveEffect",            HTTP_POST, [](AsyncWebServerRequest * pRequest)        { MoveEffect(pRequest); });
+        _server.on("/copyEffect",            HTTP_POST, [](AsyncWebServerRequest * pRequest)        { CopyEffect(pRequest); });
+        _server.on("/deleteEffect",          HTTP_POST, [](AsyncWebServerRequest * pRequest)        { DeleteEffect(pRequest); });
 
         _server.on("/settings/effect/specs", HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { GetEffectSettingSpecs(pRequest); });
         _server.on("/settings/effect",       HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { GetEffectSettings(pRequest); });

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -451,6 +451,7 @@ void LoadEffectFactories()
         ADD_EFFECT(EFFECT_STRIP_TAPE_REEL, TapeReelEffect, "TapeReelEffect");
 
     #elif CUBE
+
         // Simple rainbow pallette
         ADD_EFFECT(EFFECT_STRIP_PALETTE, PaletteEffect, rainbowPalette, 256 / 16, .2, 0);
 
@@ -489,6 +490,7 @@ void LoadEffectFactories()
         //std::make_shared<GhostWave>("GhostWave Rainbow", &rainbowPalette),
 
     #elif ATOMLIGHT
+
         ADD_EFFECT(EFFECT_STRIP_COLOR_FILL, ColorFillEffect, CRGB::White, 1);
         // std::make_shared<FireFanEffect>(NUM_LEDS, 1, 15, 80, 2, 7, Sequential, true, false),
         // std::make_shared<FireFanEffect>(NUM_LEDS, 1, 15, 80, 2, 7, Sequential, true, false, true),

--- a/src/jsonserializer.cpp
+++ b/src/jsonserializer.cpp
@@ -34,6 +34,11 @@
 
 DRAM_ATTR std::unique_ptr<JSONWriter> g_ptrJSONWriter = nullptr;
 
+bool BoolFromText(const String& text)
+{
+    return text == "true" || strtol(text.c_str(), NULL, 10);
+}
+
 bool LoadJSONFile(const char *fileName, size_t& bufferSize, std::unique_ptr<AllocatedJsonDocument>& pJsonDoc)
 {
     bool jsonReadSuccessful = false;

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -217,6 +217,11 @@ void CWebServer::CopyEffect(AsyncWebServerRequest * pRequest)
     }
 
     auto effect = g_ptrEffectManager->CopyEffect(index);
+    if (!effect)
+    {
+        AddCORSHeaderAndSendOKResponse(pRequest);
+        return;
+    }
 
     ApplyEffectSettings(pRequest, effect);
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -115,7 +115,6 @@ void CWebServer::GetEffectListText(AsyncWebServerRequest * pRequest)
             auto effect = effectsList[i];
             effectDoc["name"]    = effect->FriendlyName();
             effectDoc["enabled"] = effect->IsEnabled();
-            effectDoc["hasSettings"] = effect->HasSettings();
 
             if (!j["Effects"].add(effectDoc))
             {
@@ -326,7 +325,7 @@ bool CWebServer::CheckAndGetSettingsEffect(AsyncWebServerRequest * pRequest, std
     auto effectsList = g_ptrEffectManager->EffectsList();
     auto effectIndex = GetEffectIndexFromParam(pRequest, post);
 
-    if (effectIndex < 0 || effectIndex >= effectsList.size() || !effectsList[effectIndex]->HasSettings())
+    if (effectIndex < 0 || effectIndex >= effectsList.size())
     {
         AddCORSHeaderAndSendOKResponse(pRequest);
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -103,7 +103,6 @@ void CWebServer::GetEffectListText(AsyncWebServerRequest * pRequest)
         j["currentEffect"]         = g_ptrEffectManager->GetCurrentEffectIndex();
         j["millisecondsRemaining"] = g_ptrEffectManager->GetTimeRemainingForCurrentEffect();
         j["effectInterval"]        = g_ptrEffectManager->GetInterval();
-        j["enabledCount"]          = g_ptrEffectManager->EnabledCount();
 
         auto effectsList = g_ptrEffectManager->EffectsList();
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -47,8 +47,7 @@ bool CWebServer::PushPostParamIfPresent<bool>(AsyncWebServerRequest * pRequest, 
 {
     return PushPostParamIfPresent<bool>(pRequest, paramName, setter, [](AsyncWebParameter * param) constexpr
     {
-        const String& value = param->value();
-        return value == "true" || strtol(value.c_str(), NULL, 10);
+        return BoolFromText(param->value());
     });
 }
 
@@ -115,6 +114,7 @@ void CWebServer::GetEffectListText(AsyncWebServerRequest * pRequest)
             auto effect = effectsList[i];
             effectDoc["name"]    = effect->FriendlyName();
             effectDoc["enabled"] = effect->IsEnabled();
+            effectDoc["core"]    = effect->IsCoreEffect();
 
             if (!j["Effects"].add(effectDoc))
             {
@@ -197,9 +197,54 @@ void CWebServer::MoveEffect(AsyncWebServerRequest * pRequest)
 
     auto fromIndex = GetEffectIndexFromParam(pRequest, true);
     if (fromIndex == -1)
+    {
+        AddCORSHeaderAndSendOKResponse(pRequest);
         return;
+    }
 
     PushPostParamIfPresent<size_t>(pRequest, "newIndex", SET_VALUE(g_ptrEffectManager->MoveEffect(fromIndex, value)));
+    AddCORSHeaderAndSendOKResponse(pRequest);
+}
+
+void CWebServer::CopyEffect(AsyncWebServerRequest * pRequest)
+{
+    debugV("CopyEffect");
+
+    auto index = GetEffectIndexFromParam(pRequest, true);
+    if (index == -1)
+    {
+        AddCORSHeaderAndSendOKResponse(pRequest);
+        return;
+    }
+
+    auto effect = g_ptrEffectManager->CopyEffect(index);
+
+    ApplyEffectSettings(pRequest, effect);
+
+    if (g_ptrEffectManager->AppendEffect(effect))
+        SendEffectSettingsResponse(pRequest, effect);
+    else
+        AddCORSHeaderAndSendOKResponse(pRequest);
+}
+
+void CWebServer::DeleteEffect(AsyncWebServerRequest * pRequest)
+{
+    debugV("DeleteEffect");
+
+    auto index = GetEffectIndexFromParam(pRequest, true);
+    if (index == -1)
+    {
+        AddCORSHeaderAndSendOKResponse(pRequest);
+        return;
+    }
+
+    if (index < g_ptrEffectManager->EffectCount() && g_ptrEffectManager->EffectsList()[index]->IsCoreEffect())
+    {
+        AddCORSHeaderAndSendBadRequest(pRequest, "Can't delete core effect");
+        return;
+    }
+
+    g_ptrEffectManager->DeleteEffect(index);
     AddCORSHeaderAndSendOKResponse(pRequest);
 }
 
@@ -283,7 +328,7 @@ void CWebServer::GetSettings(AsyncWebServerRequest * pRequest)
     debugV("GetSettings");
 
     auto response = new AsyncJsonResponse(false, JSON_BUFFER_BASE_SIZE);
-    response->addHeader("Server","NightDriverStrip");
+    response->addHeader("Server", "NightDriverStrip");
     auto root = response->getRoot();
     JsonObject jsonObject = root.to<JsonObject>();
 
@@ -381,15 +426,8 @@ void CWebServer::GetEffectSettings(AsyncWebServerRequest * pRequest)
     SendEffectSettingsResponse(pRequest, effect);
 }
 
-void CWebServer::SetEffectSettings(AsyncWebServerRequest * pRequest)
+bool CWebServer::ApplyEffectSettings(AsyncWebServerRequest * pRequest, std::shared_ptr<LEDStripEffect> & effect)
 {
-    debugV("SetEffectSettings");
-
-    std::shared_ptr<LEDStripEffect> effect;
-
-    if (!CheckAndGetSettingsEffect(pRequest, effect, true))
-        return;
-
     bool settingChanged = false;
 
     for (auto& settingSpec : effect->GetSettingSpecs())
@@ -399,7 +437,19 @@ void CWebServer::SetEffectSettings(AsyncWebServerRequest * pRequest)
             || settingChanged;
     }
 
-    if (settingChanged)
+    return settingChanged;
+}
+
+void CWebServer::SetEffectSettings(AsyncWebServerRequest * pRequest)
+{
+    debugV("SetEffectSettings");
+
+    std::shared_ptr<LEDStripEffect> effect;
+
+    if (!CheckAndGetSettingsEffect(pRequest, effect, true))
+        return;
+
+    if (ApplyEffectSettings(pRequest, effect))
         SaveEffectManagerConfig();
 
     SendEffectSettingsResponse(pRequest, effect);
@@ -420,9 +470,7 @@ void CWebServer::ValidateAndSetSetting(AsyncWebServerRequest * pRequest)
             else
             // We found multiple known settings in the request, which we don't allow
             {
-                String responseText = "{\"message\": \"Malformed request\"}";
-                auto pResponse = pRequest->beginResponse(HTTP_CODE_BAD_REQUEST, "text/json", responseText);
-                AddCORSHeaderAndSendResponse(pRequest, pResponse);
+                AddCORSHeaderAndSendBadRequest(pRequest, "Malformed request");
                 return;
             }
         }
@@ -446,9 +494,7 @@ void CWebServer::ValidateAndSetSetting(AsyncWebServerRequest * pRequest)
 
         if (!isValid)
         {
-            String responseText = "{\"message\": \"" + validationMessage + "\"}";
-            auto pResponse = pRequest->beginResponse(HTTP_CODE_BAD_REQUEST, "text/json", responseText);
-            AddCORSHeaderAndSendResponse(pRequest, pResponse);
+            AddCORSHeaderAndSendBadRequest(pRequest, validationMessage);
             return;
         }
     }

--- a/tools/NightDriverStrip.postman_collection.json
+++ b/tools/NightDriverStrip.postman_collection.json
@@ -281,6 +281,24 @@
 							"type": "text"
 						},
 						{
+							"key": "friendlyName",
+							"value": "Subscribers",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "maximumEffectTime",
+							"value": "30000",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "clearMaximumEffectTime",
+							"value": "true",
+							"type": "text",
+							"disabled": true
+						},
+						{
 							"key": "youtubeChannelGuid",
 							"value": "9558daa1-eae8-482f-8066-17fa787bc0e4",
 							"type": "text",
@@ -316,6 +334,45 @@
 			"response": []
 		},
 		{
+			"name": "Copy effect",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "effectIndex",
+							"value": "0",
+							"type": "text"
+						},
+						{
+							"key": "friendlyName",
+							"value": "Spectrum Copy",
+							"type": "text"
+						},
+						{
+							"key": "maximumEffectTime",
+							"value": "30000",
+							"type": "text",
+							"disabled": true
+						}
+					]
+				},
+				"url": {
+					"raw": "{{device_ip}}/copyEffect",
+					"host": [
+						"{{device_ip}}"
+					],
+					"path": [
+						"copyEffect"
+					]
+				},
+				"description": "Moves an effect to another place in the effect list."
+			},
+			"response": []
+		},
+		{
 			"name": "Move effect",
 			"request": {
 				"method": "POST",
@@ -342,6 +399,34 @@
 					],
 					"path": [
 						"moveEffect"
+					]
+				},
+				"description": "Moves an effect to another place in the effect list."
+			},
+			"response": []
+		},
+		{
+			"name": "Delete effect",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "formdata",
+					"formdata": [
+						{
+							"key": "effectIndex",
+							"value": "0",
+							"type": "text"
+						}
+					]
+				},
+				"url": {
+					"raw": "{{device_ip}}/deleteEffect",
+					"host": [
+						"{{device_ip}}"
+					],
+					"path": [
+						"deleteEffect"
 					]
 				},
 				"description": "Moves an effect to another place in the effect list."

--- a/tools/NightDriverStrip.postman_collection.json
+++ b/tools/NightDriverStrip.postman_collection.json
@@ -368,7 +368,7 @@
 						"copyEffect"
 					]
 				},
-				"description": "Moves an effect to another place in the effect list."
+				"description": "Creates a copy of an effect in the effect list and adds it to the end of the list. The new effect's settings can be set/modified in the same call."
 			},
 			"response": []
 		},
@@ -429,7 +429,7 @@
 						"deleteEffect"
 					]
 				},
-				"description": "Moves an effect to another place in the effect list."
+				"description": "Deletes an effect from the effect list. Only effects that are not part of the default set can be deleted."
 			},
 			"response": []
 		},


### PR DESCRIPTION
## Description

This:

- Exposes the friendly name and maximum effect time as settings of LEDStripEffect (and as such, any derived effect in principle).
- Adds the API-exposed ability to create a copy of an existing effect, optionally with modified settings from the original.
- Adds the API-exposed ability to delete a previously created copied effect.
- Updates documentation and Postman collection file accordingly.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).