### PR TITLE
More small fixes

### DIFF
--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -43,8 +43,6 @@
 #include <math.h>
 
 #include "effectfactories.h"
-#include "effects/strip/misceffects.h"
-#include "effects/strip/fireeffect.h"
 
 #define JSON_FORMAT_VERSION         1
 #define CURRENT_EFFECT_CONFIG_FILE  "/current.cfg"
@@ -55,9 +53,6 @@ void InitSplashEffectManager();
 void InitEffectsManager();
 void SaveEffectManagerConfig();
 void RemoveEffectManagerConfig();
-
-std::shared_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color);
-std::shared_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color, CRGB color2);
 
 // EffectManager
 //
@@ -323,41 +318,7 @@ public:
     // When a global color is set via the remote, we create a fill effect and assign it as the "remote effect"
     // which takes drawing precedence
 
-    void SetGlobalColor(CRGB color)
-    {
-        debugI("Setting Global Color");
-
-        CRGB oldColor = lastManualColor;
-        lastManualColor = color;
-
-        #if (USE_HUB75)
-                auto pMatrix = g();
-                pMatrix->setPalette(CRGBPalette16(oldColor, color));
-                pMatrix->PausePalette(true);
-        #else
-            std::shared_ptr<LEDStripEffect> effect;
-
-            if (color == CRGB(CRGB::White))
-                effect = make_shared_psram<ColorFillEffect>(CRGB::White, 1);
-            else
-
-                #if ENABLE_AUDIO
-                    #if SPECTRUM
-                        effect = GetSpectrumAnalyzer(color, oldColor);
-                    #else
-                        effect = make_shared_psram<MusicalPaletteFire>("Custom Fire", CRGBPalette16(CRGB::Black, color, CRGB::Yellow, CRGB::White), NUM_LEDS, 1, 8, 50, 1, 24, true, false);
-                    #endif
-                #else
-                    effect = make_shared_psram<PaletteFlameEffect>("Custom Fire", CRGBPalette16(CRGB::Black, color, CRGB::Yellow, CRGB::White), NUM_LEDS, 1, 8, 50, 1, 24, true, false);
-                #endif
-
-            if (effect->Init(_gfx))
-            {
-                _tempEffect = effect;
-                StartEffect();
-            }
-        #endif
-    }
+    void SetGlobalColor(CRGB color);
 
     void ClearRemoteColor(bool retainRemoteEffect = false)
     {

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -65,12 +65,14 @@ class InsulatorSpectrumEffect : public LEDStripEffect, public BeatEffectBase, pu
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        AllocatedJsonDocument jsonDoc(512);
+        AllocatedJsonDocument jsonDoc(LEDStripEffect::_jsonSize + 384);
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
         jsonDoc[PTY_PALETTE] = _Palette;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
@@ -354,7 +356,7 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeterEffe
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        AllocatedJsonDocument jsonDoc(512);
+        AllocatedJsonDocument jsonDoc(LEDStripEffect::_jsonSize + 512);
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -365,6 +367,8 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeterEffe
         jsonDoc["frt"]       = _fadeRate;
         jsonDoc["pd1"]       = _peak1DecayRate;
         jsonDoc["pd2"]       = _peak2DecayRate;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }

--- a/include/effects/strip/doublepaletteeffect.h
+++ b/include/effects/strip/doublepaletteeffect.h
@@ -57,7 +57,7 @@ class DoublePaletteEffect : public LEDStripEffect
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        AllocatedJsonDocument jsonDoc(896);
+        AllocatedJsonDocument jsonDoc(LEDStripEffect::_jsonSize + 768);
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -66,6 +66,8 @@ class DoublePaletteEffect : public LEDStripEffect
         _PaletteEffect1.SerializeToJSON(paletteObj);
         paletteObj = jsonDoc.createNestedObject("pt2");
         _PaletteEffect2.SerializeToJSON(paletteObj);
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -695,7 +695,7 @@ public:
 
   bool SerializeToJSON(JsonObject& jsonObject) override
   {
-    AllocatedJsonDocument jsonDoc(512);
+    AllocatedJsonDocument jsonDoc(LEDStripEffect::_jsonSize + 512);
 
     JsonObject root = jsonDoc.to<JsonObject>();
     LEDStripEffect::SerializeToJSON(root);
@@ -703,6 +703,8 @@ public:
     jsonDoc[PTY_PALETTE] = _Palette;
     jsonDoc["rpm"] = _bReplaceMagenta;
     jsonDoc["sch"] = _sparkleChance;
+
+    assert(!jsonDoc.overflowed());
 
     return jsonObject.set(jsonDoc.as<JsonObjectConst>());
   }
