### PR TITLE
Check for JSON buffer overflows

### DIFF
--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -142,6 +142,8 @@ class DeviceConfig : public IJSONSerializable
         if (includeSensitive)
             jsonDoc[OpenWeatherApiKeyTag] = openWeatherApiKey;
 
+        assert(!jsonDoc.overflowed());
+
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -79,6 +79,8 @@ class DeviceConfig : public IJSONSerializable
     std::vector<std::reference_wrapper<SettingSpec>> settingSpecReferences;
     size_t writerIndex;
 
+    static constexpr int _jsonSize = 1024;
+
     void SaveToJSON();
 
     template <typename T>
@@ -125,7 +127,7 @@ class DeviceConfig : public IJSONSerializable
 
     bool SerializeToJSON(JsonObject& jsonObject, bool includeSensitive)
     {
-        AllocatedJsonDocument jsonDoc(1024);
+        AllocatedJsonDocument jsonDoc(_jsonSize));
 
         // Add serialization logic for additionl settings to this code
         jsonDoc[LocationTag] = location;

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -127,7 +127,7 @@ class DeviceConfig : public IJSONSerializable
 
     bool SerializeToJSON(JsonObject& jsonObject, bool includeSensitive)
     {
-        AllocatedJsonDocument jsonDoc(_jsonSize));
+        AllocatedJsonDocument jsonDoc(_jsonSize);
 
         // Add serialization logic for additionl settings to this code
         jsonDoc[LocationTag] = location;

--- a/include/effects/matrix/PatternSMNoise.h
+++ b/include/effects/matrix/PatternSMNoise.h
@@ -383,12 +383,14 @@ class PatternSMNoise : public LEDStripEffect
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<192> jsonDoc;
+        StaticJsonDocument<LEDStripEffect::_jsonSize> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
         jsonDoc[PTY_EFFECT] = to_value(_effect);
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }

--- a/include/effects/matrix/PatternSMPicasso3in1.h
+++ b/include/effects/matrix/PatternSMPicasso3in1.h
@@ -173,12 +173,14 @@ class PatternSMPicasso3in1 : public LEDStripEffect
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<192> jsonDoc;
+        StaticJsonDocument<LEDStripEffect::_jsonSize> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
         jsonDoc[PTY_SCALE] = _scale;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -189,6 +189,8 @@ class PatternSubscribers : public LEDStripEffect
         jsonDoc["ycg"] = youtubeChannelGuid;
         jsonDoc["ycn"] = youtubeChannelName;
 
+        assert(!jsonDoc.overflowed());
+
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
@@ -251,6 +253,9 @@ class PatternSubscribers : public LEDStripEffect
 
         jsonDoc[NAME_OF(youtubeChannelGuid)] = youtubeChannelGuid;
         jsonDoc[NAME_OF(youtubeChannelName)] = youtubeChannelName;
+
+        if (jsonDoc.overflowed())
+            debugE("JSON buffer overflow while serializing settings for PatternSubscribers - object incomplete!");
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -446,12 +446,14 @@ class WaveformEffect : public LEDStripEffect
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<192> jsonDoc;
+        StaticJsonDocument<LEDStripEffect::_jsonSize> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
         jsonDoc["inc"] = _increment;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
@@ -539,7 +541,7 @@ class GhostWave : public WaveformEffect
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<192> jsonDoc;
+        StaticJsonDocument<LEDStripEffect::_jsonSize> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -547,6 +549,8 @@ class GhostWave : public WaveformEffect
         jsonDoc[PTY_BLUR] = _blur;
         jsonDoc[PTY_ERASE] = _erase;
         jsonDoc[PTY_FADE] = _fade;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
@@ -625,7 +629,7 @@ class SpectrumBarEffect : public LEDStripEffect
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<192> jsonDoc;
+        StaticJsonDocument<LEDStripEffect::_jsonSize> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -633,6 +637,8 @@ class SpectrumBarEffect : public LEDStripEffect
         jsonDoc[PTY_SPEED]    = _scrollIncrement;
         jsonDoc[PTY_DELTAHUE] = _hueIncrement;
         jsonDoc[PTY_HUESTEP]  = _hueStep;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }

