### PR TITLE
Address issues raised in issue 390

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ I recommend you do the following:
 - Copy include/secrets.example.h to include/secrets.h; Set your WiFi SSID and password in include/secrets.h.
 - Build the source code. In particular, build the `DEMO` configuration. Some pointers on what's needed to do this can be found [below](#build-pointers).
 - Upload the resultant binary to the ESP32
-- Connect PIN5 and GND and 5V of a WS2812B strip to the ESP32
+- Connect the wire associated with LED_PIN0 in your include/globals.h and GND and 5V of a WS2812B strip to the ESP32. For
+  example, this will be Pin 5 for ATOMLIGHT, but even for DEMO, may be Pin 32 for M5STICKC, M5STICKCPLUS, or M5STACKCORE2
+  or 21 for the LILYGOTDISPLAYS3.
 - Provide an adequate power source for the LEDs and ESP32
 - Enjoy the pretty lights
 - Start enabling features in the `globals.h` or platformio.ini file like WiFi and WebServer. See [Feature Defines](#feature-defines) below.

--- a/include/effectdependencies.h
+++ b/include/effectdependencies.h
@@ -57,7 +57,7 @@
 // Externals
 //
 
-#if USE_MATRIX
+#if USE_HUB75
     #include "ledmatrixgfx.h"
     #include "effects/strip/misceffects.h"
     #include "effects/matrix/PatternSerendipity.h"
@@ -83,6 +83,6 @@
     #include "effects/matrix/PatternWeather.h"
 #endif
 
-#ifdef USE_STRIP
+#ifdef USE_NEOPIXEL
     #include "ledstripgfx.h"
 #endif

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -309,7 +309,7 @@ public:
         CRGB oldColor = lastManualColor;
         lastManualColor = color;
 
-        #if (USE_MATRIX)
+        #if (USE_HUB75)
                 auto pMatrix = g();
                 pMatrix->setPalette(CRGBPalette16(oldColor, color));
                 pMatrix->PausePalette(true);
@@ -343,7 +343,7 @@ public:
         if (!retainRemoteEffect)
             _tempEffect = nullptr;
 
-        #if (USE_MATRIX)
+        #if (USE_HUB75)
             g()->PausePalette(false);
         #endif
     }
@@ -355,7 +355,7 @@ public:
 
         std::shared_ptr<LEDStripEffect> & effect = _tempEffect ? _tempEffect : _vEffects[_iCurrentEffect];
 
-        #if USE_MATRIX
+        #if USE_HUB75
             auto pMatrix = std::static_pointer_cast<LEDMatrixGFX>(_gfx[0]);
             pMatrix->SetCaption(effect->FriendlyName(), CAPTION_TIME);
         #endif

--- a/include/effects/matrix/PatternFlowField.h
+++ b/include/effects/matrix/PatternFlowField.h
@@ -53,7 +53,7 @@
 
 #pragma once
 
-#if USE_MATRIX
+#if USE_HUB75
 
 class PatternFlowField : public LEDStripEffect
 {

--- a/include/effects/matrix/PatternMandala.h
+++ b/include/effects/matrix/PatternMandala.h
@@ -58,7 +58,7 @@
 
 #ifndef PatternMandala_H
 #define PatternMandala_H
-#if     USE_MATRIX
+#if     USE_HUB75
 
 class PatternMandala : public LEDStripEffect
 {

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -253,7 +253,7 @@ protected:
     }
 };
 
-#if USE_MATRIX
+#if USE_HUB75
 
 // SplashLogoEffect
 //
@@ -301,7 +301,7 @@ class SplashLogoEffect : public LEDStripEffect
     }
 };
 
-#endif // USE_MATRIX
+#endif // USE_HUB75
 
 // StatusEffect
 //

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -72,7 +72,7 @@
 #include "globals.h"
 #include <memory>
 
-#if USE_MATRIX
+#if USE_HUB75
 #define USE_NOISE 1
 #endif
 
@@ -266,7 +266,7 @@ public:
     // it's a very simple layout.  Others may need to override this function.  Using a #define here allows
     // us to avoid an extra virtual function call in the inner loop of the effects.
 
-    #if USE_MATRIX
+    #if USE_HUB75
         #define XY(x, y) ((y) * MATRIX_WIDTH + (x))
     #else
         #define XY(x, y) xy(x, y)

