### PR TITLE
Wait for WiFi credentials if not set

### DIFF
--- a/include/improvserial.h
+++ b/include/improvserial.h
@@ -48,7 +48,6 @@ extern DRAM_ATTR String WiFi_ssid;
 extern DRAM_ATTR String WiFi_password;
 bool ReadWiFiConfig();
 bool WriteWiFiConfig();
-bool ConnectToWiFi(uint cRetries);
 
 template <typename SERIALTYPE>
 class ImprovSerial

--- a/include/network.h
+++ b/include/network.h
@@ -37,7 +37,7 @@
 #if ENABLE_WIFI
     void processRemoteDebugCmd();
 
-    bool ConnectToWiFi(uint cRetries);
+    bool ConnectToWiFi(uint cRetries, bool waitForCredentials);
     void UpdateNTPTime();
     void SetupOTA(const String & strHostname);
     bool ReadWiFiConfig();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -482,7 +482,7 @@ void setup()
 
     #if ENABLE_WIFI && WAIT_FOR_WIFI
         debugI("Calling ConnectToWifi()\n");
-        if (false == ConnectToWiFi(99))
+        if (false == ConnectToWiFi(99, true))
         {
             debugI("Unable to connect to WiFi, but must have it, so rebooting...\n");
             throw std::runtime_error("Unable to connect to WiFi, but must have it, so rebooting");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -330,7 +330,7 @@ void setup()
             if (!WriteWiFiConfig())
                 debugW("Could not even write defaults to WiFi Credentials");
         }
-        else if (WiFi_ssid == "Unset" || WiFi_ssid.length() == 0)
+        else if (WiFi_ssid.length() == 0)
         {
             WiFi_password = cszPassword;
             WiFi_ssid     = cszSSID;

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -208,7 +208,7 @@ void IRAM_ATTR RemoteLoopEntry(void *)
 
 #if ENABLE_WIFI
 
-    bool ConnectToWiFi(uint cRetries)
+    bool ConnectToWiFi(uint cRetries, bool waitForCredentials = false)
     {
         static bool bPreviousConnection = false;
 
@@ -228,8 +228,17 @@ void IRAM_ATTR RemoteLoopEntry(void *)
         {
             if (WiFi_ssid.length() == 0)
             {
-                debugW("WiFi credentials not set, cannot connect. Waiting for credentials to be set...");
-                iPass = 0;
+                debugW("WiFi credentials not set, cannot connect.");
+
+                if (waitForCredentials)
+                {
+                    debugW("Waiting for WiFi credentials to be set...");
+                    iPass = 0;
+                }
+                else
+                {
+                    break;
+                }
             }
             else
             {

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -218,12 +218,6 @@ void IRAM_ATTR RemoteLoopEntry(void *)
 
         debugI("Setting host name to %s...%s", cszHostname,WLtoString(WiFi.status()));
 
-        if (WiFi_ssid == "Unset" || WiFi_ssid.length() == 0)
-        {
-            debugW("WiFi Credentials not set, cannot connect");
-            return false;
-        }
-
         debugV("Wifi.disconnect");
         WiFi.disconnect();
         debugV("Wifi.mode");
@@ -232,12 +226,20 @@ void IRAM_ATTR RemoteLoopEntry(void *)
 
         for (uint iPass = 0; iPass < cRetries; iPass++)
         {
-            debugW("Pass %u of %u: Connecting to Wifi SSID: \"%s\" - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u\n",
-                    iPass + 1, cRetries, WiFi_ssid.c_str(), ESP.getFreeHeap(), ESP.getPsramSize(), ESP.getFreePsram());
+            if (WiFi_ssid.length() == 0)
+            {
+                debugW("WiFi credentials not set, cannot connect. Waiting for credentials to be set...");
+                iPass = 0;
+            }
+            else
+            {
+                debugW("Pass %u of %u: Connecting to Wifi SSID: \"%s\" - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u\n",
+                        iPass + 1, cRetries, WiFi_ssid.c_str(), ESP.getFreeHeap(), ESP.getPsramSize(), ESP.getFreePsram());
 
-            WiFi.begin(WiFi_ssid.c_str(), WiFi_password.c_str());
+                WiFi.begin(WiFi_ssid.c_str(), WiFi_password.c_str());
 
-            debugV("Done Wifi.begin, waiting for connection...");
+                debugV("Done Wifi.begin, waiting for connection...");
+            }
 
             // Give the module a few seconds to connect
             delay(4000 + iPass * 1000);
@@ -250,7 +252,7 @@ void IRAM_ATTR RemoteLoopEntry(void *)
         }
 
         // Additional Services onwwards reliant on network so close if not up.
-        if (false == WiFi.isConnected())
+        if (!WiFi.isConnected())
         {
             debugW("Giving up on WiFi\n");
             return false;

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -175,7 +175,7 @@ void BasicInfoSummary(bool bRedraw)
         display.println(str_sprintf("CPU: %3.0f%%, %3.0f%%  ", taskManager.GetCPUUsagePercent(0), taskManager.GetCPUUsagePercent(1)));
     }
 
-    /* Old PSRAM code 
+    /* Old PSRAM code
     display.setCursor(xMargin + 0, yMargin + lineHeight * 7);
     display.println(str_sprintf("PRAM:%dK/%dK\n",
                                 ESP.getFreePsram() / 1024,


### PR DESCRIPTION
## Description

This fixes #371 by waiting for WiFi credentials indefinitely if they are not set and WiFi is required. This is to cater for the case that the LEDSTRIP project is flashed using the Web Installer, which sets the SSID to an empty string. 

If an invalid set of credentials is set, then the device will eventually reboot - as it currently does immediately if no WiFi credentials are available. Due to the 99 attempts with incremental waits, it will take about an hour and a half (5247 seconds) before the code reaches that point. Which gives sufficient opportunity to correct a typo in SSID or password if one realizes one was made.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).