### PR TITLE
Remove code setting common GPIOS to inputs when ATOMLIGHT ledstripgfx.h

### DIFF
--- a/include/ledstripgfx.h
+++ b/include/ledstripgfx.h
@@ -124,13 +124,6 @@ public:
 
         AddLEDsToFastLED(devices);
 
-        #if ATOMLIGHT                                                   // BUGBUG Why input?  Shouldn't they be output?
-            pinMode(4, INPUT);
-            pinMode(12, INPUT);
-            pinMode(13, INPUT);
-            pinMode(14, INPUT);
-            pinMode(15, INPUT);
-        #endif
     }
 
     // PostProcessFrame


### PR DESCRIPTION
If a developer put LED_PINn on pins 4, 12, 13, 14, 15, this would have ensured that no data would have ever left the chip. PIN5 would have been OK only because this code "accidientally"? missed it.

I'm highly suspicious of this code and doubt that any of us can test it and prove it's correct, we can only inspect it and reason that it's wrong.

Do you agree that it's wrong?

## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).