### PR TITLE
Fix linedraw bug

### DIFF
--- a/include/effects/matrix/PatternCube.h
+++ b/include/effects/matrix/PatternCube.h
@@ -237,9 +237,8 @@ class PatternCube : public LEDStripEffect
         for (i = 0; i < 12; i++)
         {
           e = edge + i;
-          if (!e->visible) {
-            g()->BresenhamLine(screen[e->x].x+xOffset, screen[e->x].y, screen[e->y].x+xOffset, screen[e->y].y, color);
-          }
+          if (!e->visible) 
+              g()->BresenhamLine(screen[e->x].x+xOffset, screen[e->x].y, screen[e->y].x+xOffset, screen[e->y].y, color);
         }
 
         color = g()->ColorFromCurrentPalette(hue + 128 + xOffset);
@@ -249,9 +248,7 @@ class PatternCube : public LEDStripEffect
         {
           e = edge + i;
           if (e->visible)
-          {
-            g()->BresenhamLine(screen[e->x].x+xOffset, screen[e->x].y, screen[e->y].x+xOffset, screen[e->y].y, color);
-          }
+              g()->BresenhamLine(screen[e->x].x+xOffset, screen[e->x].y, screen[e->y].x+xOffset, screen[e->y].y, color);
         }
 
         step++;

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -686,6 +686,13 @@ class SpectrumBarEffect : public LEDStripEffect
 
     virtual void Start() override
     {
+        constexpr auto kPeakDecaySpectrumBar = 2.5;
+
+        // Set the peak decay rates to something that looks good for this effect
+        
+        g_Analyzer._peak1DecayRate = kPeakDecaySpectrumBar;
+        g_Analyzer._peak2DecayRate = kPeakDecaySpectrumBar;
+        
         // This effect doesn't clear during drawing, so we need to clear to start the frame
 
         g()->Clear();

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -1110,33 +1110,42 @@ public:
         }
     }
 
-    void BresenhamLine(int x0, int y0, int x1, int y1, CRGB color, bool bMerge = false)
+void BresenhamLine(int x0, int y0, int x1, int y1, CRGB color, bool bMerge = false)
+{
+    int dx = abs(x1 - x0), sx = x0 < x1 ? 1 : -1;
+    int dy = -abs(y1 - y0), sy = y0 < y1 ? 1 : -1;
+
+    int err = dx + dy;  // Error must be declared here
+
+    for (;;)
     {
-        int dx = abs(x1 - x0), sx = x0 < x1 ? 1 : -1;
-        int dy = -abs(y1 - y0), sy = y0 < y1 ? 1 : -1;
-        for (;;)
+        if (isValidPixel(x0, y0))
+            leds[XY(x0, y0)] = bMerge ? leds[XY(x0, y0)] + color : color;
+
+        if (x0 == x1 && y0 == y1)
+            break;
+
+        int e2 = 2 * err;
+        if (e2 >= dy)
         {
-            int err = dx + dy, e2;
-
-            if (isValidPixel(x0, y0))
-                leds[XY(x0, y0)] = bMerge ? leds[XY(x0, y0)] + color : color;
-
-            if (x0 == x1 && y0 == y1)
-                break;
-
-            e2 = 2 * err;
-            if (e2 > dy)
-            {
-                err += dy;
-                x0 += sx;
-            }
-            if (e2 < dx)
-            {
-                err += dx;
-                y0 += sy;
-            }
+            err += dy;
+            x0 += sx;
         }
+        // Recheck after x-axis update
+        if (x0 == x1 && y0 == y1)
+            break;
+
+        if (e2 <= dx)
+        {
+            err += dx;
+            y0 += sy;
+        }
+        // Recheck after y-axis update
+        if (x0 == x1 && y0 == y1)
+            break;
     }
+}
+
 
     void BresenhamLine(int x0, int y0, int x1, int y1, uint8_t colorIndex, bool bMerge = false)
     {

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -1110,41 +1110,41 @@ public:
         }
     }
 