@@ -1021,7 +1023,7 @@ public:
 
   bool SerializeToJSON(JsonObject& jsonObject) override
   {
-    AllocatedJsonDocument jsonDoc(512);
+    AllocatedJsonDocument jsonDoc(LEDStripEffect::_jsonSize + 512);
 
     JsonObject root = jsonDoc.to<JsonObject>();
     LEDStripEffect::SerializeToJSON(root);
@@ -1037,6 +1039,8 @@ public:
     jsonDoc[PTY_MIRORRED] = bMirrored;
     jsonDoc[PTY_ORDER] = to_value(Order);
     jsonDoc[PTY_MULTICOLOR] = bMulticolor ? 1 : 0;
+
+    assert(!jsonDoc.overflowed());
 
     return jsonObject.set(jsonDoc.as<JsonObjectConst>());
   }

--- a/include/effects/strip/fireeffect.h
+++ b/include/effects/strip/fireeffect.h
@@ -64,6 +64,8 @@ class FireEffect : public LEDStripEffect
 
     static const uint8_t BlendTotal = (BlendSelf + BlendNeighbor1 + BlendNeighbor2 + BlendNeighbor3);
 
+    static constexpr int _jsonSize = LEDStripEffect::_jsonSize + 128;
+
     int CellCount() const { return LEDCount * CellsPerLED; }
 
   public:
@@ -101,7 +103,7 @@ class FireEffect : public LEDStripEffect
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        StaticJsonDocument<LEDStripEffect::_jsonSize + 128> jsonDoc;
+        StaticJsonDocument<_jsonSize> jsonDoc;
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -257,11 +259,14 @@ public:
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        AllocatedJsonDocument jsonDoc(512);
+        AllocatedJsonDocument jsonDoc(FireEffect::_jsonSize + 512);
 
-        FireEffect::SerializeToJSON(jsonObject);
+        JsonObject root = jsonDoc.to<JsonObject>();
+        FireEffect::SerializeToJSON(root);
 
-        jsonObject[PTY_PALETTE] = _palette;
+        jsonDoc[PTY_PALETTE] = _palette;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }

--- a/include/effects/strip/paletteeffect.h
+++ b/include/effects/strip/paletteeffect.h
@@ -91,7 +91,7 @@ class PaletteEffect : public LEDStripEffect
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        AllocatedJsonDocument jsonDoc(512);
+        AllocatedJsonDocument jsonDoc(LEDStripEffect::_jsonSize + 512);
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -105,6 +105,8 @@ class PaletteEffect : public LEDStripEffect
         jsonDoc[PTY_BLEND] = to_value(_blend);
         jsonDoc[PTY_ERASE] = _bErase;
         jsonDoc["bns"] = _brightness;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }

--- a/include/effects/strip/particles.h
+++ b/include/effects/strip/particles.h
@@ -82,7 +82,7 @@ public:
     MovingObject(float maxSpeed = 0.25) : _maxSpeed(maxSpeed)
     {
         // Return a random value between -maxSpeed and +maxSpeed
-        
+
         _velocity = random_range(0.0f, _maxSpeed * 2) - _maxSpeed;
     }
 
@@ -716,12 +716,14 @@ class MoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase, p
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        AllocatedJsonDocument jsonDoc(512);
+        AllocatedJsonDocument jsonDoc(LEDStripEffect::_jsonSize + 512);
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
         jsonDoc[PTY_PALETTE] = _Palette;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
@@ -806,12 +808,14 @@ class NewMoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        AllocatedJsonDocument jsonDoc(512);
+        AllocatedJsonDocument jsonDoc(LEDStripEffect::_jsonSize + 512);
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
         jsonDoc[PTY_PALETTE] = _Palette;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
@@ -892,12 +896,14 @@ class SparklySpinningMusicEffect : public LEDStripEffect, public BeatEffectBase,
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        AllocatedJsonDocument jsonDoc(512);
+        AllocatedJsonDocument jsonDoc(LEDStripEffect::_jsonSize + 512);
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
         jsonDoc[PTY_PALETTE] = _Palette;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }

--- a/include/effects/strip/snakeeffect.h
+++ b/include/effects/strip/snakeeffect.h
@@ -82,13 +82,15 @@ class SnakeEffect : public LEDStripEffect
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        AllocatedJsonDocument jsonDoc(512);
+        AllocatedJsonDocument jsonDoc(LEDStripEffect::_jsonSize + 64);
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
         jsonDoc[PTY_LEDCOUNT] = LEDCount;
         jsonDoc[PTY_SPEED] = SnakeSpeed;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }

--- a/include/effects/strip/stareffect.h
+++ b/include/effects/strip/stareffect.h
@@ -467,7 +467,7 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
-        AllocatedJsonDocument jsonDoc(512);
+        AllocatedJsonDocument jsonDoc(LEDStripEffect::_jsonSize + 512);
 
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
@@ -481,6 +481,8 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
         jsonDoc[PTY_BLUR] = _blurFactor;
         jsonDoc["msf"] = _musicFactor;
         jsonDoc[PTY_COLOR] = _skyColor;
