### PR TITLE
Update jsonserializer.cpp to break infinite fail

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -439,42 +439,42 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     // known to work with at least one other type of device as well.
 
     #ifndef PROJECT_NAME
-    #define PROJECT_NAME                    "Mesmerizer"
+    #define PROJECT_NAME                "Mesmerizer"
     #endif
 
-    #define SHOW_FPS_ON_MATRIX              0
-    #define ENABLE_AUDIOSERIAL              0   // Report peaks at 2400baud on serial port for PETRock consumption
-    #define ENABLE_WIFI                     1   // Connect to WiFi
-    #define INCOMING_WIFI_ENABLED           1   // Accepting incoming color data and commands
-    #define WAIT_FOR_WIFI                   0   // Hold in setup until we have WiFi - for strips without effects
-    #define TIME_BEFORE_LOCAL               2   // How many seconds before the lamp times out and shows local content
-    #define ENABLE_WEBSERVER                1  // Turn on the internal webserver
-    #define ENABLE_NTP                      1   // Set the clock from the web
-    #define ENABLE_OTA                      1   // Accept over the air flash updates
-    #define ENABLE_REMOTE                   1   // IR Remote Control
-    #define ENABLE_AUDIO                    1   // Listen for audio from the microphone and process it
-    #define SCALE_AUDIO_EXPONENTIAL         0
-    #define ENABLE_AUDIO_SMOOTHING          1
-    #define REQUIRE_EFFECTS_SERIALIZATION   1   // Require effects serialization to succeed
+    #define SHOW_FPS_ON_MATRIX          0
+    #define ENABLE_AUDIOSERIAL          0   // Report peaks at 2400baud on serial port for PETRock consumption
+    #define ENABLE_WIFI                 1   // Connect to WiFi
+    #define INCOMING_WIFI_ENABLED       1   // Accepting incoming color data and commands
+    #define WAIT_FOR_WIFI               0   // Hold in setup until we have WiFi - for strips without effects
+    #define TIME_BEFORE_LOCAL           2   // How many seconds before the lamp times out and shows local content
+    #define ENABLE_WEBSERVER            1  // Turn on the internal webserver
+    #define ENABLE_NTP                  1   // Set the clock from the web
+    #define ENABLE_OTA                  1   // Accept over the air flash updates
+    #define ENABLE_REMOTE               1   // IR Remote Control
+    #define ENABLE_AUDIO                1   // Listen for audio from the microphone and process it
+    #define SCALE_AUDIO_EXPONENTIAL     0
+    #define ENABLE_AUDIO_SMOOTHING      1
+    #define EFFECT_PERSISTENCE_CRITICAL 1   // Require effects serialization to succeed
 
-    #define DEFAULT_EFFECT_INTERVAL         (MILLIS_PER_SECOND * 60 * 2)
-    #define MILLIS_PER_FRAME                0
+    #define DEFAULT_EFFECT_INTERVAL     (MILLIS_PER_SECOND * 60 * 2)
+    #define MILLIS_PER_FRAME            0
 
-    #define NUM_CHANNELS                    1
-    #define RING_SIZE_0                     24
-    #define BONUS_PIXELS                    0
-    #define MATRIX_WIDTH                    64
-    #define MATRIX_HEIGHT                   32
-    #define NUM_FANS                        128
-    #define FAN_SIZE                        16
-    #define NUM_BANDS                       16
-    #define NUM_LEDS                        (MATRIX_WIDTH*MATRIX_HEIGHT)
-    #define IR_REMOTE_PIN                   39
-    #define INPUT_PIN                       36
-    #define LED_FAN_OFFSET_BU               6
-    #define POWER_LIMIT_MW                  (5 * 8 * 1000)         // Expects at least a 5V, 8A supply
+    #define NUM_CHANNELS                1
+    #define RING_SIZE_0                 24
+    #define BONUS_PIXELS                0
+    #define MATRIX_WIDTH                64
+    #define MATRIX_HEIGHT               32
+    #define NUM_FANS                    128
+    #define FAN_SIZE                    16
+    #define NUM_BANDS                   16
+    #define NUM_LEDS                    (MATRIX_WIDTH*MATRIX_HEIGHT)
+    #define IR_REMOTE_PIN               39
+    #define INPUT_PIN                   36
+    #define LED_FAN_OFFSET_BU           6
+    #define POWER_LIMIT_MW              (5 * 8 * 1000)         // Expects at least a 5V, 8A supply
 