-void BresenhamLine(int x0, int y0, int x1, int y1, CRGB color, bool bMerge = false)
-{
-    int dx = abs(x1 - x0), sx = x0 < x1 ? 1 : -1;
-    int dy = -abs(y1 - y0), sy = y0 < y1 ? 1 : -1;
-
-    int err = dx + dy;  // Error must be declared here
-
-    for (;;)
+    void BresenhamLine(int x0, int y0, int x1, int y1, CRGB color, bool bMerge = false)
     {
-        if (isValidPixel(x0, y0))
-            leds[XY(x0, y0)] = bMerge ? leds[XY(x0, y0)] + color : color;
+        int dx = abs(x1 - x0), sx = x0 < x1 ? 1 : -1;
+        int dy = -abs(y1 - y0), sy = y0 < y1 ? 1 : -1;
 
-        if (x0 == x1 && y0 == y1)
-            break;
+        int err = dx + dy;  // Error must be declared here
 
-        int e2 = 2 * err;
-        if (e2 >= dy)
+        for (;;)
         {
-            err += dy;
-            x0 += sx;
-        }
-        // Recheck after x-axis update
-        if (x0 == x1 && y0 == y1)
-            break;
+            if (isValidPixel(x0, y0))
+                leds[XY(x0, y0)] = bMerge ? leds[XY(x0, y0)] + color : color;
 
-        if (e2 <= dx)
-        {
-            err += dx;
-            y0 += sy;
+            if (x0 == x1 && y0 == y1)
+                break;
+
+            int e2 = 2 * err;
+            if (e2 >= dy)
+            {
+                err += dy;
+                x0 += sx;
+            }
+            // Recheck after x-axis update
+            if (x0 == x1 && y0 == y1)
+                break;
+
+            if (e2 <= dx)
+            {
+                err += dx;
+                y0 += sy;
+            }
+            // Recheck after y-axis update
+            if (x0 == x1 && y0 == y1)
+                break;
         }
-        // Recheck after y-axis update
-        if (x0 == x1 && y0 == y1)
-            break;
     }
-}
 
 
     void BresenhamLine(int x0, int y0, int x1, int y1, uint8_t colorIndex, bool bMerge = false)

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -219,16 +219,16 @@ public:
         memset(leds, 0, sizeof(CRGB) * _width * _height);
     }
 
-    virtual bool isValidPixel(int x, int y) const
+    virtual bool isValidPixel(uint x, uint y) const
     {
         // Check that the pixel location is within the matrix's bounds
-        return x >= 0 && x < _width && y >= 0 && y < _height;
+        return x < _width && y < _height;
     }
 
-    virtual bool isValidPixel(int n) const
+    virtual bool isValidPixel(uint n) const
     {
         // Check that the pixel location is within the matrix's bounds
-        return n >= 0 && n < _width * _height;
+        return n < _width * _height;
     }
 
     // Matrices that are built from individually addressable strips like WS2812b generally
@@ -438,9 +438,8 @@ public:
         // if needed...
 
         float p = fPos;
-        if (p >= 0 && p < GetLEDCount())
-            for (int i = 0; i < NUM_CHANNELS; i++)
-                leds[(int)p] = bMerge ? leds[(int)p] + c1 : c1;
+        if (p >= 0 && isValidPixel(p))
+            leds[(int)p] = bMerge ? leds[(int)p] + c1 : c1;
 
         p = fPos + (1.0 - frac1);
         count -= (1.0 - frac1);
@@ -449,18 +448,16 @@ public:
 
         while (count >= 1)
         {
-            if (p >= 0 && p < GetLEDCount())
-                for (int i = 0; i < NUM_CHANNELS; i++)
-                    leds[(int)p] = bMerge ? leds[(int)p] + c : c;
+            if (p >= 0 && isValidPixel(p))
+                leds[(int)p] = bMerge ? leds[(int)p] + c : c;
             count--;
             p++;
         };
 
         // Final pixel, if in bounds
         if (count > 0)
-            if (p >= 0 && p < GetLEDCount())
-                for (int i = 0; i < NUM_CHANNELS; i++)
-                    leds[(int)p] = bMerge ? leds[(int)p] + c2 : c2;
+            if (p >= 0 && isValidPixel(p))
+                leds[(int)p] = bMerge ? leds[(int)p] + c2 : c2;
     }
 
     void blurRows(CRGB *leds, uint16_t width, uint16_t height, uint16_t first, fract8 blur_amount)

