### PR TITLE
Isolate current effect save

### DIFF
--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -64,6 +64,7 @@ class DeviceConfig : public IJSONSerializable
     bool use24HourClock;
     bool useCelsius;
     String ntpServer;
+    bool rememberCurrentEffect;
 
     std::vector<SettingSpec> settingSpecs;
     size_t writerIndex;
@@ -104,6 +105,7 @@ class DeviceConfig : public IJSONSerializable
     static constexpr const char * Use24HourClockTag = NAME_OF(use24HourClock);
     static constexpr const char * UseCelsiusTag = NAME_OF(useCelsius);
     static constexpr const char * NTPServerTag = NAME_OF(ntpServer);
+    static constexpr const char * RememberCurrentEffectTag = NAME_OF(rememberCurrentEffect);
 
     DeviceConfig();
 
@@ -124,6 +126,7 @@ class DeviceConfig : public IJSONSerializable
         jsonDoc[Use24HourClockTag] = use24HourClock;
         jsonDoc[UseCelsiusTag] = useCelsius;
         jsonDoc[NTPServerTag] = ntpServer;
+        jsonDoc[RememberCurrentEffectTag] = rememberCurrentEffect;
 
         if (includeSensitive)
             jsonDoc[OpenWeatherApiKeyTag] = openWeatherApiKey;
@@ -146,6 +149,7 @@ class DeviceConfig : public IJSONSerializable
         SetIfPresentIn(jsonObject, use24HourClock, Use24HourClockTag);
         SetIfPresentIn(jsonObject, useCelsius, UseCelsiusTag);
         SetIfPresentIn(jsonObject, ntpServer, NTPServerTag);
+        SetIfPresentIn(jsonObject, rememberCurrentEffect, RememberCurrentEffectTag);
 
         if (ntpServer.isEmpty())
             ntpServer = DEFAULT_NTP_SERVER;
@@ -247,6 +251,17 @@ class DeviceConfig : public IJSONSerializable
     {
         SetAndSave(ntpServer, newNTPServer);
     }
+
+    bool RememberCurrentEffect() const
+    {
+        return rememberCurrentEffect;
+    }
+
+    void SetRememberCurrentEffect(bool newRememberCurrentEffect)
+    {
+        SetAndSave(rememberCurrentEffect, newRememberCurrentEffect);
+    }
+
 
 };
 

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -57,14 +57,14 @@ class DeviceConfig : public IJSONSerializable
 {
     // Add variables for additional settings to this list
     String location;
-    bool locationIsZip;
+    bool locationIsZip = false;
     String countryCode;
     String timeZone;
     String openWeatherApiKey;
-    bool use24HourClock;
-    bool useCelsius;
+    bool use24HourClock = false;
+    bool useCelsius = false;
     String ntpServer;
-    bool rememberCurrentEffect;
+    bool rememberCurrentEffect = false;
 
     std::vector<SettingSpec> settingSpecs;
     size_t writerIndex;

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -47,7 +47,7 @@
 #include "effects/strip/fireeffect.h"
 
 #define JSON_FORMAT_VERSION         1
-#define CURRENT_EFFECT_CONFIG_FILE  "current.cfg"
+#define CURRENT_EFFECT_CONFIG_FILE  "/current.cfg"
 
 extern uint8_t g_Brightness;
 extern uint8_t g_Fader;

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -46,7 +46,8 @@
 #include "effects/strip/misceffects.h"
 #include "effects/strip/fireeffect.h"
 
-#define JSON_FORMAT_VERSION 1
+#define JSON_FORMAT_VERSION         1
+#define CURRENT_EFFECT_CONFIG_FILE  "current.cfg"
 
 extern uint8_t g_Brightness;
 extern uint8_t g_Fader;
@@ -57,6 +58,9 @@ void InitSplashEffectManager();
 void InitEffectsManager();
 void SaveEffectManagerConfig();
 void RemoveEffectManagerConfig();
+void SaveCurrentEffectIndex();
+bool ReadCurrentEffectIndex(size_t& index);
+
 std::shared_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color);
 std::shared_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color, CRGB color2);
 extern DRAM_ATTR std::shared_ptr<GFXBase> g_aptrDevices[NUM_CHANNELS];