-    #define TOGGLE_BUTTON_1                 0
+    #define TOGGLE_BUTTON_1             0
 
 #elif TTGO
 
@@ -800,64 +800,64 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     // It displays a spectrum analyzer and music visualizer
 
     #ifndef PROJECT_NAME
-    #define PROJECT_NAME                    "Spectrum"
+    #define PROJECT_NAME                "Spectrum"
     #endif
 
-    #define ENABLE_AUDIOSERIAL              1   // Report peaks at 2400baud on serial port for PETRock consumption
-    #define ENABLE_WIFI                     1   // Connect to WiFi
-    #define INCOMING_WIFI_ENABLED           1   // Accepting incoming color data and commands
-    #define WAIT_FOR_WIFI                   0   // Hold in setup until we have WiFi - for strips without effects
-    #define TIME_BEFORE_LOCAL               2   // How many seconds before the lamp times out and shows local content
-    #define ENABLE_WEBSERVER                1   // Turn on the internal webserver
-    #define ENABLE_NTP                      1   // Set the clock from the web
-    #define ENABLE_OTA                      0   // Accept over the air flash updates
-    #define ENABLE_REMOTE                   1   // IR Remote Control
-    #define ENABLE_AUDIO                    1   // Listen for audio from the microphone and process it
-    #define REQUIRE_EFFECTS_SERIALIZATION   1   // Require effects serialization to succeed
+    #define ENABLE_AUDIOSERIAL          1   // Report peaks at 2400baud on serial port for PETRock consumption
+    #define ENABLE_WIFI                 1   // Connect to WiFi
+    #define INCOMING_WIFI_ENABLED       1   // Accepting incoming color data and commands
+    #define WAIT_FOR_WIFI               0   // Hold in setup until we have WiFi - for strips without effects
+    #define TIME_BEFORE_LOCAL           2   // How many seconds before the lamp times out and shows local content
+    #define ENABLE_WEBSERVER            1   // Turn on the internal webserver
+    #define ENABLE_NTP                  1   // Set the clock from the web
+    #define ENABLE_OTA                  0   // Accept over the air flash updates
+    #define ENABLE_REMOTE               1   // IR Remote Control
+    #define ENABLE_AUDIO                1   // Listen for audio from the microphone and process it
+    #define EFFECT_PERSISTENCE_CRITICAL 1   // Require effects serialization to succeed
 
     #if USE_PSRAM
-        #define MAX_BUFFERS                 500
+        #define MAX_BUFFERS             500
     #else
-        #define MAX_BUFFERS                 10
+        #define MAX_BUFFERS             10
     #endif
 
-    #define DEFAULT_EFFECT_INTERVAL         (60*60*24*5)
+    #define DEFAULT_EFFECT_INTERVAL     (60*60*24*5)
 
     #if SPECTRUM_WROVER_KIT
-        #define LED_PIN0                    5
+        #define LED_PIN0                5
     #elif ELECROW
-        #define LED_PIN0                    19
+        #define LED_PIN0                19
     #else
-        #define LED_PIN0                    26
+        #define LED_PIN0                26
     #endif
 
     #if ELECROW
-        #define IR_REMOTE_PIN               20
+        #define IR_REMOTE_PIN           20
     #endif
 
-    #define NUM_CHANNELS                    1
-    #define RING_SIZE_0                     24
-    #define BONUS_PIXELS                    0
-    #define MATRIX_WIDTH                    48
-    #define MATRIX_HEIGHT                   16
-    #define NUM_FANS                        MATRIX_WIDTH
-    #define FAN_SIZE                        MATRIX_HEIGHT
-    #define NUM_BANDS                       16
-    #define NUM_LEDS                        (MATRIX_WIDTH*MATRIX_HEIGHT)
-    #define LED_FAN_OFFSET_BU               6
-    #define POWER_LIMIT_MW                  (10 * 5 * 1000)         // Expects at least a 5V, 20A supply (100W)
+    #define NUM_CHANNELS                1
+    #define RING_SIZE_0                 24
+    #define BONUS_PIXELS                0
+    #define MATRIX_WIDTH                48
+    #define MATRIX_HEIGHT               16
+    #define NUM_FANS                    MATRIX_WIDTH
+    #define FAN_SIZE                    MATRIX_HEIGHT
+    #define NUM_BANDS                   16
+    #define NUM_LEDS                    (MATRIX_WIDTH*MATRIX_HEIGHT)
+    #define LED_FAN_OFFSET_BU           6
+    #define POWER_LIMIT_MW              (10 * 5 * 1000)         // Expects at least a 5V, 20A supply (100W)
 
     // The mic in the M5 is not quite as sensitive as the Mesermizer, so it gets a lower minimum VU than default
