### PR TITLE
Fix Web Installer overflow handling

### DIFF
--- a/WebInstaller/index.html
+++ b/WebInstaller/index.html
@@ -8,7 +8,7 @@
 <style>
 html {
   height: 100%;
-  overflow: hidden;
+  overflow: auto;
 }
 body {
   background: black no-repeat center center fixed;

--- a/WebInstaller/index.html
+++ b/WebInstaller/index.html
@@ -16,7 +16,6 @@ body {
   -moz-background-size: cover;
   -o-background-size: cover;
   background-size: cover;
-  height: 100%;
   color: white;
   font-family:Arial, Helvetica, sans-serif
 }
@@ -200,6 +199,5 @@ div#container {
       });
       */
     </script>
-
   </body>
   </html>


### PR DESCRIPTION
## Description

This fixes the "sidenote issue" mentioned in #425, that being that the Web Installer does not allow scrolling when the Web Installer page doesn't fit in the browser window, like when a larger font size is chosen.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).