@@ -276,13 +280,13 @@ public:
         // "ivl" contains the effect interval in ms
         SetInterval(jsonObject.containsKey("ivl") ? jsonObject["ivl"] : DEFAULT_EFFECT_INTERVAL, true);
 
-        // "cei" contains the current effect index
-        if (jsonObject.containsKey("cei"))
-        {
+        // Try to read the effectindex from its own file. If that fails, "cei" may contain the current effect index instead
+        if (!ReadCurrentEffectIndex(_iCurrentEffect) && jsonObject.containsKey("cei"))
             _iCurrentEffect = jsonObject["cei"];
-            if (_iCurrentEffect >= EffectCount())
-                _iCurrentEffect = EffectCount() - 1;
-        }
+
+        // Make sure that if we read an index, it's sane
+        if (_iCurrentEffect >= EffectCount())
+            _iCurrentEffect = EffectCount() - 1;
 
         construct(true);
 
@@ -315,7 +319,6 @@ public:
         jsonObject[PTY_VERSION] = JSON_FORMAT_VERSION;
 
         jsonObject["ivl"] = _effectInterval;
-        jsonObject["cei"] = _iCurrentEffect;
 
         JsonArray effectsArray = jsonObject.createNestedArray("efs");
 
@@ -500,11 +503,20 @@ public:
             std::rotate(_vEffects.rend() - from - 1, _vEffects.rend() - from, _vEffects.rend() - to);
 
         if (from == _iCurrentEffect)
+        {
             _iCurrentEffect = to;
+            SaveCurrentEffectIndex();
+        }
         else if (from < _iCurrentEffect && to >= _iCurrentEffect)
+        {
             _iCurrentEffect--;
+            SaveCurrentEffectIndex();
+        }
         else if (from > _iCurrentEffect && to <= _iCurrentEffect)
+        {
             _iCurrentEffect++;
+            SaveCurrentEffectIndex();
+        }
 
         SaveEffectManagerConfig();
     }
@@ -579,7 +591,10 @@ public:
         _vEffects.erase(_vEffects.begin() + index);
 
         if (index <= _iCurrentEffect)
+        {
             _iCurrentEffect--;
+            SaveCurrentEffectIndex();
+        }
 
         SaveEffectManagerConfig();
 
@@ -638,7 +653,7 @@ public:
 
     // Change the current effect; marks the state as needing attention so this get noticed next frame
 
-    void SetCurrentEffectIndex(size_t i, bool skipSave = false)
+    void SetCurrentEffectIndex(size_t i)
     {
         if (i >= _vEffects.size())
         {
@@ -650,8 +665,7 @@ public:
 
         StartEffect();
 
-        if (!skipSave)
-            SaveEffectManagerConfig();
+        SaveCurrentEffectIndex();
     }
 
     uint GetTimeUsedByCurrentEffect() const
@@ -720,8 +734,7 @@ public:
         } while (enabled && false == _bPlayAll && false == IsEffectEnabled(_iCurrentEffect));
 
         StartEffect();
-        if (!skipSave)
-            SaveEffectManagerConfig();
+        SaveCurrentEffectIndex();
     }
 
     // Go back to the previous effect and abort the current one.
@@ -740,7 +753,7 @@ public:
         } while (enabled && false == _bPlayAll && false == IsEffectEnabled(_iCurrentEffect));
 
         StartEffect();
-        SaveEffectManagerConfig();
+        SaveCurrentEffectIndex();
     }
 
     bool Init()

--- a/include/jsonserializer.h
+++ b/include/jsonserializer.h
@@ -167,7 +167,7 @@ class JSONWriter
     // Flag a writer for invocation and wake up the task that calls them
     void FlagWriter(size_t index);
 
-    // Flush outstanding writes now
+    // Flush pending writes now
     void FlushWrites(bool halt = false);
 };
 

--- a/include/jsonserializer.h
+++ b/include/jsonserializer.h
@@ -155,7 +155,9 @@ class JSONWriter
     };
 
     std::vector<WriterEntry> writers;
-    std::atomic_ulong latestFlagMs;
+    std::atomic_ulong        latestFlagMs;
+    std::atomic_bool         flushRequested;
+    std::atomic_bool         haltWrites;
 
   public:
 
