### PR TITLE
Add PrepareFrame() and PostProcessFrame() to GFXBase and subclasses

### DIFF
--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -60,13 +60,11 @@ bool ReadCurrentEffectIndex(size_t& index);
 
 std::shared_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color);
 std::shared_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color, CRGB color2);
-extern DRAM_ATTR std::unique_ptr<EffectFactories> g_ptrEffectFactories;
 
 // EffectManager
 //
 // Handles keeping track of the effects, which one is active, asking it to draw, etc.
 
-template <typename GFXTYPE>
 class  EffectManager : public IJSONSerializable
 {
     std::vector<std::shared_ptr<LEDStripEffect>> _vEffects;
@@ -80,7 +78,7 @@ class  EffectManager : public IJSONSerializable
     bool _clearTempEffectWhenExpired = false;
     bool _newFrameAvailable = false;
 
-    std::vector<std::shared_ptr<GFXTYPE>> _gfx;
+    std::vector<std::shared_ptr<GFXBase>> _gfx;
     std::shared_ptr<LEDStripEffect> _tempEffect;
 
     void construct(bool clearTempEffect)
@@ -100,66 +98,8 @@ class  EffectManager : public IJSONSerializable
         }
     }
 
-    void LoadJSONAndMissingEffects(const JsonArrayConst& effectsArray)
-    {
-        std::set<int> loadedEffectNumbers;
-
-        // Create effects from JSON objects, using the respective factories in g_EffectFactories
-        auto& jsonFactories = g_ptrEffectFactories->GetJSONFactories();
-
-        for (auto effectObject : effectsArray)
-        {
-            int effectNumber = effectObject[PTY_EFFECTNR];
-            auto factoryEntry = jsonFactories.find(effectNumber);
-
-            if (factoryEntry == jsonFactories.end())
-                continue;
-
-            auto pEffect = factoryEntry->second(effectObject);
-            if (pEffect)
-            {
-                if (effectObject[PTY_COREEFFECT].as<int>())
-                    pEffect->MarkAsCoreEffect();
-
-                _vEffects.push_back(pEffect);
-                loadedEffectNumbers.insert(effectNumber);
-            }
-        }
-
-        // Now add missing effects from the default factory list
-        auto &defaultFactories = g_ptrEffectFactories->GetDefaultFactories();
-
-        // We iterate manually, so we can use where we are as the starting point for a later inner loop
-        for (auto iter = defaultFactories.begin(); iter != defaultFactories.end(); iter++)
-        {
-            int effectNumber = iter->EffectNumber;
-
-            // If we've already loaded this effect (number) from JSON, we can move on to check the next one
-            if (loadedEffectNumbers.count(effectNumber))
-                continue;
-
-            // We found an effect (number) in the default list that we have not yet loaded from JSON.
-            //   So, we go through the rest of the default factory list to create and add to our effects
-            //   list all instances of this effect.
-            std::for_each(iter, defaultFactories.end(), [&](const EffectFactories::NumberedFactory& numberedFactory)
-                {
-                    if (numberedFactory.EffectNumber != effectNumber)
-                        return;
-
-                    auto pEffect = numberedFactory.Factory();
-                    if (pEffect)
-                    {
-                        // Effects in the default list are core effects. These can be disabled but not deleted.
-                        pEffect->MarkAsCoreEffect();
-                        _vEffects.push_back(pEffect);
-                    }
-                }
-            );
-
-            // Register that we added this effect number, so we don't add the respective effects more than once
-            loadedEffectNumbers.insert(effectNumber);
-        }
-    }
+    // Implementation is in effects.cpp
+    void LoadJSONAndMissingEffects(const JsonArrayConst& effectsArray);
 
     void ClearEffects()
     {
@@ -170,7 +110,7 @@ public:
     static const uint csFadeButtonSpeed = 15 * 1000;
     static const uint csSmoothButtonSpeed = 60 * 1000;
 
-    EffectManager(std::shared_ptr<LEDStripEffect> effect, std::vector<std::shared_ptr<GFXTYPE>>& gfx)
+    EffectManager(std::shared_ptr<LEDStripEffect> effect, std::vector<std::shared_ptr<GFXBase>>& gfx)
         : _gfx(gfx)
     {
         debugV("EffectManager Splash Effect Constructor");
@@ -181,7 +121,7 @@ public:
         construct(false);
     }
 
-    EffectManager(std::vector<std::shared_ptr<GFXTYPE>>& gfx)
+    EffectManager(std::vector<std::shared_ptr<GFXBase>>& gfx)
         : _gfx(gfx)
     {
         debugV("EffectManager Constructor");
@@ -189,7 +129,7 @@ public:
         LoadDefaultEffects();
     }
 
-    EffectManager(const JsonObjectConst& jsonObject, std::vector<std::shared_ptr<GFXTYPE>>& gfx)
+    EffectManager(const JsonObjectConst& jsonObject, std::vector<std::shared_ptr<GFXBase>>& gfx)
         : _gfx(gfx)
     {
         debugV("EffectManager JSON Constructor");
@@ -218,26 +158,8 @@ public:
         _newFrameAvailable = available;
     }
 
-    void LoadDefaultEffects()
-    {
-        for (auto &numberedFactory : g_ptrEffectFactories->GetDefaultFactories())
-        {
-            auto pEffect = numberedFactory.Factory();
-            if (pEffect)
-            {
-                // Effects in the default list are core effects. These can be disabled but not deleted.
-                pEffect->MarkAsCoreEffect();
-                _vEffects.push_back(pEffect);
-            }
-        }
-
-        for (int i = 0; i < _vEffects.size(); i++)
-            EnableEffect(i, true);
-
-        SetInterval(DEFAULT_EFFECT_INTERVAL, true);
-
-        construct(true);
-    }
+    // Implementation is in effects.cpp
+    void LoadDefaultEffects();
 
     // DeserializeFromJSON
     //
@@ -349,13 +271,13 @@ public:
         return true;
     }
 
-    std::shared_ptr<GFXTYPE> operator[](size_t index) const
+    std::shared_ptr<GFXBase> operator[](size_t index) const
     {
         return _gfx[index];
     }
 
     // Must provide at least one drawing instance, like the first matrix or strip we are drawing on
-    inline std::shared_ptr<GFXTYPE> g() const
+    inline std::shared_ptr<GFXBase> g() const
     {
         return _gfx[0];
     }
@@ -539,39 +461,8 @@ public:
     }
 
     // Creates a copy of an existing effect in the list. Note that the effect is created but not yet added to the effect list;
-    //   use the AppendEffect() function for that.
-    std::shared_ptr<LEDStripEffect> CopyEffect(size_t index)
-    {
-        if (index >= _vEffects.size())
-        {
-            debugW("Invalid index for CopyEffect");
-            return nullptr;
-        }
-
-        static size_t jsonBufferSize = JSON_BUFFER_BASE_SIZE;
-
-        auto& sourceEffect = _vEffects[index];
-
-        std::unique_ptr<AllocatedJsonDocument> ptrJsonDoc = nullptr;
-
-        SerializeWithBufferSize(ptrJsonDoc, jsonBufferSize,
-            [&sourceEffect](JsonObject &jsonObject) { return sourceEffect->SerializeToJSON(jsonObject); });
-
-        auto jsonEffectFactories = g_ptrEffectFactories->GetJSONFactories();
-        auto factoryEntry = jsonEffectFactories.find(sourceEffect->EffectNumber());
-
-        if (factoryEntry == jsonEffectFactories.end())
-            return nullptr;
-
-        auto copiedEffect = factoryEntry->second(ptrJsonDoc->as<JsonObjectConst>());
-
-        if (!copiedEffect)
-            return nullptr;
-
-        copiedEffect->SetEnabled(false);
-
-        return copiedEffect;
-    }
+    //   use the AppendEffect() function for that. Implementation is in effects.cpp.
+    std::shared_ptr<LEDStripEffect> CopyEffect(size_t index);
 
     // Adds an effect to the effect list and enables it. If an effect is added that is already in the effect list then the result
     //   is undefined but potentially messy.

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -354,11 +354,6 @@ public:
         return _gfx[index];
     }
 
-    size_t gCount()
-    {
-        return _gfx.size();
-    }
-
     // Must provide at least one drawing instance, like the first matrix or strip we are drawing on
     inline std::shared_ptr<GFXTYPE> g() const
     {

--- a/include/effects/matrix/PatternMisc.h
+++ b/include/effects/matrix/PatternMisc.h
@@ -77,23 +77,25 @@ class PatternSunburst : public LEDStripEffect
 
     virtual void Draw() override
     {
-      uint8_t dim = beatsin8(2, 210, 250);
-      g()->DimAll(dim);
+        uint8_t dim = beatsin8(2, 210, 250);
+        g()->DimAll(dim);
 
-      for (int i = 2; i <= MATRIX_WIDTH / 2; i++)
-      {
-        CRGB color = g()->ColorFromCurrentPalette((i - 2) * (240 / (MATRIX_WIDTH / 2)));
+        for (int i = 2; i <= MATRIX_WIDTH / 2; i++)
+        {
+            CRGB color = g()->ColorFromCurrentPalette((i - 2) * (240 / (MATRIX_WIDTH / 2)));
 
-        // The LIB8TION library defines beatsin8, but this needed beatcos8 which did not exist, so I
-        // added it to the graphics interface rathe than adding it to a custom version of lib8tion
+            // The LIB8TION library defines beatsin8, but this needed beatcos8 which did not exist, so I
+            // added it to the graphics interface rathe than adding it to a custom version of lib8tion
 
-        uint8_t x = g()->beatcos8((17 - i) * 2, MATRIX_CENTER_X - i, MATRIX_CENTER_X + i);
-        uint8_t y = beatsin8((17 - i) * 2, MATRIX_CENTER_Y - i, MATRIX_CENTER_Y + i);
+            uint8_t x = g()->beatcos8((17 - i) * 2, MATRIX_CENTER_X - i, MATRIX_CENTER_X + i);
+            uint8_t y = beatsin8((17 - i) * 2, MATRIX_CENTER_Y - i, MATRIX_CENTER_Y + i);
 
-        if (color.r != 0 || color.g != 0 || color.b !=0 )
-          if (g()->isValidPixel(x,y))
-            g()->setPixel(x, y, color);
-      }
+            if (color.r != 0 || color.g != 0 || color.b != 0)
+            {
+                if (g()->isValidPixel(x,y))
+                    g()->setPixel(x, y, color);
+            }
+        }
     }
 };
 
