### PR TITLE
Fix S3 crash, make invalid pixel draws errors

### DIFF
--- a/include/effects/matrix/PatternBounce.h
+++ b/include/effects/matrix/PatternBounce.h
@@ -106,7 +106,8 @@ public:
             boid.applyForce(gravity);
             boid.update();
 
-            g()->setPixel(boid.location.x, boid.location.y, g()->ColorFromCurrentPalette(boid.colorIndex));
+            if (g()->isValidPixel(boid.location.x, boid.location.y))
+                g()->setPixel(boid.location.x, boid.location.y, g()->ColorFromCurrentPalette(boid.colorIndex));
 
             if (boid.location.y >= MATRIX_HEIGHT - 1)
             {

--- a/include/effects/matrix/PatternClock.h
+++ b/include/effects/matrix/PatternClock.h
@@ -36,7 +36,7 @@ class PatternClock : public LEDStripEffect
     // Radius is the lesser of the height and width so that the round clock can fit
     // on rectangular display
 
-    const int    radius = std::min(MATRIX_WIDTH, MATRIX_HEIGHT) / 2 - 1;
+    int    radius;
     const size_t SECONDS_PER_MINUTE = 60;
     const size_t SECONDS_PER_HOUR   = SECONDS_PER_MINUTE * 60;
     const size_t SECONDS_PER_DAY    = SECONDS_PER_HOUR * 24;
@@ -70,11 +70,15 @@ class PatternClock : public LEDStripEffect
 
         // Draw the clock face, outer ring and inner dot where the hands mount
 
+        radius = std::min(MATRIX_WIDTH, MATRIX_HEIGHT) / 2 - 1;
+
         g()->Clear();
-        g()->drawCircle(MATRIX_WIDTH/2, MATRIX_HEIGHT/2, radius, GREEN16);
-        g()->drawCircle(MATRIX_WIDTH/2, MATRIX_HEIGHT/2, 1, GREEN16);
+        g()->DrawSafeCircle(MATRIX_WIDTH/2, MATRIX_HEIGHT/2, radius+1, GREEN16);
+        g()->DrawSafeCircle(MATRIX_WIDTH/2, MATRIX_HEIGHT/2, 1, GREEN16);
 
         // Draw the hour ticks around the outside of the clock every 30 degrees
+
+        radius = radius - 1;
 
         for (int z = 0; z < 360; z = z + 30)
         {

--- a/include/effects/matrix/PatternFlowField.h
+++ b/include/effects/matrix/PatternFlowField.h
@@ -113,7 +113,8 @@ public:
             boid->velocity.y = -((float)cos8(angle) * 0.0078125 - 1.0);
             boid->update();
 
-            g()->drawPixel(boid->location.x, boid->location.y, g()->ColorFromCurrentPalette(angle + hue)); // color
+            if (g()->isValidPixel(boid->location.x, boid->location.y))
+                g()->drawPixel(boid->location.x, boid->location.y, g()->ColorFromCurrentPalette(angle + hue)); // color
 
             if (boid->location.x < 0 || boid->location.x >= MATRIX_WIDTH ||
                 boid->location.y < 0 || boid->location.y >= MATRIX_HEIGHT)

--- a/include/effects/matrix/PatternMisc.h
+++ b/include/effects/matrix/PatternMisc.h
@@ -91,7 +91,8 @@ class PatternSunburst : public LEDStripEffect
         uint8_t y = beatsin8((17 - i) * 2, MATRIX_CENTER_Y - i, MATRIX_CENTER_Y + i);
 
         if (color.r != 0 || color.g != 0 || color.b !=0 )
-          g()->setPixel(x, y, color);
+          if (g()->isValidPixel(x,y))
+            g()->setPixel(x, y, color);
       }
     }
 };
@@ -143,7 +144,8 @@ class PatternRose : public LEDStripEffect
           color = g()->ColorFromCurrentPalette((31 - i) * 14);
         }
 
-        g()->setPixel(x, y, color);
+        if (g()->isValidPixel(x, y))
+          g()->setPixel(x, y, color);
       }
     }
 };
