### PR TITLE
Eliminate duplicated test in PatternSpiro

### DIFF
--- a/include/effects/matrix/PatternSpiro.h
+++ b/include/effects/matrix/PatternSpiro.h
@@ -113,7 +113,7 @@ public:
       CRGB color = graphics->ColorFromCurrentPalette(hueoffset + i * spirooffset, 128);
       graphics->leds[graphics->xy(x2, y2)] += color;
 
-      if ((x2 == MATRIX_CENTER_X && y2 == MATRIX_CENTER_Y) || (x2 == MATRIX_CENTER_X && y2 == MATRIX_CENTER_Y))
+      if (x2 == MATRIX_CENTER_X && y2 == MATRIX_CENTER_Y)
         change = true;
     }
 


### PR DESCRIPTION
## Description
This caught my eye while I was running over nearby code. The left and the
right of that || test were identical.
I chased the code through that gist through its origin git history through
git blame and this change went in with a description that was something
like "make more awesomer".

Removing it changes no behaviour. It just removes a nail that's poking
through the floor surface.

Tested: successful compilation on mesmerizer. Should compile everywhere
without change because it was already if (something || that_same_something).

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