+
+        assert(!jsonDoc.overflowed());
 
         return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -34,6 +34,7 @@
 #if ENABLE_AUDIO
 
 #include <esp_task_wdt.h>
+#include "soundanalyzer.h"
 
 // AudioSamplerTaskEntry
 // A background task that samples audio, computes the VU, stores it for effect use, etc.

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -45,6 +45,8 @@ extern DRAM_ATTR std::mutex g_buffer_mutex;
 
 extern const CRGBPalette16 vuPaletteGreen;
 
+std::shared_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color);    // Defined in effectmanager.cpp
+
 // WiFiDraw
 //
 // Draws from WiFi color data if available, returns pixels drawn this frame
@@ -256,7 +258,7 @@ void IRAM_ATTR DrawLoopTaskEntry(void *)
     // Run the draw loop
 
     debugW("Entering main draw loop!");
-  
+
     for (;;)
     {
         g_Values.AppTime.NewFrame();

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -33,6 +33,8 @@
 #include "globals.h"
 #include "systemcontainer.h"
 
+#include "effects/strip/misceffects.h"
+
 // Variables we need further down
 
 extern DRAM_ATTR std::unique_ptr<EffectFactories> g_ptrEffectFactories;
@@ -314,3 +316,41 @@ std::shared_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color)
 }
 
 #endif
+
+#include "effects/strip/fireeffect.h"
+
+void EffectManager::SetGlobalColor(CRGB color)
+{
+    debugI("Setting Global Color");
+
+    CRGB oldColor = lastManualColor;
+    lastManualColor = color;
+
+    #if (USE_HUB75)
+            auto pMatrix = g();
+            pMatrix->setPalette(CRGBPalette16(oldColor, color));
+            pMatrix->PausePalette(true);
+    #else
+        std::shared_ptr<LEDStripEffect> effect;
+
+        if (color == CRGB(CRGB::White))
+            effect = make_shared_psram<ColorFillEffect>(CRGB::White, 1);
+        else
+
+            #if ENABLE_AUDIO
+                #if SPECTRUM
+                    effect = GetSpectrumAnalyzer(color, oldColor);
+                #else
+                    effect = make_shared_psram<MusicalPaletteFire>("Custom Fire", CRGBPalette16(CRGB::Black, color, CRGB::Yellow, CRGB::White), NUM_LEDS, 1, 8, 50, 1, 24, true, false);
+                #endif
+            #else
+                effect = make_shared_psram<PaletteFlameEffect>("Custom Fire", CRGBPalette16(CRGB::Black, color, CRGB::Yellow, CRGB::White), NUM_LEDS, 1, 8, 50, 1, 24, true, false);
+            #endif
+
+        if (effect->Init(_gfx))
+        {
+            _tempEffect = effect;
+            StartEffect();
+        }
+    #endif
+}

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -41,6 +41,7 @@
 #include "effects/strip/tempeffect.h"
 #include "effects/strip/stareffect.h"
 #include "effects/strip/laserline.h"
+#include "effects/strip/misceffects.h"
 #include "effects/matrix/PatternClock.h"       // No matrix dependencies
 
 #if ENABLE_AUDIO
@@ -58,7 +59,6 @@
 
 #if USE_HUB75
     #include "ledmatrixgfx.h"
-    #include "effects/strip/misceffects.h"
 
     #include "effects/matrix/PatternSMStrobeDiffusion.h"
     #include "effects/matrix/PatternSM2DDPR.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -164,6 +164,7 @@
 #include "globals.h"
 #include "deviceconfig.h"
 #include "systemcontainer.h"
+#include "soundanalyzer.h"
 #include "values.h"
 #include "improvserial.h"                       // ImprovSerial impl for setting WiFi credentials over the serial port
 #include <TJpg_Decoder.h>

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -39,6 +39,7 @@
 #include "ledviewer.h"                          // For the LEDViewer task and object
 #include "network.h"
 #include "systemcontainer.h"
+#include "soundanalyzer.h"
 
 extern DRAM_ATTR std::mutex g_buffer_mutex;
 

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include "globals.h"
 #include "systemcontainer.h"
+#include "soundanalyzer.h"
 
 #if defined(TOGGLE_BUTTON_1) || defined(TOGGLE_BUTTON_2)
   #include "Bounce2.h"                            // For Bounce button class

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -31,6 +31,7 @@
 #include "globals.h"
 #include "webserver.h"
 #include "systemcontainer.h"
+#include "soundanalyzer.h"
 
 // Static member initializers
 


### PR DESCRIPTION
## Description

This:

- Applies JSON buffer overflow checking to more places, in follow up to #466 - and actually complete that implementation across all effects.
- Makes the link between `EffectManager`'s declaration and certain effects cleaner, thereby preventing circular dependency problems that have otherwise known to occur (as illustrated in the discussion of #456). It also makes the inclusion of "soundanalyzer.h" more explicit in source files that need it.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).