### PR TITLE
Use c_str() where appropriate when printing hostnames at startup.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -268,7 +268,7 @@ void PrintOutputHeader()
         debugI("ESP32 PSRAM Init: %s", psramInit() ? "OK" : "FAIL");
     #endif
 
-    debugI("Version %u: Wifi SSID: '"%s\" - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u",
+    debugI("Version %u: Wifi SSID: \"%s\" - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u",
             FLASH_VERSION, cszSSID, ESP.getFreeHeap(), ESP.getPsramSize(), ESP.getFreePsram());
     debugI("ESP32 Clock Freq : %d MHz", ESP.getCpuFreqMHz());
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -268,7 +268,7 @@ void PrintOutputHeader()
         debugI("ESP32 PSRAM Init: %s", psramInit() ? "OK" : "FAIL");
     #endif
 
-    debugI("Version %u: Wifi SSID: %s - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u",
+    debugI("Version %u: Wifi SSID: '"%s\" - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u",
             FLASH_VERSION, cszSSID, ESP.getFreeHeap(), ESP.getPsramSize(), ESP.getFreePsram());
     debugI("ESP32 Clock Freq : %d MHz", ESP.getCpuFreqMHz());
 }
@@ -440,19 +440,19 @@ void setup()
         // Height and width get reversed here because the display is actually portrait, not landscape.  Once
         // we set the rotation, it works as expected in landscape.
         Serial.println("Creating TFT Screen");
-        g_pDisplay = std::make_unique<TFTScreen>(TFT_HEIGHT, TFT_WIDTH);      
+        g_pDisplay = std::make_unique<TFTScreen>(TFT_HEIGHT, TFT_WIDTH);
 
     #elif USE_LCD
 
         Serial.println("Creating LCD Screen");
-        g_pDisplay = std::make_unique<LCDScreen>(TFT_HEIGHT, TFT_WIDTH);      
+        g_pDisplay = std::make_unique<LCDScreen>(TFT_HEIGHT, TFT_WIDTH);
 
     #elif M5STICKC || M5STICKCPLUS || M5STACKCORE2
-        
+
         #if USE_M5DISPLAY
             M5.begin();
             Serial.println("Creating M5 Screen");
-            g_pDisplay = std::make_unique<M5Screen>(TFT_HEIGHT, TFT_WIDTH);      
+            g_pDisplay = std::make_unique<M5Screen>(TFT_HEIGHT, TFT_WIDTH);
         #else
             M5.begin(false);
         #endif
@@ -461,10 +461,10 @@ void setup()
 
         #if USE_SSD1306
             Serial.println("Creating SSD1306 Screen");
-            g_pDisplay = std::make_unique<SSD1306Screen>(128, 64);                    
+            g_pDisplay = std::make_unique<SSD1306Screen>(128, 64);
         #else
         Serial.println("Creating OLED Screen");
-            g_pDisplay = std::make_unique<OLEDScreen>(128, 64);                        
+            g_pDisplay = std::make_unique<OLEDScreen>(128, 64);
         #endif
 
     #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -372,7 +372,7 @@ void PrintOutputHeader()
         debugI("ESP32 PSRAM Init: %s", psramInit() ? "OK" : "FAIL");
     #endif
 
-    debugI("Version %u: Wifi SSID: %s - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u",
+    debugI("Version %u: Wifi SSID: \"%s\" - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u",
             FLASH_VERSION, cszSSID, ESP.getFreeHeap(), ESP.getPsramSize(), ESP.getFreePsram());
     debugI("ESP32 Clock Freq : %d MHz", ESP.getCpuFreqMHz());
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -430,7 +430,7 @@ void setup()
     Debug.setSerialEnabled(true);
 
     // Enabling PSRAM allows us to use the extra 4MB of RAM on the ESP32-WROVER chip, but it caused
-    // problems with the S3 rebooting when WiFi connected, so for now, I've limited the default 
+    // problems with the S3 rebooting when WiFi connected, so for now, I've limited the default
     // allocator to be PSRAM only on the MESMERIZER project where it's well tested.
 
     #if MESMERIZER
@@ -773,7 +773,7 @@ void setup()
     debugV("Initializing compression...");
     CheckHeap();
 
-    #if ENABLE_WIFI 
+    #if ENABLE_WIFI
         g_TaskManager.StartNetworkThread();
         CheckHeap();
     #endif

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -96,7 +96,7 @@ extern uint32_t g_FPS;
             g_ptrDeviceConfig->RemovePersisted();
             RemoveEffectManagerConfig();
         }
-        else 
+        else
         {
             debugA("Unknown Command.  Extended Commands:");
             debugA("clock               Refresh time from server");
@@ -236,8 +236,8 @@ void IRAM_ATTR RemoteLoopEntry(void *)
 
         for (uint iPass = 0; iPass < cRetries; iPass++)
         {
-            debugW("Pass %u of %u: Connecting to Wifi SSID: %s - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u\n",
-                    iPass + 1, cRetries, WiFi_ssid, ESP.getFreeHeap(), ESP.getPsramSize(), ESP.getFreePsram());
+            debugW("Pass %u of %u: Connecting to Wifi SSID: \"%s\" - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u\n",
+                    iPass + 1, cRetries, WiFi_ssid.c_str(), ESP.getFreeHeap(), ESP.getPsramSize(), ESP.getFreePsram());
 
             WiFi.begin(WiFi_ssid.c_str(), WiFi_password.c_str());
 
@@ -506,7 +506,7 @@ bool WriteWiFiConfig()
 
     if (success)
         // Do not check in code that displays the password in logs, etc.
-        debugW("Stored SSID and Password to NVS: %s, *******", WiFi_ssid);
+        debugW("Stored SSID and Password to NVS: %s, *******", WiFi_ssid.c_str());
 
     nvs_commit(nvsRWHandle);
     nvs_close(nvsRWHandle);
@@ -550,7 +550,7 @@ bool WriteWiFiConfig()
     }
 #endif
 
-#if INCOMING_WIFI_ENABLED 
+#if INCOMING_WIFI_ENABLED
 
     // SocketServerTaskEntry
     //

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -308,7 +308,7 @@ void IRAM_ATTR RemoteLoopEntry(void *)
 // as this code does not validate!  This is where the commands and pixel data are received
 // from the server.
 
-bool ProcessIncomingData(std::unique_ptr<uint8_t []> & payloadData, size_t payloadLength)
+bool ProcessIncomingData(std::unique_ptr<uint8_t []> & payloadData, size_t payloadLength);
 {
     #if !INCOMING_WIFI_ENABLED
         return false;

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -220,8 +220,8 @@ void IRAM_ATTR RemoteLoopEntry(void *)
 
         for (uint iPass = 0; iPass < cRetries; iPass++)
         {
-            debugW("Pass %u of %u: Connecting to Wifi SSID: %s - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u\n",
-                    iPass + 1, cRetries, WiFi_ssid, ESP.getFreeHeap(), ESP.getPsramSize(), ESP.getFreePsram());
+            debugW("Pass %u of %u: Connecting to Wifi SSID: \"%s\" - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u\n",
+                    iPass + 1, cRetries, WiFi_ssid.c_str(), ESP.getFreeHeap(), ESP.getPsramSize(), ESP.getFreePsram());
 
             WiFi.begin(WiFi_ssid.c_str(), WiFi_password.c_str());
 
@@ -490,7 +490,7 @@ bool WriteWiFiConfig()
 
     if (success)
         // Do not check in code that displays the password in logs, etc.
-        debugW("Stored SSID and Password to NVS: %s, *******", WiFi_ssid);
+        debugW("Stored SSID and Password to NVS: %s, *******", WiFi_ssid.c_str());
 
     nvs_commit(nvsRWHandle);
     nvs_close(nvsRWHandle);
@@ -504,7 +504,7 @@ bool WriteWiFiConfig()
 
 void IRAM_ATTR ColorDataTaskEntry(void *)
 {
-    LEDViewer _viewer(12000);    
+    LEDViewer _viewer(12000);
     int socket = -1;
 
     for(;;)
@@ -512,7 +512,7 @@ void IRAM_ATTR ColorDataTaskEntry(void *)
         while (!WiFi.isConnected())
             delay(250);
 
-        if (!_viewer.begin()) 
+        if (!_viewer.begin())
         {
             debugE("Unable to start color data server!");
             delay(1000);

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -308,7 +308,7 @@ void IRAM_ATTR RemoteLoopEntry(void *)
 // as this code does not validate!  This is where the commands and pixel data are received
 // from the server.
 
-bool ProcessIncomingData(std::unique_ptr<uint8_t []> & payloadData, size_t payloadLength);
+bool ProcessIncomingData(std::unique_ptr<uint8_t []> & payloadData, size_t payloadLength)
 {
     #if !INCOMING_WIFI_ENABLED
         return false;


### PR DESCRIPTION
## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->
When printing hostnames, use c_str when printing Strings as C strings.

Bonus tweak: quote hostnames that might be empty or control
characgters (ugh)  for confirmation that they're not empty.

Before:
(I) (ConnectToWiFi)(C0) Setting host name to NightDriverStrip...WL_NO_SHIELD
(W) (ConnectToWiFi)(C0) Pass 1 of 5: Connecting to Wifi SSID: ���? - ESP32 Free Memory: 110316, PSRAM:4175835, PSRAM Free: 1022535
After:
(I) (ConnectToWiFi)(C0) Setting host name to NightDriverStrip...WL_NO_SHIELD
(W) (ConnectToWiFi)(C0) Pass 1 of 5: Connecting to Wifi SSID: "ElderOfTheInternet" - ESP32 Free Memory: 110008, PSRAM:4175803, PSRAM Free: 1013543



A reviewer may grant a Blinken Bit violation in the Holy Whitespace Wars as
my editor removes trailing whitespace in source lines automatically because
that's the way God herself intends line endings to be. Whether you're
Team Tabs or Team Spaces, surely we can all agree that whitespace at the
END of a line is always a mistake.

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