@@ -186,7 +188,8 @@ class PatternPinwheel : public LEDStripEffect
         y = g()->beatcos8((64 - i) * 2, MATRIX_HEIGHT - i, i + 1);
         color = g()->ColorFromCurrentPalette((64 - i) * 14);
 
-        g()->setPixel(x, y, color);
+        if (g()->isValidPixel(x, y))
+          g()->setPixel(x, y, color);
       }
     }
 };

--- a/include/effects/matrix/PatternPongClock.h
+++ b/include/effects/matrix/PatternPongClock.h
@@ -460,7 +460,8 @@ class PatternPongClock : public LEDStripEffect
         uint8_t plot_x = (int)(ballpos_x + 0.5f);
         uint8_t plot_y = (int)(ballpos_y + 0.5f);
 
-        g->setPixel(plot_x, plot_y, WHITE16);
+        if (g->isValidPixel(plot_x, plot_y))
+            g->setPixel(plot_x, plot_y, WHITE16);
 
         // check if a bat missed the ball. if it did, reset the game.
         if (ballpos_x < 0 || ballpos_x > MATRIX_WIDTH)

--- a/include/effects/matrix/PatternPulse.h
+++ b/include/effects/matrix/PatternPulse.h
@@ -96,7 +96,7 @@ class PatternPulse : public LEDStripEffect
 
         if (step == 0)
         {
-            graphics->drawCircle(centerX, centerY, step, graphics->to16bit(graphics->ColorFromCurrentPalette(hue)));
+            graphics->DrawSafeCircle(centerX, centerY, step, graphics->to16bit(graphics->ColorFromCurrentPalette(hue)));
             step++;
         }
         else
@@ -104,12 +104,12 @@ class PatternPulse : public LEDStripEffect
             if (step < maxSteps)
             {
                 // initial pulse
-                graphics->drawCircle(centerX, centerY, step, graphics->to16bit(ColorFromPalette(RainbowColors_p, hue, pow(fadeRate, step - 2) * 255)));
+                graphics->DrawSafeCircle(centerX, centerY, step, graphics->to16bit(ColorFromPalette(RainbowColors_p, hue, pow(fadeRate, step - 2) * 255)));
 
                 // secondary pulse
                 if (step > 5)
                 {
-                    graphics->drawCircle(centerX, centerY, step - 3, graphics->to16bit(ColorFromPalette(RainbowColors_p, hue, pow(fadeRate, step - 2) * 255)));
+                    graphics->DrawSafeCircle(centerX, centerY, step - 3, graphics->to16bit(ColorFromPalette(RainbowColors_p, hue, pow(fadeRate, step - 2) * 255)));
                 }
                 step++;
             }
@@ -132,7 +132,7 @@ class PatternPulsar : public BeatEffectBase, public LEDStripEffect
         int hue;
         int centerX;
         int centerY;
-        int maxSteps = random(32)+16;
+        int maxSteps = random(8)+6;
         int step = -1;
     };
 
@@ -170,7 +170,7 @@ class PatternPulsar : public BeatEffectBase, public LEDStripEffect
         else
         {
             PulsePop small;
-            small.maxSteps = random(12)+4;
+            small.maxSteps = random(8)+4;
             _pops.push_back( small );
         }
 
