### PR TITLE
[Quality of Developer Life] Add a new telnet/serial debugger command: uptime.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,8 @@ jobs:
 
     - name: Install PlatformIO
       run: |
-        python -c "$(curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py)"
+        curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py -o get-platformio.py
+        python get-platformio.py
         echo "/home/runner/.platformio/penv/bin" >> $GITHUB_PATH
 
     - name: Copy secrets and clear SSID

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Install PlatformIO
       run: |
-        python -c "$(curl -fsSL https://raw.githubusercontent.com/platformio/platformio/master/scripts/get-platformio.py)"
+        python -c "$(curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py)"
         echo "/home/runner/.platformio/penv/bin" >> $GITHUB_PATH
 
     - name: Copy secrets and clear SSID

--- a/include/ntptimeclient.h
+++ b/include/ntptimeclient.h
@@ -60,6 +60,8 @@ class NTPTimeClient
     }
 
     static bool UpdateClockFromWeb(WiFiUDP * pUDP);
+
+    static void ShowUptime();
 };
 
 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -81,12 +81,17 @@ DRAM_ATTR std::mutex NTPTimeClient::_clockMutex;                                
             g_ptrSystem->DeviceConfig().RemovePersisted();
             RemoveEffectManagerConfig();
         }
+        else if (str.equalsIgnoreCase("uptime"))
+        {
+             NTPTimeClient::ShowUptime();
+        }
         else
         {
             debugA("Unknown Command.  Extended Commands:");
             debugA("clock               Refresh time from server");
             debugA("stats               Display buffers, memory, etc");
             debugA("clearsettings       Reset persisted user settings");
+            debugA("uptime              Show system uptime, reset reason");
         }
     }
 #endif

--- a/src/ntptimeclient.cpp
+++ b/src/ntptimeclient.cpp
@@ -151,16 +151,11 @@ bool NTPTimeClient::UpdateClockFromWeb(WiFiUDP * pUDP)
     return true;
 }
 
-// This is underdesigned for general use. It's very specifically a
-// throwaway meant only for debugging. It's not really NTP related.
-//
-// It contains some ESP32-specific goo, but that's allowed elsewhere.
+// Not NTP related. Convenience utility for debugging. Callable from gdb
+// serial shell, or network log debugger.
 
 void NTPTimeClient::ShowUptime()
 {
-    // I hate C99 time handling so much, but C17's <chrono> isn't likely
-    // worth the lift.
-
     struct timeval timeval = { 0 };
     // Microseconds since boot. File wrap bugreport in 292 million years.
     auto uptime = esp_timer_get_time();
@@ -189,10 +184,10 @@ void NTPTimeClient::ShowUptime()
         case ESP_RST_DEEPSLEEP: reason_text = "Reset in deep sleep"; break;
         case ESP_RST_BROWNOUT: reason_text = "Brownout"; break;
         case ESP_RST_SDIO: reason_text = "Reset over SDIO"; break;
-	// Documented,  but seemingly not implemented yet.
+	// Documented,  but not defined in ESP-IDF esp_system.h (v5.1.0) yet.
         // case ESP_RST_USB: reason_text = "Reset by USB peripheral"; break;
 	default: reason_text = "Unknown"; break;
     }
-    debugI("Last boot reason: %s", reason_text);
+    debugI("Last boot reason: (%d): %s", reason, reason_text);
 
 }


### PR DESCRIPTION
I've had this in my tree for a while, but while soaking the new effects,
it's actually justified its bits per blinken, IMO.

Help text:
(processRemoteDebugCmd)(C1) uptime              Show system uptime, reset reason

Sample invocation:
uptime
* Debug: Command received: uptime
(I) (ShowUptime)(C1) Uptime: 0 days - 00:04:50
(I) (ShowUptime)(C1) Last boot reason: Power On
(I) (loop)(C1) Here
(I) (esp32_partition_table_read)(C1) Reading partitions
(I) (esp32_partition_table_read)(C1) nvs 36864 8192

It's quite ESP32-specific in some ways and it's definitely force-fit
into ntpclient (hey, it's gotta be somewhere, right?) but I really don't
think it's any weirder or less justified that a lot of the existing
code.

I had a version of this that displayed the uptime in an overlay, but it
destroyed the FPS. If someone is interested in pair-programming a
follow-up to this PR that adds that, I'm down.

## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
* [x] I make up random text and append it to the forms just to test validation.