--- a/include/globals.h
+++ b/include/globals.h
@@ -1237,11 +1237,11 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 #endif
 
 #ifndef MATRIX_REFRESH_RATE
-#define MATRIX_REFRESH_RATE 100
+#define MATRIX_REFRESH_RATE 180
 #endif
 
 #ifndef MATRIX_CALC_DIVIDER
-#define MATRIX_CALC_DIVIDER 2
+#define MATRIX_CALC_DIVIDER 3
 #endif
 
 

--- a/include/ledmatrixgfx.h
+++ b/include/ledmatrixgfx.h
@@ -128,8 +128,9 @@ public:
     {
         if (x >= 0 && x < _width && y >= 0 && y < _height)
             return y * MATRIX_WIDTH + x;
-        else
-            throw std::runtime_error(str_sprintf("Invalid index in xy: x=%d, y=%d, NUM_LEDS=%d", x, y, NUM_LEDS).c_str());
+
+        debugE("%s", str_sprintf("Invalid index in xy: x=%d, y=%d, NUM_LEDS=%d", x, y, NUM_LEDS).c_str());
+        return 0;
     }
 
     // Whereas an LEDStripGFX would track it's own memory for the CRGB array, we simply point to the buffer already used for

--- a/include/soundanalyzer.h
+++ b/include/soundanalyzer.h
@@ -85,7 +85,7 @@ void IRAM_ATTR AudioSerialTaskEntry(void *);
 // Simple data class that holds the music peaks for up to 32 bands.  When the sound analyzer finishes a pass, its
 // results are simplified down to this small class of band peaks.
 
-#define MIN_VU 256              // Minimum VU value to use for the span when computing VURatio.  Contributes to
+#define MIN_VU 128              // Minimum VU value to use for the span when computing VURatio.  Contributes to
                                 // how dynamic the music is (smaller values == more dynamic)
 
 

--- a/include/taskmgr.h
+++ b/include/taskmgr.h
@@ -164,6 +164,18 @@ public:
     {
     }
 
