### PR TITLE
Improve logging on where signal is going, Various specifier fixes

### DIFF
--- a/include/ledstripgfx.h
+++ b/include/ledstripgfx.h
@@ -23,7 +23,7 @@
 //
 // Description:
 //
-//   Provides a Adafruit_GFX implementation for our RGB LED panel so that
+//   Provides an Adafruit_GFX implementation for our RGB LED panel so that
 //   we can use primitives such as lines and fills on it.
 //
 // History:     Oct-9-2018         Davepl      Created from other projects
@@ -45,13 +45,13 @@ protected:
         // Macro to add LEDs to a channel
 
         #define ADD_CHANNEL(channel) \
-            debugI("Adding %d LEDs to channel %d on FastLED.", devices[channel]->GetLEDCount(), channel); \
+            debugI("Adding %zu LEDs to pin %d from channel %d on FastLED.", devices[channel]->GetLEDCount(), LED_PIN ## channel, channel); \
             FastLED.addLeds<WS2812B, LED_PIN ## channel, COLOR_ORDER>(devices[channel]->leds, devices[channel]->GetLEDCount()); \
-            pinMode(LED_PIN ## channel, OUTPUT);
+            pinMode(LED_PIN ## channel, OUTPUT)
 
         debugI("Adding LEDs to FastLED...");
 
-        // The following "unrolled conditional compile loop" to set up the channels is needed because the led pin
+        // The following "unrolled conditional compile loop" to set up the channels is needed because the LED pin
         //   is a template parameter to FastLED.addLeds()
 
         #if NUM_CHANNELS >= 1
@@ -97,7 +97,7 @@ public:
 
     LEDStripGFX(size_t w, size_t h) : GFXBase(w, h)
     {
-        debugV("Creating Device of size %d x %d", w, h);
+        debugV("Creating Device of size %zu x %zu", w, h);
         leds = static_cast<CRGB *>(calloc(w * h, sizeof(CRGB)));
         if(!leds)
             throw std::runtime_error("Unable to allocate LEDs in LEDStripGFX");

--- a/src/socketserver.cpp
+++ b/src/socketserver.cpp
@@ -71,7 +71,7 @@ int SocketServer::ProcessIncomingConnectionsLoop()
 
             if (expandedSize > MAXIMUM_PACKET_SIZE)
             {
-                debugE("Expanded packet would be %d but buffer is only %lu !!!!\n", expandedSize, MAXIMUM_PACKET_SIZE);
+                debugE("Expanded packet would be %d but buffer is only %d !!!!\n", expandedSize, MAXIMUM_PACKET_SIZE);
                 break;
             }
 
@@ -169,7 +169,7 @@ int SocketServer::ProcessIncomingConnectionsLoop()
                 size_t totalExpected = STANDARD_DATA_HEADER_SIZE + length32 * LED_DATA_SIZE;
                 if (totalExpected > MAXIMUM_PACKET_SIZE)
                 {
-                    debugW("Too many bytes promised (%zu) - more than we can use for our LEDs at max packet (%lu)\n", totalExpected, MAXIMUM_PACKET_SIZE);
+                    debugW("Too many bytes promised (%zu) - more than we can use for our LEDs at max packet (%u)\n", totalExpected, MAXIMUM_PACKET_SIZE);
                     break;
                 }
 

--- a/src/socketserver.cpp
+++ b/src/socketserver.cpp
@@ -169,11 +169,11 @@ int SocketServer::ProcessIncomingConnectionsLoop()
                 size_t totalExpected = STANDARD_DATA_HEADER_SIZE + length32 * LED_DATA_SIZE;
                 if (totalExpected > MAXIMUM_PACKET_SIZE)
                 {
-                    debugW("Too many bytes promised (%zu) - more than we can use for our LEDs at max packet (%u)\n", totalExpected, MAXIMUM_PACKET_SIZE);
+                    debugW("Too many bytes promised (%zu) - more than we can use for our LEDs at max packet (%lu)\n", totalExpected, MAXIMUM_PACKET_SIZE);
                     break;
                 }
 
-                debugV("Expecting %d total bytes", totalExpected);
+                debugV("Expecting %zu total bytes", totalExpected);
                 if (false == ReadUntilNBytesReceived(new_socket, totalExpected))
                 {
                     debugW("Error in getting pixel data from wifi\n");
@@ -189,7 +189,7 @@ int SocketServer::ProcessIncomingConnectionsLoop()
                 }
 
                 // Consume the data by resetting the buffer
-                debugV("Consuming the data as WIFI_COMMAND_PIXELDATA64 by setting _cbReceived to from %d down 0.", _cbReceived);
+                debugV("Consuming the data as WIFI_COMMAND_PIXELDATA64 by setting _cbReceived to from %zu down 0.", _cbReceived);
                 ResetReadBuffer();
 
                 bSendResponsePacket = true;

--- a/src/socketserver.cpp
+++ b/src/socketserver.cpp
@@ -71,7 +71,7 @@ int SocketServer::ProcessIncomingConnectionsLoop()
 
             if (expandedSize > MAXIMUM_PACKET_SIZE)
             {
-                debugE("Expanded packet would be %d but buffer is only %d !!!!\n", expandedSize, MAXIMUM_PACKET_SIZE);
+                debugE("Expanded packet would be %d but buffer is only %lu !!!!\n", expandedSize, MAXIMUM_PACKET_SIZE);
                 break;
             }
 
@@ -135,13 +135,13 @@ int SocketServer::ProcessIncomingConnectionsLoop()
 
                     if (length32 != numbands * sizeof(float))
                     {
-                        debugE("Expecting %d bytes for %d audio bands, but received %d.  Ensure float size and endianness matches between sender and receiver systems.", totalExpected, NUM_BANDS, _cbReceived);
+                        debugE("Expecting %zu bytes for %d audio bands, but received %zu.  Ensure float size and endianness matches between sender and receiver systems.", totalExpected, NUM_BANDS, _cbReceived);
                         break;
                     }
 
                     if (false == ReadUntilNBytesReceived(new_socket, totalExpected))
                     {
-                        debugE("Error in getting peak data from wifi, could not read the %d bytes", totalExpected);
+                        debugE("Error in getting peak data from wifi, could not read the %zu bytes", totalExpected);
                         break;
                     }
 
@@ -149,7 +149,7 @@ int SocketServer::ProcessIncomingConnectionsLoop()
                         break;
 
                     // Consume the data by resetting the buffer
-                    debugV("Consuming the data as WIFI_COMMAND_PEAKDATA by setting _cbReceived to from %d down 0.", _cbReceived);
+                    debugV("Consuming the data as WIFI_COMMAND_PEAKDATA by setting _cbReceived to from %zu down 0.", _cbReceived);
 
                 #endif
                 ResetReadBuffer();
@@ -169,7 +169,7 @@ int SocketServer::ProcessIncomingConnectionsLoop()
                 size_t totalExpected = STANDARD_DATA_HEADER_SIZE + length32 * LED_DATA_SIZE;
                 if (totalExpected > MAXIMUM_PACKET_SIZE)
                 {
-                    debugW("Too many bytes promised (%u) - more than we can use for our LEDs at max packet (%u)\n", totalExpected, MAXIMUM_PACKET_SIZE);
+                    debugW("Too many bytes promised (%zu) - more than we can use for our LEDs at max packet (%u)\n", totalExpected, MAXIMUM_PACKET_SIZE);
                     break;
                 }
 

--- a/src/socketserver.cpp
+++ b/src/socketserver.cpp
@@ -71,7 +71,7 @@ int SocketServer::ProcessIncomingConnectionsLoop()
 
             if (expandedSize > MAXIMUM_PACKET_SIZE)
             {
-                debugE("Expanded packet would be %d but buffer is only %d !!!!\n", expandedSize, MAXIMUM_PACKET_SIZE);
+                debugE("Expanded packet would be %u but buffer is only %u !!!!\n", expandedSize, MAXIMUM_PACKET_SIZE);
                 break;
             }
 


### PR DESCRIPTION
- Format specifier fixes in socketserver
- Format specifier fixes in socketserver
- Specifier fixes in ledstrip

## Description
More Correctness fixes in specifiers.

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