--- a/include/effects/strip/bouncingballeffect.h
+++ b/include/effects/strip/bouncingballeffect.h
@@ -101,6 +101,8 @@ private:
         jsonDoc[PTY_MIRORRED] = _bMirrored;
         jsonDoc[PTY_ERASE] = _bErase;
 
+        assert(!jsonDoc.overflowed());
+
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -770,13 +770,15 @@ public:
 
   bool SerializeToJSON(JsonObject& jsonObject) override
   {
-    StaticJsonDocument<192> jsonDoc;
+    StaticJsonDocument<LEDStripEffect::_jsonSize> jsonDoc;
 
     JsonObject root = jsonDoc.to<JsonObject>();
     LEDStripEffect::SerializeToJSON(root);
 
     jsonDoc[PTY_ORDER] = to_value(_order);
     jsonDoc["stp"] = _step;
+
+    assert(!jsonDoc.overflowed());
 
     return jsonObject.set(jsonDoc.as<JsonObjectConst>());
   }

--- a/include/effects/strip/fireeffect.h
+++ b/include/effects/strip/fireeffect.h
@@ -115,6 +115,8 @@ class FireEffect : public LEDStripEffect
         jsonDoc[PTY_REVERSED] = bReversed;
         jsonDoc[PTY_MIRORRED] = bMirrored;
 
+        assert(!jsonDoc.overflowed());
+
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
@@ -368,6 +370,8 @@ public:
         jsonDoc[PTY_REVERSED] = _Reversed;
         jsonDoc[PTY_COOLING] = _Cooling;
 
+        assert(!jsonDoc.overflowed());
+
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
@@ -521,7 +525,7 @@ public:
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<192> jsonDoc;
+        StaticJsonDocument<LEDStripEffect::_jsonSize> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -534,6 +538,8 @@ public:
         jsonDoc[PTY_SPARKHEIGHT] = _SparkHeight;
         jsonDoc["trb"] = _Turbo;
         jsonDoc[PTY_MIRORRED] = _Mirrored;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
@@ -702,6 +708,8 @@ class BaseFireEffect : public LEDStripEffect
         jsonDoc[PTY_MIRORRED] = bMirrored;
         jsonDoc[PTY_LEDCOUNT] = LEDCount;
         jsonDoc["clc"] = CellCount;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }

--- a/include/effects/strip/laserline.h
+++ b/include/effects/strip/laserline.h
@@ -92,13 +92,15 @@ class LaserLineEffect : public BeatEffectBase, public LEDStripEffect
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<192> jsonDoc;
+        StaticJsonDocument<LEDStripEffect::_jsonSize> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
         jsonDoc[PTY_SIZE] = _defaultSize;
         jsonDoc[PTY_SPEED] = _defaultSpeed;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }

--- a/include/effects/strip/meteoreffect.h
+++ b/include/effects/strip/meteoreffect.h
@@ -191,6 +191,8 @@ class MeteorEffect : public LEDStripEffect
         jsonDoc[PTY_MINSPEED] = _meteorSpeedMin;
         jsonDoc[PTY_MAXSPEED] = _meteorSpeedMax;
 
+        assert(!jsonDoc.overflowed());
+
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -66,13 +66,15 @@ class SimpleRainbowTestEffect : public LEDStripEffect
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<192> jsonDoc;
+        StaticJsonDocument<LEDStripEffect::_jsonSize> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
         jsonDoc[PTY_EVERYNTH] = _EveryNth;
         jsonDoc[PTY_SPEEDDIVISOR] = _SpeedDivisor;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
@@ -114,13 +116,15 @@ class RainbowTwinkleEffect : public LEDStripEffect
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<192> jsonDoc;
+        StaticJsonDocument<LEDStripEffect::_jsonSize> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
         jsonDoc[PTY_SPEEDDIVISOR] = _speedDivisor;
         jsonDoc[PTY_DELTAHUE] = _deltaHue;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
@@ -177,13 +181,15 @@ protected:
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<192> jsonDoc;
+        StaticJsonDocument<LEDStripEffect::_jsonSize> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
         jsonDoc[PTY_SPEEDDIVISOR] = _speedDivisor;
         jsonDoc[PTY_DELTAHUE] = _deltaHue;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
