### PR TITLE
Fixed #468 Webserver supports index.js and index.js.gz

### DIFF
--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -154,6 +154,7 @@ void CWebServer::begin()
     ServeEmbeddedFile("/", html_file);
     ServeEmbeddedFile("/index.html", html_file);
     ServeEmbeddedFile("/index.js", js_file);
+    ServeEmbeddedFile("/index.js.gz", js_file);
     ServeEmbeddedFile("/favicon.ico", ico_file);
     ServeEmbeddedFile("/timezones.json", timezones_file);
 


### PR DESCRIPTION
## Description
 Added support for the webserver to support either index.js or index.js.gz and respond with index.js.gz. This enabled production and development environments to work correctly when serving the required files.

## Contributing requirements
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).