### PR TITLE
Remove upload_port from platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = 
+default_envs =
 
 ; ==================
 ; Base configuration
@@ -146,7 +146,6 @@ extends         = base
 board           = esp-wrover-kit
 monitor_speed   = 115200
 upload_speed    = 1500000
-upload_port     = /dev/cu.usbserial-8411101
 
 [dev_tinypico]
 extends         = base


### PR DESCRIPTION
## Description

One hard-coded `upload_port` escaped my review on earlier in-fork merges.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).