-    #define MIN_VU                          180
-    #define NOISE_CUTOFF                    1000
+    #define MIN_VU                      180
+    #define NOISE_CUTOFF                1000
 
     #if !(ELECROW)
-        #define TOGGLE_BUTTON_1             37
-        #define TOGGLE_BUTTON_2             39
+        #define TOGGLE_BUTTON_1         37
+        #define TOGGLE_BUTTON_2         39
     #endif
 
     #if !(SPECTRUM_WROVER_KIT)
-        #define NUM_INFO_PAGES              2
+        #define NUM_INFO_PAGES          2
     #endif
 
 #elif FANSET
@@ -1216,8 +1216,8 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 #define ENABLE_REMOTE 0
 #endif
 
-#ifndef REQUIRE_EFFECTS_SERIALIZATION
-#define REQUIRE_EFFECTS_SERIALIZATION 0
+#ifndef EFFECT_PERSISTENCE_CRITICAL
+#define EFFECT_PERSISTENCE_CRITICAL 0
 #endif
 
 #ifndef MATRIX_REFRESH_RATE

--- a/include/globals.h
+++ b/include/globals.h
@@ -439,41 +439,42 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     // known to work with at least one other type of device as well.
 
     #ifndef PROJECT_NAME
-    #define PROJECT_NAME            "Mesmerizer"
+    #define PROJECT_NAME                    "Mesmerizer"
     #endif
 
-    #define SHOW_FPS_ON_MATRIX      0
-    #define ENABLE_AUDIOSERIAL      0   // Report peaks at 2400baud on serial port for PETRock consumption
-    #define ENABLE_WIFI             1   // Connect to WiFi
-    #define INCOMING_WIFI_ENABLED   1   // Accepting incoming color data and commands
-    #define WAIT_FOR_WIFI           0   // Hold in setup until we have WiFi - for strips without effects
-    #define TIME_BEFORE_LOCAL       2   // How many seconds before the lamp times out and shows local content
-    #define ENABLE_WEBSERVER        1  // Turn on the internal webserver
-    #define ENABLE_NTP              1   // Set the clock from the web
-    #define ENABLE_OTA              1   // Accept over the air flash updates
-    #define ENABLE_REMOTE           1   // IR Remote Control
-    #define ENABLE_AUDIO            1   // Listen for audio from the microphone and process it
-    #define SCALE_AUDIO_EXPONENTIAL 0
-    #define ENABLE_AUDIO_SMOOTHING  1
+    #define SHOW_FPS_ON_MATRIX              0
+    #define ENABLE_AUDIOSERIAL              0   // Report peaks at 2400baud on serial port for PETRock consumption
+    #define ENABLE_WIFI                     1   // Connect to WiFi
+    #define INCOMING_WIFI_ENABLED           1   // Accepting incoming color data and commands
+    #define WAIT_FOR_WIFI                   0   // Hold in setup until we have WiFi - for strips without effects
+    #define TIME_BEFORE_LOCAL               2   // How many seconds before the lamp times out and shows local content
+    #define ENABLE_WEBSERVER                1  // Turn on the internal webserver
+    #define ENABLE_NTP                      1   // Set the clock from the web
+    #define ENABLE_OTA                      1   // Accept over the air flash updates
+    #define ENABLE_REMOTE                   1   // IR Remote Control
+    #define ENABLE_AUDIO                    1   // Listen for audio from the microphone and process it
+    #define SCALE_AUDIO_EXPONENTIAL         0
+    #define ENABLE_AUDIO_SMOOTHING          1
+    #define REQUIRE_EFFECTS_SERIALIZATION   1   // Require effects serialization to succeed
 
-    #define DEFAULT_EFFECT_INTERVAL     (MILLIS_PER_SECOND * 60 * 2)
-    #define MILLIS_PER_FRAME        0
+    #define DEFAULT_EFFECT_INTERVAL         (MILLIS_PER_SECOND * 60 * 2)
+    #define MILLIS_PER_FRAME                0
 
