### PR TITLE
Cleanup excessive virtual function decoration.

### DIFF
--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -112,7 +112,7 @@ class DeviceConfig : public IJSONSerializable
 
     DeviceConfig();
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         return SerializeToJSON(jsonObject, true);
     }
@@ -138,7 +138,7 @@ class DeviceConfig : public IJSONSerializable
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
-    virtual bool DeserializeFromJSON(const JsonObjectConst& jsonObject) override
+    bool DeserializeFromJSON(const JsonObjectConst& jsonObject) override
     {
         return DeserializeFromJSON(jsonObject, false);
     }

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -183,7 +183,7 @@ public:
     //
     // Lastly, the function calls the construct() method, indicating successful deserialization.
 
-    virtual bool DeserializeFromJSON(const JsonObjectConst& jsonObject) override
+    bool DeserializeFromJSON(const JsonObjectConst& jsonObject) override
     {
         ClearEffects();
 
@@ -252,7 +252,7 @@ public:
     //
     // If all effects are successfully serialized, the function returns true, indicating successful serialization.
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         // Set JSON format version to be able to detect and manage future incompatible structural updates
         jsonObject[PTY_VERSION] = JSON_FORMAT_VERSION;

--- a/include/effects/matrix/Boid.h
+++ b/include/effects/matrix/Boid.h
@@ -68,7 +68,7 @@
 
 #include "Vector.h"
 
-class Boid 
+class Boid
 {
   public:
 

--- a/include/effects/matrix/Geometry.h
+++ b/include/effects/matrix/Geometry.h
@@ -4,7 +4,7 @@
  *
  * Portions of this code are adapted from Noel Bundy's work: https://github.com/TwystNeko/Object3d
  * Copyright (c) 2014 Noel Bundy
- * 
+ *
  * Portions of this code are adapted from the Petty library: https://code.google.com/p/peggy/
  * Copyright (c) 2008 Windell H Oskay.  All right reserved.
  *
@@ -139,7 +139,7 @@ struct triFace
     this->sommets[2]=c;
   }
   void set(int a, int b, int c)
-  { 
+  {
     this->length =3;
     this->sommets[0]=a;
     this->sommets[1]=b;

--- a/include/effects/matrix/PatternAlienText.h
+++ b/include/effects/matrix/PatternAlienText.h
@@ -77,7 +77,7 @@ public:
   {
   }
 
-  virtual void Start() override
+  void Start() override
   {
       x = leftMargin;
       y = topMargin;
@@ -85,7 +85,7 @@ public:
       debugW("Starting AlienText...");
   }
 
-  virtual void Draw() override
+  void Draw() override
   {
     std::shared_ptr<GFXBase> graphics = _GFX[0];
 

--- a/include/effects/matrix/PatternBounce.h
+++ b/include/effects/matrix/PatternBounce.h
@@ -72,12 +72,12 @@ public:
     {
     }
 
-    virtual bool RequiresDoubleBuffering() const override
+    bool RequiresDoubleBuffering() const override
     {
         return true;
     }
 
-    virtual void Start() override
+    void Start() override
     {
         unsigned int colorWidth = 256 / count;
         for (int i = 0; i < count; i++)
@@ -92,7 +92,7 @@ public:
         }
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         // dim all pixels on the display
 

--- a/include/effects/matrix/PatternCircuit.h
+++ b/include/effects/matrix/PatternCircuit.h
@@ -186,7 +186,7 @@ public:
         g()->Clear();
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         // Reset after 20 seconds
         const auto kResetEveryNSeconds = 20;

--- a/include/effects/matrix/PatternClock.h
+++ b/include/effects/matrix/PatternClock.h
@@ -48,12 +48,12 @@ class PatternClock : public LEDStripEffect
     {
     }
 
-    virtual bool RequiresDoubleBuffering() const override
+    bool RequiresDoubleBuffering() const override
     {
         return false;
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         // Get the hours, minutes, and seconds of hte current time
 

--- a/include/effects/matrix/PatternCube.h
+++ b/include/effects/matrix/PatternCube.h
@@ -187,7 +187,7 @@ class PatternCube : public LEDStripEffect
         return 40;
     }
 
-    virtual bool RequiresDoubleBuffering() const override
+    bool RequiresDoubleBuffering() const override
     {
         return false;
     }
@@ -209,7 +209,7 @@ class PatternCube : public LEDStripEffect
       construct();
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
       g()->Clear();
       zCamera = beatsin8(2, 100, 140);

--- a/include/effects/matrix/PatternFlowField.h
+++ b/include/effects/matrix/PatternFlowField.h
@@ -77,7 +77,7 @@ public:
 
     uint8_t hue = 0;
 
-    virtual void Start() override
+    void Start() override
     {
         x = random16();
         y = random16();
@@ -94,7 +94,7 @@ public:
         return 16;
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         g()->DimAll(240);
 

--- a/include/effects/matrix/PatternLife.h
+++ b/include/effects/matrix/PatternLife.h
@@ -95,7 +95,7 @@ private:
     unsigned long seed;
 
 
-    virtual bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
+    bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
     {
         LEDStripEffect::Init(gfx);
 
@@ -108,7 +108,7 @@ private:
         return true;
     }
 
-    virtual bool RequiresDoubleBuffering() const override
+    bool RequiresDoubleBuffering() const override
     {
         return true;
     }
@@ -208,7 +208,7 @@ public:
         bStuckInLoop = 0;
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         if (cGeneration == 0)
             Reset();

--- a/include/effects/matrix/PatternMandala.h
+++ b/include/effects/matrix/PatternMandala.h
@@ -89,12 +89,12 @@ public:
         return 30;
     }
 
-    virtual bool RequiresDoubleBuffering() const override
+    bool RequiresDoubleBuffering() const override
     {
         return true;
     }
 
-    virtual void Start() override
+    void Start() override
     {
         // set to reasonable values to avoid a black out
         g()->GetNoise().noisesmoothing = 100;
@@ -118,7 +118,7 @@ public:
         dsy = random8();
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         // a new parameter set every 15 seconds
         EVERY_N_SECONDS(15)
@@ -136,7 +136,7 @@ public:
         g()->GetNoise().noise_z += dz * 4;
 
         g()->FillGetNoise();
-  
+
         ShowNoiseLayer(0, 1, 0);
 
         g()->Caleidoscope3();

--- a/include/effects/matrix/PatternMaze.h
+++ b/include/effects/matrix/PatternMaze.h
@@ -255,7 +255,7 @@ public:
     {
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         if (cellCount < 1)
         {
@@ -297,7 +297,7 @@ public:
         return true;
     }
 
-    virtual void Start() override
+    void Start() override
     {
         g()->Clear();
     }

--- a/include/effects/matrix/PatternMisc.h
+++ b/include/effects/matrix/PatternMisc.h
@@ -75,7 +75,7 @@ class PatternSunburst : public LEDStripEffect
         return 60;
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         uint8_t dim = beatsin8(2, 210, 250);
         g()->DimAll(dim);
@@ -116,12 +116,12 @@ class PatternRose : public LEDStripEffect
         return 60;
     }
 
-    virtual bool RequiresDoubleBuffering() const override
+    bool RequiresDoubleBuffering() const override
     {
         return true;
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         uint8_t dim = beatsin8(2, 170, 250);
         g()->DimAll(dim);
@@ -165,7 +165,7 @@ class PatternPinwheel : public LEDStripEffect
     {
     }
 
-    virtual void Start() override
+    void Start() override
     {
         g()->Clear();
     }
@@ -175,7 +175,7 @@ class PatternPinwheel : public LEDStripEffect
         return 45;
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         uint8_t dim = beatsin8(2, 30, 70);
         fadeAllChannelsToBlackBy(dim);
@@ -217,7 +217,7 @@ public:
     int _lastX = -1;
     int _lastY = -1;
 
-    virtual void Draw() override
+    void Draw() override
     {
         // dim all pixels on the display slightly
         // to 250/255 (98%) of their current brightness
@@ -279,12 +279,12 @@ public:
         return 16;
     }
 
-    virtual bool RequiresDoubleBuffering() const override
+    bool RequiresDoubleBuffering() const override
     {
         return false;
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         for (uint16_t x = 0; x < MATRIX_WIDTH; x++)
         {

--- a/include/effects/matrix/PatternNoiseSmearing.h
+++ b/include/effects/matrix/PatternNoiseSmearing.h
@@ -69,7 +69,7 @@ public:
   {
   }
 
-  virtual void Draw() override
+  void Draw() override
   {
     g()->DimAll(235);
     g()->BlurFrame(50);
@@ -109,7 +109,7 @@ public:
   {
   }
 
-  virtual void Draw() override
+  void Draw() override
   {
     g()->DimAll(230);
 
@@ -150,7 +150,7 @@ public:
   {
   }
 
-  virtual void Draw() override
+  void Draw() override
   {
     g()->DimAll(20);
 
@@ -198,7 +198,7 @@ public:
   {
   }
 
-  virtual void Draw() override
+  void Draw() override
   {
     g()->DimAll(10);
 

--- a/include/effects/matrix/PatternPongClock.h
+++ b/include/effects/matrix/PatternPongClock.h
@@ -108,12 +108,12 @@ class PatternPongClock : public LEDStripEffect
         return 35;
     }
 
-    virtual bool RequiresDoubleBuffering() const override
+    bool RequiresDoubleBuffering() const override
     {
         return false;
     }
 
-    virtual void Start() override
+    void Start() override
     {
         time_t ttime = time(0);
         tm *local_time = localtime(&ttime);
@@ -129,7 +129,7 @@ class PatternPongClock : public LEDStripEffect
             hours = 12;
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         time_t ttime = time(0);
         tm *local_time = localtime(&ttime);

--- a/include/effects/matrix/PatternPulse.h
+++ b/include/effects/matrix/PatternPulse.h
@@ -80,7 +80,7 @@ class PatternPulse : public LEDStripEffect
     {
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         auto graphics = g();
 
@@ -176,7 +176,7 @@ class PatternPulsar : public BeatEffectBase, public LEDStripEffect
 
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         ProcessAudio();
         fadeAllChannelsToBlackBy(10);

--- a/include/effects/matrix/PatternQR.h
+++ b/include/effects/matrix/PatternQR.h
@@ -66,16 +66,16 @@ public:
         free(qrcodeData);
     }
 
-    virtual void Start() override
+    void Start() override
     {
     }
 
-    virtual size_t DesiredFramesPerSecond() const override
+    size_t DesiredFramesPerSecond() const override
     {
         return 20;
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         String sIP = WiFi.isConnected() ? "http://" + WiFi.localIP().toString() : "No Wifi";
         if (sIP != lastData)

--- a/include/effects/matrix/PatternRadar.h
+++ b/include/effects/matrix/PatternRadar.h
@@ -69,7 +69,7 @@ public:
   {
   }
 
-  virtual void Draw() override
+  void Draw() override
   {
     auto graphics = (GFXBase *)_GFX[0].get();
     graphics->DimAll(254);

--- a/include/effects/matrix/PatternSerendipity.h
+++ b/include/effects/matrix/PatternSerendipity.h
@@ -102,7 +102,7 @@ public:
     {
     }
 
-    virtual bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
+    bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
     {
         if (!LEDStripEffect::Init(gfx))
             return false;
@@ -148,7 +148,7 @@ public:
         return true;
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         auto graphics = g();
 

--- a/include/effects/matrix/PatternSpin.h
+++ b/include/effects/matrix/PatternSpin.h
@@ -80,14 +80,14 @@ public:
     float speed = speedStart;
     float velocity = velocityStart;
 
-    virtual void Start() override
+    void Start() override
     {
         speed = speedStart;
         velocity = velocityStart;
         degrees = 0;
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         g()->DimAll(190);
 

--- a/include/effects/matrix/PatternSpiro.h
+++ b/include/effects/matrix/PatternSpiro.h
@@ -93,7 +93,7 @@ public:
   {
       return 120;
   }
-  virtual void Draw() override
+  void Draw() override
   {
     auto graphics = g();
     graphics->DimAll(253);

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -126,7 +126,7 @@ class PatternSubscribers : public LEDStripEffect
 
   protected:
 
-    virtual bool FillSettingSpecs() override
+    bool FillSettingSpecs() override
     {
         if (!LEDStripEffect::FillSettingSpecs())
             return false;
@@ -170,7 +170,7 @@ class PatternSubscribers : public LEDStripEffect
         g_ptrSystem->NetworkReader().CancelReader(readerIndex);
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<256> jsonDoc;
 
@@ -183,12 +183,12 @@ class PatternSubscribers : public LEDStripEffect
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
-    virtual bool RequiresDoubleBuffering() const override
+    bool RequiresDoubleBuffering() const override
     {
         return true;            // BUGBUG Flickers without this, but should NOT need it?
     }
 
-    virtual bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
+    bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
     {
         if (!LEDStripEffect::Init(gfx))
             return false;
@@ -198,7 +198,7 @@ class PatternSubscribers : public LEDStripEffect
         return true;
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         LEDMatrixGFX::backgroundLayer.fillScreen(rgb24(0, 16, 64));
         LEDMatrixGFX::backgroundLayer.setFont(font5x7);
@@ -233,7 +233,7 @@ class PatternSubscribers : public LEDStripEffect
         LEDMatrixGFX::backgroundLayer.drawString(x,   y,   rgb24(255,255,255),    pszText);
     }
 
-    virtual bool SerializeSettingsToJSON(JsonObject& jsonObject) override
+    bool SerializeSettingsToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<384> jsonDoc;
         auto rootObject = jsonDoc.to<JsonObject>();
@@ -246,7 +246,7 @@ class PatternSubscribers : public LEDStripEffect
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
-    virtual bool SetSetting(const String& name, const String& value) override
+    bool SetSetting(const String& name, const String& value) override
     {
         RETURN_IF_SET(name, NAME_OF(youtubeChannelGuid), youtubeChannelGuid, value);
         RETURN_IF_SET(name, NAME_OF(youtubeChannelName), youtubeChannelName, value);

--- a/include/effects/matrix/PatternSwirl.h
+++ b/include/effects/matrix/PatternSwirl.h
@@ -83,7 +83,7 @@ public:
         graphics->leds[graphics->xy(i, j)] += color;
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         auto graphics = _GFX[0];
 

--- a/include/effects/matrix/PatternWave.h
+++ b/include/effects/matrix/PatternWave.h
@@ -96,10 +96,10 @@ public:
         construct();
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         auto graphics = g();
-        
+
         int n = 0;
 
         switch (rotation) {
@@ -119,7 +119,7 @@ public:
                 for (int y = 0; y < MATRIX_HEIGHT; y++) {
                     n = quadwave8(y * 2 + theta) / scale;
                     if (n < MATRIX_WIDTH)
-                    {                    
+                    {
                         graphics->setPixel(n, y, graphics->ColorFromCurrentPalette(y + hue));
                         if (waveCount == 2)
                             graphics->setPixel(maxX - n, y, graphics->ColorFromCurrentPalette(y + hue));

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -115,12 +115,12 @@ private:
         return false;
     }
 
-    virtual size_t DesiredFramesPerSecond() const override
+    size_t DesiredFramesPerSecond() const override
     {
         return 25;
     }
 
-    virtual bool RequiresDoubleBuffering() const override
+    bool RequiresDoubleBuffering() const override
     {
         return false;
     }
@@ -337,7 +337,7 @@ public:
         g_ptrSystem->NetworkReader().CancelReader(readerIndex);
     }
 
-    virtual bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
+    bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
     {
         if (!LEDStripEffect::Init(gfx))
             return false;
@@ -347,7 +347,7 @@ public:
         return true;
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         const int fontHeight = 7;
         const int fontWidth  = 5;

--- a/include/effects/strip/bouncingballeffect.h
+++ b/include/effects/strip/bouncingballeffect.h
@@ -90,7 +90,7 @@ private:
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<256> jsonDoc;
 
@@ -110,7 +110,7 @@ private:
         return 61;
     }
 
-    virtual bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
+    bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
     {
         if (!LEDStripEffect::Init(gfx))
             return false;
@@ -140,7 +140,7 @@ private:
     //
     // Draw each of the balls.  When any ball gets too little energy it would just sit at the base so it is re-kicked with new energy.#pragma endregion
 
-    virtual void Draw() override
+    void Draw() override
     {
         // Erase the drawing area
         if (_bErase)

--- a/include/effects/strip/doublepaletteeffect.h
+++ b/include/effects/strip/doublepaletteeffect.h
@@ -55,7 +55,7 @@ class DoublePaletteEffect : public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         AllocatedJsonDocument jsonDoc(896);
 
@@ -70,7 +70,7 @@ class DoublePaletteEffect : public LEDStripEffect
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
-    virtual bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
+    bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
     {
         LEDStripEffect::Init(gfx);
         if (!_PaletteEffect1.Init(gfx) || !_PaletteEffect2.Init(gfx))
@@ -78,7 +78,7 @@ class DoublePaletteEffect : public LEDStripEffect
         return true;
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         setAllOnAllChannels(0,0,0);
         _PaletteEffect1.Draw();

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -365,7 +365,7 @@ class EmptyEffect : public LEDStripEffect
 {
   using LEDStripEffect::LEDStripEffect;
 
-  virtual void Draw() override
+  void Draw() override
   {
     FastLED.clear(false);
     DrawEffect();
@@ -389,7 +389,7 @@ public:
   {
   }
 
-  virtual void Draw() override
+  void Draw() override
   {
     fadeToBlackBy(FastLED.leds(), NUM_LEDS, 20);
     DrawEffect();
@@ -457,7 +457,7 @@ class CountEffect : public LEDStripEffect
   const int DRAW_LEN = 16;
   const int OPEN_LEN = NUM_FANS * FAN_SIZE - DRAW_LEN;
 
-  virtual void Draw() override
+  void Draw() override
   {
     static float i = 0;
     EVERY_N_MILLISECONDS(30)
@@ -502,7 +502,7 @@ public:
   {
   }
 
-  virtual void Draw() override
+  void Draw() override
   {
     EVERY_N_MILLISECONDS(250)
     {
@@ -589,7 +589,7 @@ public:
   {
   }
 
-  virtual void Draw() override
+  void Draw() override
   {
     EVERY_N_MILLISECONDS(250)
     {
@@ -699,7 +699,7 @@ public:
   {
   }
 
-  virtual bool SerializeToJSON(JsonObject& jsonObject) override
+  bool SerializeToJSON(JsonObject& jsonObject) override
   {
     AllocatedJsonDocument jsonDoc(512);
 
@@ -713,7 +713,7 @@ public:
     return jsonObject.set(jsonDoc.as<JsonObjectConst>());
   }
 
-  virtual void Draw() override
+  void Draw() override
   {
     EVERY_N_MILLISECONDS(20) // Update the reels based on the direction
     {
@@ -774,7 +774,7 @@ public:
   {
   }
 
-  virtual bool SerializeToJSON(JsonObject& jsonObject) override
+  bool SerializeToJSON(JsonObject& jsonObject) override
   {
     StaticJsonDocument<128> jsonDoc;
 
@@ -787,7 +787,7 @@ public:
     return jsonObject.set(jsonDoc.as<JsonObjectConst>());
   }
 
-  virtual void Draw() override
+  void Draw() override
   {
     FastLED.clear(false);
     DrawEffect();
@@ -811,7 +811,7 @@ class ColorCycleEffectBottomUp : public LEDStripEffect
 public:
   using LEDStripEffect::LEDStripEffect;
 
-  virtual void Draw() override
+  void Draw() override
   {
     FastLED.clear(false);
     DrawEffect();
@@ -835,7 +835,7 @@ class ColorCycleEffectTopDown : public LEDStripEffect
 public:
   using LEDStripEffect::LEDStripEffect;
 
-  virtual void Draw() override
+  void Draw() override
   {
     FastLED.clear(false);
     DrawEffect();
@@ -859,7 +859,7 @@ class ColorCycleEffectSequential : public LEDStripEffect
 public:
   using LEDStripEffect::LEDStripEffect;
 
-  virtual void Draw() override
+  void Draw() override
   {
     FastLED.clear(false);
     DrawEffect();
@@ -885,7 +885,7 @@ class SpinningPaletteEffect : public PaletteEffect
 public:
   using PaletteEffect::PaletteEffect;
 
-  virtual void Draw() override
+  void Draw() override
   {
     PaletteEffect::Draw();
     for (int i = 0; i < NUM_FANS; i++)
@@ -906,7 +906,7 @@ class ColorCycleEffectRightLeft : public LEDStripEffect
 public:
   using LEDStripEffect::LEDStripEffect;
 
-  virtual void Draw() override
+  void Draw() override
   {
     FastLED.clear(false);
     DrawEffect();
@@ -928,7 +928,7 @@ class ColorCycleEffectLeftRight : public LEDStripEffect
 public:
   using LEDStripEffect::LEDStripEffect;
 
-  virtual void Draw() override
+  void Draw() override
   {
     FastLED.clear(false);
     DrawEffect();
@@ -1020,7 +1020,7 @@ public:
     abHeat.reset( psram_allocator<uint8_t>().allocate(CellCount()) );
   }
 
-  virtual bool SerializeToJSON(JsonObject& jsonObject) override
+  bool SerializeToJSON(JsonObject& jsonObject) override
   {
     AllocatedJsonDocument jsonDoc(512);
 
@@ -1046,13 +1046,13 @@ public:
     return ColorFromPalette(Palette, temp, 255);
   }
 
-  virtual void Draw() override
+  void Draw() override
   {
     FastLED.clear(false);
     DrawFire(Order);
   }
 
-  virtual size_t DesiredFramesPerSecond() const override
+  size_t DesiredFramesPerSecond() const override
   {
     return 60;
   }
@@ -1172,7 +1172,7 @@ public:
     DrawFanPixels(q, lineLen, color, BottomUp);
   }
 
-  virtual void Draw() override
+  void Draw() override
   {
     FastLED.clear();
     DrawColor(CRGB::Red, 0);
@@ -1188,7 +1188,7 @@ class HueTest : public LEDStripEffect
 public:
   using LEDStripEffect::LEDStripEffect;
 
-  virtual void Draw() override
+  void Draw() override
   {
     FastLED.clear();
     int iFan = 0;
@@ -1211,7 +1211,7 @@ public:
   {
   }
 
-  virtual void Draw() override
+  void Draw() override
   {
     for (int i = 0; i < NUM_FANS; i++)
     {
@@ -1406,12 +1406,12 @@ public:
   {
   }
 
-  virtual size_t DesiredFramesPerSecond() const override
+  size_t DesiredFramesPerSecond() const override
   {
     return 30;
   }
 
-  virtual void Draw() override
+  void Draw() override
   {
     fadeAllChannelsToBlackBy(20);
     for (int i = 0; i < _maxParticles; i++)

--- a/include/effects/strip/fireeffect.h
+++ b/include/effects/strip/fireeffect.h
@@ -99,7 +99,7 @@ class FireEffect : public LEDStripEffect
         construct();
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<256> jsonDoc;
 
@@ -122,7 +122,7 @@ class FireEffect : public LEDStripEffect
     {
     }
 
-    virtual size_t DesiredFramesPerSecond() const override
+    size_t DesiredFramesPerSecond() const override
     {
         return 45;
     }
@@ -146,7 +146,7 @@ class FireEffect : public LEDStripEffect
         }
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         FastLED.clear(false);
         DrawFire();
@@ -253,7 +253,7 @@ public:
         construct();
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         AllocatedJsonDocument jsonDoc(512);
 
@@ -356,7 +356,7 @@ public:
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<256> jsonDoc;
 
@@ -370,7 +370,7 @@ public:
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         Fire(_Cooling, 180, 5);
         delay(20);
@@ -521,7 +521,7 @@ public:
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 
@@ -540,7 +540,7 @@ public:
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
-    virtual bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
+    bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
     {
         LEDStripEffect::Init(gfx);
         _Temperatures = (float *)PreferPSRAMAlloc(sizeof(float) * _cLEDs);
@@ -557,7 +557,7 @@ public:
         free(_Temperatures);
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         float deltaTime = (float)g_Values.AppTime.LastFrameTime();
         setAllOnAllChannels(0, 0, 0);
@@ -687,7 +687,7 @@ class BaseFireEffect : public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<256> jsonDoc;
 
@@ -724,7 +724,7 @@ class BaseFireEffect : public LEDStripEffect
         }
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         FastLED.showColor(CRGB::Red);
         return;

--- a/include/effects/strip/laserline.h
+++ b/include/effects/strip/laserline.h
@@ -90,7 +90,7 @@ class LaserLineEffect : public BeatEffectBase, public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 
@@ -103,7 +103,7 @@ class LaserLineEffect : public BeatEffectBase, public LEDStripEffect
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
-    virtual bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
+    bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
     {
         debugW("Initialized LaserLine Effect");
         _gfx = gfx[0];
@@ -112,7 +112,7 @@ class LaserLineEffect : public BeatEffectBase, public LEDStripEffect
         return true;
     }
 
-    virtual void Draw() override
+    void Draw() 
     {
         ProcessAudio();
 

--- a/include/effects/strip/meteoreffect.h
+++ b/include/effects/strip/meteoreffect.h
@@ -54,7 +54,7 @@ public:
 
     }
 
-    virtual void Init(std::shared_ptr<GFXBase> pGFX, size_t meteors = 4, uint size = 4, uint decay = 3, float minSpeed = 0.5, float maxSpeed = 0.5)
+    virtual void Init(std::shared_ptr<GFXBase> pGFX, size_t meteors = 4, int size = 4, int decay = 3, float minSpeed = 0.5, float maxSpeed = 0.5)
     {
         meteorCount = meteors;
         meteorSize = size;
@@ -178,7 +178,7 @@ class MeteorEffect : public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<256> jsonDoc;
 
@@ -194,7 +194,7 @@ class MeteorEffect : public LEDStripEffect
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
-    virtual bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
+    bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
     {
         if (!LEDStripEffect::Init(gfx))
             return false;
@@ -209,7 +209,7 @@ class MeteorEffect : public LEDStripEffect
         return true;
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         for (int i = 0; i < _Meteors.size(); i++)
             _Meteors[i].Draw(_GFX[i]);

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -61,7 +61,7 @@ class SimpleRainbowTestEffect : public LEDStripEffect
         debugV("SimpleRainbowTestEffect JSON constructor");
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 
@@ -74,7 +74,7 @@ class SimpleRainbowTestEffect : public LEDStripEffect
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         fillRainbowAllChannels(0, _cLEDs, beatsin16(4, 0, 256), 8, _EveryNth);
         delay(10);
@@ -109,7 +109,7 @@ class RainbowTwinkleEffect : public LEDStripEffect
         debugV("RainbowFill JSON constructor");
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 
@@ -122,7 +122,7 @@ class RainbowTwinkleEffect : public LEDStripEffect
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         static float hue = 0.0f;
         static unsigned long lastms = millis();
@@ -172,7 +172,7 @@ protected:
         debugV("RainbowFill JSON constructor");
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 
@@ -185,7 +185,7 @@ protected:
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         static float hue = 0.0f;
         static unsigned long lastms = millis();
@@ -232,7 +232,7 @@ protected:
         debugV("Color Fill JSON constructor");
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 
@@ -245,7 +245,7 @@ protected:
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         if (_everyNth != 1)
           fillSolidOnAllChannels(CRGB::Black);
@@ -288,12 +288,12 @@ class SplashLogoEffect : public LEDStripEffect
         return 5.0 * MILLIS_PER_SECOND;
     }
 
-    virtual bool CanDisplayVUMeter() const override
+    bool CanDisplayVUMeter() const override
     {
         return false;
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         fillSolidOnAllChannels(CRGB::Black);
         if (JDR_OK != TJpgDec.drawJpg(0, 0, logo.contents, logo.length))        // Draw the image
@@ -339,7 +339,7 @@ class StatusEffect : public LEDStripEffect
         debugV("Status Fill JSON constructor");
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 
@@ -352,7 +352,7 @@ class StatusEffect : public LEDStripEffect
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         CRGB color = _color;
 
@@ -413,7 +413,7 @@ class TwinkleEffect : public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<256> jsonDoc;
 
@@ -432,7 +432,7 @@ class TwinkleEffect : public LEDStripEffect
 
     std::deque<size_t> litPixels;
 
-    virtual void Draw() override
+    void Draw() override
     {
         EVERY_N_MILLISECONDS(_updateSpeed)
         {

--- a/include/effects/strip/musiceffect.h
+++ b/include/effects/strip/musiceffect.h
@@ -123,7 +123,7 @@ class SimpleColorBeat : public BeatEffectBase, public LEDStripEffect
 
     int _iLastInsulator = -1;
 
-    virtual void Draw() override
+    void Draw() override
     {
         ProcessAudio();
 
@@ -134,7 +134,7 @@ class SimpleColorBeat : public BeatEffectBase, public LEDStripEffect
         delay(1);
     }
 
-    virtual void HandleBeat(bool bMajor, float elapsed, float span)
+    void HandleBeat(bool bMajor, float elapsed, float span) override
     {
         CRGB c;
         int  cInsulators = 1;

--- a/include/effects/strip/paletteeffect.h
+++ b/include/effects/strip/paletteeffect.h
@@ -89,7 +89,7 @@ class PaletteEffect : public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         AllocatedJsonDocument jsonDoc(512);
 
@@ -113,7 +113,7 @@ class PaletteEffect : public LEDStripEffect
     {
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         if (_bErase)
           setAllOnAllChannels(0,0,0);

--- a/include/effects/strip/particles.h
+++ b/include/effects/strip/particles.h
@@ -111,7 +111,7 @@ class FadingObject : public Lifespan
 
   public:
 
-    virtual double TotalLifetime() const
+    double TotalLifetime() const override
     {
         return PreignitionTime() + IgnitionTime() + HoldTime() + FadeTime();
     }
@@ -367,10 +367,10 @@ class RingParticle : public FadingColoredObject
         }
     }
 
-    virtual float PreignitionTime() const         { return 0.0f;          }
-    virtual float IgnitionTime()    const         { return _ignitionTime; }
-    virtual float HoldTime()        const         { return 0.0f;          }
-    virtual float FadeTime()        const         { return _fadeTime;     }
+    float PreignitionTime() const override         { return 0.0f;          }
+    float IgnitionTime()    const override         { return _ignitionTime; }
+    float HoldTime()        const override         { return 0.0f;          }
+    float FadeTime()        const override         { return _fadeTime;     }
 };
 
 
@@ -608,10 +608,10 @@ class SpinningPaletteRingParticle : public FadingObject
           _GFX[0]->setPixelsF(_start + random(0, _length), 1, CRGB::White, true);
     }
 
-    virtual float PreignitionTime() const         { return 0.0f;          }
-    virtual float IgnitionTime() const            { return _ignitionTime; }
-    virtual float HoldTime() const                { return 0.0f;          }
-    virtual float FadeTime() const                { return 1.00;          }
+    float PreignitionTime() const override         { return 0.0f;          }
+    float IgnitionTime() const override            { return _ignitionTime; }
+    float HoldTime() const override                { return 0.0f;          }
+    float FadeTime() const override                { return 1.00;          }
 };
 
 
@@ -681,10 +681,10 @@ class HotWhiteRingParticle : public FadingObject
         }
     }
 
-    virtual float PreignitionTime() const         { return 0.0f;          }
-    virtual float IgnitionTime()    const         { return _ignitionTime; }
-    virtual float HoldTime()        const         { return 0.0f;          }
-    virtual float FadeTime()        const         { return _fadeTime;     }
+    float PreignitionTime() const override         { return 0.0f;          }
+    float IgnitionTime()    const override         { return _ignitionTime; }
+    float HoldTime()        const override         { return 0.0f;          }
+    float FadeTime()        const override         { return _fadeTime;     }
 };
 
 #if ENABLE_AUDIO

--- a/include/effects/strip/snakeeffect.h
+++ b/include/effects/strip/snakeeffect.h
@@ -80,7 +80,7 @@ class SnakeEffect : public LEDStripEffect
         construct();
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         AllocatedJsonDocument jsonDoc(512);
 
@@ -107,7 +107,7 @@ class SnakeEffect : public LEDStripEffect
         winMode = 0;
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         setAllOnAllChannels(0,0,0); // Clear
 

--- a/include/effects/strip/stareffect.h
+++ b/include/effects/strip/stareffect.h
@@ -82,10 +82,10 @@ class RandomPaletteColorStar : public MovingFadingPaletteObject, public ObjectSi
 
 class LongLifeSparkleStar : public MovingFadingPaletteObject, public ObjectSize
 {
-    virtual float PreignitionTime() const         { return .25f;  }
-    virtual float IgnitionTime()    const         { return 5.0f;  }
-    virtual float HoldTime()        const         { return 0.00f; }
-    virtual float FadeTime()        const         { return 0.0f;  }
+    float PreignitionTime() const override         { return .25f;  }
+    float IgnitionTime()    const override         { return 5.0f;  }
+    float HoldTime()        const override         { return 0.00f; }
+    float FadeTime()        const override         { return 0.0f;  }
 
   public:
 
@@ -140,10 +140,10 @@ class QuietStar : public RandomPaletteColorStar
       : RandomPaletteColorStar(palette, blendType, maxSpeed, starSize)
     {}
 
-    virtual float PreignitionTime() const { return 1.0f; }
-    virtual float IgnitionTime()    const { return 0.00f; }
-    virtual float HoldTime()        const { return 0.00f; }
-    virtual float FadeTime()        const { return 2.0f;  }
+    float PreignitionTime() const override { return 1.0f; }
+    float IgnitionTime()    const override { return 0.00f; }
+    float HoldTime()        const override { return 0.00f; }
+    float FadeTime()        const override { return 2.0f;  }
     virtual float StarSize()        const { return 1;     }
 };
 
@@ -218,7 +218,7 @@ class BubblyStar : public Star
         return EFFECT_STAR_BUBBLY;
     }
 
-    virtual float GetStarSize()
+    float GetStarSize() override
     {
         float x = Age()/TotalLifetime();
         float ratio1 = -1 * (2*(x-.5)) * (2*(x-.5)) + 1;
@@ -226,13 +226,13 @@ class BubblyStar : public Star
         return width;
     }
 
-    virtual ~BubblyStar()
+    ~BubblyStar() override
     {}
 
-    virtual float PreignitionTime() const  { return 0.00f; }
-    virtual float IgnitionTime()    const  { return 0.05f; }
-    virtual float HoldTime()        const  { return 0.25f; }
-    virtual float FadeTime()        const  { return 0.50f; }
+    float PreignitionTime() const override  { return 0.00f; }
+    float IgnitionTime()    const override  { return 0.05f; }
+    float HoldTime()        const override  { return 0.25f; }
+    float FadeTime()        const override  { return 0.50f; }
 };
 
 class FlashStar : public Star
@@ -244,10 +244,10 @@ class FlashStar : public Star
         return EFFECT_STAR_FLASH;
     }
 
-    virtual float PreignitionTime() const  { return 0.00f; }
-    virtual float IgnitionTime()    const  { return 0.10f; }
-    virtual float HoldTime()        const  { return 0.10f; }
-    virtual float FadeTime()        const  { return 0.05f; }
+    float PreignitionTime() const override  { return 0.00f; }
+    float IgnitionTime()    const override  { return 0.10f; }
+    float HoldTime()        const override  { return 0.10f; }
+    float FadeTime()        const override  { return 0.05f; }
 };
 
 class ColorCycleStar : public Star
@@ -275,13 +275,13 @@ class ColorCycleStar : public Star
         return c;
     }
 
-    virtual ~ColorCycleStar()
+    ~ColorCycleStar() override
     {}
 
-    virtual float PreignitionTime() const { return 2.0f; }
-    virtual float IgnitionTime()    const { return 0.0f;}
-    virtual float HoldTime()        const { return 2.00f; }
-    virtual float FadeTime()        const { return 0.5f;  }
+    float PreignitionTime() const override { return 2.0f; }
+    float IgnitionTime()    const override { return 0.0f;}
+    float HoldTime()        const override { return 2.00f; }
+    float FadeTime()        const override { return 0.5f;  }
     virtual float StarSize()        const { return 1;     }
 };
 
@@ -306,7 +306,7 @@ class MultiColorStar : public Star
         return c;
     }
 
-    virtual ~MultiColorStar()
+    ~MultiColorStar() override
     {}
 
     static int GetStarTypeNumber()
@@ -314,10 +314,10 @@ class MultiColorStar : public Star
         return EFFECT_STAR_MULTI_COLOR;
     }
 
-    virtual float PreignitionTime() const { return 2.0f; }
-    virtual float IgnitionTime()    const { return 0.0f; }
-    virtual float HoldTime()        const { return 2.00f;}
-    virtual float FadeTime()        const { return 0.5f; }
+    float PreignitionTime() const override { return 2.0f; }
+    float IgnitionTime()    const override { return 0.0f; }
+    float HoldTime()        const override { return 2.00f;}
+    float FadeTime()        const override { return 0.5f; }
     virtual float StarSize()        const { return 1;    }
 };
 
@@ -333,7 +333,7 @@ class ChristmasLightStar : public Star
         _colorIndex = iColor;
     }
 
-    virtual ~ChristmasLightStar()
+    ~ChristmasLightStar() override
     {}
 
     static int GetStarTypeNumber()
@@ -341,10 +341,10 @@ class ChristmasLightStar : public Star
         return EFFECT_STAR_CHRISTMAS;
     }
 
-    virtual float PreignitionTime() const { return 0.20f; }
-    virtual float IgnitionTime()    const { return 0.00f; }
-    virtual float HoldTime()        const { return 6.0f;  }
-    virtual float FadeTime()        const { return 1.25f; }
+    float PreignitionTime() const override { return 0.20f; }
+    float IgnitionTime()    const override { return 0.00f; }
+    float HoldTime()        const override { return 6.0f;  }
+    float FadeTime()        const override { return 1.25f; }
     virtual float StarSize()        const { return 0.00f; }
 };
 
@@ -359,7 +359,7 @@ class HotWhiteStar : public Star
     {
     }
 
-    virtual ~HotWhiteStar()
+    ~HotWhiteStar() override
     {}
 
     static int GetStarTypeNumber()
@@ -367,10 +367,10 @@ class HotWhiteStar : public Star
         return EFFECT_STAR_HOT_WHITE;
     }
 
-    virtual float PreignitionTime() const { return 0.00f;  }
-    virtual float IgnitionTime()    const { return 0.20f;  }
-    virtual float HoldTime()        const { return 0.00f;  }
-    virtual float FadeTime()        const { return 2.00f;  }
+    float PreignitionTime() const override { return 0.00f;  }
+    float IgnitionTime()    const override { return 0.20f;  }
+    float HoldTime()        const override { return 0.00f;  }
+    float FadeTime()        const override { return 2.00f;  }
 
     virtual CRGB RenderColor(TBlendType blend)
     {
@@ -465,7 +465,7 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
     {
     }
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         AllocatedJsonDocument jsonDoc(512);
 
@@ -531,7 +531,7 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
             _allParticles.pop_back();
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
         CreateStars();
         Update();
@@ -600,7 +600,7 @@ public:
     {
     }
 
-    virtual bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
+    bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
     {
         LEDStripEffect::Init(gfx);
         for (int i = 0; i < NUM_TWINKLES; i++)
@@ -608,7 +608,7 @@ public:
         return true;
     }
 
-    virtual void Draw() override
+    void Draw() override
     {
 
         // Init all the memory slots to -1 which means "empty slot"

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -141,7 +141,7 @@ public:
         ResetOscillators();
     }
 
-    virtual ~GFXBase()
+    ~GFXBase() override
     {
     }
 
@@ -302,7 +302,7 @@ public:
             debugE("Invalid drawPixel request: x=%d, y=%d, NUM_LEDS=%d", x, y, NUM_LEDS);
     }
 
-    virtual void drawPixel(int16_t x, int16_t y, uint16_t color) override
+    void drawPixel(int16_t x, int16_t y, uint16_t color) override
     {
         if (isValidPixel(x, y))
             leds[XY(x, y)] = from16Bit(color);

--- a/include/ledmatrixgfx.h
+++ b/include/ledmatrixgfx.h
@@ -124,7 +124,7 @@ public:
         return (int) totalPower;
     }
 
-    virtual uint16_t xy(uint16_t x, uint16_t y) const override
+    uint16_t xy(uint16_t x, uint16_t y) const override
     {
         if (x >= 0 && x < _width && y >= 0 && y < _height)
             return y * MATRIX_WIDTH + x;
@@ -141,14 +141,14 @@ public:
         leds = pLeds;
     }
 
-    virtual void fillLeds(std::unique_ptr<CRGB []> & pLEDs) override
+    void fillLeds(std::unique_ptr<CRGB []> & pLEDs) override
     {
         // A mesmerizer panel has the same layout as in memory, so we can memcpy.
 
         memcpy(leds, pLEDs.get(), sizeof(CRGB) * GetLEDCount());
     }
 
-    virtual void Clear() override
+    void Clear() override
     {
         // NB: We directly clear the backbuffer because otherwise effects would start with a snapshot of the effect
         //     before them on the next buffer swap.  So we clear the backbuffer and then the leds, which point to
@@ -190,7 +190,7 @@ public:
         captionStartTime = millis();
     }
 
-    virtual void MoveInwardX(int startY = 0, int endY = MATRIX_HEIGHT - 1) override
+    void MoveInwardX(int startY = 0, int endY = MATRIX_HEIGHT - 1) override
     {
         // Optimized for Smartmatrix matrix - uses knowledge of how the pixels are laid
         // out in order to do the scroll.  We should technically use memmove instead
@@ -206,7 +206,7 @@ public:
         }
     }
 
-    virtual void MoveOutwardsX(int startY = 0, int endY = MATRIX_HEIGHT - 1) override
+    void MoveOutwardsX(int startY = 0, int endY = MATRIX_HEIGHT - 1) override
     {
         // Optimized for Smartmatrix matrix - uses knowledge of how the pixels are laid
         // out in order to do the scroll.  We should technically use memmove instead
@@ -226,13 +226,13 @@ public:
     //
     // Gets the matrix ready for the effect or wifi to render into
 
-    virtual void PrepareFrame() override;
+    void PrepareFrame() override;
 
     // PostProcessFrame
     //
     // Things we do with the matrix after rendering a frame, such as setting the brightness and swapping the backbuffer forward
 
-    virtual void PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDrawn) override;
+    void PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDrawn) override;
 
     // Matrix interop
 

--- a/include/ledstripeffect.h
+++ b/include/ledstripeffect.h
@@ -446,7 +446,7 @@ class LEDStripEffect : public IJSONSerializable
     //
     // Serialize this effects paramters to a JSON document
 
-    virtual bool SerializeToJSON(JsonObject& jsonObject) override
+    bool SerializeToJSON(JsonObject& jsonObject) override
     {
         StaticJsonDocument<128> jsonDoc;
 

--- a/include/ledstripgfx.h
+++ b/include/ledstripgfx.h
@@ -103,7 +103,7 @@ public:
             throw std::runtime_error("Unable to allocate LEDs in LEDStripGFX");
     }
 
-    virtual ~LEDStripGFX()
+    ~LEDStripGFX() override
     {
         free(leds);
         leds = nullptr;
@@ -137,7 +137,7 @@ public:
     //
     // PostProcessFrame sends the data to the LED strip.  If it's fewer than the size of the strip, we only send that many.
 
-    virtual void PostProcessFrame(uint16_t wifiPixelsDrawn, uint16_t localPixelsDrawn) override;
+    void PostProcessFrame(uint16_t wifiPixelsDrawn, uint16_t localPixelsDrawn) override;
 };
 
 #if HEXAGON


### PR DESCRIPTION
Since C++11, Ex0actly one of virtual or overide should be used.
http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rh-override0x

## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [ ] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [ ] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [ ] I selected `main` as the target branch.
* [ ] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).