### PR TITLE
Bump smallest effect JSON buffer size to 192 bytes

### DIFF
--- a/include/effects/matrix/PatternSMNoise.h
+++ b/include/effects/matrix/PatternSMNoise.h
@@ -383,7 +383,7 @@ class PatternSMNoise : public LEDStripEffect
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<192> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);

--- a/include/effects/matrix/PatternSMPicasso3in1.h
+++ b/include/effects/matrix/PatternSMPicasso3in1.h
@@ -173,7 +173,7 @@ class PatternSMPicasso3in1 : public LEDStripEffect
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<192> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -212,7 +212,7 @@ class PatternSMPicasso3in1 : public LEDStripEffect
         static int last_scale = _scale;
 
         // Force a recalibration on effect change.
-        if (last_scale != Scale) 
+        if (last_scale != Scale)
         {
             debugA("Recalibrating from %d to %d", last_scale, Scale);
                 PicassoGenerate(true);

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -446,7 +446,7 @@ class WaveformEffect : public LEDStripEffect
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<192> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -539,7 +539,7 @@ class GhostWave : public WaveformEffect
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<192> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -625,7 +625,7 @@ class SpectrumBarEffect : public LEDStripEffect
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<192> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -690,10 +690,10 @@ class SpectrumBarEffect : public LEDStripEffect
         constexpr auto kPeakDecaySpectrumBar = 2.5;
 
         // Set the peak decay rates to something that looks good for this effect
-        
+
         g_Analyzer._peak1DecayRate = kPeakDecaySpectrumBar;
         g_Analyzer._peak2DecayRate = kPeakDecaySpectrumBar;
-        
+
         // This effect doesn't clear during drawing, so we need to clear to start the frame
 
         g()->Clear();

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -770,7 +770,7 @@ public:
 
   bool SerializeToJSON(JsonObject& jsonObject) override
   {
-    StaticJsonDocument<128> jsonDoc;
+    StaticJsonDocument<192> jsonDoc;
 
     JsonObject root = jsonDoc.to<JsonObject>();
     LEDStripEffect::SerializeToJSON(root);

--- a/include/effects/strip/fireeffect.h
+++ b/include/effects/strip/fireeffect.h
@@ -297,7 +297,7 @@ class MusicalPaletteFire : public PaletteFlameEffect, protected BeatEffectBase
                        bool mirrored = false)
         : PaletteFlameEffect(strName, palette, ledCount, cellsPerLED, cooling, sparking, sparks, sparkHeight, reversed, mirrored),
           BeatEffectBase(1.00, 0.01)
-            
+
 
     {
         construct();
@@ -306,7 +306,7 @@ class MusicalPaletteFire : public PaletteFlameEffect, protected BeatEffectBase
     MusicalPaletteFire(const JsonObjectConst& jsonObject)
         : PaletteFlameEffect(jsonObject),
           BeatEffectBase(1.00, 0.01)
-          
+
     {
         construct();
     }
@@ -521,7 +521,7 @@ public:
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<192> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);

--- a/include/effects/strip/laserline.h
+++ b/include/effects/strip/laserline.h
@@ -92,7 +92,7 @@ class LaserLineEffect : public BeatEffectBase, public LEDStripEffect
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<192> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -112,7 +112,7 @@ class LaserLineEffect : public BeatEffectBase, public LEDStripEffect
         return true;
     }
 
-    void Draw() 
+    void Draw()
     {
         ProcessAudio();
 

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -160,7 +160,7 @@ protected:
   public:
 
     RainbowFillEffect(float speedDivisor = 12.0f, int deltaHue = 14)
-      : LEDStripEffect(EFFECT_STRIP_RAINBOW_FILL, "RainobwFill Rainbow"),
+      : LEDStripEffect(EFFECT_STRIP_RAINBOW_FILL, "RainbowFill Rainbow"),
         _speedDivisor(speedDivisor),
         _deltaHue(deltaHue)
     {

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -66,7 +66,7 @@ class SimpleRainbowTestEffect : public LEDStripEffect
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<192> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -114,7 +114,7 @@ class RainbowTwinkleEffect : public LEDStripEffect
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<192> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -177,7 +177,7 @@ protected:
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<192> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -237,7 +237,7 @@ protected:
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<192> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -344,7 +344,7 @@ class StatusEffect : public LEDStripEffect
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<192> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);

--- a/include/ledstripeffect.h
+++ b/include/ledstripeffect.h
@@ -482,7 +482,7 @@ class LEDStripEffect : public IJSONSerializable
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<192> jsonDoc;
 
         jsonDoc[PTY_EFFECTNR]       = _effectNumber;
         jsonDoc["fn"]               = _friendlyName;
@@ -535,7 +535,7 @@ class LEDStripEffect : public IJSONSerializable
     // that's serialized by this function.
     virtual bool SerializeSettingsToJSON(JsonObject& jsonObject)
     {
-        StaticJsonDocument<128> jsonDoc;
+        StaticJsonDocument<192> jsonDoc;
 
         jsonDoc[ACTUAL_NAME_OF(_friendlyName)] = _friendlyName;
         jsonDoc[ACTUAL_NAME_OF(_maximumEffectTime)] = _maximumEffectTime;


### PR DESCRIPTION
## Description

This increases the smallest JSON buffer size used for effect serialization from 128 to 192 bytes. It seems that the introduction of the "mi" property in #454 makes that some effects that serialize additional properties (like RainbowFillEffect) now run out of buffer space, meaning properties get lost while serializing. 

As such, this PR fixes #457. 

Thanks to @revision29 for reporting this.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).