--- a/include/globals.h
+++ b/include/globals.h
@@ -125,9 +125,9 @@
 
 #define FLASH_VERSION          40   // Update ONLY this to increment the version number
 
-#ifndef USE_MATRIX                   // We support strips by default unless specifically defined out
-    #ifndef USE_STRIP
-        #define USE_STRIP 1
+#ifndef USE_HUB75                   // We support strips by default unless specifically defined out
+    #ifndef USE_NEOPIXEL
+        #define USE_NEOPIXEL 1
     #endif
 #endif
 
@@ -1074,7 +1074,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 #define PROJECT_NAME        "NightDriver"
 #endif
 
-#if USE_MATRIX
+#if USE_HUB75
 #include "MatrixHardware_ESP32_Custom.h"
 #define SM_INTERNAL     // Silence build messages from their header
 #include <SmartMatrix.h>
@@ -1583,7 +1583,7 @@ inline bool SetSocketBlockingEnabled(int fd, bool blocking)
 
 // Conditional includes depending on which project is being build
 
-#if USE_MATRIX
+#if USE_HUB75
     #include "effects/matrix/PatternSubscribers.h"  // For subscriber count effect
 #endif
 

--- a/include/globals.h
+++ b/include/globals.h
@@ -239,7 +239,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 #if DEMO
 
     // This is a simple demo configuration.  To build, simply connect the data lead from a WS2812B
-    // strip to pin 5.  This does not use the OLED, LCD, or anything fancy, it simply drives the
+    // strip to pin 5 or other pin marked PIN0 below.  This does not use the OLED, LCD, or anything fancy, it simply drives the
     // LEDs with a simple rainbow effect as specified in effects.cpp for DEMO.
     //
     // Please ensure you supply sufficent power to your strip, as even the DEMO of 144 LEDs, if set
@@ -249,11 +249,9 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #endif
 
     #define MATRIX_WIDTH            144
-    #define MATRIX_HEIGHT           8
+    #define MATRIX_HEIGHT           1
     #define NUM_LEDS                (MATRIX_WIDTH*MATRIX_HEIGHT)
     #define NUM_CHANNELS            1
-    #define NUM_RINGS               5
-    #define RING_SIZE_0             24
     #define ENABLE_AUDIO            0
 
     #define POWER_LIMIT_MW       12 * 10 * 1000   // 10 amp supply at 5 volts assumed

--- a/include/ledmatrixgfx.h
+++ b/include/ledmatrixgfx.h
@@ -32,7 +32,7 @@
 
 #pragma once
 
-#if USE_MATRIX
+#if USE_HUB75
 
 #include <SmartMatrix.h>
 

--- a/include/ledstripeffect.h
+++ b/include/ledstripeffect.h
@@ -210,7 +210,7 @@ class LEDStripEffect : public IJSONSerializable
 
     // mg is a shortcut for MATRIX projects to retrieve a pointer to the specialized LEDMatrixGFX type
 
