### PR TITLE
Make USE_REMOTE and USE_BUTTONS_ more atomic

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -1570,7 +1570,7 @@ inline bool SetSocketBlockingEnabled(int fd, bool blocking)
 #include "ledviewer.h"                          // For the LEDViewer task and object
 #include "network.h"                            // Networking
 #include "ledbuffer.h"                          // Buffer manager for strip
-#if TOGGLE_BUTTON_1 || TOGGLE_BUTTON_2
+#if defined(TOGGLE_BUTTON_1) || defined(TOGGLE_BUTTON_2)
 #include "Bounce2.h"                            // For Bounce button class
 #endif
 #include "colordata.h"                          // color palettes

--- a/include/globals.h
+++ b/include/globals.h
@@ -1570,7 +1570,9 @@ inline bool SetSocketBlockingEnabled(int fd, bool blocking)
 #include "ledviewer.h"                          // For the LEDViewer task and object
 #include "network.h"                            // Networking
 #include "ledbuffer.h"                          // Buffer manager for strip
+#if TOGGLE_BUTTON_1 || TOGGLE_BUTTON_2
 #include "Bounce2.h"                            // For Bounce button class
+#endif
 #include "colordata.h"                          // color palettes
 #include "drawing.h"                            // drawing code
 #include "taskmgr.h"                            // for cpu usage, etc

--- a/include/remotecontrol.h
+++ b/include/remotecontrol.h
@@ -29,12 +29,12 @@
 //---------------------------------------------------------------------------
 
 #pragma once
+#if ENABLE_REMOTE
 #include <IRremoteESP8266.h>
 #include <IRrecv.h>
 #include <IRutils.h>
 #include <limits>
 
-#if ENABLE_REMOTE
 
 #define key24  true
 #define key44  false

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -162,6 +162,10 @@
 #include "systemcontainer.h"
 #include "values.h"
 
+#if TOGGLE_BUTTON_1 || TOGGLE_BUTTON_2
+  #include "Bounce2.h"                            // For Bounce button class
+#endif
+
 void IRAM_ATTR ScreenUpdateLoopEntry(void *);
 
 //
@@ -239,11 +243,11 @@ void TerminateHandler()
     Serial.flush();
 }
 
-#ifdef TOGGLE_BUTTON_1
+#if TOGGLE_BUTTON_1
 Bounce2::Button Button1;
 #endif
 
-#ifdef TOGGLE_BUTTON_2
+#if TOGGLE_BUTTON_2
 Bounce2::Button Button2;
 #endif
 
@@ -374,13 +378,13 @@ void setup()
         #endif
     #endif
 
-    #ifdef TOGGLE_BUTTON_1
+    #if TOGGLE_BUTTON_1
         Button1.attach(TOGGLE_BUTTON_1, INPUT_PULLUP);
         Button1.interval(1);
         Button1.setPressedState(LOW);
     #endif
 
-    #ifdef TOGGLE_BUTTON_2
+    #if TOGGLE_BUTTON_2
         Button2.attach(TOGGLE_BUTTON_2, INPUT_PULLUP);
         Button2.interval(1);
         Button2.setPressedState(LOW);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -162,7 +162,7 @@
 #include "systemcontainer.h"
 #include "values.h"
 
-#if TOGGLE_BUTTON_1 || TOGGLE_BUTTON_2
+#if defined(TOGGLE_BUTTON_1) || defined(TOGGLE_BUTTON_2)
   #include "Bounce2.h"                            // For Bounce button class
 #endif
 
@@ -243,11 +243,11 @@ void TerminateHandler()
     Serial.flush();
 }
 
-#if TOGGLE_BUTTON_1
+#ifdef TOGGLE_BUTTON_1
 Bounce2::Button Button1;
 #endif
 
-#if TOGGLE_BUTTON_2
+#ifdef TOGGLE_BUTTON_2
 Bounce2::Button Button2;
 #endif
 
@@ -378,13 +378,13 @@ void setup()
         #endif
     #endif
 
-    #if TOGGLE_BUTTON_1
+    #ifdef TOGGLE_BUTTON_1
         Button1.attach(TOGGLE_BUTTON_1, INPUT_PULLUP);
         Button1.interval(1);
         Button1.setPressedState(LOW);
     #endif
 
