### PR TITLE
Fixed effectmanager.h to fill color

### DIFF
--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -329,6 +329,18 @@ public:
 
         CRGB oldColor = lastManualColor;
         lastManualColor = color;
+        
+        //This block shifts the hue of the received color to be used in the audio reactive monochromatic fire effect.
+        //Becaue of scope errors by the compiler, the color conversion happens here.
+        CHSV colorVarientHSV = rgb2hsv_approximate(color);
+        if (colorVarientHSV.hue > 244 ) {
+            colorVarientHSV.hue -= 10;
+        } else {
+            colorVarientHSV.hue += 10;
+        }
+        CRGB colorVarientRGB = color;
+        hsv2rgb_spectrum(colorVarientHSV,colorVarientRGB);
+        //End of color shift block
 
         #if (USE_HUB75)
                 auto pMatrix = g();
@@ -342,10 +354,11 @@ public:
             else
 
                 #if ENABLE_AUDIO
+                    
                     #if SPECTRUM
                         effect = GetSpectrumAnalyzer(color, oldColor);
                     #else
-                        effect = make_shared_psram<ColorFillEffect>(color, 1);
+                        effect = make_shared_psram<MusicalPaletteFire>("Custom Color Fire", CRGBPalette16(CRGB::Black, color, colorVarientRGB, CRGB::White), NUM_LEDS, 1, 8, 50, 1, 24, true, false);
                     #endif
                 #else
                     effect = make_shared_psram<ColorFillEffect>(color, 1);

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -330,17 +330,7 @@ public:
         CRGB oldColor = lastManualColor;
         lastManualColor = color;
         
-        //This block shifts the hue of the received color to be used in the audio reactive monochromatic fire effect.
-        //Becaue of scope errors by the compiler, the color conversion happens here.
-        CHSV colorVarientHSV = rgb2hsv_approximate(color);
-        if (colorVarientHSV.hue > 244 ) {
-            colorVarientHSV.hue -= 10;
-        } else {
-            colorVarientHSV.hue += 10;
-        }
-        CRGB colorVarientRGB = color;
-        hsv2rgb_spectrum(colorVarientHSV,colorVarientRGB);
-        //End of color shift block
+       
 
         #if (USE_HUB75)
                 auto pMatrix = g();
@@ -348,21 +338,21 @@ public:
                 pMatrix->PausePalette(true);
         #else
             std::shared_ptr<LEDStripEffect> effect;
-
-            if (color == CRGB(CRGB::White))
-                effect = make_shared_psram<ColorFillEffect>(CRGB::White, 1);
-            else
-
-                #if ENABLE_AUDIO
-                    
-                    #if SPECTRUM
-                        effect = GetSpectrumAnalyzer(color, oldColor);
-                    #else
-                        effect = make_shared_psram<MusicalPaletteFire>("Custom Color Fire", CRGBPalette16(CRGB::Black, color, colorVarientRGB, CRGB::White), NUM_LEDS, 1, 8, 50, 1, 24, true, false);
-                    #endif
+            #if ENABLE_AUDIO
+                
+                #if SPECTRUM
+                    effect = GetSpectrumAnalyzer(color, oldColor);
                 #else
-                    effect = make_shared_psram<ColorFillEffect>(color, 1);
+                    CHSV colorVarientHSV = rgb2hsv_approximate(color);
+                    colorVariantHSV.hue += 10; // A hue-shifted version of the received color to build the monochromatic effect.
+
+                    CRGB colorVariantRGB = color; // Initializing this variable to receive the color conversion from hsv to rgb.
+                    hsv2rgb_spectrum(colorVariantHSV, colorVariantRGB);
+                    effect = make_shared_psram<MusicalPaletteFire>("Custom Color Fire", CRGBPalette16(CRGB::Black, color, colorVariantRGB, CRGB::White), NUM_LEDS, 1, 8, 50, 1, 24, true, false);
                 #endif
+            #else
+                effect = make_shared_psram<ColorFillEffect>(color, 1);
+            #endif
 
             if (effect->Init(_gfx))
             {

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -345,10 +345,10 @@ public:
                     #if SPECTRUM
                         effect = GetSpectrumAnalyzer(color, oldColor);
                     #else
-                        effect = make_shared_psram<MusicalPaletteFire>("Custom Fire", CRGBPalette16(CRGB::Black, color, CRGB::Yellow, CRGB::White), NUM_LEDS, 1, 8, 50, 1, 24, true, false);
+                        effect = make_shared_psram<ColorFillEffect>(color, 1);
                     #endif
                 #else
-                    effect = make_shared_psram<PaletteFlameEffect>("Custom Fire", CRGBPalette16(CRGB::Black, color, CRGB::Yellow, CRGB::White), NUM_LEDS, 1, 8, 50, 1, 24, true, false);
+                    effect = make_shared_psram<ColorFillEffect>(color, 1);
                 #endif
 
             if (effect->Init(_gfx))


### PR DESCRIPTION
## Description
In the main branch this effect did not fill a solid color. Instead, it created a fire fill effect. This tweak fixes that. I am attempting this from a new branch created for this specific fix.

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).