-    #if USE_MATRIX
+    #if USE_HUB75
       std::shared_ptr<LEDMatrixGFX> mg(size_t channel = 0)
       {
         return std::static_pointer_cast<LEDMatrixGFX>(_GFX[channel]);

--- a/include/values.h
+++ b/include/values.h
@@ -14,7 +14,7 @@ struct Values
     bool UpdateStarted = false;                                             // Has an OTA update started?
     uint8_t Brightness = 255;
     uint8_t Fader = 255;
-#if USE_MATRIX
+#if USE_HUB75
     int MatrixPowerMilliwatts = 0;                                         // Matrix power draw in mw
     uint8_t MatrixScaledBrightness = 255;                                  // 0-255 scaled brightness to stay in limit
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -480,7 +480,7 @@ board_build.partitions = config/partitions_custom_noota.csv
 [env:mesmerizer]
 extends         = dev_mesmerizer
 build_flags     = -DMESMERIZER=1
-                  -DUSE_MATRIX=1
+                  -DUSE_HUB75=1
                   -DSHOW_VU_METER=1
                   -O3
                   ${psram_flags.build_flags}
@@ -495,7 +495,7 @@ debug_tool      = esp-prog
 [env:mesmerizer_lolin]
 extends         = dev_lolin_d32_pro
 build_flags     = -DMESMERIZER=1
-                  -DUSE_MATRIX=1
+                  -DUSE_HUB75=1
                   -Ofast
                   ${psram_flags.build_flags}
                   ${remote_flags.build_flags}

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -573,7 +573,7 @@ static DRAM_ATTR size_t l_EffectsManagerJSONBufferSize = 0;
 static DRAM_ATTR size_t l_EffectsManagerJSONWriterIndex = std::numeric_limits<size_t>::max();
 static DRAM_ATTR size_t l_CurrentEffectWriterIndex = std::numeric_limits<size_t>::max();
 
-#if USE_MATRIX
+#if USE_HUB75
 
     void InitSplashEffectManager()
     {

--- a/src/ledmatrixgfx.cpp
+++ b/src/ledmatrixgfx.cpp
@@ -30,7 +30,7 @@
 
 #include "globals.h"
 
-#if USE_MATRIX
+#if USE_HUB75
 
 #include "effects/matrix/Boid.h"
 #include "effects/matrix/Vector.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -430,13 +430,13 @@ void setup()
 
     // Initialize the strand controllers depending on how many channels we have
 
-    #if USE_MATRIX
+    #if USE_HUB75
         // LEDMatrixGFX is used for HUB75 projects like the Mesmerizer
         LEDMatrixGFX::InitializeHardware(devices);
     #elif HEXAGON
         // Hexagon is for a PCB wtih 271 LEDss arranged in the face of a hexagon
         HexagonGFX::InitializeHardware(devices);
-    #elif USE_STRIP
+    #elif USE_NEOPIXEL
         // LEDStripGFX is used for simple strips or for matrices woven from strips
         LEDStripGFX::InitializeHardware(devices);
     #endif
@@ -466,7 +466,7 @@ void setup()
     });
 
     // Show splash effect on matrix
-    #if USE_MATRIX
+    #if USE_HUB75
         debugI("Initializing splash effect manager...");
         InitSplashEffectManager();
     #endif
@@ -539,11 +539,11 @@ void loop()
             strOutput += str_sprintf("Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(), ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize());
             strOutput += str_sprintf("LED FPS: %d ", g_Values.FPS);
 
-            #if USE_STRIP
+            #if USE_NEOPIXEL
                 strOutput += str_sprintf("LED Bright: %3.0lf%%, LED Watts: %u, ", g_Values.Brite, g_Values.Watts);
             #endif
 
-            #if USE_MATRIX
+            #if USE_HUB75
                 strOutput += str_sprintf("Refresh: %d Hz, Power: %d mW, Brite: %3.0lf%%, ", LEDMatrixGFX::matrix.getRefreshRate(), g_Values.MatrixPowerMilliwatts, g_Values.MatrixScaledBrightness / 2.55);
             #endif
 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -136,7 +136,7 @@ void SetupOTA(const String & strHostname)
                 auto p = (progress / (total / 100));
                 debugI("OTA Progress: %u%%\r", p);
 
-                #if USE_MATRIX
+                #if USE_HUB75
                     auto pMatrix = std::static_pointer_cast<LEDMatrixGFX>(g_ptrSystem->EffectManager().GetBaseGraphics());
                     pMatrix->SetCaption(str_sprintf("Update:%d%%", p), CAPTION_TIME);
                     pMatrix->setLeds(LEDMatrixGFX::GetMatrixBackBuffer());


### PR DESCRIPTION
Addressed most concerns in https://github.com/PlummersSoftwareLLC/NightDriverStrip/discussions/390

- Fix issue 1 about PIN0 naming.
- Fix issue 2 about DEMO overdrawing by a factor of 8.
- Let device names reflect LED electrical types (HUB75, NeoPixel) and not physical orientation (MATRIX, STRIP). Build SPECTRUM uses NeoPixels, but in a MATRIX, for example. HEIGHT > 1 can be used for "grid-ness" of those builds, but it was never used as such.

Issue 3 on what RINGS are, how a line has five of them, and why it's ever
appropriate to be equal to NUM_LEDS remains open.

All are in separate submits if you want to cherry pick.

I tried to preserve the mixture of DOS and UNIX NL conventions.

## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