@@ -164,6 +166,9 @@ class JSONWriter
 
     // Flag a writer for invocation and wake up the task that calls them
     void FlagWriter(size_t index);
+
+    // Flush outstanding writes now
+    void FlushWrites(bool halt = false);
 };
 
 extern DRAM_ATTR std::unique_ptr<JSONWriter> g_ptrJSONWriter;

--- a/include/socketserver.h
+++ b/include/socketserver.h
@@ -51,7 +51,7 @@ extern "C"
 // We allocate whatever the max packet is, and use it to validate incoming packets, so right now it's set to the maxiumum
 // LED data packet you could have (header plus 3 RGBs per NUM_LED)
 
-#define MAXIUMUM_PACKET_SIZE (STANDARD_DATA_HEADER_SIZE + LED_DATA_SIZE * NUM_LEDS) // Header plus 24 bits per actual LED
+#define MAXIMUM_PACKET_SIZE (STANDARD_DATA_HEADER_SIZE + LED_DATA_SIZE * NUM_LEDS) // Header plus 24 bits per actual LED
 #define COMPRESSED_HEADER (0x44415645)                                              // asci "DAVE" as header
 
 bool ProcessIncomingData(std::unique_ptr<uint8_t []> & payloadData, size_t payloadLength);
@@ -117,7 +117,7 @@ public:
         _server_fd(0),
         _cbReceived(0)
     {
-        _abOutputBuffer.reset( psram_allocator<uint8_t>().allocate(MAXIUMUM_PACKET_SIZE) );
+        _abOutputBuffer.reset( psram_allocator<uint8_t>().allocate(MAXIMUM_PACKET_SIZE) );
         memset(&_address, 0, sizeof(_address));
     }
 