@@ -121,32 +123,33 @@ class PatternRose : public LEDStripEffect
 
     virtual void Draw() override
     {
-      uint8_t dim = beatsin8(2, 170, 250);
-      g()->DimAll(dim);
+        uint8_t dim = beatsin8(2, 170, 250);
+        g()->DimAll(dim);
 
 
-      for (uint16_t i = 0; i < MATRIX_HEIGHT; i++)
-      {
-        CRGB color;
-
-        uint8_t x = 0;
-        uint8_t y = 0;
-
-        if (i < 16) {
-          x = g()->beatcos8((i + 1) * 2, i, MATRIX_HEIGHT - i) + 16;
-          y = beatsin8((i + 1) * 2, i, MATRIX_HEIGHT - i);
-          color = g()->ColorFromCurrentPalette(i * 14);
-        }
-        else
+        for (uint16_t i = 0; i < MATRIX_HEIGHT; i++)
         {
-          x = beatsin8((32 - i) * 2, MATRIX_WIDTH - i, i + 1) + 16;
-          y = g()->beatcos8((32 - i) * 2, MATRIX_WIDTH - i, i + 1);
-          color = g()->ColorFromCurrentPalette((31 - i) * 14);
-        }
+            CRGB color;
 
-        if (g()->isValidPixel(x, y))
-          g()->setPixel(x, y, color);
-      }
+            uint8_t x = 0;
+            uint8_t y = 0;
+
+            if (i < 16)
+            {
+                x = g()->beatcos8((i + 1) * 2, i, MATRIX_HEIGHT - i) + 16;
+                y = beatsin8((i + 1) * 2, i, MATRIX_HEIGHT - i);
+                color = g()->ColorFromCurrentPalette(i * 14);
+            }
+            else
+            {
+                x = beatsin8((32 - i) * 2, MATRIX_WIDTH - i, i + 1) + 16;
+                y = g()->beatcos8((32 - i) * 2, MATRIX_WIDTH - i, i + 1);
+                color = g()->ColorFromCurrentPalette((31 - i) * 14);
+            }
+
+            if (g()->isValidPixel(x, y))
+                g()->setPixel(x, y, color);
+        }
     }
 };
 
@@ -164,7 +167,7 @@ class PatternPinwheel : public LEDStripEffect
 
     virtual void Start() override
     {
-      g()->Clear();
+        g()->Clear();
     }
 
     virtual size_t DesiredFramesPerSecond() const override
@@ -174,23 +177,23 @@ class PatternPinwheel : public LEDStripEffect
 
     virtual void Draw() override
     {
-      uint8_t dim = beatsin8(2, 30, 70);
-      fadeAllChannelsToBlackBy(dim);
+        uint8_t dim = beatsin8(2, 30, 70);
+        fadeAllChannelsToBlackBy(dim);
 
-      for (uint8_t i = 0; i < 64; i++)
-      {
-        CRGB color;
+        for (uint8_t i = 0; i < 64; i++)
+        {
+            CRGB color;
 
-        uint8_t x = 0;
-        uint8_t y = 0;
+            uint8_t x = 0;
+            uint8_t y = 0;
 
-        x = beatsin8((64 - i) * 2, MATRIX_HEIGHT - i, i + 1) + 16;
-        y = g()->beatcos8((64 - i) * 2, MATRIX_HEIGHT - i, i + 1);
-        color = g()->ColorFromCurrentPalette((64 - i) * 14);
+            x = beatsin8((64 - i) * 2, MATRIX_HEIGHT - i, i + 1) + 16;
+            y = g()->beatcos8((64 - i) * 2, MATRIX_HEIGHT - i, i + 1);
+            color = g()->ColorFromCurrentPalette((64 - i) * 14);
 
-        if (g()->isValidPixel(x, y))
-          g()->setPixel(x, y, color);
-      }
+            if (g()->isValidPixel(x, y))
+                g()->setPixel(x, y, color);
+        }
     }
 };
 
@@ -240,8 +243,8 @@ public:
         // draw a pixel at x,y using a color from the current palette
         if (_lastX == -1)
         {
-          _lastX = x;
-          _lastY = y;
+            _lastX = x;
+            _lastY = y;
         }
 
         g()->drawLine(_lastX, _lastY, x, y, g()->ColorFromCurrentPalette(hue));
@@ -283,34 +286,31 @@ public:
 
     virtual void Draw() override
     {
-
-        for (uint16_t x = 0; x < MATRIX_WIDTH; x++) {
-            for (uint16_t y = 0; y < MATRIX_HEIGHT; y++) {
-                g()->leds[g()->xy(x, y)] =
-                  (x ^ y ^ flip) < count ?
-                      g()->ColorFromCurrentPalette(((x ^ y) << 2) + generation)
+        for (uint16_t x = 0; x < MATRIX_WIDTH; x++)
+        {
+            for (uint16_t y = 0; y < MATRIX_HEIGHT; y++)
+            {
+                g()->leds[g()->xy(x, y)] = (x ^ y ^ flip) < count
+                    ? g()->ColorFromCurrentPalette(((x ^ y) << 2) + generation)
                     : CRGB::Black;
-
-                // The below is more pleasant
-               // effects.leds[XY(x, y)] = effects.ColorFromCurrentPalette(((x ^ y) << 2) + generation) ;
             }
         }
 
         count += dir;
 
         if (count <= 0 || count >= MATRIX_WIDTH) {
-          dir = -dir;
+            dir = -dir;
         }
 
-        if (count <= 0) {
-          if (flip == 0)
-            flip = MATRIX_WIDTH-1;
-          else
-            flip = 0;
+        if (count <= 0)
+        {
+            if (flip == 0)
+                flip = MATRIX_WIDTH-1;
+            else
+                flip = 0;
         }
 
         generation++;
-
     }
 };
 

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -450,8 +450,6 @@ public:
   }
 };
 
-extern void ShowTM1814();
-
 class CountEffect : public LEDStripEffect
 {
   using LEDStripEffect::LEDStripEffect;
@@ -479,11 +477,8 @@ class CountEffect : public LEDStripEffect
         if (t >= OPEN_LEN)
           t -= OPEN_LEN;
       }
-#if ATOMISTRING
-      ShowTM1814();
-#else
+
       FastLED.show();
-#endif
     }
   }
 

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -69,6 +69,7 @@
 #include "pixeltypes.h"
 #include "effects/matrix/Boid.h"
 #include "effects/matrix/Vector.h"
+#include "globals.h"
 #include <memory>
 
 #if USE_MATRIX
@@ -1261,6 +1262,10 @@ public:
             }
         } // end column loop
     }     /// MoveY
+
+    virtual void PrepareFrame() {}
+
+    virtual void PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDrawn) {}
 
     #if USE_NOISE
         void MoveFractionalNoiseX(uint8_t amt = 16)

--- a/include/globals.h
+++ b/include/globals.h
@@ -138,7 +138,8 @@
 #define FLASH_VERSION_NAME XSTR(FLASH_VERSION)
 
 #define FASTLED_INTERNAL        1       // Silence FastLED build banners
-#define NTP_DELAY_COUNT         10*60   // delay count for ntp update, in seconds
+#define NTP_DELAY_SECONDS       30*60   // delay count for NTP update, in seconds
+#define NTP_DELAY_ERROR_SECONDS 30      // delay count for NTP updates if no time was set, in seconds
 #define NTP_PACKET_LENGTH       48      // ntp packet length
 
 // C Helpers and Macros

--- a/include/globals.h
+++ b/include/globals.h
@@ -137,9 +137,9 @@
 #define FLASH_VERSION_NAME_X(x) "v"#x
 #define FLASH_VERSION_NAME XSTR(FLASH_VERSION)
 
-#define FASTLED_INTERNAL        1   // Silence FastLED build banners
-#define NTP_DELAY_COUNT         20*60  // delay count for ntp update, in seconds
-#define NTP_PACKET_LENGTH       48  // ntp packet length
+#define FASTLED_INTERNAL        1       // Silence FastLED build banners
+#define NTP_DELAY_COUNT         10*60   // delay count for ntp update, in seconds
+#define NTP_PACKET_LENGTH       48      // ntp packet length
 
 // C Helpers and Macros
 

--- a/include/globals.h
+++ b/include/globals.h
@@ -138,7 +138,7 @@
 #define FLASH_VERSION_NAME XSTR(FLASH_VERSION)
 
 #define FASTLED_INTERNAL        1   // Silence FastLED build banners
-#define NTP_DELAY_COUNT         20  // delay count for ntp update
+#define NTP_DELAY_COUNT         20*60  // delay count for ntp update, in seconds
 #define NTP_PACKET_LENGTH       48  // ntp packet length
 
 // C Helpers and Macros

--- a/include/improvserial.h
+++ b/include/improvserial.h
@@ -44,8 +44,8 @@ enum ImprovSerialType : uint8_t
 
 static const uint8_t IMPROV_SERIAL_VERSION = 1;
 
-extern String WiFi_ssid;
-extern String WiFi_password;
+extern DRAM_ATTR String WiFi_ssid;
+extern DRAM_ATTR String WiFi_password;
 bool ReadWiFiConfig();
 bool WriteWiFiConfig();
 bool ConnectToWiFi(uint cRetries);
@@ -54,7 +54,7 @@ template <typename SERIALTYPE>
 class ImprovSerial
 {
 public:
-    
+
     void setup(const String &firmware,
                              const String &version,
                              const String &variant,
@@ -87,7 +87,7 @@ public:
             this->rx_buffer_.clear();
             this->last_read_byte_ = now;
         }
-        
+
         while (this->available_())
         {
             uint8_t byte = this->read_byte_();
@@ -223,7 +223,7 @@ protected:
                 this->command_.command  = command.command;
                 this->command_.ssid     = command.ssid;
                 this->command_.password = command.password;
-                
+
                 return true;
             }
 
@@ -249,7 +249,7 @@ protected:
                 return true;
             }
 
