### PR TITLE
Some tiny fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ to pio or in a menu option inside the PlatformIO IDE/VS Code.
 
 The effects table is persisted to a JSON file on SPIFFS at regular intervals, to retain the state of effects (and in fact the whole effect list) across reboots. This is largely in preparation for future updates to NightDriverStrip, where the composition of the effect list configuration of individual effects can be changed using the device web application. The API endpoints to facilitate this are already available and ready for use (see [Device web UI and API](#device-web-ui-and-api), below.)
 
-This makes that an override of `SerializeToJSON()` and a corresponding deserializing constructor must be provided for effects that need (or want) to persist more than the friendly name, effect number and enabled state. Those three properties are (de)serialized from/to JSON by `LEDStripEffect` by default.
+This makes that an override of `SerializeToJSON()` and a corresponding deserializing constructor must be provided for effects that need (or want) to persist more than the properties that are (de)serialized from/to JSON by `LEDStripEffect` by default.
 
 Throughout the project, the library used for JSON handling and (de)serialization is [ArduinoJson](https://arduinojson.org/). Among others, this means that:
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ _Davepl, 9/19/2021_
 - [Wifi setup](#wifi-setup)
 - [Feature defines](#feature-defines)
 - [Adding new effects](#adding-new-effects)
+- [Notes on JSON persistence](#notes-on-json-persistence)
 - [Resetting the effect list](#resetting-the-effect-list)
 - [Fetching things from the Internet](#fetching-things-from-the-internet)
 - [Build pointers](#build-pointers)
@@ -215,11 +216,23 @@ That simplest configuration, called here simply 'DEMO', is provided by a board s
 These [build types](#build-pointers) may be chosen by the '-e' argument
 to pio or in a menu option inside the PlatformIO IDE/VS Code.
 
-Concerning JSON peristence: the effects table is persisted to a JSON file on SPIFFS at regular intervals, to retain the state of effects (and in fact the whole effect list) across reboots. This is largely in preparation for future updates to NightDriverStrip, where the composition of the effect list configuration of individual effects can be changed using the device web application. The API endpoints to facilitate this are already available and ready for use (see [Device web UI and API](#device-web-ui-and-api), below.)
+## Notes on JSON persistence
 
-This makes that an override of `SerializeToJSON()` and a corresponding deserializing constructor must be provided for effects that need (or want) to persist more than the friendly name and effect number. Those two properties are (de)serialized from/to JSON by `LEDStripEffect` by default.
+The effects table is persisted to a JSON file on SPIFFS at regular intervals, to retain the state of effects (and in fact the whole effect list) across reboots. This is largely in preparation for future updates to NightDriverStrip, where the composition of the effect list configuration of individual effects can be changed using the device web application. The API endpoints to facilitate this are already available and ready for use (see [Device web UI and API](#device-web-ui-and-api), below.)
 
-**Note**: in line with the convention in ArduinoJson, which is the library used by the JSON serialization logic, `SerializeToJSON()` _must_ return `true` _except_ when an ArduinoJson function (like `JsonObject::set()`) returns `false` to indicate it ran out of buffer memory. Any `SerializeToJSON()` function returning `false` will trigger an increase in the serialization buffer and a restart of the serialization process.
+This makes that an override of `SerializeToJSON()` and a corresponding deserializing constructor must be provided for effects that need (or want) to persist more than the friendly name, effect number and enabled state. Those three properties are (de)serialized from/to JSON by `LEDStripEffect` by default.
+
+Throughout the project, the library used for JSON handling and (de)serialization is [ArduinoJson](https://arduinojson.org/). Among others, this means that:
+
+- in line with the convention in ArduinoJson, `SerializeToJSON()` functions _must_ return `true` _except_ when an ArduinoJson function (like `JsonObject::set()`) returns `false` to indicate it ran out of buffer memory. Any `SerializeToJSON()` function returning `false` will trigger an increase in the overall serialization buffer and a restart of the serialization process.
+- the memory required for an individual class instance's (de)serialization operation needs to be reserved _beforehand_, by creating either:
+
+  - a `StaticJsonDocument<`_buffer size_`>()` that reserves memory on the stack. This can be used for small buffer sizes (smaller than 1024 bytes) only.
+  - an `AllocatedJsonDocument(`_buffer size_`)` that reserves memory on the heap.
+
+  How much memory is actually required depends on the number, type and contents of the (de)serialized properties, and is effectively a bit of a guessing game - which means the values you'll see throughout the codebase are educated guesses as well. When properties that are serialized last fail to show up in the JSON that is generated, it is reasonable to assume the serialization process ran out of buffer memory and that buffer memory thus needs to be increased.
+
+To get a better understanding of the specifics related to JSON (de)serialization, you could consider taking a look at the respective tutorials in the ["First contact" section](https://arduinojson.org/v6/doc/#first-contact) of the ArduinoJson documentation.
 
 ## Resetting the effect list
 

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -126,6 +126,8 @@ class PatternSubscribers : public LEDStripEffect
 
   protected:
 
+    static constexpr int _jsonSize = LEDStripEffect::_jsonSize + 192;
+
     // Add our own SettingSpec instances to the standard set
     bool FillSettingSpecs() override
     {
@@ -179,7 +181,7 @@ class PatternSubscribers : public LEDStripEffect
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<256> jsonDoc;
+        StaticJsonDocument<_jsonSize> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -243,7 +245,7 @@ class PatternSubscribers : public LEDStripEffect
     // Extension override to serialize our settings on top of those from LEDStripEffect
     bool SerializeSettingsToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<384> jsonDoc;
+        StaticJsonDocument<_jsonSize> jsonDoc;
 
         LEDStripEffect::SerializeSettingsToJSON(jsonObject);
 

--- a/include/effects/strip/bouncingballeffect.h
+++ b/include/effects/strip/bouncingballeffect.h
@@ -91,7 +91,7 @@ private:
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<256> jsonDoc;
+        StaticJsonDocument<LEDStripEffect::_jsonSize + 128> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);

--- a/include/effects/strip/fireeffect.h
+++ b/include/effects/strip/fireeffect.h
@@ -101,7 +101,7 @@ class FireEffect : public LEDStripEffect
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<256> jsonDoc;
+        StaticJsonDocument<LEDStripEffect::_jsonSize + 128> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -359,7 +359,7 @@ public:
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<256> jsonDoc;
+        StaticJsonDocument<LEDStripEffect::_jsonSize + 64> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -689,7 +689,7 @@ class BaseFireEffect : public LEDStripEffect
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<256> jsonDoc;
+        StaticJsonDocument<LEDStripEffect::_jsonSize + 128> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);

--- a/include/effects/strip/meteoreffect.h
+++ b/include/effects/strip/meteoreffect.h
@@ -180,7 +180,7 @@ class MeteorEffect : public LEDStripEffect
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<256> jsonDoc;
+        StaticJsonDocument<LEDStripEffect::_jsonSize + 128> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -418,7 +418,7 @@ class TwinkleEffect : public LEDStripEffect
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<256> jsonDoc;
+        StaticJsonDocument<LEDStripEffect::_jsonSize + 64> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);

--- a/include/globals.h
+++ b/include/globals.h
@@ -330,7 +330,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define TOGGLE_BUTTON_2 39
 
     #define NUM_INFO_PAGES          2
-    #define ONSCREEN_SPECTRUM_PAGE  1   // Show a little spctrum analyzer on one of the info pages (slower)
 
 #elif TREESET
 
@@ -432,7 +431,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define LED_PIN0 32
 
     #define NUM_INFO_PAGES          2
-    #define ONSCREEN_SPECTRUM_PAGE  1   // Show a little spectrum analyzer on one of the info pages (slower)
 
 #elif MESMERIZER
 
@@ -516,8 +514,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define POWER_LIMIT_MW  (1 * 5 * 1000)         // Expects at least a 5V, 1A supply
 
     #define TOGGLE_BUTTON_1         35
-    #define NUM_INFO_PAGES          4
-    #define ONSCREEN_SPECTRUM_PAGE  2   // Show a little spectrum analyzer on one of the info pages (slower)
+    #define NUM_INFO_PAGES          2
 
 #elif XMASTREES
 
@@ -855,7 +852,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
     #if !(SPECTRUM_WROVER_KIT)
         #define NUM_INFO_PAGES          2
-        #define ONSCREEN_SPECTRUM_PAGE  1   // Show a little spectrum analyzer on one of the info pages (slower)
     #endif
 
 #elif FANSET
@@ -907,7 +903,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
     #if !(SPECTRUM_WROVER_KIT)
         #define NUM_INFO_PAGES          2
-        #define ONSCREEN_SPECTRUM_PAGE  1   // Show a little spectrum analyzer on one of the info pages (slower)
     #endif
 
 
@@ -981,9 +976,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define TOGGLE_BUTTON_2 39
 
     #define NUM_INFO_PAGES          2
-    #define ONSCREEN_SPECTRUM_PAGE  1   // Show a little spectrum analyzer on one of the info pages (slower)
-
-
 
 #elif CUBE
 

--- a/include/ledstripeffect.h
+++ b/include/ledstripeffect.h
@@ -73,6 +73,7 @@ class LEDStripEffect : public IJSONSerializable
     bool   _enabled = true;
     size_t _maximumEffectTime = 0;
     std::vector<std::reference_wrapper<SettingSpec>> _settingSpecs;
+    static constexpr int _jsonSize = 192;
 
     std::vector<std::shared_ptr<GFXBase>> _GFX;
 
@@ -482,7 +483,7 @@ class LEDStripEffect : public IJSONSerializable
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<192> jsonDoc;
+        StaticJsonDocument<_jsonSize> jsonDoc;
 
         jsonDoc[PTY_EFFECTNR]       = _effectNumber;
         jsonDoc["fn"]               = _friendlyName;
@@ -535,7 +536,7 @@ class LEDStripEffect : public IJSONSerializable
     // that's serialized by this function.
     virtual bool SerializeSettingsToJSON(JsonObject& jsonObject)
     {
-        StaticJsonDocument<192> jsonDoc;
+        StaticJsonDocument<_jsonSize> jsonDoc;
 
         jsonDoc[ACTUAL_NAME_OF(_friendlyName)] = _friendlyName;
         jsonDoc[ACTUAL_NAME_OF(_maximumEffectTime)] = _maximumEffectTime;

--- a/include/ledstripeffect.h
+++ b/include/ledstripeffect.h
@@ -73,6 +73,9 @@ class LEDStripEffect : public IJSONSerializable
     bool   _enabled = true;
     size_t _maximumEffectTime = 0;
     std::vector<std::reference_wrapper<SettingSpec>> _settingSpecs;
+
+    // JSON document size used for serializations of this class. Should probably be made bigger for effects (i.e. subclasses)
+    //   that serialize additional properties.
     static constexpr int _jsonSize = 192;
 
     std::vector<std::shared_ptr<GFXBase>> _GFX;

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -28,6 +28,7 @@
 // History:     Jul-14-2021         Davepl      Moved out of main.cpp
 //---------------------------------------------------------------------------
 
+#include <algorithm>
 #include "globals.h"
 #include "systemcontainer.h"
 
@@ -46,12 +47,11 @@
 
 DRAM_ATTR std::mutex Screen::_screenMutex;              // The storage for the mutex of the screen class
 
+// How many screen pages do we have
+constexpr uint8_t g_InfoPageCount = std::clamp(NUM_INFO_PAGES, 1, 2);
+
 // What page of screen we are showing
-#if NUM_INFO_PAGES > 0
-DRAM_ATTR uint8_t g_InfoPage = NUM_INFO_PAGES - 1;      // Default to last page
-#else
-DRAM_ATTR uint8_t g_InfoPage = 0;                       // Default to first page
-#endif
+DRAM_ATTR uint8_t g_InfoPage = g_InfoPageCount - 1;      // Default to last page
 
 // BasicInfoSummary
 //
@@ -441,7 +441,7 @@ void IRAM_ATTR ScreenUpdateLoopEntry(void *)
 
             // When the button is pressed advance to the next information page on the little display
 
-            g_InfoPage = (g_InfoPage + 1) % NUM_INFO_PAGES;
+            g_InfoPage = (g_InfoPage + 1) % g_InfoPageCount;
             bRedraw = true;
         }
 #endif

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -207,13 +207,10 @@ void CWebServer::GetEffectListText(AsyncWebServerRequest * pRequest)
         j["eternalInterval"]       = effectManager.IsIntervalEternal();
         j["effectInterval"]        = effectManager.GetEffectiveInterval();
 
-        auto effectsList = effectManager.EffectsList();
-
-        for (int i = 0; i < effectManager.EffectCount(); i++)
+        for (auto effect : effectManager.EffectsList())
         {
             StaticJsonDocument<256> effectDoc;
 
-            auto effect = effectsList[i];
             effectDoc["name"]    = effect->FriendlyName();
             effectDoc["enabled"] = effect->IsEnabled();
             effectDoc["core"]    = effect->IsCoreEffect();


### PR DESCRIPTION
## Description

This implements a small number of tiny fixes that were triggered by recent changes or conversations.  
Concretely:

- It changes the way effects calculate the memory they need to reserve to serialize themselves to JSON.
- It fixes an invalid `NUM_INFO_PAGES` define for TTGO.
- It removes defines of `ONSCREEN_SPECTRUM_PAGE` from globals.h, because it is no longer used anywhere.
- It sanitizes the value of `NUM_INFO_PAGES` down to the values that are actually valid for screen.cpp (1 or 2).
- It replaces an index-based for loop in webserver.cpp by a range-based one, which makes more sense at that spot.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).