@@ -179,8 +179,6 @@ class PatternPulsar : public BeatEffectBase, public LEDStripEffect
     virtual void Draw() override
     {
         ProcessAudio();
-        //VUMeterEffect::DrawVUMeter(graphics, 0);
-        //blur2d(graphics->leds, MATRIX_WIDTH, MATRIX_HEIGHT, 25);
         fadeAllChannelsToBlackBy(10);
 
         // Add some sparkle
@@ -203,7 +201,7 @@ class PatternPulsar : public BeatEffectBase, public LEDStripEffect
 
             if (pop->step == 0)
             {
-                g()->drawCircle(pop->centerX, pop->centerY, pop->step, g()->to16bit(g()->ColorFromCurrentPalette(pop->hue)));
+                g()->DrawSafeCircle(pop->centerX, pop->centerY, pop->step, g()->to16bit(g()->ColorFromCurrentPalette(pop->hue)));
                 pop->step++;
                 pop++;
             }
@@ -212,11 +210,11 @@ class PatternPulsar : public BeatEffectBase, public LEDStripEffect
                 if (pop->step < pop->maxSteps)
                 {
                     // initial pulse
-                    g()->drawCircle(pop->centerX, pop->centerY, pop->step, g()->to16bit(g()->ColorFromCurrentPalette(pop->hue, pow(fadeRate, pop->step - 1) * 255)));
+                    g()->DrawSafeCircle(pop->centerX, pop->centerY, pop->step, g()->to16bit(g()->ColorFromCurrentPalette(pop->hue, pow(fadeRate, pop->step - 1) * 255)));
 
                     // secondary pulse
                     if (pop->step > 3)
-                        g()->drawCircle(pop->centerX, pop->centerY, pop->step - 3, g()->to16bit(g()->ColorFromCurrentPalette(pop->hue, pow(fadeRate, pop->step - 2) * 255)));
+                        g()->DrawSafeCircle(pop->centerX, pop->centerY, pop->step - 3, g()->to16bit(g()->ColorFromCurrentPalette(pop->hue, pow(fadeRate, pop->step - 2) * 255)));
 
                     // This looks like PDP-11 code to me.  double post-inc for the win!
                     pop++->step++;

--- a/include/effects/matrix/PatternSwirl.h
+++ b/include/effects/matrix/PatternSwirl.h
@@ -96,8 +96,8 @@ public:
         graphics->BlurFrame(blurAmount);
 
         // Use two out-of-sync sine waves
-        uint8_t i = beatsin8(27, borderWidth, MATRIX_WIDTH - borderWidth);
-        uint8_t j = beatsin8(41, borderWidth, MATRIX_HEIGHT - borderWidth);
+        uint8_t i = beatsin8(27, borderWidth, MATRIX_WIDTH - 1 - borderWidth);
+        uint8_t j = beatsin8(41, borderWidth, MATRIX_HEIGHT - 1 - borderWidth);
         // Also calculate some reflections
         uint8_t ni = (MATRIX_WIDTH - 1) - i;
         uint8_t nj = (MATRIX_HEIGHT - 1) - j;

--- a/include/effects/matrix/PatternWave.h
+++ b/include/effects/matrix/PatternWave.h
@@ -106,36 +106,48 @@ public:
             case 0:
                 for (int x = 0; x < MATRIX_WIDTH; x++) {
                     n = quadwave8(x * 2 + theta) / scale;
-                    graphics->setPixel(x, n, graphics->ColorFromCurrentPalette(x + hue));
-                    if (waveCount == 2)
-                        graphics->setPixel(x, maxY - n, graphics->ColorFromCurrentPalette(x + hue));
+                    if (n < MATRIX_HEIGHT)
+                    {
+                        graphics->setPixel(x, n, graphics->ColorFromCurrentPalette(x + hue));
+                        if (waveCount == 2)
+                            graphics->setPixel(x, maxY - n, graphics->ColorFromCurrentPalette(x + hue));
+                    }
                 }
                 break;
 
             case 1:
                 for (int y = 0; y < MATRIX_HEIGHT; y++) {
                     n = quadwave8(y * 2 + theta) / scale;
-                    graphics->setPixel(n, y, graphics->ColorFromCurrentPalette(y + hue));
-                    if (waveCount == 2)
-                        graphics->setPixel(maxX - n, y, graphics->ColorFromCurrentPalette(y + hue));
+                    if (n < MATRIX_WIDTH)
+                    {                    
+                        graphics->setPixel(n, y, graphics->ColorFromCurrentPalette(y + hue));
+                        if (waveCount == 2)
+                            graphics->setPixel(maxX - n, y, graphics->ColorFromCurrentPalette(y + hue));
+                    }
                 }
                 break;
 
             case 2:
                 for (int x = 0; x < MATRIX_WIDTH; x++) {
                     n = quadwave8(x * 2 - theta) / scale;
-                    graphics->setPixel(x, n, graphics->ColorFromCurrentPalette(x + hue));
-                    if (waveCount == 2)
-                        graphics->setPixel(x, maxY - n, graphics->ColorFromCurrentPalette(x + hue));
+                    if (n < MATRIX_HEIGHT)
+                    {
+                        graphics->setPixel(x, n, graphics->ColorFromCurrentPalette(x + hue));
+                        if (waveCount == 2)
+                            graphics->setPixel(x, maxY - n, graphics->ColorFromCurrentPalette(x + hue));
+                    }
                 }
                 break;
 
             case 3:
                 for (int y = 0; y < MATRIX_HEIGHT; y++) {
                     n = quadwave8(y * 2 - theta) / scale;
-                    graphics->setPixel(n, y, graphics->ColorFromCurrentPalette(y + hue));
-                    if (waveCount == 2)
-                        graphics->setPixel(maxX - n, y, graphics->ColorFromCurrentPalette(y + hue));
+                    if (n < MATRIX_WIDTH)
+                    {
+                        graphics->setPixel(n, y, graphics->ColorFromCurrentPalette(y + hue));
+                        if (waveCount == 2)
+                            graphics->setPixel(maxX - n, y, graphics->ColorFromCurrentPalette(y + hue));
+                    }
                 }
                 break;
         }

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -166,7 +166,8 @@ public:
         if (x >= 0 && x < _width && y >= 0 && y < _height)
             return leds[xy(x, y)];
         else
-            throw std::runtime_error(str_sprintf("Invalid index in getPixel: x=%d, y=%d, NUM_LEDS=%d", x, y, NUM_LEDS).c_str());
+            debugE("Invalid index in getPixel: x=%d, y=%d, NUM_LEDS=%d", x, y, NUM_LEDS);
+        return CRGB::Black;
     }
 
     virtual CRGB getPixel(int16_t i) const