@@ -237,13 +243,15 @@ protected:
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<192> jsonDoc;
+        StaticJsonDocument<LEDStripEffect::_jsonSize> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
         jsonDoc[PTY_EVERYNTH] = _everyNth;
         jsonDoc[PTY_COLOR] = _color;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
@@ -344,13 +352,15 @@ class StatusEffect : public LEDStripEffect
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<192> jsonDoc;
+        StaticJsonDocument<LEDStripEffect::_jsonSize> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
         jsonDoc[PTY_EVERYNTH] = _everyNth;
         jsonDoc[PTY_COLOR] = _color;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
@@ -426,6 +436,8 @@ class TwinkleEffect : public LEDStripEffect
         jsonDoc["ctd"] = _countToDraw;
         jsonDoc[PTY_FADE] = _fadeFactor;
         jsonDoc[PTY_SPEED] = _updateSpeed;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }

--- a/include/ledstripeffect.h
+++ b/include/ledstripeffect.h
@@ -502,6 +502,8 @@ class LEDStripEffect : public IJSONSerializable
         if (_coreEffect)
             jsonDoc[PTY_COREEFFECT] = 1;
 
+        assert(!jsonDoc.overflowed());
+
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
@@ -544,6 +546,9 @@ class LEDStripEffect : public IJSONSerializable
         jsonDoc[ACTUAL_NAME_OF(_friendlyName)] = _friendlyName;
         jsonDoc[ACTUAL_NAME_OF(_maximumEffectTime)] = _maximumEffectTime;
         jsonDoc["hasMaximumEffectTime"] = HasMaximumEffectTime();
+
+        if (jsonDoc.overflowed())
+            debugE("JSON buffer overflow while serializing settings for LEDStripEffect - object incomplete!");
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }

--- a/platformio.ini
+++ b/platformio.ini
@@ -51,7 +51,7 @@ lib_deps        = crankyoldgit/IRremoteESP8266  @ ^2.7.20
                   kosme/arduinoFFT              @ ^1.5.6
                   me-no-dev/AsyncTCP            @ ^1.1.1
                   https://github.com/PlummersSoftwareLLC/ESPAsyncWebServer.git
-                  bblanchon/ArduinoJson         @ ^6.8.14
+                  bblanchon/ArduinoJson         @ ^6.21.3
                   thomasfredericks/Bounce2      @ ^2.7.0
                   https://github.com/PlummersSoftwareLLC/RemoteDebug
                   QRCode                        @ ^0.0.1

--- a/src/deviceconfig.cpp
+++ b/src/deviceconfig.cpp
@@ -125,7 +125,7 @@ DeviceConfig::ValidateResponse DeviceConfig::ValidateOpenWeatherAPIKey(const Str
 
         case HTTP_CODE_UNAUTHORIZED:
         {
-            AllocatedJsonDocument jsonDoc(1024);
+            AllocatedJsonDocument jsonDoc(_jsonSize);
             deserializeJson(jsonDoc, http.getString());
 
             String message = "";

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -413,6 +413,9 @@ void CWebServer::SendSettingSpecsResponse(AsyncWebServerRequest * pRequest, cons
                     break;
             }
 
+            if (jsonDoc.overflowed())
+                debugE("JSON buffer overflow while serializing SettingSpec - object incomplete!");
+
             if (!specObject.set(jsonDoc.as<JsonObjectConst>()))
             {
                 bufferOverflow = true;


### PR DESCRIPTION
## Description

While looking into the documentation concerning the upgrade from ArduinoJson version 6 to 7 in follow up to #463, I found that in ArduinoJson version 6.17, a function `JsonDocument::overflowed()` was introduced that indicates if the JSON buffer that was reserved for the document ran out of space during serialization. 

This PR checks for this condition, and:

- aborts through `assert()` in cases an incomplete JSON serialization impacts the core functionality of the project, or
- logs an error in cases where it doesn't. This is the case if it concerns objects that are returned by the web API.

Although this doesn't take the guesswork out of the buffer size to allocate, it does flag when that size turns out to be too small.

Finally, I've replaced JSON buffer size literals with a `_jsonSize` constexpr where appropriate.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).