-            case improv::GET_WIFI_NETWORKS: 
+            case improv::GET_WIFI_NETWORKS:
             {
                 auto numSsid = WiFi.scanNetworks();
                 if (numSsid > 0)
@@ -264,7 +264,7 @@ protected:
                 }
 
                 // Send empty response to signify the end of the list.
-    
+
                 std::vector<uint8_t> data = improv::build_rpc_response(improv::GET_WIFI_NETWORKS, std::vector<String>{}, false);
                 this->send_response_(data);
                 return true;

--- a/include/ledmatrixgfx.h
+++ b/include/ledmatrixgfx.h
@@ -63,12 +63,10 @@ public:
     static const uint8_t kDefaultBrightness = 255; // full (100%) brightness
     static const rgb24   defaultBackgroundColor;
 
-    #if USE_MATRIX
     static SMLayerBackground<SM_RGB, kBackgroundLayerOptions> backgroundLayer;
     static SMLayerBackground<SM_RGB, kBackgroundLayerOptions> titleLayer;
     static SmartMatrixHub75Refresh<COLOR_DEPTH, kMatrixWidth, kMatrixHeight, kPanelType, kMatrixOptions> matrixRefresh;
     static SmartMatrixHub75Calc<COLOR_DEPTH, kMatrixWidth, kMatrixHeight, kPanelType, kMatrixOptions> matrix;
-    #endif
 
     LEDMatrixGFX(size_t w, size_t h) : GFXBase(w, h)
     {
@@ -223,6 +221,18 @@ public:
             memcpy(pLinemem2 + 1, pLinemem2, sizeof(CRGB) * (MATRIX_WIDTH / 2));
         }
     }
+
+    // PrepareFrame
+    //
+    // Gets the matrix ready for the effect or wifi to render into
+
+    virtual void PrepareFrame() override;
+
+    // PostProcessFrame
+    //
+    // Things we do with the matrix after rendering a frame, such as setting the brightness and swapping the backbuffer forward
+
+    virtual void PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDrawn) override;
 
     // Matrix interop
 

--- a/include/ledstripgfx.h
+++ b/include/ledstripgfx.h
@@ -124,6 +124,12 @@ public:
             pinMode(15, INPUT);
         #endif
     }
+
+    // PostProcessFrame
+    //
+    // PostProcessFrame sends the data to the LED strip.  If it's fewer than the size of the strip, we only send that many.
+
+    virtual void PostProcessFrame(uint16_t wifiPixelsDrawn, uint16_t localPixelsDrawn) override;
 };
 
 #if HEXAGON
@@ -236,43 +242,6 @@ class HexagonGFX : public LEDStripGFX
         for (int i = indent; i < getRowWidth(HEX_MAX_DIMENSION-indent-1)-indent; ++i)
             setPixel(getStartIndexOfRow(HEX_MAX_DIMENSION-indent-1) + i, color);
 
-    }
-
-    // PostProcessFrame
-    //
-    // PostProcessFrame sends the data to the LED strip.  If it's fewer than the size of the strip, we only send that many.
-
-    virtual void PostProcessFrame(uint16_t wifiPixelsDrawn, uint16_t localPixelsDrawn) override
-    {
-        auto pixelsDrawn = wifiPixelsDrawn ? wifiPixelsDrawn : localPixelsDrawn;
-
-        // If we drew no pixels, there's nothing to post process
-        if (pixelsDrawn == 0)
-        {
-            debugV("Frame draw ended without any pixels drawn.");
-            return;
-        }
-
-        // If we've drawn anything from either source, we can now show it if we have LEDs to output to
-        if (FastLED.count() == 0)
-        {
-            debugW("Draw loop is drawing before LEDs are ready, so delaying 100ms...");
-            delay(100);
-            return;
-        }
-
-        debugV("Telling FastLED that we'll be drawing %d pixels\n", pixelsDrawn);
-
-        auto& effectManager = g_ptrSystem->EffectManager();
-
-        for (int i = 0; i < FastLED.count(); i++)
-            FastLED[i].setLeds(effectManager[i]->leds, pixelsDrawn);
-
-        FastLED.show(g_Values.Fader);
-
-        g_Values.FPS = FastLED.getFPS();
-        g_Values.Brite = 100.0 * calculate_max_brightness_for_power_mW(g_Values.Brightness, POWER_LIMIT_MW) / 255;
-        g_Values.Watts = calculate_unscaled_power_mW(effectManager.g()->leds, pixelsDrawn) / 1000; // 1000 for mw->W
     }
 };
 

--- a/include/ledstripgfx.h
+++ b/include/ledstripgfx.h
@@ -71,7 +71,7 @@ public:
         #define ADD_CHANNEL(channel) \
             debugI("Adding %d LEDs to channel %d on FastLED.", devices[channel]->GetLEDCount(), channel); \
             FastLED.addLeds<WS2812B, LED_PIN ## channel, COLOR_ORDER>(devices[channel]->leds, devices[channel]->GetLEDCount()); \
-            pinMode(LED_PIN ## channel , OUTPUT);
+            pinMode(LED_PIN ## channel, OUTPUT);
 
         debugI("Adding LEDs to FastLED...");
 
@@ -236,6 +236,43 @@ class HexagonGFX : public LEDStripGFX
         for (int i = indent; i < getRowWidth(HEX_MAX_DIMENSION-indent-1)-indent; ++i)
             setPixel(getStartIndexOfRow(HEX_MAX_DIMENSION-indent-1) + i, color);
 
+    }
+
+    // PostProcessFrame
+    //
+    // PostProcessFrame sends the data to the LED strip.  If it's fewer than the size of the strip, we only send that many.
+
+    virtual void PostProcessFrame(uint16_t wifiPixelsDrawn, uint16_t localPixelsDrawn) override
+    {
+        auto pixelsDrawn = wifiPixelsDrawn ? wifiPixelsDrawn : localPixelsDrawn;
+
+        // If we drew no pixels, there's nothing to post process
+        if (pixelsDrawn == 0)
+        {
+            debugV("Frame draw ended without any pixels drawn.");
+            return;
+        }
+
+        // If we've drawn anything from either source, we can now show it if we have LEDs to output to
+        if (FastLED.count() == 0)
+        {
+            debugW("Draw loop is drawing before LEDs are ready, so delaying 100ms...");
+            delay(100);
+            return;
+        }
+
+        debugV("Telling FastLED that we'll be drawing %d pixels\n", pixelsDrawn);
+
+        auto& effectManager = g_ptrSystem->EffectManager();
+
+        for (int i = 0; i < FastLED.count(); i++)
+            FastLED[i].setLeds(effectManager[i]->leds, pixelsDrawn);
+
+        FastLED.show(g_Values.Fader);
+
+        g_Values.FPS = FastLED.getFPS();
+        g_Values.Brite = 100.0 * calculate_max_brightness_for_power_mW(g_Values.Brightness, POWER_LIMIT_MW) / 255;
+        g_Values.Watts = calculate_unscaled_power_mW(effectManager.g()->leds, pixelsDrawn) / 1000; // 1000 for mw->W
     }
 };
 