@@ -135,7 +135,7 @@ public:
 
     bool begin()
     {
-        _pBuffer.reset( psram_allocator<uint8_t>().allocate(MAXIUMUM_PACKET_SIZE) );
+        _pBuffer.reset( psram_allocator<uint8_t>().allocate(MAXIMUM_PACKET_SIZE) );
 
         _cbReceived = 0;
 
@@ -188,7 +188,7 @@ public:
         // This test caps maximum packet size as a full buffer read of LED data.  If other packets wind up being longer,
         // the buffer itself and this test might need to change
 
-        if (cbNeeded > MAXIUMUM_PACKET_SIZE)
+        if (cbNeeded > MAXIMUM_PACKET_SIZE)
         {
             debugW("Unexpected request for %d bytes in ReadUntilNBytesReceived\n", cbNeeded);
             return false;
@@ -299,9 +299,9 @@ public:
                 uint32_t reserved       = _pBuffer[15] << 24 | _pBuffer[14] << 16 | _pBuffer[13] << 8 | _pBuffer[12];
                 debugV("Compressed Header: compressedSize: %u, expandedSize: %u, reserved: %u", compressedSize, expandedSize, reserved);
 
-                if (expandedSize > MAXIUMUM_PACKET_SIZE)
+                if (expandedSize > MAXIMUM_PACKET_SIZE)
                 {
-                    debugE("Expanded packet would be %d but buffer is only %d !!!!\n", expandedSize, MAXIUMUM_PACKET_SIZE);
+                    debugE("Expanded packet would be %d but buffer is only %d !!!!\n", expandedSize, MAXIMUM_PACKET_SIZE);
                     break;
                 }
 
@@ -317,8 +317,8 @@ public:
                 // one big read one time would work best, and we use that to copy it to a regular RAM buffer.
 
                 #if USE_PSRAM
-                    std::unique_ptr<uint8_t []> _abTempBuffer = std::make_unique<uint8_t []>(MAXIUMUM_PACKET_SIZE);
-                    memcpy(_abTempBuffer.get(), _pBuffer.get(), MAXIUMUM_PACKET_SIZE);
+                    std::unique_ptr<uint8_t []> _abTempBuffer = std::make_unique<uint8_t []>(MAXIMUM_PACKET_SIZE);
+                    memcpy(_abTempBuffer.get(), _pBuffer.get(), MAXIMUM_PACKET_SIZE);
                     auto pSourceBuffer = &_abTempBuffer[COMPRESSED_HEADER_SIZE];
                 #else
                     auto pSourceBuffer = &_pBuffer[COMPRESSED_HEADER_SIZE];
@@ -396,9 +396,9 @@ public:
                     debugW("Uncompressed Header: channel16=%u, length=%u, seconds=%llu, micro=%llu", channel16, length32, seconds, micros);
 
                     size_t totalExpected = STANDARD_DATA_HEADER_SIZE + length32 * LED_DATA_SIZE;
-                    if (totalExpected > MAXIUMUM_PACKET_SIZE)
+                    if (totalExpected > MAXIMUM_PACKET_SIZE)
                     {
-                        debugW("Too many bytes promised (%u) - more than we can use for our LEDs at max packet (%u)\n", totalExpected, MAXIUMUM_PACKET_SIZE);
+                        debugW("Too many bytes promised (%u) - more than we can use for our LEDs at max packet (%u)\n", totalExpected, MAXIMUM_PACKET_SIZE);
                         break;
                     }
 

--- a/include/types.h
+++ b/include/types.h
@@ -65,6 +65,7 @@ struct SettingSpec
     String FriendlyName;
     String Description;
     SettingType Type;
+    bool HasValidation = false;
 
     SettingSpec(const String& name, const String& friendlyName, const String& description, SettingType type)
       : Name(name),

--- a/src/deviceconfig.cpp
+++ b/src/deviceconfig.cpp
@@ -96,6 +96,13 @@ DeviceConfig::DeviceConfig()
         "The hostname or IP address of the NTP server to be used for time synchronization.",
         SettingSpec::SettingType::String
     );
+    settingSpecs.emplace_back(
+        NAME_OF(rememberCurrentEffect),
+        "Remember current effect",
+        "A boolean that indicates if the current effect index should be saved after an effect transition, so the device resumes "
+        "from the same effect when restarted. Enabling this will lead to more wear on the flash chip of your device.",
+        SettingSpec::SettingType::String
+    );
 
     writerIndex = g_ptrJSONWriter->RegisterWriter(
         [this]() { SaveToJSONFile(DEVICE_CONFIG_FILE, g_DeviceConfigJSONBufferSize, *this); }
@@ -121,6 +128,7 @@ DeviceConfig::DeviceConfig()
         use24HourClock = false;
         useCelsius = false;
         ntpServer = DEFAULT_NTP_SERVER;
+        rememberCurrentEffect = false;
 
         SetTimeZone(cszTimeZone, true);
 

--- a/src/deviceconfig.cpp
+++ b/src/deviceconfig.cpp
@@ -68,9 +68,9 @@ DeviceConfig::DeviceConfig()
     settingSpecs.emplace_back(
         NAME_OF(openWeatherApiKey),
         "Open Weather API key",
-        "The API key for the <a href=\"https://openweathermap.org/api\">Weather API provided by Open Weather Map</a>.",
+        "The API key for the <a href=\"https://openweathermap.org/api\">Weather API provided by Open Weather Map</a> (write only).",
         SettingSpec::SettingType::String
-    );
+    ).HasValidation = true;
     settingSpecs.emplace_back(
         NAME_OF(timeZone),
         "Time zone",

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -639,8 +639,9 @@ void RemoveEffectManagerConfig()
 
 void SaveCurrentEffectIndex()
 {
-    // Default value for writer index is max value for size_t, so nothing will happen if writer has not yet been registered
-    g_ptrJSONWriter->FlagWriter(g_CurrentEffectWriterIndex);
+    if (g_ptrDeviceConfig->RememberCurrentEffect())
+        // Default value for writer index is max value for size_t, so nothing will happen if writer has not yet been registered
+        g_ptrJSONWriter->FlagWriter(g_CurrentEffectWriterIndex);
 }
 
 void WriteCurrentEffectIndexFile()

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -567,6 +567,7 @@ void LoadEffectFactories()
 extern DRAM_ATTR std::unique_ptr<EffectManager<GFXBase>> g_ptrEffectManager;
 DRAM_ATTR size_t g_EffectsManagerJSONBufferSize = 0;
 DRAM_ATTR size_t g_EffectsManagerJSONWriterIndex = std::numeric_limits<size_t>::max();
+DRAM_ATTR size_t g_CurrentEffectWriterIndex = std::numeric_limits<size_t>::max();
 
 #if USE_MATRIX
 
@@ -578,6 +579,10 @@ DRAM_ATTR size_t g_EffectsManagerJSONWriterIndex = std::numeric_limits<size_t>::
     }
 
 #endif
+
+// Declare it here just so InitEffectsManager can refer to it. We define it a little further down
+
+void WriteCurrentEffectIndexFile();
 
 // InitEffectsManager
 //
@@ -592,6 +597,7 @@ void InitEffectsManager()
     g_EffectsManagerJSONWriterIndex = g_ptrJSONWriter->RegisterWriter(
         []() { SaveToJSONFile(EFFECTS_CONFIG_FILE, g_EffectsManagerJSONBufferSize, *g_ptrEffectManager); }
     );
+    g_CurrentEffectWriterIndex = g_ptrJSONWriter->RegisterWriter(WriteCurrentEffectIndexFile);
 
     std::unique_ptr<AllocatedJsonDocument> pJsonDoc;
 
@@ -627,6 +633,65 @@ void SaveEffectManagerConfig()
 void RemoveEffectManagerConfig()
 {
     RemoveJSONFile(EFFECTS_CONFIG_FILE);
+    // We take the liberty of also removing the file with the current effect config index
+    SPIFFS.remove(CURRENT_EFFECT_CONFIG_FILE);
+}
+
+void SaveCurrentEffectIndex()
+{
+    // Default value for writer index is max value for size_t, so nothing will happen if writer has not yet been registered
+    g_ptrJSONWriter->FlagWriter(g_CurrentEffectWriterIndex);
+}
+
+void WriteCurrentEffectIndexFile()
+{
+    SPIFFS.remove(CURRENT_EFFECT_CONFIG_FILE);
+
+    File file = SPIFFS.open(CURRENT_EFFECT_CONFIG_FILE, FILE_WRITE);
+
+    if (!file)
+    {
+        debugE("Unable to open file %s for writing!", CURRENT_EFFECT_CONFIG_FILE);
+        return;
+    }
+
+    auto bytesWritten = file.print(g_ptrEffectManager->GetCurrentEffectIndex());
+    debugI("Number of bytes written to file %s: %zu", CURRENT_EFFECT_CONFIG_FILE, bytesWritten);
+
+    file.flush();
+    file.close();
+
+    if (bytesWritten == 0)
+    {
+        debugE("Unable to write JSON to file %s!", CURRENT_EFFECT_CONFIG_FILE);
+        SPIFFS.remove(CURRENT_EFFECT_CONFIG_FILE);
+    }
+}
+
+bool ReadCurrentEffectIndex(size_t& index)
+{
+    File file = SPIFFS.open(CURRENT_EFFECT_CONFIG_FILE);
+    bool readIndex = false;
+
+    if (file)
+    {
+        if (file.size() > 0)
+        {
+            debugI("Attempting to read file %s", CURRENT_EFFECT_CONFIG_FILE);
+
+            auto valueString = file.readString();
+
+            if (!valueString.isEmpty())
+            {
+                index = strtoul(valueString.c_str(), NULL, 10);
+                readIndex = true;
+            }
+        }
+
+        file.close();
+    }
+
+    return readIndex;
 }
 
 // Dirty hack to support FastLED, which calls out of band to get the pixel index for "the" array, without

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -663,7 +663,7 @@ void WriteCurrentEffectIndexFile()
 
     if (bytesWritten == 0)
     {
-        debugE("Unable to write JSON to file %s!", CURRENT_EFFECT_CONFIG_FILE);
+        debugE("Unable to write to file %s!", CURRENT_EFFECT_CONFIG_FILE);
         SPIFFS.remove(CURRENT_EFFECT_CONFIG_FILE);
     }
 }

