### PR TITLE
Correct the Setting Spec Type of rememberCurrentEffect

### DIFF
--- a/src/deviceconfig.cpp
+++ b/src/deviceconfig.cpp
@@ -101,7 +101,7 @@ DeviceConfig::DeviceConfig()
         "Remember current effect",
         "A boolean that indicates if the current effect index should be saved after an effect transition, so the device resumes "
         "from the same effect when restarted. Enabling this will lead to more wear on the flash chip of your device.",
-        SettingSpec::SettingType::String
+        SettingSpec::SettingType::Boolean
     );
 
     writerIndex = g_ptrJSONWriter->RegisterWriter(


### PR DESCRIPTION
Was String, I think it should be Boolean to match the other flags.

## Description
Noticed that the rememberCurrentEffect Setting Spec Type was not boolean as are the other flag settings.

## Contributing requirements
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).