--- a/include/ledstripgfx.h
+++ b/include/ledstripgfx.h
@@ -39,33 +39,9 @@
 
 class LEDStripGFX : public GFXBase
 {
-public:
-
-    LEDStripGFX(size_t w, size_t h) : GFXBase(w, h)
+protected:
+    static void AddLEDsToFastLED(std::vector<std::shared_ptr<GFXBase>>& devices)
     {
-        debugV("Creating Device of size %d x %d", w, h);
-        leds = static_cast<CRGB *>(calloc(w * h, sizeof(CRGB)));
-        if(!leds)
-            throw std::runtime_error("Unable to allocate LEDs in LEDStripGFX");
-    }
-
-    virtual ~LEDStripGFX()
-    {
-        free(leds);
-        leds = nullptr;
-    }
-
-    static void InitializeHardware(std::vector<std::shared_ptr<GFXBase>>& devices)
-    {
-        // We can't have more than 8 channels, because we don't have more than 8 pins
-        int channelCount = std::min(NUM_CHANNELS, 8);
-
-        for (int i = 0; i < channelCount; i++)
-        {
-            debugW("Allocating LEDStripGFX for channel %d", i);
-            devices.push_back(make_shared_psram<LEDStripGFX>(MATRIX_WIDTH, MATRIX_HEIGHT));
-        }
-
         // Macro to add LEDs to a channel
 
         #define ADD_CHANNEL(channel) \
@@ -115,6 +91,36 @@ public:
         #endif
 
         g_Values.Brightness = 255;
+    }
+
+public:
+
+    LEDStripGFX(size_t w, size_t h) : GFXBase(w, h)
+    {
+        debugV("Creating Device of size %d x %d", w, h);
+        leds = static_cast<CRGB *>(calloc(w * h, sizeof(CRGB)));
+        if(!leds)
+            throw std::runtime_error("Unable to allocate LEDs in LEDStripGFX");
+    }
+
+    virtual ~LEDStripGFX()
+    {
+        free(leds);
+        leds = nullptr;
+    }
+
+    static void InitializeHardware(std::vector<std::shared_ptr<GFXBase>>& devices)
+    {
+        // We can't have more than 8 channels, because we don't have more than 8 pins
+        int channelCount = std::min(NUM_CHANNELS, 8);
+
+        for (int i = 0; i < channelCount; i++)
+        {
+            debugW("Allocating LEDStripGFX for channel %d", i);
+            devices.push_back(make_shared_psram<LEDStripGFX>(MATRIX_WIDTH, MATRIX_HEIGHT));
+        }
+
+        AddLEDsToFastLED(devices);
 
         #if ATOMLIGHT                                                   // BUGBUG Why input?  Shouldn't they be output?
             pinMode(4, INPUT);
@@ -149,11 +155,16 @@ class HexagonGFX : public LEDStripGFX
 
     static void InitializeHardware(std::vector<std::shared_ptr<GFXBase>>& devices)
     {
-        for (int i = 0; i < NUM_CHANNELS; i++)
+        // We can't have more than 8 channels, because we don't have more than 8 pins
+        int channelCount = std::min(NUM_CHANNELS, 8);
+
+        for (int i = 0; i < channelCount; i++)
         {
             debugW("Allocating HexagonGFX for channel %d", i);
             devices.push_back(make_shared_psram<HexagonGFX>(NUM_LEDS));
         }
+
+        AddLEDsToFastLED(devices);
     }
 
     virtual int getStartIndexOfRow(int row) const

--- a/include/network.h
+++ b/include/network.h
@@ -41,8 +41,8 @@
     void SetupOTA(const String & strHostname);
     bool ReadWiFiConfig();
     bool WriteWiFiConfig();
-    extern String WiFi_password;
-    extern String WiFi_ssid;
+    extern DRAM_ATTR String WiFi_password;
+    extern DRAM_ATTR String WiFi_ssid;
 
     // Static Helpers
     //

--- a/include/systemcontainer.h
+++ b/include/systemcontainer.h
@@ -162,7 +162,7 @@ class SystemContainer
     // -------------------------------------------------------------
     // EffectManager
 
-    SC_FORWARDING_PROPERTY(EffectManager, EffectManager<GFXBase>)
+    SC_FORWARDING_PROPERTY(EffectManager, EffectManager)
 
     // -------------------------------------------------------------
     // TaskManager

--- a/platformio.ini
+++ b/platformio.ini
@@ -225,7 +225,7 @@ build_flags     = -DUNITY_INCLUDE_DOUBLE
                   -DUNITY_DOUBLE_PRECISION=1e-12    ; Make doubles real 8 byte doubles
 
 [matrix_config]
-lib_deps        = https://github.com/PlummersSoftwareLLC/SmartMatrix.git#8e625f839f9f38111f13b18eec29eeb6c2916eba
+lib_deps        = https://github.com/PlummersSoftwareLLC/SmartMatrix.git
 board_build.embed_files = assets/bmp/brokenclouds.jpg
                           assets/bmp/clearsky.jpg
                           assets/bmp/fewclouds.jpg

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -35,13 +35,12 @@
 #include "effects/matrix/spectrumeffects.h"
 #include "systemcontainer.h"
 
-CRGB g_SinglePixel = CRGB::Blue;
-CLEDController *g_ledSinglePixel;
+static DRAM_ATTR CRGB l_SinglePixel = CRGB::Blue;
 
 // The g_buffer_mutex is a global mutex used to protect access while adding or removing frames
 // from the led buffer.
 
-extern std::mutex g_buffer_mutex;
+extern DRAM_ATTR std::mutex g_buffer_mutex;
 
 extern const CRGBPalette16 vuPaletteGreen;
 
@@ -221,7 +220,7 @@ void ShowOnboardRGBLED()
 void PrepareOnboardPixel()
 {
     #ifdef ONBOARD_PIXEL_POWER
-        g_ledSinglePixel = &FastLED.addLeds<WS2812B, ONBOARD_PIXEL_DATA, ONBOARD_PIXEL_ORDER>(&g_SinglePixel, 1);
+        FastLED.addLeds<WS2812B, ONBOARD_PIXEL_DATA, ONBOARD_PIXEL_ORDER>(&l_SinglePixel, 1);
         pinMode(ONBOARD_PIXEL_POWER, OUTPUT);
         digitalWrite(ONBOARD_PIXEL_POWER, HIGH);
     #endif
@@ -233,7 +232,7 @@ void ShowOnboardPixel()
     // the color maps to the sound level.  If no audio, it shows the middle LED color from the strip.
 
     #ifdef ONBOARD_PIXEL_POWER
-        g_SinglePixel = FastLED[0].leds()[0];
+        l_SinglePixel = FastLED[0].leds()[0];
     #endif
 }
 

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -43,13 +43,7 @@ CLEDController *g_ledSinglePixel;
 
 extern std::mutex g_buffer_mutex;
 
-#if USE_MATRIX
-extern SmartMatrixHub75Calc<COLOR_DEPTH, LEDMatrixGFX::kMatrixWidth, LEDMatrixGFX::kMatrixHeight, LEDMatrixGFX::kPanelType, LEDMatrixGFX::kMatrixOptions> LEDMatrixGFX::matrix;
-#endif
-
 extern const CRGBPalette16 vuPaletteGreen;
-
-void ShowTM1814();
 
 // DrawLoop
 //
@@ -57,124 +51,6 @@ void ShowTM1814();
 // we will draw the local effect instead
 
 DRAM_ATTR uint64_t g_usLastWifiDraw = 0;
-
-#if USE_MATRIX
-
-// MatrixPreDraw
-//
-// Gets the matrix ready for the effect or wifi to render into
-
-void MatrixPreDraw()
-{
-    // We treat the internal matrix buffer as our own little playground to draw in, but that assumes they're
-    // both 24-bits RGB triplets.  Or at least the same size!
-
-    static_assert(sizeof(CRGB) == sizeof(LEDMatrixGFX::SM_RGB), "Code assumes 24 bits in both places");
-
-    EVERY_N_MILLIS(MILLIS_PER_FRAME)
-    {
-
-        #if SHOW_FPS_ON_MATRIX
-            LEDMatrixGFX::backgroundLayer.setFont(gohufont11);
-            // 3 is half char width at curret font size, 5 is half the height.
-            string output = "FPS: " + std::to_string(g_Values.FPS);
-            LEDMatrixGFX::backgroundLayer.drawString(MATRIX_WIDTH / 2 - (3 * output.length()), MATRIX_HEIGHT / 2 - 5, rgb24(255, 255, 255), rgb24(0, 0, 0), output.c_str());
-        #endif
-
-        auto graphics = g_ptrSystem->EffectManager()[0];
-
-        LEDMatrixGFX::matrix.setCalcRefreshRateDivider(MATRIX_CALC_DIVIDER);
-        LEDMatrixGFX::matrix.setRefreshRate(MATRIX_REFRESH_RATE);
-
-        auto pMatrix = std::static_pointer_cast<LEDMatrixGFX>(g_ptrSystem->EffectManager().GetBaseGraphics());
-        pMatrix->setLeds(LEDMatrixGFX::GetMatrixBackBuffer());
-
-        // We set ourselves to the lower of the fader value or the brightness value,
-        // so that we can fade between effects without having to change the brightness
-        // setting.
-
-        if (g_ptrSystem->EffectManager().GetCurrentEffect().ShouldShowTitle() && pMatrix->GetCaptionTransparency() > 0.00)
-        {
-            LEDMatrixGFX::titleLayer.setFont(font3x5);
-            uint8_t brite = (uint8_t)(pMatrix->GetCaptionTransparency() * 255.0);
-            LEDMatrixGFX::titleLayer.setBrightness(brite); // 255 would obscure it entirely
-            debugV("Caption: %d", brite);
-
-            rgb24 chromaKeyColor = rgb24(255, 0, 255);
-            rgb24 shadowColor = rgb24(0, 0, 0);
-            rgb24 titleColor = rgb24(255, 255, 255);
-
-            LEDMatrixGFX::titleLayer.setChromaKeyColor(chromaKeyColor);
-            LEDMatrixGFX::titleLayer.enableChromaKey(true);
-            LEDMatrixGFX::titleLayer.setFont(font6x10);
-            LEDMatrixGFX::titleLayer.fillScreen(chromaKeyColor);
-
-            const size_t kCharWidth = 6;
-            const size_t kCharHeight = 10;
-
-            const auto caption = pMatrix->GetCaption();
-
-            int y = MATRIX_HEIGHT - 2 - kCharHeight;
-            int w = caption.length() * kCharWidth;
-            int x = (MATRIX_WIDTH / 2) - (w / 2) + 1;
-
-            auto szCaption = caption.c_str();
-            LEDMatrixGFX::titleLayer.drawString(x - 1, y, shadowColor, szCaption);
-            LEDMatrixGFX::titleLayer.drawString(x + 1, y, shadowColor, szCaption);
-            LEDMatrixGFX::titleLayer.drawString(x, y - 1, shadowColor, szCaption);
-            LEDMatrixGFX::titleLayer.drawString(x, y + 1, shadowColor, szCaption);
-            LEDMatrixGFX::titleLayer.drawString(x, y, titleColor, szCaption);
-        }
-        else
-        {
-            LEDMatrixGFX::titleLayer.enableChromaKey(false);
-            LEDMatrixGFX::titleLayer.setBrightness(0);
-        }
-    }
-}
-
-// MatrixPostDraw
-//
-// Things we do with the matrix after rendering a frame, such as setting the brightness and swapping the backbuffer forward
-
-void MatrixPostDraw(size_t pixelsDrawn)
-{
-    if (pixelsDrawn > 0)
-    {
-        auto pMatrix = std::static_pointer_cast<LEDMatrixGFX>( g_ptrSystem->EffectManager().g() );
-
-        constexpr auto kCaptionPower = 500;                                                 // A guess as the power the caption will consume
-        g_Values.MatrixPowerMilliwatts = pMatrix->EstimatePowerDraw();                             // What our drawn pixels will consume
-
-        if (pMatrix->GetCaptionTransparency() > 0)
-            g_Values.MatrixPowerMilliwatts += kCaptionPower;
-
-        const double kMaxPower = g_ptrSystem->DeviceConfig().GetPowerLimit();
-        uint8_t scaledBrightness = std::clamp(kMaxPower / g_Values.MatrixPowerMilliwatts, 0.0, 1.0) * 255;
-
-        // If the target brightness is lower than current, we drop to it immediately, but if its higher, we ramp the brightness back in
-        // somewhat slowly to avoid flicker.  We do this by using a weighted average of the current and former brightness.  To avoid
-        // an ansymptote near the max, we always increase by at least one step if we're lower than the target.
-
-        constexpr auto kWeightedAverageAmount = 10;
-        if (scaledBrightness <= g_Values.MatrixScaledBrightness)
-            g_Values.MatrixScaledBrightness = scaledBrightness;
-        else
-            g_Values.MatrixScaledBrightness = std::max(g_Values.MatrixScaledBrightness + 1,
-                                                       (( g_Values.MatrixScaledBrightness * (kWeightedAverageAmount-1) ) + scaledBrightness) / kWeightedAverageAmount);
-
-        // We set ourselves to the lower of the fader value or the brightness value, or the power constrained value,
-        // whichever is lowest, so that we can fade between effects without having to change the brightness setting.
-
-        auto targetBrightness = min({ g_Values.Brightness, g_Values.Fader, g_Values.MatrixScaledBrightness });
-
-        debugV("MW: %d, Setting Scaled Brightness to: %d", g_Values.MatrixPowerMilliwatts, targetBrightness);
-        pMatrix->SetBrightness(targetBrightness );
-
-        LEDMatrixGFX::MatrixSwapBuffers(g_ptrSystem->EffectManager().GetCurrentEffect().RequiresDoubleBuffering(), pMatrix->GetCaptionTransparency() > 0);
-    }
-}
-#endif
 
 // WiFiDraw
 //
@@ -270,43 +146,6 @@ uint16_t LocalDraw()
 
     debugV("Local draw not drawing");
     return 0;
-}
-
-// ShowStrip
-//
-// ShowStrip sends the data to the LED strip.  If it's fewer than the size of the strip, we only send that many.
-
-void ShowStrip(uint16_t numToShow)
-{
-    // If we've drawn anything from either source, we can now show it
-
-    if (FastLED.count() == 0)
-    {
-        debugW("Draw loop is drawing before LEDs are ready, so delaying 100ms...");
-        delay(100);
-    }
-    else
-    {
-        if (numToShow > 0)
-        {
-            debugV("Telling FastLED that we'll be drawing %d pixels\n", numToShow);
-
-            auto& effectManager = g_ptrSystem->EffectManager();
-
-            for (int i = 0; i < effectManager.gCount(); i++)
-                FastLED[i].setLeds(effectManager[i]->leds, numToShow);
-
-            FastLED.show(g_Values.Fader);
-
-            g_Values.FPS = FastLED.getFPS();
-            g_Values.Brite = 100.0 * calculate_max_brightness_for_power_mW(g_Values.Brightness, POWER_LIMIT_MW) / 255;
-            g_Values.Watts = calculate_unscaled_power_mW(effectManager.g()->leds, numToShow) / 1000; // 1000 for mw->W
-        }
-        else
-        {
-            debugV("Draw loop ended without a draw.");
-        }
-    }
 }
 
 // CalcDelayUntilNextFrame
@@ -426,10 +265,9 @@ void IRAM_ATTR DrawLoopTaskEntry(void *)
         uint16_t wifiPixelsDrawn    = 0;
         double frameStartTime       = g_Values.AppTime.FrameStartTime();
 
-        #if USE_MATRIX
-            // Get the matrix ready for drawing, set the LED array to point to the back buffer
-            MatrixPreDraw();
-        #endif
+        auto graphics = g_ptrSystem->EffectManager().GetBaseGraphics();
+
+        graphics->PrepareFrame();
 
         if (WiFi.isConnected())
             wifiPixelsDrawn = WiFiDraw();
@@ -439,18 +277,7 @@ void IRAM_ATTR DrawLoopTaskEntry(void *)
         if (wifiPixelsDrawn == 0)
             localPixelsDrawn = LocalDraw();
 
-        #if USE_MATRIX
-            // Swap the back buffer forward, set the auto-brightness.  It only does anything if pixels were drawn,
-            // but is always called for orthogonality with the PreDraw() call.
-            MatrixPostDraw(localPixelsDrawn + wifiPixelsDrawn);
-        #endif
-
-        #if USE_STRIP
-            if (wifiPixelsDrawn)
-                ShowStrip(wifiPixelsDrawn);
-            else if (localPixelsDrawn)
-                ShowStrip(localPixelsDrawn);
-        #endif
+        graphics->PostProcessFrame(wifiPixelsDrawn, localPixelsDrawn);
 
         // If we drew any pixels by any method, we'll call that a frame and track it for FPS purposes.  We also notify the
         // color data thread that a new frame is available and can be transmitted to clients

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -258,8 +258,8 @@ std::shared_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color)
 #define STARRYNIGHT_PROBABILITY 1.0
 #define STARRYNIGHT_MUSICFACTOR 1.0
 