@@ -174,7 +175,8 @@ public:
         if (i >= 0 && i < GetLEDCount())
             return leds[i];
         else
-            throw std::runtime_error("Pixel out of range in getPixel(x)");
+            debugE("Pixel out of range in getPixel(x)");
+        return CRGB::Black;
     }
 
     static uint8_t beatcos8(accum88 beats_per_minute, uint8_t lowest = 0, uint8_t highest = 255, uint32_t timebase = 0, uint8_t phase_offset = 0)
@@ -234,6 +236,18 @@ public:
         memset(leds, 0, sizeof(CRGB) * _width * _height);
     }
 
+    virtual bool isValidPixel(int x, int y)
+    {
+        // Check that the pixel location is within the matrix's bounds
+        return x >= 0 && x < _width && y >= 0 && y < _height;
+    }
+
+    virtual bool isValidPixel(int n)
+    {
+        // Check that the pixel location is within the matrix's bounds
+        return n >= 0 && n < _width * _height;
+    }
+
     // Matrices that are built from individually addressable strips like WS2812b generally
     // follow a boustrophodon layout as follows:
     //
@@ -273,12 +287,18 @@ public:
 
     virtual void drawPixel(int16_t x, int16_t y, CRGB color)
     {
-        leds[xy(x, y)] = color;
+        if (x >= 0 && x < _width && y >= 0 && y < _height)
+            leds[xy(x, y)] = color;
+        else
+            debugE("Invalid drawPixel request: x=%d, y=%d, NUM_LEDS=%d", x, y, NUM_LEDS);
     }
 
     virtual void drawPixel(int16_t x, int16_t y, uint16_t color) override
     {
-        leds[xy(x, y)] = from16Bit(color);
+        if (x >= 0 && x < _width && y >= 0 && y < _height)
+            leds[xy(x, y)] = from16Bit(color);
+        else
+            debugE("Invalid drawPixel request: x=%d, y=%d, NUM_LEDS=%d", x, y, NUM_LEDS);
     }
 
     virtual void fillLeds(std::unique_ptr<CRGB[]> &pLEDs)