-    #if TOGGLE_BUTTON_2
+    #ifdef TOGGLE_BUTTON_2
         Button2.attach(TOGGLE_BUTTON_2, INPUT_PULLUP);
         Button2.interval(1);
         Button2.setPressedState(LOW);

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -31,6 +31,10 @@
 #include "globals.h"
 #include "systemcontainer.h"
 
+#if TOGGLE_BUTTON_1 || TOGGLE_BUTTON_2
+  #include "Bounce2.h"                            // For Bounce button class
+#endif
+
 #if USE_SCREEN
 
 #if USE_TFTSPI
@@ -411,11 +415,11 @@ void IRAM_ATTR UpdateScreen(bool bRedraw)
 // this or modify it to fit a screen you do have.  You could also try serial output, as it's on a low-pri thread it shouldn't
 // disturb the primary cores, but I haven't tried it myself.
 
-#ifdef TOGGLE_BUTTON_1
+#if TOGGLE_BUTTON_1
 extern Bounce2::Button Button1;
 #endif
 
-#ifdef TOGGLE_BUTTON_2
+#if TOGGLE_BUTTON_2
 extern Bounce2::Button Button2;
 #endif
 
@@ -429,7 +433,7 @@ void IRAM_ATTR ScreenUpdateLoopEntry(void *)
         // bRedraw is set when the page changes so that it can get a full redraw.  It is also set initially as
         // nothing has been drawn for any page yet
 
-#ifdef TOGGLE_BUTTON_1
+#if TOGGLE_BUTTON_1
         Button1.update();
         if (Button1.pressed())
         {
@@ -442,7 +446,7 @@ void IRAM_ATTR ScreenUpdateLoopEntry(void *)
         }
 #endif
 
-#ifdef TOGGLE_BUTTON_2
+#if TOGGLE_BUTTON_2
         Button2.update();
         if (Button2.pressed())
         {

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -31,7 +31,7 @@
 #include "globals.h"
 #include "systemcontainer.h"
 
-#if TOGGLE_BUTTON_1 || TOGGLE_BUTTON_2
+#if defined(TOGGLE_BUTTON_1) || defined(TOGGLE_BUTTON_2)
   #include "Bounce2.h"                            // For Bounce button class
 #endif
 
@@ -415,11 +415,11 @@ void IRAM_ATTR UpdateScreen(bool bRedraw)
 // this or modify it to fit a screen you do have.  You could also try serial output, as it's on a low-pri thread it shouldn't
 // disturb the primary cores, but I haven't tried it myself.
 
-#if TOGGLE_BUTTON_1
+#ifdef TOGGLE_BUTTON_1
 extern Bounce2::Button Button1;
 #endif
 
-#if TOGGLE_BUTTON_2
+#ifdef TOGGLE_BUTTON_2
 extern Bounce2::Button Button2;
 #endif
 
@@ -433,7 +433,7 @@ void IRAM_ATTR ScreenUpdateLoopEntry(void *)
         // bRedraw is set when the page changes so that it can get a full redraw.  It is also set initially as
         // nothing has been drawn for any page yet
 
-#if TOGGLE_BUTTON_1
+#ifdef TOGGLE_BUTTON_1
         Button1.update();
         if (Button1.pressed())
         {
@@ -446,7 +446,7 @@ void IRAM_ATTR ScreenUpdateLoopEntry(void *)
         }
 #endif
 
-#if TOGGLE_BUTTON_2
+#ifdef TOGGLE_BUTTON_2
         Button2.update();
         if (Button2.pressed())
         {


### PR DESCRIPTION
- Make USE_REMOTE and USE_BUTTON more self-contained.
- Missing file from previous commit.

## Description
    IMO, this change stands on its own as just good style of constraining
    the code that uses remote into the files and blocks that use remote.

    More motivationally, the remote code is Really Annoying to build. It's
    a lot of files to compile in the hope that -ffunction-sections will
    actually throw them away. Better to simply not compile them. This makes
    that possible.

    With this change, it's possble to lib_ignore Bounce2 and IRremoteESP8266
    (and U8g2 and QRcode...) these modules, though I haven't reconciled how
    to do so against our recommended document and style. As such, the change
    that REALLY takes advantage of this,
    +lib_ignore  = U8g2
    +       Bounce2
    +       IRremoteESP8266
    +       QRCode
    +board = esp32-s3-devkitc-1-n16r8v

    is not included here. I think this change stands on its own and lays
    bricks for that later change.

    Tested: successful buddybuild.

## Contributing requirements

Same blinken. Fewer bits. Positive improvement!

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