-    #define NUM_CHANNELS    1
-    #define RING_SIZE_0     24
-    #define BONUS_PIXELS    0
-    #define MATRIX_WIDTH    64
-    #define MATRIX_HEIGHT   32
-    #define NUM_FANS        128
-    #define FAN_SIZE        16
-    #define NUM_BANDS       16
-    #define NUM_LEDS        (MATRIX_WIDTH*MATRIX_HEIGHT)
-    #define IR_REMOTE_PIN   39
-    #define INPUT_PIN       36
-    #define LED_FAN_OFFSET_BU 6
-    #define POWER_LIMIT_MW  (5 * 8 * 1000)         // Expects at least a 5V, 8A supply
+    #define NUM_CHANNELS                    1
+    #define RING_SIZE_0                     24
+    #define BONUS_PIXELS                    0
+    #define MATRIX_WIDTH                    64
+    #define MATRIX_HEIGHT                   32
+    #define NUM_FANS                        128
+    #define FAN_SIZE                        16
+    #define NUM_BANDS                       16
+    #define NUM_LEDS                        (MATRIX_WIDTH*MATRIX_HEIGHT)
+    #define IR_REMOTE_PIN                   39
+    #define INPUT_PIN                       36
+    #define LED_FAN_OFFSET_BU               6
+    #define POWER_LIMIT_MW                  (5 * 8 * 1000)         // Expects at least a 5V, 8A supply
 
-    #define TOGGLE_BUTTON_1 0
+    #define TOGGLE_BUTTON_1                 0
 
 #elif TTGO
 
@@ -716,7 +717,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
     #define ENABLE_WIFI                 1   // Connect to WiFi
     #define INCOMING_WIFI_ENABLED       1   // Accepting incoming color data and commands
-    
+
     #define WAIT_FOR_WIFI               1   // Hold in setup until we have WiFi - for strips without effects
     #define TIME_BEFORE_LOCAL           5   // How many seconds before the lamp times out and shows local content
     #define COLORDATA_SERVER_ENABLED    0   // Also provides a response packet
@@ -799,63 +800,64 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     // It displays a spectrum analyzer and music visualizer
 
     #ifndef PROJECT_NAME
-    #define PROJECT_NAME            "Spectrum"
+    #define PROJECT_NAME                    "Spectrum"
     #endif
 
-    #define ENABLE_AUDIOSERIAL      1   // Report peaks at 2400baud on serial port for PETRock consumption
-    #define ENABLE_WIFI             1   // Connect to WiFi
-    #define INCOMING_WIFI_ENABLED   1   // Accepting incoming color data and commands
-    #define WAIT_FOR_WIFI           0   // Hold in setup until we have WiFi - for strips without effects
-    #define TIME_BEFORE_LOCAL       2   // How many seconds before the lamp times out and shows local content
-    #define ENABLE_WEBSERVER        1   // Turn on the internal webserver
-    #define ENABLE_NTP              1   // Set the clock from the web
-    #define ENABLE_OTA              0   // Accept over the air flash updates
-    #define ENABLE_REMOTE           1   // IR Remote Control
-    #define ENABLE_AUDIO            1   // Listen for audio from the microphone and process it
+    #define ENABLE_AUDIOSERIAL              1   // Report peaks at 2400baud on serial port for PETRock consumption
+    #define ENABLE_WIFI                     1   // Connect to WiFi
+    #define INCOMING_WIFI_ENABLED           1   // Accepting incoming color data and commands
+    #define WAIT_FOR_WIFI                   0   // Hold in setup until we have WiFi - for strips without effects
+    #define TIME_BEFORE_LOCAL               2   // How many seconds before the lamp times out and shows local content
+    #define ENABLE_WEBSERVER                1   // Turn on the internal webserver
+    #define ENABLE_NTP                      1   // Set the clock from the web
+    #define ENABLE_OTA                      0   // Accept over the air flash updates
+    #define ENABLE_REMOTE                   1   // IR Remote Control
+    #define ENABLE_AUDIO                    1   // Listen for audio from the microphone and process it
+    #define REQUIRE_EFFECTS_SERIALIZATION   1   // Require effects serialization to succeed
 
     #if USE_PSRAM
-        #define MAX_BUFFERS         500
+        #define MAX_BUFFERS                 500
     #else
-        #define MAX_BUFFERS         10
+        #define MAX_BUFFERS                 10
     #endif
 
-    #define DEFAULT_EFFECT_INTERVAL     (60*60*24*5)
+    #define DEFAULT_EFFECT_INTERVAL         (60*60*24*5)
 
     #if SPECTRUM_WROVER_KIT
-        #define LED_PIN0        5
+        #define LED_PIN0                    5
     #elif ELECROW
-        #define LED_PIN0        19
+        #define LED_PIN0                    19
     #else
-        #define LED_PIN0        26
+        #define LED_PIN0                    26
     #endif
 
     #if ELECROW