-DRAM_ATTR std::unique_ptr<EffectFactories> g_ptrEffectFactories = nullptr;
-std::map<int, JSONEffectFactory> g_JsonStarryNightEffectFactories =
+static DRAM_ATTR std::unique_ptr<EffectFactories> l_ptrEffectFactories = nullptr;
+static std::map<int, JSONEffectFactory> l_JsonStarryNightEffectFactories =
 {
     { EFFECT_STAR,
         [](const JsonObjectConst& jsonObject)->std::shared_ptr<LEDStripEffect> { return make_shared_psram<StarryNightEffect<Star>>(jsonObject); } },
@@ -281,28 +281,28 @@ std::map<int, JSONEffectFactory> g_JsonStarryNightEffectFactories =
 
 std::shared_ptr<LEDStripEffect> CreateStarryNightEffectFromJSON(const JsonObjectConst& jsonObject)
 {
-    auto entry = g_JsonStarryNightEffectFactories.find(jsonObject[PTY_STARTYPENR]);
+    auto entry = l_JsonStarryNightEffectFactories.find(jsonObject[PTY_STARTYPENR]);
 
-    return entry != g_JsonStarryNightEffectFactories.end()
+    return entry != l_JsonStarryNightEffectFactories.end()
         ? entry->second(jsonObject)
         : nullptr;
 }
 
-#define ADD_EFFECT(effectNumber, effectType, ...)   g_ptrEffectFactories->AddEffect(effectNumber, \
+#define ADD_EFFECT(effectNumber, effectType, ...)   l_ptrEffectFactories->AddEffect(effectNumber, \
     []()                                 ->std::shared_ptr<LEDStripEffect> { return make_shared_psram<effectType>(__VA_ARGS__); }, \
     [](const JsonObjectConst& jsonObject)->std::shared_ptr<LEDStripEffect> { return make_shared_psram<effectType>(jsonObject); })
 
-#define ADD_STARRY_NIGHT_EFFECT(starType, ...)      g_ptrEffectFactories->AddEffect(EFFECT_STRIP_STARRY_NIGHT, \
+#define ADD_STARRY_NIGHT_EFFECT(starType, ...)      l_ptrEffectFactories->AddEffect(EFFECT_STRIP_STARRY_NIGHT, \
     []()                                 ->std::shared_ptr<LEDStripEffect> { return make_shared_psram<StarryNightEffect<starType>>(__VA_ARGS__); }, \
     [](const JsonObjectConst& jsonObject)->std::shared_ptr<LEDStripEffect> { return CreateStarryNightEffectFromJSON(jsonObject); })
 
 void LoadEffectFactories()
 {
     // Check if the factories have already been loaded
-    if (g_ptrEffectFactories)
+    if (l_ptrEffectFactories)
         return;
 
-    g_ptrEffectFactories = make_unique_psram<EffectFactories>();
+    l_ptrEffectFactories = make_unique_psram<EffectFactories>();
 
     // Fill effect factories
     #if DEMO
@@ -566,12 +566,12 @@ void LoadEffectFactories()
     // If this assert fires, you have not defined any effects in the table above.  If adding a new config, you need to
     // add the list of effects in this table as shown for the various other existing configs.  You MUST have at least
     // one effect even if it's the Status effect.
-    assert(!g_ptrEffectFactories->IsEmpty());
+    assert(!l_ptrEffectFactories->IsEmpty());
 }
 
-DRAM_ATTR size_t g_EffectsManagerJSONBufferSize = 0;
-DRAM_ATTR size_t g_EffectsManagerJSONWriterIndex = std::numeric_limits<size_t>::max();
-DRAM_ATTR size_t g_CurrentEffectWriterIndex = std::numeric_limits<size_t>::max();
+static DRAM_ATTR size_t l_EffectsManagerJSONBufferSize = 0;
+static DRAM_ATTR size_t l_EffectsManagerJSONWriterIndex = std::numeric_limits<size_t>::max();
+static DRAM_ATTR size_t l_CurrentEffectWriterIndex = std::numeric_limits<size_t>::max();
 
 #if USE_MATRIX
 
@@ -598,14 +598,14 @@ void InitEffectsManager()
 
     LoadEffectFactories();
 
-    g_EffectsManagerJSONWriterIndex = g_ptrSystem->JSONWriter().RegisterWriter(
-        []() { SaveToJSONFile(EFFECTS_CONFIG_FILE, g_EffectsManagerJSONBufferSize, g_ptrSystem->EffectManager()); }
+    l_EffectsManagerJSONWriterIndex = g_ptrSystem->JSONWriter().RegisterWriter(
+        []() { SaveToJSONFile(EFFECTS_CONFIG_FILE, l_EffectsManagerJSONBufferSize, g_ptrSystem->EffectManager()); }
     );
-    g_CurrentEffectWriterIndex = g_ptrSystem->JSONWriter().RegisterWriter(WriteCurrentEffectIndexFile);
+    l_CurrentEffectWriterIndex = g_ptrSystem->JSONWriter().RegisterWriter(WriteCurrentEffectIndexFile);
 
     std::unique_ptr<AllocatedJsonDocument> pJsonDoc;
 
-    if (LoadJSONFile(EFFECTS_CONFIG_FILE, g_EffectsManagerJSONBufferSize, pJsonDoc))
+    if (LoadJSONFile(EFFECTS_CONFIG_FILE, l_EffectsManagerJSONBufferSize, pJsonDoc))
     {
         debugI("Creating EffectManager from JSON config");
 
@@ -628,14 +628,14 @@ void InitEffectsManager()
         throw std::runtime_error("Could not initialize effect manager");
 
     // We won't need the default factories any more, so swipe them from memory
-    g_ptrEffectFactories->ClearDefaultFactories();
+    l_ptrEffectFactories->ClearDefaultFactories();
 }
 
 void SaveEffectManagerConfig()
 {
     debugV("Saving effect manager config...");
     // Default value for writer index is max value for size_t, so nothing will happen if writer has not yet been registered
-    g_ptrSystem->JSONWriter().FlagWriter(g_EffectsManagerJSONWriterIndex);
+    g_ptrSystem->JSONWriter().FlagWriter(l_EffectsManagerJSONWriterIndex);
 }
 
 void RemoveEffectManagerConfig()
@@ -649,7 +649,7 @@ void SaveCurrentEffectIndex()
 {
     if (g_ptrSystem->DeviceConfig().RememberCurrentEffect())
         // Default value for writer index is max value for size_t, so nothing will happen if writer has not yet been registered
-        g_ptrSystem->JSONWriter().FlagWriter(g_CurrentEffectWriterIndex);
+        g_ptrSystem->JSONWriter().FlagWriter(l_CurrentEffectWriterIndex);
 }
 
 void WriteCurrentEffectIndexFile()
@@ -703,24 +703,117 @@ bool ReadCurrentEffectIndex(size_t& index)
     return readIndex;
 }
 
