### PR TITLE
Config dialog improvements

### DIFF
--- a/site/src/components/home/config/configDialog.jsx
+++ b/site/src/components/home/config/configDialog.jsx
@@ -56,7 +56,7 @@ const ConfigInput = ({setting, updateData, updateError}) => {
     }, [setting, updateError, error]);
     useEffect(() => {
         if(value !== setting.value) {
-            if(value === '') {
+            if(value === '' && !setting.optional) {
                 updateData(setting.name, undefined);
             } else {
                 updateData(setting.name, value);
@@ -247,7 +247,8 @@ const settingProps = PropTypes.shape({
     typeName: PropTypes.string.isRequired, 
     value: PropTypes.any,
     readOnly: PropTypes.bool,
-    writeOnly: PropTypes.bool
+    writeOnly: PropTypes.bool,
+    optional: PropTypes.bool
 });
 
 

--- a/site/src/components/home/config/configDialog.jsx
+++ b/site/src/components/home/config/configDialog.jsx
@@ -56,7 +56,7 @@ const ConfigInput = ({setting, updateData, updateError}) => {
     }, [setting, updateError, error]);
     useEffect(() => {
         if(value !== setting.value) {
-            if(value === '' && !setting.optional) {
+            if(value === '' && !setting.emptyAllowed) {
                 updateData(setting.name, undefined);
             } else {
                 updateData(setting.name, value);
@@ -248,7 +248,7 @@ const settingProps = PropTypes.shape({
     value: PropTypes.any,
     readOnly: PropTypes.bool,
     writeOnly: PropTypes.bool,
-    optional: PropTypes.bool
+    emptyAllowed: PropTypes.bool
 });
 
 

--- a/site/src/components/home/config/configDialog.jsx
+++ b/site/src/components/home/config/configDialog.jsx
@@ -69,8 +69,8 @@ const ConfigInput = ({setting, updateData, updateError}) => {
     let max;
     switch(setting.type) {
     case settingType.Integer:
-        min = setting.minimumValue ? setting.minimumValue : (-2)**31;
-        max = setting.maximumValue ? setting.maximumValue : 2**31 -1;
+        min = setting.minimumValue !== undefined ? setting.minimumValue : (-2)**31;
+        max = setting.maximumValue !== undefined ? setting.maximumValue : 2**31 -1;
         return <TextField
             {...baseProps}
             {...textFieldProps}
@@ -81,8 +81,8 @@ const ConfigInput = ({setting, updateData, updateError}) => {
             }}
         />;  
     case settingType.PositiveBigInteger:
-        min = setting.minimumValue ? setting.minimumValue : 0;
-        max = setting.maximumValue ? setting.maximumValue : 2**32;
+        min = setting.minimumValue !== undefined ? setting.minimumValue : 0;
+        max = setting.maximumValue !== undefined ? setting.maximumValue : 2**32;
         return <TextField
             {...baseProps}
             {...textFieldProps}
@@ -94,8 +94,8 @@ const ConfigInput = ({setting, updateData, updateError}) => {
             }}
         />;
     case settingType.Float:
-        min = setting.minimumValue ? setting.minimumValue :  -3.4028235E+38;
-        max = setting.maximumValue ? setting.maximumValue : 3.4028235E+38;
+        min = setting.minimumValue !== undefined ? setting.minimumValue :  -3.4028235E+38;
+        max = setting.maximumValue !== undefined ? setting.maximumValue : 3.4028235E+38;
         return <TextField
             {...baseProps}
             {...textFieldProps}


### PR DESCRIPTION
## Description
Fixed #472 Added support for `emptyAllowed` configurations to be saved.
Fixed #476 Added support for configuration to limit between min and max values for numeric input types. If no min/max is set the dataTypes min/max is used as a proxy.  

## Contributing requirements
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).