-        #define IR_REMOTE_PIN   20
+        #define IR_REMOTE_PIN               20
     #endif
 
-    #define NUM_CHANNELS    1
-    #define RING_SIZE_0     24
-    #define BONUS_PIXELS    0
-    #define MATRIX_WIDTH    48
-    #define MATRIX_HEIGHT   16
-    #define NUM_FANS        MATRIX_WIDTH
-    #define FAN_SIZE        MATRIX_HEIGHT
-    #define NUM_BANDS       16
-    #define NUM_LEDS        (MATRIX_WIDTH*MATRIX_HEIGHT)
-    #define LED_FAN_OFFSET_BU 6
-    #define POWER_LIMIT_MW  (10 * 5 * 1000)         // Expects at least a 5V, 20A supply (100W)
+    #define NUM_CHANNELS                    1
+    #define RING_SIZE_0                     24
+    #define BONUS_PIXELS                    0
+    #define MATRIX_WIDTH                    48
+    #define MATRIX_HEIGHT                   16
+    #define NUM_FANS                        MATRIX_WIDTH
+    #define FAN_SIZE                        MATRIX_HEIGHT
+    #define NUM_BANDS                       16
+    #define NUM_LEDS                        (MATRIX_WIDTH*MATRIX_HEIGHT)
+    #define LED_FAN_OFFSET_BU               6
+    #define POWER_LIMIT_MW                  (10 * 5 * 1000)         // Expects at least a 5V, 20A supply (100W)
 
     // The mic in the M5 is not quite as sensitive as the Mesermizer, so it gets a lower minimum VU than default
-    #define MIN_VU          180
-    #define NOISE_CUTOFF    1000
+    #define MIN_VU                          180
+    #define NOISE_CUTOFF                    1000
 
     #if !(ELECROW)
-        #define TOGGLE_BUTTON_1 37
-        #define TOGGLE_BUTTON_2 39
+        #define TOGGLE_BUTTON_1             37
+        #define TOGGLE_BUTTON_2             39
     #endif
 
     #if !(SPECTRUM_WROVER_KIT)
-        #define NUM_INFO_PAGES          2
+        #define NUM_INFO_PAGES              2
     #endif
 
 #elif FANSET
@@ -1212,6 +1214,10 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
 #ifndef ENABLE_REMOTE
 #define ENABLE_REMOTE 0
+#endif
+
+#ifndef REQUIRE_EFFECTS_SERIALIZATION
+#define REQUIRE_EFFECTS_SERIALIZATION 0
 #endif
 
 #ifndef MATRIX_REFRESH_RATE

--- a/include/jsonserializer.h
+++ b/include/jsonserializer.h
@@ -125,7 +125,7 @@ namespace ArduinoJson
 }
 
 bool BoolFromText(const String& text);
-void SerializeWithBufferSize(std::unique_ptr<AllocatedJsonDocument>& pJsonDoc, size_t& bufferSize, std::function<bool(JsonObject&)> serializationFunction);
+bool SerializeWithBufferSize(std::unique_ptr<AllocatedJsonDocument>& pJsonDoc, size_t& bufferSize, std::function<bool(JsonObject&)> serializationFunction);
 bool LoadJSONFile(const String & fileName, size_t& bufferSize, std::unique_ptr<AllocatedJsonDocument>& pJsonDoc);
 bool SaveToJSONFile(const String & fileName, size_t& bufferSize, IJSONSerializable& object);
 bool RemoveJSONFile(const String & fileName);

