### PR TITLE
Fix Subscribers effect settings serialization bug

### DIFF
--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -249,7 +249,8 @@ class PatternSubscribers : public LEDStripEffect
     {
         StaticJsonDocument<_jsonSize> jsonDoc;
 
-        LEDStripEffect::SerializeSettingsToJSON(jsonObject);
+        JsonObject root = jsonDoc.to<JsonObject>();
+        LEDStripEffect::SerializeSettingsToJSON(root);
 
         jsonDoc[NAME_OF(youtubeChannelGuid)] = youtubeChannelGuid;
         jsonDoc[NAME_OF(youtubeChannelName)] = youtubeChannelName;


### PR DESCRIPTION
## Description

This fixes a bug in the Subscribers effect due to which the settings in the LEDStripEffect base class were not returned. More precisely phrased they were serialized, but then overwritten by the settings specific to PatternSubscribers.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).