### PR TITLE
8M Flash, 60Hz, enable OTA, improve OTA

### DIFF
--- a/config/partitions_custom_8M.csv
+++ b/config/partitions_custom_8M.csv
@@ -1,0 +1,11 @@
+# ESP-IDF Partition Table
+# Adjusted to accommodate 8M flash size and includes a second 'app1' partition for OTA updates
+# Name,   Type, SubType,     Offset,      Size, Flags
+
+# Note that our NVS code assumes name 'storage' for the NVS partition
+
+nvs,         data,   nvs,       0x009000,  0x002000,
+otadata,     data,   ota,       0x00b000,  0x002000,
+app0,        app,    ota_0,     0x010000,  0x320000,
+app1,        app,    ota_1,     0x330000,  0x320000,
+storage,     data,   spiffs,    0x650000,  0x1B0000 

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -202,6 +202,11 @@ public:
         ClearEffects();
     }
 
+    std::shared_ptr<GFXBase> GetBaseGraphics()
+    {
+        return _gfx[0];
+    }
+
     bool IsNewFrameAvailable() const
     {
         return _newFrameAvailable;

--- a/include/globals.h
+++ b/include/globals.h
@@ -465,7 +465,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define TIME_BEFORE_LOCAL       2   // How many seconds before the lamp times out and shows local content
     #define ENABLE_WEBSERVER        1  // Turn on the internal webserver
     #define ENABLE_NTP              1   // Set the clock from the web
-    #define ENABLE_OTA              0   // Accept over the air flash updates
+    #define ENABLE_OTA              1   // Accept over the air flash updates
     #define ENABLE_REMOTE           1   // IR Remote Control
     #define ENABLE_AUDIO            1   // Listen for audio from the microphone and process it
     #define SCALE_AUDIO_EXPONENTIAL 0
@@ -1226,11 +1226,11 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 #endif
 
 #ifndef MATRIX_REFRESH_RATE
-#define MATRIX_REFRESH_RATE 90
+#define MATRIX_REFRESH_RATE 120
 #endif
 
 #ifndef MATRIX_CALC_DIVIDER
-#define MATRIX_CALC_DIVIDER 1
+#define MATRIX_CALC_DIVIDER 2
 #endif
 
 

--- a/include/taskmgr.h
+++ b/include/taskmgr.h
@@ -48,12 +48,12 @@
 #include "ledstripeffect.h"
 
 // Stack size for the taskmgr's idle threads
-#define IDLE_STACK_SIZE 4096
-#define DEFAULT_STACK_SIZE 4096+512
-#define DRAWING_STACK_SIZE 4096
-#define AUDIO_STACK_SIZE 4096
-#define JSON_STACK_SIZE 4096
+#define DEFAULT_STACK_SIZE 2048+512
 
+#define IDLE_STACK_SIZE    2048
+#define DRAWING_STACK_SIZE 4096
+#define AUDIO_STACK_SIZE   4096
+#define JSON_STACK_SIZE    4096
 
 class IdleTask
 {

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,8 +17,8 @@ default_envs =
 ; Options that are used (or extended) in all device sections (and hence environments) are defined here
 
 [base]
-upload_port     = /dev/cu.usbserial-8411101
-monitor_port    = /dev/cu.usbserial-8411101
+upload_port     =
+monitor_port    =
 upload_speed    = 1500000
 
 build_flags     = -std=gnu++17

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs =
+default_envs = 
 
 ; ==================
 ; Base configuration
@@ -17,8 +17,8 @@ default_envs =
 ; Options that are used (or extended) in all device sections (and hence environments) are defined here
 
 [base]
-upload_port     =
-monitor_port    =
+upload_port     = /dev/cu.usbserial-8411101
+monitor_port    = /dev/cu.usbserial-8411101
 upload_speed    = 1500000
 
 build_flags     = -std=gnu++17
@@ -469,7 +469,8 @@ lib_deps        = ${dev_wrover.lib_deps}
                   ${matrix_config.lib_deps}
 board_build.embed_files = ${env.board_build.embed_files}
                           ${matrix_config.board_build.embed_files}
-board_build.partitions = config/partitions_custom_noota.csv
+board_build.partitions = config/partitions_custom_8M.csv
+board_upload.flash_size = 8MB
 debug_tool      = esp-prog
 
 [env:mesmerizer_lolin]

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -450,6 +450,6 @@ void IRAM_ATTR DrawLoopTaskEntry(void *)
         // so we'll slow down to share the CPU a bit once the update has begun
 
         if (g_bUpdateStarted)
-            delay(100);
+            delay(500);
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -710,7 +710,8 @@ void loop()
             Serial.println(strOutput);
         }
 
-        // Once an update is underway, we loop tightly on ArduinoOTA.handle.  Otherweise we delay a bit to share the CPU.
+        // Once an update is underway, we loop tightly on ArduinoOTA.handle.  Otherwise we delay a bit to share the CPU.
+
         
         if (!g_bUpdateStarted)
             delay(10);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -663,17 +663,14 @@ void loop()
         #endif
 
         #if ENABLE_OTA
-            EVERY_N_MILLIS(10)
+            try
             {
-                try
-                {
-                    if (WiFi.isConnected())
-                        ArduinoOTA.handle();
-                }
-                catch(const std::exception& e)
-                {
-                    debugW("Exception in OTA code caught");
-                }
+                if (WiFi.isConnected())
+                    ArduinoOTA.handle();
+            }
+            catch(const std::exception& e)
+            {
+                debugW("Exception in OTA code caught");
             }
         #endif
 
@@ -713,6 +710,9 @@ void loop()
             Serial.println(strOutput);
         }
 
-        delay(5);
+        // Once an update is underway, we loop tightly on ArduinoOTA.handle.  Otherweise we delay a bit to share the CPU.
+        
+        if (!g_bUpdateStarted)
+            delay(10);
     }
 }


### PR DESCRIPTION
8M Flash, 60Hz, enable OTA, improve OTA

Adds new partition tabe file with 8M suffice for mesmerizer that makes use of 8M of flash, which makes enough room for a second OTA partition.

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).