--- a/src/jsonserializer.cpp
+++ b/src/jsonserializer.cpp
@@ -201,7 +201,7 @@ void IRAM_ATTR JSONWriterTaskEntry(void *)
             if (!g_ptrJSONWriter)
                 continue;
 
-            // If a flush was requested then we execute outstanding writes now
+            // If a flush was requested then we execute pending writes now
             if (g_ptrJSONWriter->flushRequested)
             {
                 g_ptrJSONWriter->flushRequested = false;

--- a/src/jsonserializer.cpp
+++ b/src/jsonserializer.cpp
@@ -176,6 +176,14 @@ void JSONWriter::FlagWriter(size_t index)
     g_TaskManager.NotifyJSONWriterThread();
 }
 
+void JSONWriter::FlushWrites(bool halt)
+{
+    flushRequested = true;
+    haltWrites = halt;
+
+    g_TaskManager.NotifyJSONWriterThread();
+}
+
 // JSONWriterTaskEntry
 //
 // Invoke functions that write serialized JSON objects to SPIFFS at request, with some delay
@@ -191,6 +199,17 @@ void IRAM_ATTR JSONWriterTaskEntry(void *)
             ulTaskNotifyTake(pdTRUE, notifyWait);
 
             if (!g_ptrJSONWriter)
