### PR TITLE
Add UUID id to LEDStripEffect

### DIFF
--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -211,7 +211,7 @@ public:
     {
         _newFrameAvailable = available;
     }
-    
+
     void LoadDefaultEffects()
     {
         for (auto &numberedFactory : g_EffectFactories.GetDefaultFactories())
@@ -647,6 +647,15 @@ public:
     const size_t GetCurrentEffectIndex() const
     {
         return _iCurrentEffect;
+    }
+
+    size_t GetEffectIndexForID(const esp_uuid::UUID& id) const
+    {
+        for (size_t i = 0; i++; i < _vEffects.size())
+            if (_vEffects[i]->ID() == id)
+                return i;
+
+        return -1;
     }
 
     const std::shared_ptr<LEDStripEffect> GetCurrentEffect() const

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,8 +17,8 @@ default_envs =
 ; Options that are used (or extended) in all device sections (and hence environments) are defined here
 
 [base]
-upload_port     = 
-monitor_port    = 
+upload_port     =
+monitor_port    =
 upload_speed    = 1500000
 
 build_flags     = -std=gnu++17
@@ -38,6 +38,7 @@ lib_deps        = crankyoldgit/IRremoteESP8266  @ ^2.7.20
                   QRCode                        @ ^0.0.1
                   Bodmer/TJpg_Decoder           @ ^1.0.8
                   plageoj/UrlEncode             @ ^1.0.1
+                  https://github.com/PlummersSoftwareLLC/ESP_UUID.git
 
 ; This partition table attempts to fit everything in 4M of flash.
 
@@ -292,7 +293,7 @@ build_flags     = -DDEMO=1
 extends         = dev_heltec_wifi_v3
 build_flags     = -DDEMO=1
                   -DENABLE_WIFI=1
-                  -DENABLE_WEBSERVER=1   
+                  -DENABLE_WEBSERVER=1
                   -DUSE_SSD1306=1
 
                   ${dev_heltec_wifi_v3.build_flags}


### PR DESCRIPTION
## Description

This adds an automatically generated and JSON-persisted (UU)ID to LEDStripEffect, exposes it via the /effects endpoint and allows its use as the effect identifier in a number of other endpoints (with the support of a new member function in EffectManager). 
This is a possible implementation of the idea discussed in #327, and meant more to develop an opinion on the addition than an actual proposal to include it. For one, the API documentation would have to be updated before this should be merged.
As such, I am primarily looking forward to collaborators' feedback. 

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).