### PR TITLE
Fix NTP update and restore use of (checked) NUM_CHANNELS

### DIFF
--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -158,7 +158,7 @@ inline void ClearFanPixels(float fPos, float count, PixelOrder order = Sequentia
   fPos += iFan * FAN_SIZE;
   while (count > 0)
   {
-    for (int i = 0; i < FastLED.count(); i++)
+    for (int i = 0; i < NUM_CHANNELS; i++)
       FastLED[i][GetFanPixelOrder(fPos + (int)count, order)] = CRGB::Black;
     count--;
   }
@@ -251,7 +251,7 @@ inline void DrawFanPixels(float fPos, float count, CRGB color, PixelOrder order 
 
   if (remaining > 0.0f && amtFirstPixel > 0.0f && iPos < NUM_LEDS)
   {
-    for (int i = 0; i < FastLED.count(); i++)
+    for (int i = 0; i < NUM_CHANNELS; i++)
     {
       auto index = GetFanPixelOrder(iPos, order);
       CRGB newColor = LEDStripEffect::ColorFraction(color, amtFirstPixel);
@@ -267,7 +267,7 @@ inline void DrawFanPixels(float fPos, float count, CRGB color, PixelOrder order 
 
   while (remaining > 1.0f && iPos < NUM_LEDS)
   {
-    for (int i = 0; i < FastLED.count(); i++)
+    for (int i = 0; i < NUM_CHANNELS; i++)
       FastLED[i][GetFanPixelOrder(iPos, order)] += color;
     iPos++;
     remaining--;
@@ -277,7 +277,7 @@ inline void DrawFanPixels(float fPos, float count, CRGB color, PixelOrder order 
 
   if (remaining > 0.0f)
   {
-    for (int i = 0; i < FastLED.count(); i++)
+    for (int i = 0; i < NUM_CHANNELS; i++)
       FastLED[i][GetFanPixelOrder(iPos, order)] += LEDStripEffect::ColorFraction(color, remaining);
     iPos++;
   }
@@ -319,7 +319,7 @@ inline void DrawRingPixels(float fPos, float count, CRGB color, int iInsulator, 
   iPos %= GetRingSize(iRing);
   if (remaining > 0.0f && amtFirstPixel > 0.0f)
   {
-    for (int i = 0; i < FastLED.count(); i++)
+    for (int i = 0; i < NUM_CHANNELS; i++)
     {
       if (!bMerge)
         FastLED[i][bPos + iPos] = CRGB::Black;
@@ -332,7 +332,7 @@ inline void DrawRingPixels(float fPos, float count, CRGB color, int iInsulator, 
 
   while (remaining > 1.0f)
   {
-    for (int i = 0; i < FastLED.count(); i++)
+    for (int i = 0; i < NUM_CHANNELS; i++)
     {
       iPos %= GetRingSize(iRing);
       if (!bMerge)
@@ -347,7 +347,7 @@ inline void DrawRingPixels(float fPos, float count, CRGB color, int iInsulator, 
   iPos %= GetRingSize(iRing);
   if (remaining > 0.0f)
   {
-    for (int i = 0; i < FastLED.count(); i++)
+    for (int i = 0; i < NUM_CHANNELS; i++)
     {
       if (!bMerge)
         FastLED[i][bPos + iPos] = CRGB::Black;
@@ -1105,7 +1105,7 @@ public:
       // for (int iCell = 0; iCell < CellsPerLED; iCell++)
       //   maxv = max(maxv, heat[i * CellsPerLED + iCell]);
 
-      for (int iChannel = 0; iChannel < FastLED.count(); iChannel++)
+      for (int iChannel = 0; iChannel < NUM_CHANNELS; iChannel++)
       {
         CRGB color = GetBlackBodyHeatColor(abHeat[i * CellsPerLED]);
 

--- a/include/ledstripgfx.h
+++ b/include/ledstripgfx.h
@@ -112,9 +112,11 @@ public:
     static void InitializeHardware(std::vector<std::shared_ptr<GFXBase>>& devices)
     {
         // We can't have more than 8 channels, because we don't have more than 8 pins
-        int channelCount = std::min(NUM_CHANNELS, 8);
+        #if NUM_CHANNELS > 8
+            #error The maximum value of NUM_CHANNELS is 8
+        #endif
 
-        for (int i = 0; i < channelCount; i++)
+        for (int i = 0; i < NUM_CHANNELS; i++)
         {
             debugW("Allocating LEDStripGFX for channel %d", i);
             devices.push_back(make_shared_psram<LEDStripGFX>(MATRIX_WIDTH, MATRIX_HEIGHT));
@@ -156,9 +158,11 @@ class HexagonGFX : public LEDStripGFX
     static void InitializeHardware(std::vector<std::shared_ptr<GFXBase>>& devices)
     {
         // We can't have more than 8 channels, because we don't have more than 8 pins
-        int channelCount = std::min(NUM_CHANNELS, 8);
+        #if NUM_CHANNELS > 8
+            #error The maximum value of NUM_CHANNELS is 8
+        #endif
 
-        for (int i = 0; i < channelCount; i++)
+        for (int i = 0; i < NUM_CHANNELS; i++)
         {
             debugW("Allocating HexagonGFX for channel %d", i);
             devices.push_back(make_shared_psram<HexagonGFX>(NUM_LEDS));

--- a/src/ledstripgfx.cpp
+++ b/src/ledstripgfx.cpp
@@ -55,7 +55,7 @@ void LEDStripGFX::PostProcessFrame(uint16_t wifiPixelsDrawn, uint16_t localPixel
 
     auto& effectManager = g_ptrSystem->EffectManager();
 
-    for (int i = 0; i < FastLED.count(); i++)
+    for (int i = 0; i < NUM_CHANNELS; i++)
         FastLED[i].setLeds(effectManager[i]->leds, pixelsDrawn);
 
     FastLED.show(g_Values.Fader);

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -743,10 +743,10 @@ bool WriteWiFiConfig()
 #if ENABLE_WIFI && ENABLE_NTP
     void UpdateNTPTime()
     {
+        static unsigned long lastUpdate = 0;
+
         if (WiFi.isConnected())
         {
-            static unsigned long lastUpdate = 0;
-
             // If we've already retrieved the time successfully, we'll only actually update every NTP_DELAY_SECONDS seconds
             if (!NTPTimeClient::HasClockBeenSet() || (millis() - lastUpdate) > ((NTP_DELAY_SECONDS) * 1000))
             {


### PR DESCRIPTION
## Description

This fixes two bugs that were recently introduced:

- The static variable that keeps track of the last successful NTP time update is now in the right place and should as such indeed retain values across invocations.
- NUM_CHANNELS is used once again as the number of available channels, because FastLED.count() returns a value that is one too high if an on-board LED is present. Many thanks to @davepl for finding that one.
- To prevent an invalid NUM_CHANNELS causing problems, defining it to a value > 8 will now trigger a compile-time error.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).