-// Dirty hack to support FastLED, which calls out of band to get the pixel index for "the" array, without
-// any indication of which array or who's asking, so we assume the first matrix.  If you have trouble with
-// more than one matrix and some FastLED functions like blur2d, this would be why.
-
-uint16_t XY(uint8_t x, uint8_t y)
+void EffectManager::LoadJSONAndMissingEffects(const JsonArrayConst& effectsArray)
 {
-    // Have a drink on me!
-    return g_ptrSystem->EffectManager()[0]->xy(x, y);
+    std::set<int> loadedEffectNumbers;
+
+    // Create effects from JSON objects, using the respective factories in g_EffectFactories
+    auto& jsonFactories = l_ptrEffectFactories->GetJSONFactories();
+
+    for (auto effectObject : effectsArray)
+    {
+        int effectNumber = effectObject[PTY_EFFECTNR];
+        auto factoryEntry = jsonFactories.find(effectNumber);
+
+        if (factoryEntry == jsonFactories.end())
+            continue;
+
+        auto pEffect = factoryEntry->second(effectObject);
+        if (pEffect)
+        {
+            if (effectObject[PTY_COREEFFECT].as<int>())
+                pEffect->MarkAsCoreEffect();
+
+            _vEffects.push_back(pEffect);
+            loadedEffectNumbers.insert(effectNumber);
+        }
+    }
+
+    // Now add missing effects from the default factory list
+    auto &defaultFactories = l_ptrEffectFactories->GetDefaultFactories();
+
+    // We iterate manually, so we can use where we are as the starting point for a later inner loop
+    for (auto iter = defaultFactories.begin(); iter != defaultFactories.end(); iter++)
+    {
+        int effectNumber = iter->EffectNumber;
+
+        // If we've already loaded this effect (number) from JSON, we can move on to check the next one
+        if (loadedEffectNumbers.count(effectNumber))
+            continue;
+
+        // We found an effect (number) in the default list that we have not yet loaded from JSON.
+        //   So, we go through the rest of the default factory list to create and add to our effects
+        //   list all instances of this effect.
+        std::for_each(iter, defaultFactories.end(), [&](const EffectFactories::NumberedFactory& numberedFactory)
+            {
+                if (numberedFactory.EffectNumber != effectNumber)
+                    return;
+
+                auto pEffect = numberedFactory.Factory();
+                if (pEffect)
+                {
+                    // Effects in the default list are core effects. These can be disabled but not deleted.
+                    pEffect->MarkAsCoreEffect();
+                    _vEffects.push_back(pEffect);
+                }
+            }
+        );
+
+        // Register that we added this effect number, so we don't add the respective effects more than once
+        loadedEffectNumbers.insert(effectNumber);
+    }
 }
 
-// btimap_output
-//
-// Output function for the jpeg library.  It doesn't provide any mechanism for passing a this pointer or other context,
-// so it has to assume that it will be drawing to the main channel 0.
-
-bool bitmap_output(int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t *bitmap)
+void EffectManager::LoadDefaultEffects()
 {
-    auto pgfx = g_ptrSystem->EffectManager().g();
-    pgfx->drawRGBBitmap(x, y, bitmap, w, h);
-    return true;
+    for (auto &numberedFactory : l_ptrEffectFactories->GetDefaultFactories())
+    {
+        auto pEffect = numberedFactory.Factory();
+        if (pEffect)
+        {
+            // Effects in the default list are core effects. These can be disabled but not deleted.
+            pEffect->MarkAsCoreEffect();
+            _vEffects.push_back(pEffect);
+        }
+    }
+
+    for (int i = 0; i < _vEffects.size(); i++)
+        EnableEffect(i, true);
+
+    SetInterval(DEFAULT_EFFECT_INTERVAL, true);
+
+    construct(true);
+}
+
+std::shared_ptr<LEDStripEffect> EffectManager::CopyEffect(size_t index)
+{
+    if (index >= _vEffects.size())
+    {
+        debugW("Invalid index for CopyEffect");
+        return nullptr;
+    }
+
+    static size_t jsonBufferSize = JSON_BUFFER_BASE_SIZE;
+
+    auto& sourceEffect = _vEffects[index];
+
+    std::unique_ptr<AllocatedJsonDocument> ptrJsonDoc = nullptr;
+
+    SerializeWithBufferSize(ptrJsonDoc, jsonBufferSize,
+        [&sourceEffect](JsonObject &jsonObject) { return sourceEffect->SerializeToJSON(jsonObject); });
+
+    auto jsonEffectFactories = l_ptrEffectFactories->GetJSONFactories();
+    auto factoryEntry = jsonEffectFactories.find(sourceEffect->EffectNumber());
+
+    if (factoryEntry == jsonEffectFactories.end())
+        return nullptr;
+
+    auto copiedEffect = factoryEntry->second(ptrJsonDoc->as<JsonObjectConst>());
+
+    if (!copiedEffect)
+        return nullptr;
+
+    copiedEffect->SetEnabled(false);
+
+    return copiedEffect;
 }

--- a/src/ledmatrixgfx.cpp
+++ b/src/ledmatrixgfx.cpp
@@ -46,94 +46,93 @@ SMLayerBackground<LEDMatrixGFX::SM_RGB, LEDMatrixGFX::kBackgroundLayerOptions> L
 SMLayerBackground<LEDMatrixGFX::SM_RGB, LEDMatrixGFX::kBackgroundLayerOptions> LEDMatrixGFX::titleLayer(LEDMatrixGFX::kMatrixWidth, LEDMatrixGFX::kMatrixHeight);
 SmartMatrixHub75Calc<COLOR_DEPTH, LEDMatrixGFX::kMatrixWidth, LEDMatrixGFX::kMatrixHeight, LEDMatrixGFX::kPanelType, LEDMatrixGFX::kMatrixOptions> LEDMatrixGFX::matrix;
 