@@ -295,23 +315,72 @@ public:
     {
         if (x >= 0 && x < _width && y >= 0 && y < _height)
             leds[xy(x, y)] = from16Bit(color);
+        else
+            debugE("Invalid setPixel request: x=%d, y=%d, NUM_LEDS=%d", x, y, NUM_LEDS);
+
     }
 
     void setPixel(int16_t x, int16_t y, CRGB color)
     {
         if (x >= 0 && x < _width && y >= 0 && y < _height)
             leds[xy(x, y)] = color;
+        else
+            debugE("Invalid setPixel request: x=%d, y=%d, NUM_LEDS=%d", x, y, NUM_LEDS);
     }
 
     virtual void setPixel(int16_t x, int r, int g, int b)
     {
-        setPixel(x, CRGB(r, g, b));
+        if (x < NUM_LEDS)
+            setPixel(x, CRGB(r, g, b));
+        else
+            debugE("Invalid setPixel request: x=%d, NUM_LEDS=%d", x, NUM_LEDS);
+        
     }
 
     virtual void setPixel(int x, CRGB color)
     {
         if (x >= 0 && x < _width * _height)
             leds[x] = color;
+        else
+            debugE("Invalid setPixel request: x=%d, NUM_LEDS=%d", x, NUM_LEDS);
+    }
+
+    // DrawSafeCircle
+    // 
+    // Draws a circle, but does not draw pixels that are out of bounds.  This is useful
+    // for drawing circles that are larger than the matrix, or for drawing circles that
+    // are partially off the matrix.  This is important for the pulsar effect.   Note that
+    // the Adafruit versions do no bounds checking
+
+    virtual void DrawSafeCircle(int centerX, int centerY, int radius, CRGB color)
+    {
+        int x = radius;
+        int y = 0;
+        int err = 0;
+
+        while (x >= y)
+        {
+            // Only set the points on the circle's circumference
+            if (isValidPixel(centerX+x, centerY+y)) setPixel(centerX+x, centerY+y, color);
+            if (isValidPixel(centerX+y, centerY+x)) setPixel(centerX+y, centerY+x, color);
+            if (isValidPixel(centerX-y, centerY+x)) setPixel(centerX-y, centerY+x, color);
+            if (isValidPixel(centerX-x, centerY+y)) setPixel(centerX-x, centerY+y, color);
+            if (isValidPixel(centerX-x, centerY-y)) setPixel(centerX-x, centerY-y, color);
+            if (isValidPixel(centerX-y, centerY-x)) setPixel(centerX-y, centerY-x, color);
+            if (isValidPixel(centerX+y, centerY-x)) setPixel(centerX+y, centerY-x, color);
+            if (isValidPixel(centerX+x, centerY-y)) setPixel(centerX+x, centerY-y, color);
+
+            if (err <= 0)
+            {
+                y += 1;
+                err += 2*y + 1;
+            }
+            if (err > 0)
+            {
+                x -= 1;
+                err -= 2*x + 1;
+            }
+        }
     }
 
     // setPixelsF - Floating point variant
