### PR TITLE
Remove uncalled function, proto for parse_improv_serial_byte

### DIFF
--- a/include/improv.h
+++ b/include/improv.h
@@ -20,11 +20,11 @@
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
 //
-//    Uses the improv namespace to call functions from that file. It 
-//    then sets up a callback function to be called when data is received 
-//    from the serial port. When data is received, the callback function parses 
-//    the data using parse_improv_serial_byte from the improv namespace and sends 
-//    a response using build_rpc_response from the improv namespace. The response 
+//    Uses the improv namespace to call functions from that file. It
+//    then sets up a callback function to be called when data is received
+//    from the serial port. When data is received, the callback function parses
+//    the data using parse_improv_serial_byte from the improv namespace and sends
+//    a response using build_rpc_response from the improv namespace. The response
 //    consists of the command type and a vector of strings.
 //
 // Description:
@@ -107,9 +107,6 @@ namespace improv
 
     ImprovCommand parse_improv_data(const std::vector<uint8_t> &data, bool check_checksum = true);
     ImprovCommand parse_improv_data(const uint8_t *data, size_t length, bool check_checksum = true);
-
-    bool parse_improv_serial_byte(size_t position, uint8_t byte, const uint8_t *buffer,
-                                  std::function<bool(ImprovCommand)> &&callback, std::function<void(Error)> &&on_error);
 
     std::vector<uint8_t> build_rpc_response(Command command, const std::vector<String> &datum, bool add_checksum = true);
 

--- a/src/improv.cpp
+++ b/src/improv.cpp
@@ -88,56 +88,6 @@ namespace improv
         return improv_command;
     }
 
-    bool parse_improv_serial_byte(size_t position, uint8_t byte, const uint8_t *buffer,
-                                  std::function<bool(ImprovCommand)> &&callback, std::function<void(Error)> &&on_error)
-    {
-        if (position == 0)
-            return byte == 'I';
-        if (position == 1)
-            return byte == 'M';
-        if (position == 2)
-            return byte == 'P';
-        if (position == 3)
-            return byte == 'R';
-        if (position == 4)
-            return byte == 'O';
-        if (position == 5)
-            return byte == 'V';
-
-        if (position == 6)
-            return byte == IMPROV_SERIAL_VERSION;
-
-        if (position <= 8)
-            return true;
-
-        uint8_t type = buffer[7];
-        uint8_t data_len = buffer[8];
-
-        if (position <= 8 + data_len)
-            return true;
-
-        if (position == 8 + data_len + 1)
-        {
-            uint8_t checksum = 0x00;
-            for (size_t i = 0; i < position; i++)
-                checksum += buffer[i];
-
-            if (checksum != byte)
-            {
-                on_error(ERROR_INVALID_RPC);
-                return false;
-            }
-
-            if (type == TYPE_RPC)
-            {
-                auto command = parse_improv_data(&buffer[9], data_len, false);
-                return callback(command);
-            }
-        }
-
-        return false;
-    }
-
     // Combines the command, a list of strings, and an optional checksum into a vector of bytes (uses String)
 
     std::vector<uint8_t> build_rpc_response(Command command, const std::vector<String> &datum, bool add_checksum)


### PR DESCRIPTION
Was replaced by parse_improv_serial_byte_() that's class-local.

## Description
Tested: local run on Demo, Mesmerizer.
Successful buddy build.
As is appropriate for this Haloween night, it's thoroughly and completely dead.

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
