### PR TITLE
Updated ledstripgfx.cpp to apply system brightness to pixels.

### DIFF
--- a/src/ledstripgfx.cpp
+++ b/src/ledstripgfx.cpp
@@ -53,11 +53,10 @@ void LEDStripGFX::PostProcessFrame(uint16_t wifiPixelsDrawn, uint16_t localPixel
 
     auto& effectManager = g_ptrSystem->EffectManager();
 
-    for (int i = 0; i < NUM_CHANNELS; i++) {
+    for (int i = 0; i < NUM_CHANNELS; i++) 
+    {
         FastLED[i].setLeds(effectManager.g(i)->leds, pixelsDrawn);
-        for (int j = 0; j < FastLED[i].size(); j++){
-            FastLED[i][j].fadeLightBy(255-g_ptrSystem->DeviceConfig().GetBrightness());
-        }
+        fadeLightBy(FastLED[i].leds(), FastLED[i].size(),255-g_ptrSystem->DeviceConfig().GetBrightness());
     }
     FastLED.show(g_Values.Fader); //Shows the pixels
 

--- a/src/ledstripgfx.cpp
+++ b/src/ledstripgfx.cpp
@@ -56,7 +56,7 @@ void LEDStripGFX::PostProcessFrame(uint16_t wifiPixelsDrawn, uint16_t localPixel
     for (int i = 0; i < NUM_CHANNELS; i++) 
     {
         FastLED[i].setLeds(effectManager.g(i)->leds, pixelsDrawn);
-        fadeLightBy(FastLED[i].leds(), FastLED[i].size(),255-g_ptrSystem->DeviceConfig().GetBrightness());
+        fadeLightBy(FastLED[i].leds(), FastLED[i].size(), 255 - g_ptrSystem->DeviceConfig().GetBrightness());
     }
     FastLED.show(g_Values.Fader); //Shows the pixels
 

--- a/src/ledstripgfx.cpp
+++ b/src/ledstripgfx.cpp
@@ -53,9 +53,13 @@ void LEDStripGFX::PostProcessFrame(uint16_t wifiPixelsDrawn, uint16_t localPixel
 
     auto& effectManager = g_ptrSystem->EffectManager();
 
-    for (int i = 0; i < NUM_CHANNELS; i++)
+    for (int i = 0; i < NUM_CHANNELS; i++) {
         FastLED[i].setLeds(effectManager.g(i)->leds, pixelsDrawn);
-    FastLED.show(g_Values.Fader);
+        for (int j = 0; j < FastLED[i].size(); j++){
+            FastLED[i][j].fadeLightBy(255-g_ptrSystem->DeviceConfig().GetBrightness());
+        }
+    }
+    FastLED.show(g_Values.Fader); //Shows the pixels
 
     g_Values.FPS = FastLED.getFPS();
     g_Values.Brite = 100.0 * calculate_max_brightness_for_power_mW(g_ptrSystem->DeviceConfig().GetBrightness(), POWER_LIMIT_MW) / 255;


### PR DESCRIPTION
## Description
Recently a device brightness level was added. This code takes advantage of that by applying it to led strip pixels just before they are displayed by FastLED. 

After the pixels are added to FastLED, we iterate each one and apply the system level brightness. This only applies to regular strip effects, and not to matrices. If you notice it is actually calling the fadeLightBy method of the CRGB color object. So we are actually passing an inverse of the brightness level.

The awesomeness of this is that a person can set the global brightness and not cause eye pain to themselves or loved ones, especially when working with lights at night.

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).