@@ -738,7 +807,7 @@ public:
     // copy one diagonal triangle into the other one within a 16x16
     void Caleidoscope3()
     {
-        for (int x = 0; x <= ((_width + 1) / 2); x++)
+        for (int x = 0; x < ((_width + 1) / 2); x++)
         {
             for (int y = 0; y <= x; y++)
             {
@@ -750,7 +819,7 @@ public:
     // copy one diagonal triangle into the other one within a 16x16 (90 degrees rotated compared to Caleidoscope3)
     void Caleidoscope4()
     {
-        for (int x = 0; x <= ((_width + 1) / 2); x++)
+        for (int x = 0; x < ((_width + 1) / 2); x++)
         {
             for (int y = 0; y <= ((_height + 1) / 2) - x; y++)
             {
@@ -1088,9 +1157,12 @@ public:
         int err = dx + dy, e2;
         for (;;)
         {
-            leds[xy(x0, y0)] = bMerge ? leds[xy(x0, y0)] + color : color;
+            if (isValidPixel(x0, y0))
+                leds[xy(x0, y0)] = bMerge ? leds[xy(x0, y0)] + color : color;
+
             if (x0 == x1 && y0 == y1)
                 break;
+
             e2 = 2 * err;
             if (e2 > dy)
             {

--- a/include/ledmatrixgfx.h
+++ b/include/ledmatrixgfx.h
@@ -87,7 +87,10 @@ public:
     
     virtual uint16_t xy(uint16_t x, uint16_t y) const override
     {
-        return y * MATRIX_WIDTH + x;    
+        if (x >= 0 && x < _width && y >= 0 && y < _height)
+            return y * MATRIX_WIDTH + x;    
+        else
+            throw std::runtime_error(str_sprintf("Invalid index in xy: x=%d, y=%d, NUM_LEDS=%d", x, y, NUM_LEDS).c_str());
     }
 
     // Whereas an LEDStripGFX would track it's own memory for the CRGB array, we simply point to the buffer already used for

--- a/include/taskmgr.h
+++ b/include/taskmgr.h
@@ -48,10 +48,11 @@
 #include "ledstripeffect.h"
 
 // Stack size for the taskmgr's idle threads
-#define IDLE_STACK_SIZE 2048
-#define DEFAULT_STACK_SIZE 2048+512
+#define IDLE_STACK_SIZE 4096
+#define DEFAULT_STACK_SIZE 4096+512
 #define DRAWING_STACK_SIZE 4096
 #define AUDIO_STACK_SIZE 4096
+#define JSON_STACK_SIZE 4096
 
 
 class IdleTask
@@ -337,7 +338,7 @@ public:
     void StartJSONWriterThread()
     {
         Serial.print( str_sprintf(">> Launching JSON Writer Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
-        xTaskCreatePinnedToCore(JSONWriterTaskEntry, "JSON Writer Loop", DEFAULT_STACK_SIZE, nullptr, JSONWRITER_PRIORITY, &_taskJSONWriter, JSONWRITER_CORE);
+        xTaskCreatePinnedToCore(JSONWriterTaskEntry, "JSON Writer Loop", JSON_STACK_SIZE, nullptr, JSONWRITER_PRIORITY, &_taskJSONWriter, JSONWRITER_CORE);
     }
 
     void NotifyJSONWriterThread()

--- a/platformio.ini
+++ b/platformio.ini
@@ -5,11 +5,11 @@
 ;   Library options: dependencies, extra library storages
 ;   Advanced options: extra scripting
 ;
-; Please visit documentation for the other options and examples
+; Please visit documenation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = mesmerizer
+default_envs =
 
 ; ==================
 ; Base configuration
@@ -17,8 +17,8 @@ default_envs = mesmerizer
 ; Options that are used (or extended) in all device sections (and hence environments) are defined here
 
 [base]
-upload_port     = /dev/cu.usbserial-8411101
-monitor_port    = /dev/cu.usbserial-8411101
+upload_port     = 
+monitor_port    = 
 upload_speed    = 1500000
 
 build_flags     = -std=gnu++17

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -279,26 +279,20 @@ void PrintOutputHeader()
 
 void TerminateHandler()
 {
-    Serial.println("-------------------------------------------------------------------------------------");
-    Serial.println("- NightDriverStrip Guru Meditation                              Unhandled Exception -");
-    Serial.println("-------------------------------------------------------------------------------------");
+    debugE("-------------------------------------------------------------------------------------");
+    debugE("- NightDriverStrip Guru Meditation                              Unhandled Exception -");
+    debugE("-------------------------------------------------------------------------------------");
 
     PrintOutputHeader();
 
-/*
     try {
         std::rethrow_exception(std::current_exception());
     }
     catch (std::exception &ex) {
         debugE("Terminated due to exception: %s", ex.what());
     }
-*/
-    Serial.flush();
 
-    while(true)
-    {
-        sleep(1);
-    }
+    Serial.flush();
 }
 
 #ifdef TOGGLE_BUTTON_1


### PR DESCRIPTION
## Description
Increases stack size to prevent S3 from crashing in JSONWriter
Makes writing out of pixel bounds at least an error message
Adds DrawSafeCircle which doesn't assume it's OK to write out of bounds
Fixes a number of effects that did write out of bounds

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).