--- a/src/deviceconfig.cpp
+++ b/src/deviceconfig.cpp
@@ -45,7 +45,7 @@ void DeviceConfig::SaveToJSON()
 DeviceConfig::DeviceConfig()
 {
     writerIndex = g_ptrSystem->JSONWriter().RegisterWriter(
-        [this] { SaveToJSONFile(DEVICE_CONFIG_FILE, g_DeviceConfigJSONBufferSize, *this); }
+        [this] { assert(SaveToJSONFile(DEVICE_CONFIG_FILE, g_DeviceConfigJSONBufferSize, *this)); }
     );
 
     std::unique_ptr<AllocatedJsonDocument> pJsonDoc(nullptr);

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -73,13 +73,11 @@ void InitEffectsManager()
 
     LoadEffectFactories();
 
-    l_EffectsManagerJSONWriterIndex = g_ptrSystem->JSONWriter().RegisterWriter(
-        []
-        {
-            if (!SaveToJSONFile(EFFECTS_CONFIG_FILE, g_EffectsManagerJSONBufferSize, g_ptrSystem->EffectManager()) && REQUIRE_EFFECTS_SERIALIZATION)
-                throw std::runtime_error("Effects serialization failed");
-        }
-    );
+    l_EffectsManagerJSONWriterIndex = g_ptrSystem->JSONWriter().RegisterWriter([]()
+    {
+        if (!SaveToJSONFile(EFFECTS_CONFIG_FILE, g_EffectsManagerJSONBufferSize, g_ptrSystem->EffectManager()) && EFFECT_PERSISTENCE_CRITICAL)
+            throw std::runtime_error("Effects serialization failed");
+    });
     l_CurrentEffectWriterIndex = g_ptrSystem->JSONWriter().RegisterWriter(WriteCurrentEffectIndexFile);
 
     std::unique_ptr<AllocatedJsonDocument> pJsonDoc;

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -74,7 +74,11 @@ void InitEffectsManager()
     LoadEffectFactories();
 
     l_EffectsManagerJSONWriterIndex = g_ptrSystem->JSONWriter().RegisterWriter(
-        [] { SaveToJSONFile(EFFECTS_CONFIG_FILE, g_EffectsManagerJSONBufferSize, g_ptrSystem->EffectManager()); }
+        []
+        {
+            if (!SaveToJSONFile(EFFECTS_CONFIG_FILE, g_EffectsManagerJSONBufferSize, g_ptrSystem->EffectManager()) && REQUIRE_EFFECTS_SERIALIZATION)
+                throw std::runtime_error("Effects serialization failed");
+        }
     );
     l_CurrentEffectWriterIndex = g_ptrSystem->JSONWriter().RegisterWriter(WriteCurrentEffectIndexFile);
 
@@ -211,8 +215,8 @@ std::shared_ptr<LEDStripEffect> EffectManager::CopyEffect(size_t index)
 
     std::unique_ptr<AllocatedJsonDocument> ptrJsonDoc = nullptr;
 
-    SerializeWithBufferSize(ptrJsonDoc, jsonBufferSize,
-        [&sourceEffect](JsonObject &jsonObject) { return sourceEffect->SerializeToJSON(jsonObject); });
+    assert(SerializeWithBufferSize(ptrJsonDoc, jsonBufferSize,
+        [&sourceEffect](JsonObject &jsonObject) { return sourceEffect->SerializeToJSON(jsonObject); }));
 
     auto jsonEffectFactories = g_ptrEffectFactories->GetJSONFactories();
     auto factoryEntry = jsonEffectFactories.find(sourceEffect->EffectNumber());

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -117,7 +117,8 @@ void SetupOTA(const String & strHostname)
         ArduinoOTA.setHostname(strHostname.c_str());
 
     ArduinoOTA
-        .onStart([] {
+        .onStart([]()
+        {
             g_Values.UpdateStarted = true;
 
             String type;
@@ -134,7 +135,8 @@ void SetupOTA(const String & strHostname)
             debugI("Start updating from OTA ");
             debugI("%s", type.c_str());
         })
-        .onEnd([] {
+        .onEnd([]()
+        {
             debugI("\nEnd OTA");
             g_Values.UpdateStarted = false;
         })


### PR DESCRIPTION
Added code to catch instances where SerializeWithBufferSize gets into an *infinite fail loop. Adjusted SaveToJSONFile to handle SerializeWithBufferSize failing.

## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->
There are times when a serializer fails to allocate memory for pJsonDoc. The SerializeWithBufferSize function interprets this as the JSON document needing more buffer. That might be the case sometimes, but it does not handle cases when the device runs out of usable memory. This code change keeps the buffer size adjustment, but adds code to handle the case where the device can't allocate memory for the JSON document.

The code allows for the allocation in SerializeWithBufferSize to fail 5 times before it stops trying. Once it stops trying it exits the loop. When SaveToJSONFile continues, it will have to handle having either a null pJsonDoc variable or pJsonDoc with a capacity of 0. If pJsonDoc is null is the result of the fail code in SerializeWithBufferSize. If SerializeWithBufferSize failed, it will skip trying to save the file. That is because if it tries to save the file with a null variable or pJsonDoc->capacity() of 0, it will cause an uncaught exception and crash the whole program and the device will reboot. So, this just returns false, causing it to skip the file writing operation.

Note: it is my assumption that the device is running out of memory. There might be some bug somewhere else in the code causing the memory allocation failure.

Fixes #473. 

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).