-
 void LEDMatrixGFX::StartMatrix()
 {
-  matrix.addLayer(&backgroundLayer);
-  matrix.addLayer(&titleLayer);
+    matrix.addLayer(&backgroundLayer);
+    matrix.addLayer(&titleLayer);
 
-  // When the matrix starts, you can ask it to leave N bytes of memory free, and this amount must be tuned.  Too much free
-  // will cause a dim panel with a low refresh, too little will starve other things.  We currently have enough RAM for
-  // use so begin() is not being called with a reserve paramter, but it can be if memory becomes scarce.
+    // When the matrix starts, you can ask it to leave N bytes of memory free, and this amount must be tuned.  Too much free
+    // will cause a dim panel with a low refresh, too little will starve other things.  We currently have enough RAM for
+    // use so begin() is not being called with a reserve paramter, but it can be if memory becomes scarce.
 
-  matrix.setCalcRefreshRateDivider(MATRIX_CALC_DIVIDER);
-  matrix.setRefreshRate(MATRIX_REFRESH_RATE);
-  matrix.begin();
+    matrix.setCalcRefreshRateDivider(MATRIX_CALC_DIVIDER);
+    matrix.setRefreshRate(MATRIX_REFRESH_RATE);
+    matrix.begin();
 
-  Serial.printf("Matrix Refresh Rate: %d\n", matrix.getRefreshRate());
+    Serial.printf("Matrix Refresh Rate: %d\n", matrix.getRefreshRate());
 
-  //backgroundLayer.setRefreshRate(100);
-  backgroundLayer.fillScreen(rgb24(0, 64, 0));
-  backgroundLayer.setFont(font6x10);
-  backgroundLayer.drawString(8, kMatrixHeight / 2 - 6, rgb24(255, 255, 255), "NightDriver");
-  backgroundLayer.swapBuffers(false);
+    //backgroundLayer.setRefreshRate(100);
+    backgroundLayer.fillScreen(rgb24(0, 64, 0));
+    backgroundLayer.setFont(font6x10);
+    backgroundLayer.drawString(8, kMatrixHeight / 2 - 6, rgb24(255, 255, 255), "NightDriver");
+    backgroundLayer.swapBuffers(false);
 
-  matrix.setBrightness(255);
+    matrix.setBrightness(255);
 }
 
 void LEDMatrixGFX::PrepareFrame()
 {
-  // We treat the internal matrix buffer as our own little playground to draw in, but that assumes they're
-  // both 24-bits RGB triplets.  Or at least the same size!
+    // We treat the internal matrix buffer as our own little playground to draw in, but that assumes they're
+    // both 24-bits RGB triplets.  Or at least the same size!
 
-  static_assert(sizeof(CRGB) == sizeof(SM_RGB), "Code assumes 24 bits in both places");
+    static_assert(sizeof(CRGB) == sizeof(SM_RGB), "Code assumes 24 bits in both places");
 
-  EVERY_N_MILLIS(MILLIS_PER_FRAME)
-  {
-    #if SHOW_FPS_ON_MATRIX
-      backgroundLayer.setFont(gohufont11);
-      // 3 is half char width at curret font size, 5 is half the height.
-      string output = "FPS: " + std::to_string(g_Values.FPS);
-      backgroundLayer.drawString(MATRIX_WIDTH / 2 - (3 * output.length()), MATRIX_HEIGHT / 2 - 5, rgb24(255, 255, 255), rgb24(0, 0, 0), output.c_str());
-    #endif
-
-    matrix.setCalcRefreshRateDivider(MATRIX_CALC_DIVIDER);
-    matrix.setRefreshRate(MATRIX_REFRESH_RATE);
-
-    setLeds(GetMatrixBackBuffer());
-
-    // We set ourselves to the lower of the fader value or the brightness value,
-    // so that we can fade between effects without having to change the brightness
-    // setting.
-
-    if (g_ptrSystem->EffectManager().GetCurrentEffect().ShouldShowTitle() && GetCaptionTransparency() > 0.00)
+    EVERY_N_MILLIS(MILLIS_PER_FRAME)
     {
-      titleLayer.setFont(font3x5);
-      uint8_t brite = (uint8_t)(GetCaptionTransparency() * 255.0);
-      titleLayer.setBrightness(brite); // 255 would obscure it entirely
-      debugV("Caption: %d", brite);
+        #if SHOW_FPS_ON_MATRIX
+            backgroundLayer.setFont(gohufont11);
+            // 3 is half char width at curret font size, 5 is half the height.
+            string output = "FPS: " + std::to_string(g_Values.FPS);
+            backgroundLayer.drawString(MATRIX_WIDTH / 2 - (3 * output.length()), MATRIX_HEIGHT / 2 - 5, rgb24(255, 255, 255), rgb24(0, 0, 0), output.c_str());
+        #endif
 
-      rgb24 chromaKeyColor = rgb24(255, 0, 255);
-      rgb24 shadowColor = rgb24(0, 0, 0);
-      rgb24 titleColor = rgb24(255, 255, 255);
+        matrix.setCalcRefreshRateDivider(MATRIX_CALC_DIVIDER);
+        matrix.setRefreshRate(MATRIX_REFRESH_RATE);
 
-      titleLayer.setChromaKeyColor(chromaKeyColor);
-      titleLayer.enableChromaKey(true);
-      titleLayer.setFont(font6x10);
-      titleLayer.fillScreen(chromaKeyColor);
+        setLeds(GetMatrixBackBuffer());
 
-      const size_t kCharWidth = 6;
-      const size_t kCharHeight = 10;
+        // We set ourselves to the lower of the fader value or the brightness value,
+        // so that we can fade between effects without having to change the brightness
+        // setting.
 
-      const auto caption = GetCaption();
+        if (g_ptrSystem->EffectManager().GetCurrentEffect().ShouldShowTitle() && GetCaptionTransparency() > 0.00)
+        {
+            titleLayer.setFont(font3x5);
+            uint8_t brite = (uint8_t)(GetCaptionTransparency() * 255.0);
+            titleLayer.setBrightness(brite); // 255 would obscure it entirely
+            debugV("Caption: %d", brite);
 
-      int y = MATRIX_HEIGHT - 2 - kCharHeight;
-      int w = caption.length() * kCharWidth;
-      int x = (MATRIX_WIDTH / 2) - (w / 2) + 1;
+            rgb24 chromaKeyColor = rgb24(255, 0, 255);
+            rgb24 shadowColor = rgb24(0, 0, 0);
+            rgb24 titleColor = rgb24(255, 255, 255);
 
-      auto szCaption = caption.c_str();
-      titleLayer.drawString(x - 1, y, shadowColor, szCaption);
-      titleLayer.drawString(x + 1, y, shadowColor, szCaption);
-      titleLayer.drawString(x, y - 1, shadowColor, szCaption);
-      titleLayer.drawString(x, y + 1, shadowColor, szCaption);
-      titleLayer.drawString(x, y, titleColor, szCaption);
+            titleLayer.setChromaKeyColor(chromaKeyColor);
+            titleLayer.enableChromaKey(true);
+            titleLayer.setFont(font6x10);
+            titleLayer.fillScreen(chromaKeyColor);
+
+            const size_t kCharWidth = 6;
+            const size_t kCharHeight = 10;
+
+            const auto caption = GetCaption();
+
+            int y = MATRIX_HEIGHT - 2 - kCharHeight;
+            int w = caption.length() * kCharWidth;
+            int x = (MATRIX_WIDTH / 2) - (w / 2) + 1;
+
+            auto szCaption = caption.c_str();
+            titleLayer.drawString(x - 1, y, shadowColor, szCaption);
+            titleLayer.drawString(x + 1, y, shadowColor, szCaption);
+            titleLayer.drawString(x, y - 1, shadowColor, szCaption);
+            titleLayer.drawString(x, y + 1, shadowColor, szCaption);
+            titleLayer.drawString(x, y, titleColor, szCaption);
+        }
+        else
+        {
+            titleLayer.enableChromaKey(false);
+            titleLayer.setBrightness(0);
+        }
     }
-    else
-    {
-      titleLayer.enableChromaKey(false);
-      titleLayer.setBrightness(0);
-    }
-  }
 }
 
 // PostProcessFrame
@@ -142,59 +141,59 @@ void LEDMatrixGFX::PrepareFrame()
 
 void LEDMatrixGFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDrawn)
 {
-  // If we drew no pixels, there's nothing to post process
-  if ((localPixelsDrawn + wifiPixelsDrawn) == 0)
-    return;
+    // If we drew no pixels, there's nothing to post process
+    if ((localPixelsDrawn + wifiPixelsDrawn) == 0)
+        return;
 
-  constexpr auto kCaptionPower = 500;                                                 // A guess as the power the caption will consume
-  g_Values.MatrixPowerMilliwatts = EstimatePowerDraw();                             // What our drawn pixels will consume
+    constexpr auto kCaptionPower = 500;                                                 // A guess as the power the caption will consume
+    g_Values.MatrixPowerMilliwatts = EstimatePowerDraw();                             // What our drawn pixels will consume
 
-  if (GetCaptionTransparency() > 0)
-    g_Values.MatrixPowerMilliwatts += kCaptionPower;
+    if (GetCaptionTransparency() > 0)
+        g_Values.MatrixPowerMilliwatts += kCaptionPower;
 
-  const double kMaxPower = g_ptrSystem->DeviceConfig().GetPowerLimit();
-  uint8_t scaledBrightness = std::clamp(kMaxPower / g_Values.MatrixPowerMilliwatts, 0.0, 1.0) * 255;
+    const double kMaxPower = g_ptrSystem->DeviceConfig().GetPowerLimit();
+    uint8_t scaledBrightness = std::clamp(kMaxPower / g_Values.MatrixPowerMilliwatts, 0.0, 1.0) * 255;
 
-  // If the target brightness is lower than current, we drop to it immediately, but if its higher, we ramp the brightness back in
-  // somewhat slowly to avoid flicker.  We do this by using a weighted average of the current and former brightness.  To avoid
-  // an ansymptote near the max, we always increase by at least one step if we're lower than the target.
+    // If the target brightness is lower than current, we drop to it immediately, but if its higher, we ramp the brightness back in
+    // somewhat slowly to avoid flicker.  We do this by using a weighted average of the current and former brightness.  To avoid
+    // an ansymptote near the max, we always increase by at least one step if we're lower than the target.
 
-  constexpr auto kWeightedAverageAmount = 10;
-  if (scaledBrightness <= g_Values.MatrixScaledBrightness)
-    g_Values.MatrixScaledBrightness = scaledBrightness;
-  else
-    g_Values.MatrixScaledBrightness = std::max(g_Values.MatrixScaledBrightness + 1,
-                                               (( g_Values.MatrixScaledBrightness * (kWeightedAverageAmount-1) ) + scaledBrightness) / kWeightedAverageAmount);
+    constexpr auto kWeightedAverageAmount = 10;
+    if (scaledBrightness <= g_Values.MatrixScaledBrightness)
+        g_Values.MatrixScaledBrightness = scaledBrightness;
+    else
+        g_Values.MatrixScaledBrightness = std::max(g_Values.MatrixScaledBrightness + 1,
+                                                   (( g_Values.MatrixScaledBrightness * (kWeightedAverageAmount-1) ) + scaledBrightness) / kWeightedAverageAmount);
 
-  // We set ourselves to the lower of the fader value or the brightness value, or the power constrained value,
-  // whichever is lowest, so that we can fade between effects without having to change the brightness setting.
+    // We set ourselves to the lower of the fader value or the brightness value, or the power constrained value,
+    // whichever is lowest, so that we can fade between effects without having to change the brightness setting.
 
-  auto targetBrightness = min({ g_Values.Brightness, g_Values.Fader, g_Values.MatrixScaledBrightness });
+    auto targetBrightness = min({ g_Values.Brightness, g_Values.Fader, g_Values.MatrixScaledBrightness });
 
-  debugV("MW: %d, Setting Scaled Brightness to: %d", g_Values.MatrixPowerMilliwatts, targetBrightness);
-  SetBrightness(targetBrightness );
+    debugV("MW: %d, Setting Scaled Brightness to: %d", g_Values.MatrixPowerMilliwatts, targetBrightness);
+    SetBrightness(targetBrightness );
 
-  MatrixSwapBuffers(g_ptrSystem->EffectManager().GetCurrentEffect().RequiresDoubleBuffering(), GetCaptionTransparency() > 0);
+    MatrixSwapBuffers(g_ptrSystem->EffectManager().GetCurrentEffect().RequiresDoubleBuffering(), GetCaptionTransparency() > 0);
 }
 
 CRGB *LEDMatrixGFX::GetMatrixBackBuffer()
 {
-  for (auto& device : g_ptrSystem->Devices())
-    device->UpdatePaletteCycle();
+    for (auto& device : g_ptrSystem->Devices())
+        device->UpdatePaletteCycle();
 
-  return (CRGB *)backgroundLayer.getRealBackBuffer();
+    return (CRGB *)backgroundLayer.getRealBackBuffer();
 }
 
 void LEDMatrixGFX::MatrixSwapBuffers(bool bSwapBackground, bool bSwapTitle)
 {
-  // If an effect redraws itself entirely ever frame, it can skip saving the most recent buffer, so
-  // can swap without waiting for a copy.
-  matrix.setCalcRefreshRateDivider(MATRIX_CALC_DIVIDER);
-  matrix.setRefreshRate(MATRIX_REFRESH_RATE);
-  matrix.setMaxCalculationCpuPercentage(95);
+    // If an effect redraws itself entirely ever frame, it can skip saving the most recent buffer, so
+    // can swap without waiting for a copy.
+    matrix.setCalcRefreshRateDivider(MATRIX_CALC_DIVIDER);
+    matrix.setRefreshRate(MATRIX_REFRESH_RATE);
+    matrix.setMaxCalculationCpuPercentage(95);
 
-  backgroundLayer.swapBuffers(bSwapBackground);
-  titleLayer.swapBuffers(bSwapTitle);
+    backgroundLayer.swapBuffers(bSwapBackground);
+    titleLayer.swapBuffers(bSwapTitle);
 }
 
 #endif

