### PR TITLE
Update WiFi connection logic and improve Improv logging

### DIFF
--- a/config/web_projects.json
+++ b/config/web_projects.json
@@ -35,9 +35,9 @@
             ]
         },
         {
-            "tag": "esp32esp32-s3",
+            "tag": "esp32-s3",
             "chipfamily": "ESP32-S3",
-            "name": "ESP32ESP32-S3-DevKitC-1",
+            "name": "ESP32-S3-DevKitC-1",
             "projects": [
                 {
                     "tag": "panlee",

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -199,7 +199,7 @@ class DeviceConfig : public IJSONSerializable
                 "Hostname",
                 "The hostname of the device. A reboot is required after changing this.",
                 SettingSpec::SettingType::String
-            ).Optional = true;
+            ).EmptyAllowed = true;
             settingSpecs.emplace_back(
                 LocationTag,
                 "Location",

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -63,6 +63,7 @@
 class DeviceConfig : public IJSONSerializable
 {
     // Add variables for additional settings to this list
+    String  hostname = cszHostname;
     String  location = cszLocation;
     bool    locationIsZip = false;
     String  countryCode = cszCountryCode;
@@ -106,6 +107,7 @@ class DeviceConfig : public IJSONSerializable
     using ValidateResponse = std::pair<bool, String>;
 
     // Add additional setting Tags to this list
+    static constexpr const char * HostnameTag = NAME_OF(hostname);
     static constexpr const char * LocationTag = NAME_OF(location);
     static constexpr const char * LocationIsZipTag = NAME_OF(locationIsZip);
     static constexpr const char * CountryCodeTag = NAME_OF(countryCode);
@@ -130,6 +132,7 @@ class DeviceConfig : public IJSONSerializable
         AllocatedJsonDocument jsonDoc(_jsonSize);
 
         // Add serialization logic for additionl settings to this code
+        jsonDoc[HostnameTag] = hostname;
         jsonDoc[LocationTag] = location;
         jsonDoc[LocationIsZipTag] = locationIsZip;
         jsonDoc[CountryCodeTag] = countryCode;
@@ -157,6 +160,7 @@ class DeviceConfig : public IJSONSerializable
     bool DeserializeFromJSON(const JsonObjectConst& jsonObject, bool skipWrite)
     {
         // Add deserialization logic for additional settings to this code
+        SetIfPresentIn(jsonObject, hostname, HostnameTag);
         SetIfPresentIn(jsonObject, location, LocationTag);
         SetIfPresentIn(jsonObject, locationIsZip, LocationIsZipTag);
         SetIfPresentIn(jsonObject, countryCode, CountryCodeTag);
@@ -191,19 +195,25 @@ class DeviceConfig : public IJSONSerializable
         {
             // Add SettingSpec for additional settings to this list
             settingSpecs.emplace_back(
-                NAME_OF(location),
+                HostnameTag,
+                "Hostname",
+                "The hostname of the device. A reboot is required after changing this.",
+                SettingSpec::SettingType::String
+            ).Optional = true;
+            settingSpecs.emplace_back(
+                LocationTag,
                 "Location",
                 "The location (city or postal code) where the device is located.",
                 SettingSpec::SettingType::String
             );
             settingSpecs.emplace_back(
-                NAME_OF(locationIsZip),
+                LocationIsZipTag,
                 "Location is postal code",
                 "A boolean indicating if the value in the 'location' setting is a postal code ('true'/1) or not ('false'/0).",
                 SettingSpec::SettingType::Boolean
             );
             settingSpecs.emplace_back(
-                NAME_OF(countryCode),
+                CountryCodeTag,
                 "Country code",
                 "The <a href=\"https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2\">ISO 3166-1 alpha-2</a> country "
                 "code for the country that the device is located in.",
@@ -211,7 +221,7 @@ class DeviceConfig : public IJSONSerializable
             );
 
             auto weatherKeySpec = settingSpecs.emplace_back(
-                NAME_OF(openWeatherApiKey),
+                OpenWeatherApiKeyTag,
                 "Open Weather API key",
                 "The API key for the <a href=\"https://openweathermap.org/api\">Weather API provided by Open Weather Map</a>.",
                 SettingSpec::SettingType::String
@@ -220,39 +230,39 @@ class DeviceConfig : public IJSONSerializable
             weatherKeySpec.Access = SettingSpec::SettingAccess::WriteOnly;
 
             settingSpecs.emplace_back(
-                NAME_OF(timeZone),
+                TimeZoneTag,
                 "Time zone",
                 "The timezone the device resides in, in <a href=\"https://en.wikipedia.org/wiki/Tz_database\">tz database</a> format. "
                 "The list of available timezone identifiers can be found in the <a href=\"/timezones.json\">timezones.json</a> file.",
                 SettingSpec::SettingType::String
             );
             settingSpecs.emplace_back(
-                NAME_OF(use24HourClock),
+                Use24HourClockTag,
                 "Use 24 hour clock",
                 "A boolean that indicates if time should be shown in 24-hour format ('true'/1) or 12-hour AM/PM format ('false'/0).",
                 SettingSpec::SettingType::Boolean
             );
             settingSpecs.emplace_back(
-                NAME_OF(useCelsius),
+                UseCelsiusTag,
                 "Use degrees Celsius",
                 "A boolean that indicates if temperatures should be shown in degrees Celsius ('true'/1) or degrees Fahrenheit ('false'/0).",
                 SettingSpec::SettingType::Boolean
             );
             settingSpecs.emplace_back(
-                NAME_OF(ntpServer),
+                NTPServerTag,
                 "NTP server address",
                 "The hostname or IP address of the NTP server to be used for time synchronization.",
                 SettingSpec::SettingType::String
             );
             settingSpecs.emplace_back(
-                NAME_OF(rememberCurrentEffect),
+                RememberCurrentEffectTag,
                 "Remember current effect",
                 "A boolean that indicates if the current effect index should be saved after an effect transition, so the device resumes "
                 "from the same effect when restarted. Enabling this will lead to more wear on the flash chip of your device.",
                 SettingSpec::SettingType::Boolean
             );
             settingSpecs.emplace_back(
-                NAME_OF(brightness),
+                BrightnessTag,
                 "Brightness",
                 "Overall brightness the connected LEDs or matrix should be run at.",
                 SettingSpec::SettingType::Integer,
@@ -261,7 +271,7 @@ class DeviceConfig : public IJSONSerializable
             ).HasValidation = true;
 
             auto& powerLimitSpec = settingSpecs.emplace_back(
-                NAME_OF(powerLimit),
+                PowerLimitTag,
                 "Power limit",
                 "The maximum power in mW that the matrix attached to the board is allowed to use. As the previous sentence implies, this "
                 "setting only applies if a matrix is used.",
@@ -292,6 +302,17 @@ class DeviceConfig : public IJSONSerializable
     {
         SetAndSave(use24HourClock, new24HourClock);
     }
+
+    const String &GetHostname() const
+    {
+        return hostname;
+    }
+
+    void SetHostname(const String &newHostname)
+    {
+        SetAndSave(hostname, newHostname);
+    }
+
 
     const String &GetLocation() const
     {

--- a/include/globals.h
+++ b/include/globals.h
@@ -716,6 +716,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
     #define ENABLE_WIFI                 1   // Connect to WiFi
     #define INCOMING_WIFI_ENABLED       1   // Accepting incoming color data and commands
+    
     #define WAIT_FOR_WIFI               1   // Hold in setup until we have WiFi - for strips without effects
     #define TIME_BEFORE_LOCAL           5   // How many seconds before the lamp times out and shows local content
     #define COLORDATA_SERVER_ENABLED    0   // Also provides a response packet

--- a/include/globals.h
+++ b/include/globals.h
@@ -710,7 +710,10 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define PROJECT_NAME            "Ledstrip"
     #endif
 
+    #ifndef ENABLE_WEBSERVER
     #define ENABLE_WEBSERVER            0   // Turn on the internal webserver
+    #endif
+
     #define ENABLE_WIFI                 1   // Connect to WiFi
     #define INCOMING_WIFI_ENABLED       1   // Accepting incoming color data and commands
     #define WAIT_FOR_WIFI               1   // Hold in setup until we have WiFi - for strips without effects

--- a/include/improvserial.h
+++ b/include/improvserial.h
@@ -273,7 +273,7 @@ protected:
 
                     log_write(".Received wifi settings ssid=\"%s\", password=******", command.ssid.c_str());
 
-                    ConnectToWiFi(WiFi_ssid.c_str(), WiFi_password.c_str());
+                    ConnectToWiFi(WiFi_ssid, WiFi_password);
                 #endif
 
                 this->set_state_(improv::STATE_PROVISIONING);

--- a/include/improvserial.h
+++ b/include/improvserial.h
@@ -117,6 +117,7 @@ public:
             if (WiFi.getMode() == WIFI_AP || (WiFi.getMode() == WIFI_STA && WiFi.isConnected()))
             {
                 log_write("Responding that wiFi is connected.");
+                debugI("Sending Improv packets to indicate WiFi is connected. Ignore any IMPROV lines that follow this one.")
                 this->set_state_(improv::STATE_PROVISIONED);
                 std::vector<uint8_t> url = this->build_rpc_settings_response_(improv::WIFI_SETTINGS);
                 this->send_response_(url);

--- a/include/improvserial.h
+++ b/include/improvserial.h
@@ -340,7 +340,7 @@ protected:
                 this->send_response_(data);
                 return true;
             }
-            
+
             default:
             {
                 log_write(".Received unknown RPC command 0x%02hhx, responding we're OK ignoring it", command.command);

--- a/include/improvserial.h
+++ b/include/improvserial.h
@@ -266,12 +266,16 @@ protected:
                 String WiFi_ssid = command.ssid.c_str();
                 String WiFi_password = command.password.c_str();
 
-                if (!WriteWiFiConfig(WiFi_ssid, WiFi_password))
-                    debugI("Failed writing WiFi config to NVS");
+                // These lines actually require WiFi to be enabled in the project
+                #if ENABLE_WIFI
+                    if (!WriteWiFiConfig(WiFi_ssid, WiFi_password))
+                        debugI("Failed writing WiFi config to NVS");
 
-                log_write(".Received wifi settings ssid=\"%s\", password=******", command.ssid.c_str());
+                    log_write(".Received wifi settings ssid=\"%s\", password=******", command.ssid.c_str());
 
-                ConnectToWiFi(WiFi_ssid.c_str(), WiFi_password.c_str());
+                    ConnectToWiFi(WiFi_ssid.c_str(), WiFi_password.c_str());
+                #endif
+
                 this->set_state_(improv::STATE_PROVISIONING);
 
                 this->command_.command  = command.command;

--- a/include/improvserial.h
+++ b/include/improvserial.h
@@ -154,12 +154,7 @@ protected:
             va_list args;
 
             va_start(args, format);
-
-            // We shifted the printf parameter check to ourselves, so we can suppress the warning here
-            #pragma GCC diagnostic ignored "-Wformat-nonliteral"
             vsnprintf(lineBuffer, bufferSize, format, args);
-            #pragma GCC diagnostic warning "-Wformat-nonliteral"
-
             va_end(args);
 
             lineBuffer[bufferSize - 1] = 0;
@@ -227,12 +222,12 @@ protected:
 
             if (checksum != byte)
             {
-                log_write("Checksum mismatch in Improv payload. Expected 0x%02hhx. Got 0x%02hhx", checksum, byte);
+                log_write("Checksum mismatch in Improv payload. Expected 0x%02hhX. Got 0x%02hhX", checksum, byte);
                 this->set_error_(improv::ERROR_INVALID_RPC);
                 return false;
             }
 
-            log_write("Received valid Improv packet of type 0x%02hhx with data length %hhu", type, data_len);
+            log_write("Received valid Improv packet of type 0x%02hhX with data length %hhu", type, data_len);
 
             if (type == TYPE_RPC)
             {
@@ -341,7 +336,7 @@ protected:
 
             default:
             {
-                log_write(".Received unknown RPC command 0x%02hhx, responding we're OK ignoring it", command.command);
+                log_write(".Received unknown RPC command 0x%02hhX, responding we're OK ignoring it", command.command);
                 this->set_error_(improv::ERROR_UNKNOWN_RPC);
                 return true;
             }
@@ -362,7 +357,7 @@ protected:
         data[8] = 1;
         data[9] = state;
 
-        log_write("..Sending current state response for state: 0x%02hhx", state);
+        log_write("..Sending current state response for state: 0x%02hhX", state);
 
         uint8_t checksum = 0x00;
         for (uint8_t d : data)
@@ -383,7 +378,7 @@ protected:
         data[8] = 1;
         data[9] = error;
 
-        log_write("..Sending error response for error: 0x%02hhx", error);
+        log_write("..Sending error response for error: 0x%02hhX", error);
 
         uint8_t checksum = 0x00;
         for (uint8_t d : data)

--- a/include/improvserial.h
+++ b/include/improvserial.h
@@ -117,7 +117,7 @@ public:
             if (WiFi.getMode() == WIFI_AP || (WiFi.getMode() == WIFI_STA && WiFi.isConnected()))
             {
                 log_write("Responding that wiFi is connected.");
-                debugI("Sending Improv packets to indicate WiFi is connected. Ignore any IMPROV lines that follow this one.")
+                debugI("Sending Improv packets to indicate WiFi is connected. Ignore any IMPROV lines that follow this one.");
                 this->set_state_(improv::STATE_PROVISIONED);
                 std::vector<uint8_t> url = this->build_rpc_settings_response_(improv::WIFI_SETTINGS);
                 this->send_response_(url);

--- a/include/network.h
+++ b/include/network.h
@@ -34,9 +34,16 @@
 #endif
 
 #if ENABLE_WIFI
+    enum class WiFiConnectResult
+    {
+      Connected,
+      Disconnected,
+      NoCredentials
+    };
+
     void processRemoteDebugCmd();
 
-    bool ConnectToWiFi(const char *ssid, const char *password);
+    WiFiConnectResult ConnectToWiFi(const char *ssid, const char *password);
     void UpdateNTPTime();
     void SetupOTA(const String & strHostname);
     bool ReadWiFiConfig(String& WiFi_ssid, String& WiFi_password);

--- a/include/network.h
+++ b/include/network.h
@@ -43,7 +43,8 @@
 
     void processRemoteDebugCmd();
 
-    WiFiConnectResult ConnectToWiFi(const char *ssid, const char *password);
+    WiFiConnectResult ConnectToWiFi(const String& ssid, const String& password);
+    WiFiConnectResult ConnectToWiFi(const String* ssid, const String* password);
     void UpdateNTPTime();
     void SetupOTA(const String & strHostname);
     bool ReadWiFiConfig(String& WiFi_ssid, String& WiFi_password);

--- a/include/network.h
+++ b/include/network.h
@@ -33,18 +33,14 @@
     #include "socketserver.h"
 #endif
 
-    extern DRAM_ATTR String WiFi_password;
-    extern DRAM_ATTR String WiFi_ssid;
 #if ENABLE_WIFI
     void processRemoteDebugCmd();
 
-    bool ConnectToWiFi(uint cRetries, bool waitForCredentials);
+    bool ConnectToWiFi(const char *ssid, const char *password);
     void UpdateNTPTime();
     void SetupOTA(const String & strHostname);
-    bool ReadWiFiConfig();
-    bool WriteWiFiConfig();
-    extern DRAM_ATTR String WiFi_password;
-    extern DRAM_ATTR String WiFi_ssid;
+    bool ReadWiFiConfig(String& WiFi_ssid, String& WiFi_password);
+    bool WriteWiFiConfig(const String& WiFi_ssid, const String& WiFi_password);
 
     // Static Helpers
     //

--- a/include/secrets.example.h
+++ b/include/secrets.example.h
@@ -32,7 +32,8 @@
 
 #define cszSSID              "Your SSID"
 #define cszPassword          "Your PASS"
-#define cszHostname          "NightDriverStrip"
+#define cszHostname          ""                     // An empty hostname will make it default to esp32-XXXXXX,
+                                                    //   with the Xs being 3 bytes of the device's MAC address
 #define cszOpenWeatherAPIKey ""                     // Your OpenWeatherMap API key goes Here
 #define cszLocation          "98074"
 #define bLocationIsZip       true

--- a/include/types.h
+++ b/include/types.h
@@ -154,6 +154,7 @@ struct SettingSpec
     SettingType Type;
     bool HasValidation = false;
     SettingAccess Access = SettingAccess::ReadWrite;
+    bool Optional = false;
 
     std::optional<double> MinimumValue = {};
     std::optional<double> MaximumValue = {};

--- a/include/types.h
+++ b/include/types.h
@@ -148,15 +148,31 @@ struct SettingSpec
         ReadWrite
     };
 
+    // "Technical" name of the setting, as in the (JSON) property it is stored in.
     const char* Name;
-    const char* FriendlyName;
-    const char* Description;
-    SettingType Type;
-    bool HasValidation = false;
-    SettingAccess Access = SettingAccess::ReadWrite;
-    bool Optional = false;
 
+    // "Friendly" name of the setting, as in the one to be presented to the user in a user interface.
+    const char* FriendlyName;
+
+    // Description of the purpose and/or value of the setting
+    const char* Description;
+
+    // Value type of the setting
+    SettingType Type;
+
+    // Indication if validation for the setting's value is available
+    bool HasValidation = false;
+
+    // Indication if a setting is read-only, write-only or read/write
+    SettingAccess Access = SettingAccess::ReadWrite;
+
+    // Indication if an empty value is allowed for the setting. This only applies to String settings.
+    bool EmptyAllowed = false;
+
+    // Minimum valid value for the setting. This only applies to numeric settings.
     std::optional<double> MinimumValue = {};
+
+    // Maximum valid value for the setting. This only applies to numeric settings.
     std::optional<double> MaximumValue = {};
 
 

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -88,7 +88,7 @@ class CWebServer
         const char *const type;
         const char *const encoding;
 
-        EmbeddedWebFile(const uint8_t start[], const uint8_t end[], const char type[], const char encoding[])
+        EmbeddedWebFile(const uint8_t* start, const uint8_t* end, const char* type, const char* encoding = nullptr)
             : EmbeddedFile(start, end), type(type), encoding(encoding)
         {
         }
@@ -186,14 +186,16 @@ class CWebServer
     // This registers a handler for GET requests for one of the known files embedded in the firmware.
     void ServeEmbeddedFile(const char strUri[], EmbeddedWebFile &file)
     {
-        _server.on(strUri, HTTP_GET, [strUri, file](AsyncWebServerRequest *request) {
+        _server.on(strUri, HTTP_GET, [strUri, file](AsyncWebServerRequest *request)
+        {
             Serial.printf("GET for: %s\n", strUri);
             AsyncWebServerResponse *response = request->beginResponse_P(200, file.type, file.contents, file.length);
-            if (file.encoding[0])
+            if (file.encoding)
             {
                 response->addHeader("Content-Encoding", file.encoding);
             }
-            request->send(response);
+
+            AddCORSHeaderAndSendResponse(request, response);
         });
     }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -311,7 +311,7 @@ build_flags     = -DDEMO=1
 ; Now for the Heltec, with WiFi and webserver enabled
 [env:heltecdemo]
 extends         = dev_heltec_wifi
-build_flags     = -DLEDSTRIP=1
+build_flags     = -DDEMO=1
                   -DENABLE_WIFI=1
                   ${dev_heltec_wifi.build_flags}
 

--- a/site/src/index.html
+++ b/site/src/index.html
@@ -17,6 +17,6 @@
 </head>
 <body>
     <div id="root"></div>
-    <script  src="index.js.gz"></script>
+    <script  src="index.js"></script>
 </body>
 </html>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -319,25 +319,10 @@ void setup()
         ESP_ERROR_CHECK(nvs_flash_erase());
         err = nvs_flash_init();
     }
+
     ESP_ERROR_CHECK(err);
 
-    // Setup config objects
-    g_ptrSystem->SetupConfig();
-
     #if ENABLE_WIFI
-
-        // This chip alone is special-cased by Improv, so we pull it
-        // from build flags. CONFIG_IDF_TARGET will be "esp32s3".
-        #if CONFIG_IDF_TARGET_ESP32S3
-            String family = "ESP32-S3";
-        #else
-	        String family = "ESP32";
-        #endif
-
-        debugW("Starting ImprovSerial for %s", family.c_str());
-        String name = "NDESP32" + get_mac_address().substring(6);
-        g_ImprovSerial.setup(PROJECT_NAME, FLASH_VERSION_NAME, family, name.c_str(), &Serial);
-
         // Read the WiFi crendentials from NVS.  If it fails, writes the defaults based on secrets.h
 
         if (!ReadWiFiConfig())
@@ -354,6 +339,24 @@ void setup()
             WiFi_ssid     = cszSSID;
         }
 
+        // This chip alone is special-cased by Improv, so we pull it
+        // from build flags. CONFIG_IDF_TARGET will be "esp32s3".
+        #if CONFIG_IDF_TARGET_ESP32S3
+            String family = "ESP32-S3";
+        #else
+	        String family = "ESP32";
+        #endif
+
+        debugW("Starting ImprovSerial for %s", family.c_str());
+        String name = "NDESP32" + get_mac_address().substring(6);
+        g_ImprovSerial.setup(PROJECT_NAME, FLASH_VERSION_NAME, family, name.c_str(), &Serial);
+
+    #endif
+
+    // Setup config objects
+    g_ptrSystem->SetupConfig();
+
+    #if ENABLE_WIFI
         // We create the network reader here, so classes can register their readers from this point onwards.
         //   Note that the thread that executes the readers is started further down, along with other networking
         //   threads.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -503,8 +503,8 @@ void setup()
     taskManager.StartRemoteThread();
 
     #if ENABLE_WIFI
-        debugI("Making first attempt to connect to WiFi.");
-        ConnectToWiFi(WiFi_ssid.c_str(), WiFi_password.c_str());
+        debugI("Making initial attempt to connect to WiFi.");
+        ConnectToWiFi(WiFi_ssid, WiFi_password);
         Debug.setSerialEnabled(true);
     #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -345,7 +345,7 @@ void setup()
         #if CONFIG_IDF_TARGET_ESP32S3
             String family = "ESP32-S3";
         #else
-	        String family = "ESP32";
+            String family = "ESP32";
         #endif
 
         debugW("Starting ImprovSerial for %s", family.c_str());

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -248,21 +248,19 @@ void IRAM_ATTR RemoteLoopEntry(void *)
                 return true;
         }
 
-        debugI("Setting host name to %s... %s", cszHostname, WLtoString(WiFi.status()));
-        WiFi.setHostname(cszHostname);
-
-        if (haveNewCredentials || millisAtLastAttempt == 0 || millisAtLastAttempt - millis() >= retryDelay)
+        if (haveNewCredentials || millisAtLastAttempt == 0 || millis() - millisAtLastAttempt >= retryDelay)
         {
-            debugV("Wifi.disconnect");
-            WiFi.disconnect();
-            debugV("Wifi.mode");
-            WiFi.mode(WIFI_STA);
-            debugV("Wifi.begin");
-
             if (WiFi_ssid.length() == 0)
                 debugW("WiFi credentials not set, cannot connect.");
             else
             {
+//                debugI("Setting host name to %s... %s", cszHostname, WLtoString(WiFi.status()));
+//                WiFi.setHostname(cszHostname);
+
+                debugV("Wifi.disconnect");
+                WiFi.disconnect();
+                debugV("Wifi.mode");
+                WiFi.mode(WIFI_STA);
                 debugW("Connecting to Wifi SSID: \"%s\" - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u\n",
                        WiFi_ssid.c_str(), ESP.getFreeHeap(), ESP.getPsramSize(), ESP.getFreePsram());
 
@@ -271,6 +269,7 @@ void IRAM_ATTR RemoteLoopEntry(void *)
                 debugV("Done Wifi.begin, waiting for connection...");
             }
 
+            millisAtLastAttempt = millis();
             retryDelay = std::min<unsigned long>(retryDelay + WIFI_WAIT_INCREASE, WIFI_WAIT_MAX);
         }
 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -232,7 +232,7 @@ void IRAM_ATTR RemoteLoopEntry(void *)
         static String WiFi_ssid;
         static String WiFi_password;
 
-        bool haveNewCredentials = ssid != nullptr && password != nullptr;
+        bool haveNewCredentials = (ssid != nullptr && password != nullptr);
 
         // If we have new credentials, then always reconnect using them
         if (haveNewCredentials)
@@ -240,6 +240,7 @@ void IRAM_ATTR RemoteLoopEntry(void *)
             WiFi_ssid = ssid;
             WiFi_password = password;
             retryDelay = WIFI_WAIT_INIT;
+            debugI("New WiFi credentials received for SSID %s", WiFi_ssid.c_str());
         }
         else
         {
@@ -278,7 +279,7 @@ void IRAM_ATTR RemoteLoopEntry(void *)
             debugW("Connected to AP with BSSID: %s\n", WiFi.BSSIDstr().c_str());
         }
         else
-        // Additional services onwwards reliant on network so close if not up.
+        // Additional services onwards reliant on network so close if not up.
         {
             debugW("Not yet connected to WiFi, waiting...\n");
             return false;

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -269,8 +269,17 @@ void IRAM_ATTR RemoteLoopEntry(void *)
             }
             else
             {
-                debugI("Setting host name to %s...", cszHostname);
-                WiFi.setHostname(cszHostname);
+                auto hostname = g_ptrSystem->DeviceConfig().GetHostname().c_str();
+
+                if (hostname[0] == '\0')
+                {
+                    debugI("No hostname configured, so skipping setting it.");
+                }
+                else
+                {
+                    debugI("Setting host name to %s...", hostname);
+                    WiFi.setHostname(hostname);
+                }
 
                 debugV("Wifi.disconnect");
                 WiFi.disconnect();
@@ -316,7 +325,7 @@ void IRAM_ATTR RemoteLoopEntry(void *)
 
         #if ENABLE_OTA
             debugI("Publishing OTA...");
-            SetupOTA(String(cszHostname));
+            SetupOTA(String(WiFi.getHostname()));
         #endif
 
         #if ENABLE_NTP
@@ -586,7 +595,7 @@ bool WriteWiFiConfig(const String& WiFi_ssid, const String& WiFi_password)
         while (!WiFi.isConnected())                             // Wait for wifi, no point otherwise
             delay(100);
 
-        Debug.begin(cszHostname, RemoteDebug::INFO);            // Initialize the WiFi debug server
+        Debug.begin(WiFi.getHostname(), RemoteDebug::INFO);     // Initialize the WiFi debug server
 
         for (;;)                                                // Call Debug.handle() 20 times a second
         {

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -399,8 +399,8 @@ void CWebServer::SendSettingSpecsResponse(AsyncWebServerRequest * pRequest, cons
                 jsonDoc["minimumValue"] = spec.MinimumValue.value();
             if (spec.MaximumValue.has_value())
                 jsonDoc["maximumValue"] = spec.MaximumValue.value();
-            if (spec.Optional)
-                jsonDoc["optional"] = true;
+            if (spec.EmptyAllowed)
+                jsonDoc["emptyAllowed"] = true;
             switch (spec.Access)
             {
                 case SettingSpec::SettingAccess::ReadOnly:

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -399,6 +399,8 @@ void CWebServer::SendSettingSpecsResponse(AsyncWebServerRequest * pRequest, cons
                 jsonDoc["minimumValue"] = spec.MinimumValue.value();
             if (spec.MaximumValue.has_value())
                 jsonDoc["maximumValue"] = spec.MaximumValue.value();
+            if (spec.Optional)
+                jsonDoc["optional"] = true;
             switch (spec.Access)
             {
                 case SettingSpec::SettingAccess::ReadOnly:
@@ -480,6 +482,7 @@ void CWebServer::SetSettingsIfPresent(AsyncWebServerRequest * pRequest)
     auto& deviceConfig = g_ptrSystem->DeviceConfig();
 
     PushPostParamIfPresent<size_t>(pRequest,"effectInterval", SET_VALUE(g_ptrSystem->EffectManager().SetInterval(value)));
+    PushPostParamIfPresent<String>(pRequest, DeviceConfig::HostnameTag, SET_VALUE(deviceConfig.SetHostname(value)));
     PushPostParamIfPresent<String>(pRequest, DeviceConfig::LocationTag, SET_VALUE(deviceConfig.SetLocation(value)));
     PushPostParamIfPresent<bool>(pRequest, DeviceConfig::LocationIsZipTag, SET_VALUE(deviceConfig.SetLocationIsZip(value)));
     PushPostParamIfPresent<String>(pRequest, DeviceConfig::CountryCodeTag, SET_VALUE(deviceConfig.SetCountryCode(value)));

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -101,6 +101,16 @@ void CWebServer::begin()
     extern const uint8_t timezones_start[] asm("_binary_config_timezones_json_start");
     extern const uint8_t timezones_end[] asm("_binary_config_timezones_json_end");
 
+    EmbeddedWebFile html_file(html_start, html_end, "text/html", "gzip");
+    EmbeddedWebFile js_file(js_start, js_end, "application/javascript", "gzip");
+    EmbeddedWebFile ico_file(ico_start, ico_end, "image/vnd.microsoft.icon", "gzip");
+    EmbeddedWebFile timezones_file(timezones_start, timezones_end - 1, "text/json"); // end - 1 because of zero-termination
+
+    debugI("Embedded html file size: %d", html_file.length);
+    debugI("Embedded jsx file size: %d", js_file.length);
+    debugI("Embedded ico file size: %d", ico_file.length);
+    debugI("Embedded timezones file size: %d", timezones_file.length);
+
     _staticStats.HeapSize = ESP.getHeapSize();
     _staticStats.DmaHeapSize = heap_caps_get_total_size(MALLOC_CAP_DMA);
     _staticStats.PsramSize = ESP.getPsramSize();
@@ -113,51 +123,52 @@ void CWebServer::begin()
 
     debugI("Connecting Web Endpoints");
 
-    _server.on("/effects",               HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { GetEffectListText(pRequest); });
-    _server.on("/getEffectList",         HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { GetEffectListText(pRequest); });
-    _server.on("/statistics",            HTTP_GET,  [this](AsyncWebServerRequest * pRequest)    { this->GetStatistics(pRequest); });
-    _server.on("/getStatistics",         HTTP_GET,  [this](AsyncWebServerRequest * pRequest)    { this->GetStatistics(pRequest); });
-    _server.on("/nextEffect",            HTTP_POST, [](AsyncWebServerRequest * pRequest)        { NextEffect(pRequest); });
-    _server.on("/previousEffect",        HTTP_POST, [](AsyncWebServerRequest * pRequest)        { PreviousEffect(pRequest); });
+    // SPIFFS file requests
 
-    _server.on("/currentEffect",         HTTP_POST, [](AsyncWebServerRequest * pRequest)        { SetCurrentEffectIndex(pRequest); });
-    _server.on("/setCurrentEffectIndex", HTTP_POST, [](AsyncWebServerRequest * pRequest)        { SetCurrentEffectIndex(pRequest); });
-    _server.on("/enableEffect",          HTTP_POST, [](AsyncWebServerRequest * pRequest)        { EnableEffect(pRequest); });
-    _server.on("/disableEffect",         HTTP_POST, [](AsyncWebServerRequest * pRequest)        { DisableEffect(pRequest); });
-    _server.on("/moveEffect",            HTTP_POST, [](AsyncWebServerRequest * pRequest)        { MoveEffect(pRequest); });
-    _server.on("/copyEffect",            HTTP_POST, [](AsyncWebServerRequest * pRequest)        { CopyEffect(pRequest); });
-    _server.on("/deleteEffect",          HTTP_POST, [](AsyncWebServerRequest * pRequest)        { DeleteEffect(pRequest); });
-
-    _server.on("/settings/effect/specs", HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { GetEffectSettingSpecs(pRequest); });
-    _server.on("/settings/effect",       HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { GetEffectSettings(pRequest); });
-    _server.on("/settings/effect",       HTTP_POST, [](AsyncWebServerRequest * pRequest)        { SetEffectSettings(pRequest); });
-    _server.on("/settings/validated",    HTTP_POST, [](AsyncWebServerRequest * pRequest)        { ValidateAndSetSetting(pRequest); });
-    _server.on("/settings/specs",        HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { GetSettingSpecs(pRequest); });
-    _server.on("/settings",              HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { GetSettings(pRequest); });
-    _server.on("/settings",              HTTP_POST, [](AsyncWebServerRequest * pRequest)        { SetSettings(pRequest); });
-    _server.on("/effectsConfig",         HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { pRequest->send(SPIFFS, EFFECTS_CONFIG_FILE, "text/json"); });
-
-    _server.on("/reset",                 HTTP_POST, [](AsyncWebServerRequest * pRequest)        { Reset(pRequest); });
-
+    _server.on("/effectsConfig",         HTTP_GET,  [](AsyncWebServerRequest* pRequest) { pRequest->send(SPIFFS, EFFECTS_CONFIG_FILE,   "text/json"); });
     #if ENABLE_IMPROV_LOGGING
-        _server.on(IMPROV_LOG_FILE,      HTTP_GET,  [](AsyncWebServerRequest * pRequest)        { pRequest->send(SPIFFS, IMPROV_LOG_FILE, "text/plain"); });
+        _server.on(IMPROV_LOG_FILE,      HTTP_GET,  [](AsyncWebServerRequest* pRequest) { pRequest->send(SPIFFS, IMPROV_LOG_FILE,       "text/plain"); });
     #endif
 
-    EmbeddedWebFile html_file(html_start, html_end, "text/html", "gzip");
-    EmbeddedWebFile js_file(js_start, js_end, "application/javascript", "gzip");
-    EmbeddedWebFile ico_file(ico_start, ico_end, "image/vnd.microsoft.icon", "gzip");
-    EmbeddedWebFile timezones_file(timezones_start, timezones_end - 1, "text/json", ""); // end - 1 because of zero-termination
+    // Instance handler requests
 
-    debugI("Embedded html file size: %d", html_file.length);
-    debugI("Embedded jsx file size: %d", js_file.length);
-    debugI("Embedded ico file size: %d", ico_file.length);
-    debugI("Embedded timezones file size: %d", timezones_file.length);
+    _server.on("/statistics",            HTTP_GET,  [this](AsyncWebServerRequest* pRequest) { this->GetStatistics(pRequest); });
+    _server.on("/getStatistics",         HTTP_GET,  [this](AsyncWebServerRequest* pRequest) { this->GetStatistics(pRequest); });
+
+    // Static handler requests
+
+    _server.on("/effects",               HTTP_GET,  GetEffectListText);
+    _server.on("/getEffectList",         HTTP_GET,  GetEffectListText);
+    _server.on("/nextEffect",            HTTP_POST, NextEffect);
+    _server.on("/previousEffect",        HTTP_POST, PreviousEffect);
+
+    _server.on("/currentEffect",         HTTP_POST, SetCurrentEffectIndex);
+    _server.on("/setCurrentEffectIndex", HTTP_POST, SetCurrentEffectIndex);
+    _server.on("/enableEffect",          HTTP_POST, EnableEffect);
+    _server.on("/disableEffect",         HTTP_POST, DisableEffect);
+    _server.on("/moveEffect",            HTTP_POST, MoveEffect);
+    _server.on("/copyEffect",            HTTP_POST, CopyEffect);
+    _server.on("/deleteEffect",          HTTP_POST, DeleteEffect);
+
+    _server.on("/settings/effect/specs", HTTP_GET,  GetEffectSettingSpecs);
+    _server.on("/settings/effect",       HTTP_GET,  GetEffectSettings);
+    _server.on("/settings/effect",       HTTP_POST, SetEffectSettings);
+    _server.on("/settings/validated",    HTTP_POST, ValidateAndSetSetting);
+    _server.on("/settings/specs",        HTTP_GET,  GetSettingSpecs);
+    _server.on("/settings",              HTTP_GET,  GetSettings);
+    _server.on("/settings",              HTTP_POST, SetSettings);
+
+    _server.on("/reset",                 HTTP_POST, Reset);
+
+    // Embedded file requests
 
     ServeEmbeddedFile("/", html_file);
     ServeEmbeddedFile("/index.html", html_file);
     ServeEmbeddedFile("/index.js", js_file);
     ServeEmbeddedFile("/favicon.ico", ico_file);
     ServeEmbeddedFile("/timezones.json", timezones_file);
+
+    // Not found handler
 
     _server.onNotFound([](AsyncWebServerRequest *request)
     {

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -31,6 +31,7 @@
 #include "globals.h"
 #include "webserver.h"
 #include "systemcontainer.h"
+#include "improvserial.h"
 
 // Static member initializers
 

--- a/tools/NightDriverStrip.postman_collection.json
+++ b/tools/NightDriverStrip.postman_collection.json
@@ -71,6 +71,18 @@
 					"mode": "formdata",
 					"formdata": [
 						{
+							"key": "effectInterval",
+							"value": "60000",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "hostname",
+							"value": "NightDriverStrip",
+							"type": "text",
+							"disabled": true
+						},
+						{
 							"key": "location",
 							"value": "Utrecht",
 							"type": "text",
@@ -113,12 +125,6 @@
 							"disabled": true
 						},
 						{
-							"key": "effectInterval",
-							"value": "60000",
-							"type": "text",
-							"disabled": true
-						},
-						{
 							"key": "youtubeChannelGuid",
 							"value": "9558daa1-eae8-482f-8066-17fa787bc0e4",
 							"type": "text",
@@ -146,6 +152,12 @@
 						{
 							"key": "rememberCurrentEffect",
 							"value": "true",
+							"type": "text",
+							"disabled": true
+						},
+						{
+							"key": "brightness",
+							"value": "255",
 							"type": "text",
 							"disabled": true
 						},


### PR DESCRIPTION
## Description

This:

- Changes the WiFi connection logic to not block the main `setup()` function.
- Makes the stored WiFI credentials (which we consider sensitive) local to the only function that really uses them, instead of global variables that are available "everywhere".
- Maintains the possibility to demand functioning WiFi connectivity at the penalty of a reboot if it's down for too long.
- Makes the hostname a device config setting, and makes the hostname consistent across use cases (WiFi, OTA, RemoteDebug).
- Significantly improves the logging of Improv traffic to SPIFFS when enabled, to the point it is actually usable to analyze issues with Improv processing.
- Fixes #425.
- Makes index.html link to index.js instead of index.js.gz, to prevent fetch errors for the latter.
- Includes a small refactor of CWebServer to improve readability and consistency.

@KeiranHines While testing the hostname setting, I found that the web UI currently does not save (i.e. send to the /settings endpoint) empty strings. Which makes sense in all current cases, except for the hostname - one may explicitly want that to be the Espressif platform's default. I've added an optional "emptyAllowed" property to the `SettingSpec` class's JSON to indicate when a string value may be empty.  

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).