### PR TITLE
Supernova: dont merge pixels from VU meter at top of screen to bottom.

### DIFF
--- a/include/effects/matrix/PatternSMSupernova.h
+++ b/include/effects/matrix/PatternSMSupernova.h
@@ -4,60 +4,80 @@
 
 // Inspired by https://editor.soulmatelights.com/gallery/1923-supernova
 
-class PatternSMSupernova : public LEDStripEffect 
-{
-    void Init()
-    {
-        memset(enlargedObjectTime, 0, sizeof(enlargedObjectTime));
-        memset(PosX, 0, sizeof(PosX));
-        memset(PosY, 0, sizeof(PosY));
-        memset(Hue, 0, sizeof(Hue));
-        memset(State, 0, sizeof(State));
-        memset(SpeedX, 0, sizeof(SpeedX));
-        memset(SpeedY, 0, sizeof(SpeedY));
-        memset(IsShift, 0, sizeof(IsShift));
+// A more cache-friendly version of the 8 independent arrays that were
+// used. This allows better locality per member, especially since we
+// access them sequentially.
+// Nothing special here; just default-zero initialized struct.
+class Object {
+  public:
+    void Objects() {
+        PosX = 0.0f;
+        PosY = 0.0f;
+        State = 0.0f;
+        SpeedX = 0.0f;
+        SpeedY = 0.0f;
+        Hue = 0;
+        IsShift = false;
     }
 
+    float PosX;
+    float PosY;
+    float SpeedX;
+    float SpeedY;
+    uint8_t Hue;
+    uint8_t State;
+    bool IsShift;
+};
+
+class PatternSMSupernova : public LEDStripEffect
+{
 public:
 
-    PatternSMSupernova() : LEDStripEffect(EFFECT_MATRIX_SMSUPERNOVA, "Supernova"), hue(0), hue2(0), step(0), deltaValue(0), enlargedObjectNUM(0) 
+    PatternSMSupernova() : LEDStripEffect(EFFECT_MATRIX_SMSUPERNOVA, "Supernova"), hue(0), hue2(0), step(0), deltaValue(0), enlargedObjectNUM(0)
     {
     }
 
-    PatternSMSupernova(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject) 
+    PatternSMSupernova(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject)
     {
     }
 
-    virtual size_t DesiredFramesPerSecond() const override 
+    virtual size_t DesiredFramesPerSecond() const override
     {
-        return 40;
+        return 120;
     }
 
-    void Start() override 
+    void Start() override
     {
-        Init();
         g()->Clear();
         enlargedObjectNUM = 200;
         if (enlargedObjectNUM > MAX_COUNT)
             enlargedObjectNUM = 200U;
-        deltaValue = enlargedObjectNUM / (sqrt3(CENTER_X_MAJOR * CENTER_X_MAJOR + CENTER_Y_MAJOR * CENTER_Y_MAJOR) * 4U) + 1U;
-        for (unsigned i = 0; i < enlargedObjectNUM; i++)
-            IsShift[i] = false;
+        deltaValue = enlargedObjectNUM /
+            (sqrt3(CENTER_X_MAJOR * CENTER_X_MAJOR +
+                   CENTER_Y_MAJOR * CENTER_Y_MAJOR) * 4U) + 1U;
     }
 
     void Draw() override {
         step = -1;
         g()->DimAll(200);
-        for (unsigned i = 0; i < enlargedObjectNUM; i++) {
-            if (!IsShift[i] && step) {
-                starfield2Emit(i);
+
+        for (auto& object : Objects) {
+            if (!object.IsShift && step) {
+                starfield2Emit(object);
                 step -= 1;
             }
-            if (IsShift[i]) {
-                particlesUpdate2(i);
-                CRGB baseRGB = ColorFromPalette(HeatColors_p, Hue[i], 255, LINEARBLEND);
-                baseRGB.nscale8(State[i]);
-                drawPixelXYF(PosX[i], PosY[i], baseRGB);
+
+            if (object.IsShift) {
+                particlesUpdate2(object);
+                // pU2() may have updated the object beyond bounds and
+                // cleared IsShift. Retest it and ignore if so.
+                // Alternate design could use pU2()'s return value for this.
+                if (object.IsShift == false) continue;;
+
+                CRGB baseRGB = ColorFromPalette(HeatColors_p, object.Hue,
+                                                255, LINEARBLEND);
+                baseRGB.nscale8(object.State);
+                drawPixelXYF(object.PosX, object.PosY, baseRGB);
             }
         }
     }
@@ -67,23 +87,17 @@ private:
     const uint8_t CENTER_Y_MINOR = (MATRIX_HEIGHT / 2) - ((MATRIX_HEIGHT - 1) & 0x01);
     const uint8_t CENTER_X_MAJOR = MATRIX_WIDTH / 2 + (MATRIX_WIDTH % 2);
     const uint8_t CENTER_Y_MAJOR = MATRIX_HEIGHT / 2 + (MATRIX_HEIGHT % 2);
-
-    static constexpr int enlargedOBJECT_MAX_COUNT = (MATRIX_WIDTH * 2);
-    static constexpr int MAX_COUNT = 254;
-
     uint8_t hue, hue2, step, deltaValue, enlargedObjectNUM;
-    long enlargedObjectTime[enlargedOBJECT_MAX_COUNT];
-    float PosX[MAX_COUNT];
-    float PosY[MAX_COUNT];
-    uint8_t Hue[MAX_COUNT];
-    uint8_t State[MAX_COUNT];
-    float SpeedX[MAX_COUNT];
-    float SpeedY[MAX_COUNT];
-    bool IsShift[MAX_COUNT];
 
-    float sqrt3(const float x) 
+    static constexpr int MAX_COUNT = 254;
+    std::array<Object, MAX_COUNT> Objects;
+
+    // Fast Babylonian Approximate square root.
+    // It's called one time in the constructor, so no need for
+    // crazy optimization here.
+    float sqrt3(const float x)
     {
-        union 
+        union
         {
             int i;
             float x;
@@ -93,46 +107,51 @@ private:
         return u.x;
     }
 
-    void particlesUpdate2(uint8_t i) 
+    void inline particlesUpdate2(Object& object)
     {
-        PosX[i] += SpeedX[i];
-        PosY[i] += SpeedY[i];
-        if (State[i] == 0 || PosX[i] < 0 || PosX[i] >= MATRIX_WIDTH || PosY[i] < 0 || PosY[i] >= MATRIX_HEIGHT)
-            IsShift[i] = false;
+        // Intentionally do a narrowing conversion here.
+        const int x = object.PosX += object.SpeedX;
+        const int y = object.PosY += object.SpeedY;
+
+        if (object.State == 0 || x < 0 || x >= MATRIX_WIDTH ||
+                                 y < 0 || y >= MATRIX_HEIGHT)
+            object.IsShift = false;
     }
 
-    void starfield2Emit(uint8_t i)
+    void inline starfield2Emit(Object& object)
     {
         if (hue++ & 0x01)
             hue2 += 1;
-        PosX[i] = MATRIX_WIDTH * 0.5;
-        PosY[i] = MATRIX_HEIGHT * 0.5;
-        SpeedX[i] = (((float)random8() - 127.) / 512.);
-        SpeedY[i] = sqrt(0.0626 - SpeedX[i] * SpeedX[i]);
+        object.PosX = MATRIX_WIDTH * 0.5;
+        object.PosY = MATRIX_HEIGHT * 0.5;
+        object.SpeedX = (((float)random8() - 127.) / 512.);
+        object.SpeedY = sqrt(0.0626 - object.SpeedX * object.SpeedX);
         if (random8(2U)) {
-            SpeedY[i] = -SpeedY[i];
+            object.SpeedY = -object.SpeedY;
         }
-        State[i] = random8(1, 250);
-        Hue[i] = hue2;
-        IsShift[i] = true;
+        object.State = random8(1, 250);
+        object.Hue = hue2;
+        object.IsShift = true;
     }
 
-    static inline uint8_t WU_WEIGHT(uint8_t a, uint8_t b) 
+    static inline uint8_t WU_WEIGHT(uint8_t a, uint8_t b)
     {
         return (uint8_t)(((a) * (b) + (a) + (b)) >> 8);
     }
 
-    void drawPixelXYF(float x, float y, CRGB color) 
+    void drawPixelXYF(float x, float y, CRGB color)
     {
-        uint8_t xx = (x - (int)x) * 255, yy = (y - (int)y) * 255, ix = 255 - xx, iy = 255 - yy;
-        uint8_t wu[4] = {WU_WEIGHT(ix, iy), WU_WEIGHT(xx, iy), WU_WEIGHT(ix, yy), WU_WEIGHT(xx, yy)};
+        const uint8_t xx = (x - (int)x) * 255, yy = (y - (int)y) * 255, ix = 255 - xx, iy = 255 - yy;
+        const uint8_t wu[4] = {WU_WEIGHT(ix, iy), WU_WEIGHT(xx, iy), WU_WEIGHT(ix, yy), WU_WEIGHT(xx, yy)};
         for (uint8_t i = 0; i < 4; i++) {
-            int16_t xn = x + (i & 1), yn = y + ((i >> 1) & 1);
+            // Until now, x and y are totally in bound, but we're about
+            // to make our coords into 4-pixel wide splotches.
+            // If we knew x and y would be ^2, we could do cute bit math,
+            // but we just clamp instead.
+            const int xn = std::clamp((int)x + (i & 1), 0, MATRIX_WIDTH - 1);
+            const int yn = std::clamp((int)y + ((i >> 1) & 1), 0, MATRIX_HEIGHT - 1);
 
-            if (!g()->isValidPixel(xn, yn))
-                continue;
-
-            CRGB clr = g()->leds[XY(xn, MATRIX_HEIGHT - 1 - yn)];
+            CRGB clr = g()->leds[XY(xn, MATRIX_HEIGHT - yn)];
             clr.r = qadd8(clr.r, (color.r * wu[i]) >> 8);
             clr.g = qadd8(clr.g, (color.g * wu[i]) >> 8);
             clr.b = qadd8(clr.b, (color.b * wu[i]) >> 8);

--- a/include/effects/matrix/PatternSMSupernova.h
+++ b/include/effects/matrix/PatternSMSupernova.h
@@ -4,93 +4,89 @@
 
 // Inspired by https://editor.soulmatelights.com/gallery/1923-supernova
 
-// A more cache-friendly version of the 8 independent arrays that were
-// used. This allows better locality per member, especially since we
-// access them sequentially.
-// Nothing special here; just default-zero initialized struct.
-class Object {
-  public:
-    void Objects() {
-        PosX = 0.0f;
-        PosY = 0.0f;
-        State = 0.0f;
-        SpeedX = 0.0f;
-        SpeedY = 0.0f;
-        Hue = 0;
-        IsShift = false;
-    }
-
-    float PosX;
-    float PosY;
-    float SpeedX;
-    float SpeedY;
-    uint8_t Hue;
-    uint8_t State;
-    bool IsShift;
-};
 
 class PatternSMSupernova : public LEDStripEffect
 {
 public:
 
-    PatternSMSupernova() : LEDStripEffect(EFFECT_MATRIX_SMSUPERNOVA, "Supernova"), hue(0), hue2(0), step(0), deltaValue(0), enlargedObjectNUM(0)
+    PatternSMSupernova() : LEDStripEffect(EFFECT_MATRIX_SMSUPERNOVA, "Supernova"), hue(0), hue2(0), step(0), enlargedDebrisItemNUM(0)
     {
     }
 
-    PatternSMSupernova(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject)
+    PatternSMSupernova(const JsonObjectConst &jsonDebrisItem) : LEDStripEffect(jsonDebrisItem)
     {
     }
 
     virtual size_t DesiredFramesPerSecond() const override
     {
-        return 120;
+        return 60;
     }
 
     void Start() override
     {
         g()->Clear();
-        enlargedObjectNUM = 200;
-        if (enlargedObjectNUM > MAX_COUNT)
-            enlargedObjectNUM = 200U;
-        deltaValue = enlargedObjectNUM /
-            (sqrt3(CENTER_X_MAJOR * CENTER_X_MAJOR +
-                   CENTER_Y_MAJOR * CENTER_Y_MAJOR) * 4U) + 1U;
+        enlargedDebrisItemNUM = 200;
+        if (enlargedDebrisItemNUM > MAX_COUNT)
+            enlargedDebrisItemNUM = 200U;
     }
 
     void Draw() override {
         step = -1;
         g()->DimAll(200);
 
-        for (auto& object : Objects) {
-            if (!object.IsShift && step) {
-                starfield2Emit(object);
+        for (auto& debris_item : _debris_items) {
+            if (!debris_item._is_shift && step) {
+                StarfieldEmit(debris_item);
                 step -= 1;
             }
 
-            if (object.IsShift) {
-                particlesUpdate2(object);
-                // pU2() may have updated the object beyond bounds and
-                // cleared IsShift. Retest it and ignore if so.
+            if (debris_item._is_shift) {
+                ParticlesUpdate(debris_item);
+                // pU2() may have updated the debris_item beyond bounds and
+                // cleared _is_shift. Retest it and ignore if so.
                 // Alternate design could use pU2()'s return value for this.
-                if (object.IsShift == false) continue;;
+                if (debris_item._is_shift == false) continue;;
 
-                CRGB baseRGB = ColorFromPalette(HeatColors_p, object.Hue,
+                CRGB baseRGB = ColorFromPalette(HeatColors_p, debris_item._hue,
                                                 255, LINEARBLEND);
-                baseRGB.nscale8(object.State);
-                drawPixelXYF(object.PosX, object.PosY, baseRGB);
+                baseRGB.nscale8(debris_item._state);
+                drawPixelXYF(debris_item._position_x, debris_item._position_y, baseRGB);
             }
         }
     }
 
 private:
-    const uint8_t CENTER_X_MINOR = (MATRIX_WIDTH / 2) - ((MATRIX_WIDTH - 1) & 0x01);
-    const uint8_t CENTER_Y_MINOR = (MATRIX_HEIGHT / 2) - ((MATRIX_HEIGHT - 1) & 0x01);
-    const uint8_t CENTER_X_MAJOR = MATRIX_WIDTH / 2 + (MATRIX_WIDTH % 2);
-    const uint8_t CENTER_Y_MAJOR = MATRIX_HEIGHT / 2 + (MATRIX_HEIGHT % 2);
-    uint8_t hue, hue2, step, deltaValue, enlargedObjectNUM;
+    // A more cache-friendly version of the 8 independent arrays that were
+    // used. This allows better locality per member, especially since we
+    // access them sequentially.
+    // Nothing special here; just a default-zero initialized struct.
+    class DebrisItem
+    {
+      public:
+        DebrisItem()
+        {
+            _position_x = 0.0f;
+            _position_y = 0.0f;
+            _state = 0.0f;
+            _speed_x = 0.0f;
+            _speed_y = 0.0f;
+            _hue = 0;
+            _is_shift = false;
+        }
+
+        float _position_x;
+        float _position_y;
+        float _speed_x;
+        float _speed_y;
+        uint8_t _hue;
+        uint8_t _state;
+        bool _is_shift;
+    };
+
+    uint8_t hue, hue2, step, enlargedDebrisItemNUM;
 
     static constexpr int MAX_COUNT = 254;
-    std::array<Object, MAX_COUNT> Objects;
+    std::array<DebrisItem, MAX_COUNT> _debris_items;
 
     // Fast Babylonian Approximate square root.
     // It's called one time in the constructor, so no need for
@@ -107,31 +103,31 @@ private:
         return u.x;
     }
 
-    void inline particlesUpdate2(Object& object)
+    void inline ParticlesUpdate(DebrisItem& debris_item)
     {
         // Intentionally do a narrowing conversion here.
-        const int x = object.PosX += object.SpeedX;
-        const int y = object.PosY += object.SpeedY;
+        const int x = debris_item._position_x += debris_item._speed_x;
+        const int y = debris_item._position_y += debris_item._speed_y;
 
-        if (object.State == 0 || x < 0 || x >= MATRIX_WIDTH ||
+        if (debris_item._state == 0 || x < 0 || x >= MATRIX_WIDTH ||
                                  y < 0 || y >= MATRIX_HEIGHT)
-            object.IsShift = false;
+            debris_item._is_shift = false;
     }
 
-    void inline starfield2Emit(Object& object)
+    void inline StarfieldEmit(DebrisItem& debris_item)
     {
         if (hue++ & 0x01)
             hue2 += 1;
-        object.PosX = MATRIX_WIDTH * 0.5;
-        object.PosY = MATRIX_HEIGHT * 0.5;
-        object.SpeedX = (((float)random8() - 127.) / 512.);
-        object.SpeedY = sqrt(0.0626 - object.SpeedX * object.SpeedX);
+        debris_item._position_x = MATRIX_WIDTH * 0.5;
+        debris_item._position_y = MATRIX_HEIGHT * 0.5;
+        debris_item._speed_x = (((float)random8() - 127.) / 512.);
+        debris_item._speed_y = sqrtf(0.0626f - debris_item._speed_x * debris_item._speed_y);
         if (random8(2U)) {
-            object.SpeedY = -object.SpeedY;
+            debris_item._speed_y = -debris_item._speed_y;
         }
-        object.State = random8(1, 250);
-        object.Hue = hue2;
-        object.IsShift = true;
+        debris_item._state = random8(1, 250);
+        debris_item._hue = hue2;
+        debris_item._is_shift = true;
     }
 
     static inline uint8_t WU_WEIGHT(uint8_t a, uint8_t b)


### PR DESCRIPTION
drawPixelXYF() was merging pixels from the VU meter t othe bottom of the
line, so if there was sound in the room, red and green smears appared.

Fixed by making it better obey the HEIGHT values and compensating for
VU.

Follow through on my whining to make it look (more) like it was written
by a programmer.  Generated assembly code is now beautiful with
references carrying values across methods. Data is now per-Blob,
sequentially accessed, and in a std::array.

More importantly, memory is accessed sequentially and locally, just
like read-ahead and paging systems like.  Most accesses should be
cache hits now.

These various minor optimizations resultign in 12 FPS improvement
according to self-reporting. It _looks_ fast.

Fixes #446.

Tested with asserts() inserted for out-of-bounds pixel accesses (now
remove) and 30+ minutes of running on stock mesmerizer.

## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
