### PR TITLE
PR #394 and #395 follow-up

### DIFF
--- a/include/effectdependencies.h
+++ b/include/effectdependencies.h
@@ -83,6 +83,6 @@
     #include "effects/matrix/PatternWeather.h"
 #endif
 
-#ifdef USE_NEOPIXEL
+#ifdef USE_WS281X
     #include "ledstripgfx.h"
 #endif

--- a/include/globals.h
+++ b/include/globals.h
@@ -126,8 +126,8 @@
 #define FLASH_VERSION          40   // Update ONLY this to increment the version number
 
 #ifndef USE_HUB75                   // We support strips by default unless specifically defined out
-    #ifndef USE_NEOPIXEL
-        #define USE_NEOPIXEL 1
+    #ifndef USE_WS281X
+        #define USE_WS281X 1
     #endif
 #endif
 
@@ -1487,7 +1487,7 @@ inline static T random_range(T lower, T upper)
 {
     static_assert(std::is_arithmetic<T>::value, "Template argument must be numeric type");
 
-    static std::random_device rd; 
+    static std::random_device rd;
     static std::mt19937 gen(rd());
 
     if constexpr (std::is_integral<T>::value) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -436,7 +436,7 @@ void setup()
     #elif HEXAGON
         // Hexagon is for a PCB wtih 271 LEDss arranged in the face of a hexagon
         HexagonGFX::InitializeHardware(devices);
-    #elif USE_NEOPIXEL
+    #elif USE_WS281X
         // LEDStripGFX is used for simple strips or for matrices woven from strips
         LEDStripGFX::InitializeHardware(devices);
     #endif
@@ -539,7 +539,7 @@ void loop()
             strOutput += str_sprintf("Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(), ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize());
             strOutput += str_sprintf("LED FPS: %d ", g_Values.FPS);
 
-            #if USE_NEOPIXEL
+            #if USE_WS281X
                 strOutput += str_sprintf("LED Bright: %3.0lf%%, LED Watts: %u, ", g_Values.Brite, g_Values.Watts);
             #endif
 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -208,6 +208,10 @@ void IRAM_ATTR RemoteLoopEntry(void *)
 
 #if ENABLE_WIFI
 
+    #define WIFI_WAIT_BASE      4000    // Initial time to wait for WiFi to come up, in ms
+    #define WIFI_WAIT_INCREASE  1000    // Increase of WiFi waiting time per cycle, in ms
+
+
     bool ConnectToWiFi(uint cRetries, bool waitForCredentials = false)
     {
         static bool bPreviousConnection = false;
@@ -251,7 +255,7 @@ void IRAM_ATTR RemoteLoopEntry(void *)
             }
 
             // Give the module a few seconds to connect
-            delay(4000 + iPass * 1000);
+            delay(WIFI_WAIT_BASE + iPass * WIFI_WAIT_INCREASE);
 
             if (WiFi.isConnected())
             {


### PR DESCRIPTION
## Description

This follows up PRs #394 and #395, in the sense that:

- USE_NEOPIXEL is renamed to USE_WS281X, in line with the conversation in #394's comments
- Constants are introduced for the WiFi waiting time in network.cpp's ConnectToWiFi(), in accordance with the review comment on #395

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).