+                continue;
+
+            // If a flush was requested then we execute outstanding writes now
+            if (g_ptrJSONWriter->flushRequested)
+            {
+                g_ptrJSONWriter->flushRequested = false;
+                break;
+            }
+
+            // If writes are halted, we don't do anything
+            if (g_ptrJSONWriter->haltWrites)
                 continue;
 
             unsigned long holdUntil = g_ptrJSONWriter->latestFlagMs + JSON_WRITER_DELAY;

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -285,9 +285,12 @@ void CWebServer::SendSettingSpecsResponse(AsyncWebServerRequest * pRequest, cons
 
             jsonDoc["name"] = spec.Name;
             jsonDoc["friendlyName"] = spec.FriendlyName;
-            jsonDoc["description"] = spec.Description;
+            if (!spec.Description.isEmpty())
+                jsonDoc["description"] = spec.Description;
             jsonDoc["type"] = to_value(spec.Type);
             jsonDoc["typeName"] = spec.ToName(spec.Type);
+            if (spec.HasValidation)
+                jsonDoc["hasValidation"] = true;
 
             if (!specObject.set(jsonDoc.as<JsonObjectConst>()))
             {

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -356,6 +356,7 @@ void CWebServer::SetSettingsIfPresent(AsyncWebServerRequest * pRequest)
     PushPostParamIfPresent<bool>(pRequest, DeviceConfig::Use24HourClockTag, SET_VALUE(g_ptrDeviceConfig->Set24HourClock(value)));
     PushPostParamIfPresent<bool>(pRequest, DeviceConfig::UseCelsiusTag, SET_VALUE(g_ptrDeviceConfig->SetUseCelsius(value)));
     PushPostParamIfPresent<String>(pRequest, DeviceConfig::NTPServerTag, SET_VALUE(g_ptrDeviceConfig->SetNTPServer(value)));
+    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::RememberCurrentEffectTag, SET_VALUE(g_ptrDeviceConfig->SetRememberCurrentEffect(value)));
 }
 
 // Set settings and return resulting config

--- a/tools/NightDriverStrip.postman_collection.json
+++ b/tools/NightDriverStrip.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "1e0cc474-dcbe-4b92-9b28-4b8a48aa8ef8",
+		"_postman_id": "150af912-7eee-48cb-99b2-f11b454c2901",
 		"name": "NightDriverStrip endpoints",
 		"description": "Call configurations to use/test some of the endpoints in the NightDriverStrip on-device API - basically those not yet covered by the web UI. These have been confirmed to work with the Mesmerizer board/project and the Spectrum project on the M5StickC Plus.\n\nNotes:\n\n- Before using the call configurations in this collection, make sure to update the value of the \"device_ip\" variable in the Variables tab of this collection. Make sure to Save the collection after doing this, because otherwise your change will not be applied.\n- The parameters for POST call configurations are listed in the Body tab of the respective configurations. As with the collection's \"device_ip\" variable, Save a configuration if you want to persist changes to its parameters.\n- By default, all parameters for all configurations are unchecked, which means nothing will be sent unless at least one parameter is checked.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -140,6 +140,12 @@
 						{
 							"key": "ntpServer",
 							"value": "0.pool.ntp.org",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "rememberCurrentEffect",
+							"value": "true",
 							"type": "text",
 							"disabled": true
 						}


### PR DESCRIPTION
## Description

This:

- Isolates the saving/storage of the current effect index from the rest of the effects config
- Makes enabling/disabling the saving (remembering) of the current effect (index) a device setting

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).