--- a/src/ledmatrixgfx.cpp
+++ b/src/ledmatrixgfx.cpp
@@ -28,9 +28,10 @@
 //
 //---------------------------------------------------------------------------
 
+#include "globals.h"
+
 #if USE_MATRIX
 
-#include "globals.h"
 #include "effects/matrix/Boid.h"
 #include "effects/matrix/Vector.h"
 #include <SmartMatrix.h>

--- a/src/ledstripgfx.cpp
+++ b/src/ledstripgfx.cpp
@@ -1,0 +1,66 @@
+//+--------------------------------------------------------------------------
+//
+// File:        ledstripgfx.cpp
+//
+// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
+//
+// This file is part of the NightDriver software project.
+//
+//    NightDriver is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    NightDriver is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with Nightdriver.  It is normally found in copying.txt
+//    If not, see <https://www.gnu.org/licenses/>.
+//
+// Description:
+//
+//    Code for handling LED strips
+//
+// History:     Jul-22-2023         Rbergen      Created
+//
+//---------------------------------------------------------------------------
+
+#include "globals.h"
+#include "ledstripgfx.h"
+#include "systemcontainer.h"
+
+void LEDStripGFX::PostProcessFrame(uint16_t wifiPixelsDrawn, uint16_t localPixelsDrawn)
+{
+    auto pixelsDrawn = wifiPixelsDrawn > 0 ? wifiPixelsDrawn : localPixelsDrawn;
+
+    // If we drew no pixels, there's nothing to post process
+    if (pixelsDrawn == 0)
+    {
+        debugV("Frame draw ended without any pixels drawn.");
+        return;
+    }
+
+    // If we've drawn anything from either source, we can now show it if we have LEDs to output to
+    if (FastLED.count() == 0)
+    {
+        debugW("Draw loop is drawing before LEDs are ready, so delaying 100ms...");
+        delay(100);
+        return;
+    }
+
+    debugV("Telling FastLED that we'll be drawing %d pixels\n", pixelsDrawn);
+
+    auto& effectManager = g_ptrSystem->EffectManager();
+
+    for (int i = 0; i < FastLED.count(); i++)
+        FastLED[i].setLeds(effectManager[i]->leds, pixelsDrawn);
+
+    FastLED.show(g_Values.Fader);
+
+    g_Values.FPS = FastLED.getFPS();
+    g_Values.Brite = 100.0 * calculate_max_brightness_for_power_mW(g_Values.Brightness, POWER_LIMIT_MW) / 255;
+    g_Values.Watts = calculate_unscaled_power_mW(effectManager.g()->leds, pixelsDrawn) / 1000; // 1000 for mw->W
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -365,9 +365,9 @@ void setup()
     //   threads.
     auto& networkReader = g_ptrSystem->SetupNetworkReader();
 
-    // Register a network reader to update the device clock at regular intervals
     #if ENABLE_NTP
-        networkReader.RegisterReader(UpdateNTPTime, (NTP_DELAY_COUNT) * 1000UL);
+        // Register a network reader to update the device clock at regular intervals
+        networkReader.RegisterReader(UpdateNTPTime, (NTP_DELAY_ERROR_SECONDS) * 1000UL);
     #endif
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -450,15 +450,15 @@ void setup()
 
     // Initialize the strand controllers depending on how many channels we have
 
-    #if USE_STRIP
-        // LEDStripGFX is used for simple strips or for matrices woven from strips
-        LEDStripGFX::InitializeHardware(devices);
+    #if USE_MATRIX
+        // LEDMatrixGFX is used for HUB75 projects like the Mesmerizer
+        LEDMatrixGFX::InitializeHardware(devices);
     #elif HEXAGON
         // Hexagon is for a PCB wtih 271 LEDss arranged in the face of a hexagon
         HexagonGFX::InitializeHardware(devices);
-    #elif USE_MATRIX
-        // LEDMatrixGFX is used for HUB75 projects like the Mesmerizer
-        LEDMatrixGFX::InitializeHardware(devices);
+    #elif USE_STRIP
+        // LEDStripGFX is used for simple strips or for matrices woven from strips
+        LEDStripGFX::InitializeHardware(devices);
     #endif
 
     // Initialize all of the built in effects

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -184,7 +184,6 @@ DRAM_ATTR String WiFi_ssid;
 DRAM_ATTR String WiFi_password;
 DRAM_ATTR std::mutex g_buffer_mutex;
 
-
 // If an insulator or tree or fan has multiple rings, this table defines how those rings are laid out such
 // that they add up to FAN_SIZE pixels total per ring.
 //
@@ -364,7 +363,12 @@ void setup()
     // We create the network reader here, so classes can register their readers from this point onwards.
     //   Note that the thread that executes the readers is started further down, along with other networking
     //   threads.
-    g_ptrSystem->SetupNetworkReader();
+    auto& networkReader = g_ptrSystem->SetupNetworkReader();
+
+    // Register a network reader to update the device clock at regular intervals
+    #if ENABLE_NTP
+        networkReader.RegisterReader(UpdateNTPTime, (NTP_DELAY_COUNT) * 1000UL);
+    #endif
 #endif
 
 #if INCOMING_WIFI_ENABLED

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -35,16 +35,9 @@
 #include "globals.h"
 #include "systemcontainer.h"
 
-#if USE_WIFI_MANAGER
-#include <ESP_WiFiManager.h>
-DRAM_ATTR ESP_WiFiManager g_WifiManager("NightDriverWiFi");
-#endif
+extern DRAM_ATTR std::mutex g_buffer_mutex;
 
-std::mutex g_buffer_mutex;
-String WiFi_ssid;
-String WiFi_password;
-DRAM_ATTR WiFiUDP g_Udp;              // UDP object used for NNTP, etc
-
+static DRAM_ATTR WiFiUDP l_Udp;              // UDP object used for NNTP, etc
 
 // processRemoteDebugCmd
 //
@@ -58,7 +51,7 @@ DRAM_ATTR WiFiUDP g_Udp;              // UDP object used for NNTP, etc
         if (str.equalsIgnoreCase("clock"))
         {
             debugA("Refreshing Time from Server...");
-            NTPTimeClient::UpdateClockFromWeb(&g_Udp);
+            NTPTimeClient::UpdateClockFromWeb(&l_Udp);
         }
         else if (str.equalsIgnoreCase("stats"))
         {
@@ -286,7 +279,7 @@ void IRAM_ATTR RemoteLoopEntry(void *)
 
         #if ENABLE_NTP
             debugI("Setting Clock...");
-            NTPTimeClient::UpdateClockFromWeb(&g_Udp);
+            NTPTimeClient::UpdateClockFromWeb(&l_Udp);
         #endif
 
         #if ENABLE_WEBSERVER
@@ -749,7 +742,7 @@ bool WriteWiFiConfig()
         if (WiFi.isConnected())
         {
             debugV("Refreshing Time from Server...");
-            NTPTimeClient::UpdateClockFromWeb(&g_Udp);
+            NTPTimeClient::UpdateClockFromWeb(&l_Udp);
 
         }
     }

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -741,9 +741,15 @@ bool WriteWiFiConfig()
     {
         if (WiFi.isConnected())
         {
-            debugV("Refreshing Time from Server...");
-            NTPTimeClient::UpdateClockFromWeb(&l_Udp);
+            static unsigned long lastUpdate = 0;
 
+            // If we've already retrieved the time successfully, we'll only actually update every NTP_DELAY_SECONDS seconds
+            if (!NTPTimeClient::HasClockBeenSet() || (millis() - lastUpdate) > ((NTP_DELAY_SECONDS) * 1000))
+            {
+                debugV("Refreshing Time from Server...");
+                if (NTPTimeClient::UpdateClockFromWeb(&l_Udp))
+                    lastUpdate = millis();
+            }
         }
     }
 #endif

--- a/src/remotecontrol.cpp
+++ b/src/remotecontrol.cpp
@@ -84,7 +84,7 @@ void RemoteControl::handle()
     else if (IR_SMOOTH == result)
     {
         effectManager.ClearRemoteColor();
-        effectManager.SetInterval(EffectManager<GFXBase>::csSmoothButtonSpeed);
+        effectManager.SetInterval(EffectManager::csSmoothButtonSpeed);
     }
     else if (IR_STROBE == result)
     {


### PR DESCRIPTION
## Description

This fixes #349, to the extent #365 hadn't already. It does this by:

- Adding PrepareFrame() and PostProcessFrame() virtual functions to `GFXBase`
- Overloading both in `LEDMatrixGFX`
- Overloading PostProcessFrame() in `LEDStripGFX`

These changes have been tested on a Mesmerizer board running Mesmerizer, and an M5StickCPlus running Spectrum.

Also, this:

- Declares globally defined variables that are actually only meant to be used by one compilation unit (.cpp file) `static` and gives them an `l_` prefix (instead of `g_` for "true" globals).
- Fixes a regression that NTP time was no longer updated at regular intervals.

**Note:** I am aware this PR will cause merge conflicts with #369. I will address these when either that PR or this one has been merged. I'm opening this now so people can take a look at it, and/or test it if they want to.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).