+    // CheckHeap
+    //
+    // Quick and dirty debug test to make sure the heap has not been corrupted
+
+    static inline void CheckHeap()
+    {
+        if (false == heap_caps_check_integrity_all(true))
+        {
+            throw std::runtime_error("Heap FAILED checks!");
+        }
+    }
+
     void begin()
     {
         Serial.printf("Replacing Idle Tasks with TaskManager...\n");
@@ -271,6 +283,7 @@ public:
         #if USE_SCREEN
             Serial.print( str_sprintf(">> Launching Screen Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
             xTaskCreatePinnedToCore(ScreenUpdateLoopEntry, "Screen Loop", DEFAULT_STACK_SIZE, nullptr, SCREEN_PRIORITY, &_taskScreen, SCREEN_CORE);
+            CheckHeap();
         #endif
     }
 
@@ -279,6 +292,7 @@ public:
         #if ENABLE_SERIAL
             Serial.print( str_sprintf(">> Launching Serial Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
             xTaskCreatePinnedToCore(AudioSerialTaskEntry, "Audio Serial Loop", DEFAULT_STACK_SIZE, nullptr, AUDIOSERIAL_PRIORITY, &_taskSerial, AUDIOSERIAL_CORE);
+            CheckHeap();
         #endif
     }
 
@@ -287,6 +301,7 @@ public:
         #if COLORDATA_SERVER_ENABLED
             Serial.print( str_sprintf(">> Launching ColorData Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
             xTaskCreatePinnedToCore(ColorDataTaskEntry, "ColorData Loop", DEFAULT_STACK_SIZE, nullptr, COLORDATA_PRIORITY, &_taskColorData, COLORDATA_CORE);
+            CheckHeap();
         #endif
     }
 
@@ -294,6 +309,7 @@ public:
     {
         Serial.print( str_sprintf(">> Launching Drawing Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
         xTaskCreatePinnedToCore(DrawLoopTaskEntry, "Draw Loop", DRAWING_STACK_SIZE, nullptr, DRAWING_PRIORITY, &_taskDraw, DRAWING_CORE);
+        CheckHeap();        
     }
 
     void StartAudioThread()
@@ -301,6 +317,7 @@ public:
         #if ENABLE_AUDIO
             Serial.print( str_sprintf(">> Launching Audio Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
             xTaskCreatePinnedToCore(AudioSamplerTaskEntry, "Audio Sampler Loop", AUDIO_STACK_SIZE, nullptr, AUDIO_PRIORITY, &_taskAudio, AUDIO_CORE);
+            CheckHeap();
         #endif
     }
 
@@ -309,6 +326,7 @@ public:
         #if ENABLE_WIFI
             Serial.print( str_sprintf(">> Launching Network Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
             xTaskCreatePinnedToCore(NetworkHandlingLoopEntry, "NetworkHandlingLoop", NET_STACK_SIZE, nullptr, NET_PRIORITY, &_taskNetwork, NET_CORE);
+            CheckHeap();
         #endif
     }
 
@@ -317,6 +335,7 @@ public:
         #if ENABLE_WIFI
             Serial.print( str_sprintf(">> Launching Debug Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
             xTaskCreatePinnedToCore(DebugLoopTaskEntry, "Debug Loop", DEFAULT_STACK_SIZE, nullptr, DEBUG_PRIORITY, &_taskDebug, DEBUG_CORE);
+            CheckHeap();
         #endif
     }
 
@@ -325,6 +344,7 @@ public:
         #if INCOMING_WIFI_ENABLED
             Serial.print( str_sprintf(">> Launching Socket Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
             xTaskCreatePinnedToCore(SocketServerTaskEntry, "Socket Server Loop", SOCKET_STACK_SIZE, nullptr, SOCKET_PRIORITY, &_taskSocket, SOCKET_CORE);
+            CheckHeap();
         #endif
     }
 
@@ -333,6 +353,7 @@ public:
         #if ENABLE_REMOTE
             Serial.print( str_sprintf(">> Launching Remote Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
             xTaskCreatePinnedToCore(RemoteLoopEntry, "IR Remote Loop", DEFAULT_STACK_SIZE, nullptr, REMOTE_PRIORITY, &_taskRemote, REMOTE_CORE);
+            CheckHeap();
         #endif
     }
 
@@ -340,6 +361,7 @@ public:
     {
         Serial.print( str_sprintf(">> Launching JSON Writer Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
         xTaskCreatePinnedToCore(JSONWriterTaskEntry, "JSON Writer Loop", JSON_STACK_SIZE, nullptr, JSONWRITER_PRIORITY, &_taskJSONWriter, JSONWRITER_CORE);
+        CheckHeap();
     }
 
     void NotifyJSONWriterThread()
@@ -378,6 +400,8 @@ public:
         else
             // Clean up the task params object if the thread was not actually created
             delete pTaskParams;
+
+        CheckHeap();
 
         return effectTask;
     }

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@
 ; mesmerizer    HUB75 info panel with audio effects, weather, info, etc,
 
 [platformio]
-default_envs = mesmerizer
+default_envs = 
 
 ; ==================
 ; Base configuration
@@ -27,8 +27,8 @@ default_envs = mesmerizer
 ; Options that are used (or extended) in all device sections (and hence environments) are defined here
 
 [base]
-upload_port     = /dev/cu.usbserial-8411301
-monitor_port    = /dev/cu.usbserial-8411301
+upload_port     = 
+monitor_port    = 
 build_type      = release
 upload_speed    = 1500000
 build_flags     = -std=gnu++17

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@
 ; mesmerizer    HUB75 info panel with audio effects, weather, info, etc,
 
 [platformio]
-default_envs = mesmerizer
+default_envs = 
 
 ; ==================
 ; Base configuration

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@
 ; mesmerizer    HUB75 info panel with audio effects, weather, info, etc,
 
 [platformio]
-default_envs = 
+default_envs = mesmerizer
 
 ; ==================
 ; Base configuration
@@ -27,8 +27,9 @@ default_envs =
 ; Options that are used (or extended) in all device sections (and hence environments) are defined here
 
 [base]
-upload_port     = 
-monitor_port    = 
+upload_port     = /dev/cu.usbserial-8411301
+monitor_port    = /dev/cu.usbserial-8411301
+build_type      = release
 upload_speed    = 1500000
 build_flags     = -std=gnu++17
                   -Dregister=                       ; Sinister: redefine 'register' so FastLED can use that keyword under C++17

--- a/samples/videoserver/videoserver.py
+++ b/samples/videoserver/videoserver.py
@@ -126,5 +126,5 @@ while True:
         sock.close()
         sock = None
 
-    time.sleep(1.0 / 100)                                        # Div by two is a manual hack to get timing closer
+    time.sleep(1.0 / 40)                                        # Div by two is a manual hack to get timing closer
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -179,6 +179,7 @@ DRAM_ATTR std::mutex g_buffer_mutex;
 // The one and only instance of ImprovSerial.  We instantiate it as the type needed
 // for the serial port on this module.  That's usually HardwareSerial but can be
 // other types on the S2, etc... which is why it's a template class.
+
 ImprovSerial<typeof(Serial)> g_ImprovSerial;
 
 // If an insulator or tree or fan has multiple rings, this table defines how those rings are laid out such
@@ -195,20 +196,6 @@ DRAM_ATTR const int g_aRingSizeTable[MAX_RINGS] =
     RING_SIZE_3,
     RING_SIZE_4
 };
-
-// CheckHeap
-//
-// Quick and dirty debug test to make sure the heap has not been corrupted
-
-inline void CheckHeap()
-{
-    #if CHECK_HEAP
-        if (false == heap_caps_check_integrity_all(true))
-        {
-            throw std::runtime_error("Heap FAILED checks!");
-        }
-    #endif
-}
 
 // PrintOutputHeader
 //
@@ -312,7 +299,6 @@ void setup()
     // Start Debug
     debugI("Starting DebugLoopTaskEntry");
     taskManager.StartDebugThread();
-    CheckHeap();
 
     // Initialize Non-Volatile Storage
     esp_err_t err = nvs_flash_init();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -197,6 +197,7 @@ DRAM_ATTR const int g_aRingSizeTable[MAX_RINGS] =
     RING_SIZE_4
 };
 
+
 // PrintOutputHeader
 //
 // Displays an info header with info about the system
@@ -222,7 +223,6 @@ void PrintOutputHeader()
 
 void TerminateHandler()
 {
-
     debugE("-------------------------------------------------------------------------------------");
     debugE("- NightDriverStrip Guru Meditation                              Unhandled Exception -");
     debugE("-------------------------------------------------------------------------------------");
@@ -234,10 +234,9 @@ void TerminateHandler()
     }
     catch (std::exception &ex) {
         debugE("Terminated due to exception: %s", ex.what());
-        Serial.flush();
-        for(;;)
-            delay(10);
     }
+
+    Serial.flush();
 }
 
 #ifdef TOGGLE_BUTTON_1
@@ -541,7 +540,7 @@ void loop()
             strOutput += str_sprintf("LED FPS: %d ", g_Values.FPS);
 
             #if USE_STRIP
-                strOutput += str_sprintf("LED Bright: %03.0f%%, LED Watts: %d, ", g_Values.Brite, g_Values.Watts);
+                strOutput += str_sprintf("LED Bright: %d, LED Watts: %d, ", g_Values.Watts, g_Values.Brite);
             #endif
 
             #if USE_MATRIX
@@ -560,8 +559,8 @@ void loop()
                 auto& bufferManager = g_ptrSystem->BufferManagers()[0];
                 strOutput += str_sprintf("Buffer: %d/%d, ", bufferManager.Depth(), bufferManager.BufferCount());
             #endif
-            
-            const auto & taskManager = g_ptrSystem->TaskManager();
+
+            auto& taskManager = g_ptrSystem->TaskManager();
             strOutput += str_sprintf("CPU: %03.0f%%, %03.0f%%, FreeDraw: %4.3lf", taskManager.GetCPUUsagePercent(0), taskManager.GetCPUUsagePercent(1), g_Values.FreeDrawTime);
 
             debugI("%s", strOutput.c_str());


### PR DESCRIPTION
I found a case where PatternCube was getting bit by the watchdog, and it turned out BresenhamLine was never returning.  That turns out to be a bug in the base library we inherited.  Instead of accumulating the error over several passes, it was resetting it every time, and that doesn't always work.  Now it does.

Also fixes an issue with SpectrumBarEffect where it would display all-same-height bars.  I believe this was related to the decay rates not being set.  If it recurs, I'll reopen the issue.

I'm also enabling a heap check after each thread is created.  We can put this in ifdef DEBUG if preferred.

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).