### PR TITLE
Reconfigure Spectrum builds

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -716,7 +716,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
     #define ENABLE_WIFI                 1   // Connect to WiFi
     #define INCOMING_WIFI_ENABLED       1   // Accepting incoming color data and commands
-    
+
     #define WAIT_FOR_WIFI               1   // Hold in setup until we have WiFi - for strips without effects
     #define TIME_BEFORE_LOCAL           5   // How many seconds before the lamp times out and shows local content
     #define COLORDATA_SERVER_ENABLED    0   // Also provides a response packet
@@ -802,7 +802,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define PROJECT_NAME            "Spectrum"
     #endif
 
-    #define ENABLE_AUDIOSERIAL      1   // Report peaks at 2400baud on serial port for PETRock consumption
+    #define ENABLE_AUDIOSERIAL      0   // Report peaks at 2400baud on serial port for PETRock consumption
     #define ENABLE_WIFI             1   // Connect to WiFi
     #define INCOMING_WIFI_ENABLED   1   // Accepting incoming color data and commands
     #define WAIT_FOR_WIFI           0   // Hold in setup until we have WiFi - for strips without effects
@@ -810,7 +810,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define ENABLE_WEBSERVER        1   // Turn on the internal webserver
     #define ENABLE_NTP              1   // Set the clock from the web
     #define ENABLE_OTA              0   // Accept over the air flash updates
-    #define ENABLE_REMOTE           1   // IR Remote Control
+    #define ENABLE_REMOTE           0   // IR Remote Control
     #define ENABLE_AUDIO            1   // Listen for audio from the microphone and process it
 
     #if USE_PSRAM

--- a/include/globals.h
+++ b/include/globals.h
@@ -804,7 +804,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
     #define ENABLE_AUDIOSERIAL          0   // Report peaks at 2400baud on serial port for PETRock consumption
     #define ENABLE_WIFI                 1   // Connect to WiFi
-    #define INCOMING_WIFI_ENABLED       1   // Accepting incoming color data and commands
+    #define INCOMING_WIFI_ENABLED       0   // Accepting incoming color data and commands
     #define WAIT_FOR_WIFI               0   // Hold in setup until we have WiFi - for strips without effects
     #define TIME_BEFORE_LOCAL           2   // How many seconds before the lamp times out and shows local content
     #define ENABLE_WEBSERVER            1   // Turn on the internal webserver

--- a/include/globals.h
+++ b/include/globals.h
@@ -802,16 +802,17 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define PROJECT_NAME            "Spectrum"
     #endif
 
-    #define ENABLE_AUDIOSERIAL      0   // Report peaks at 2400baud on serial port for PETRock consumption
-    #define ENABLE_WIFI             1   // Connect to WiFi
-    #define INCOMING_WIFI_ENABLED   1   // Accepting incoming color data and commands
-    #define WAIT_FOR_WIFI           0   // Hold in setup until we have WiFi - for strips without effects
-    #define TIME_BEFORE_LOCAL       2   // How many seconds before the lamp times out and shows local content
-    #define ENABLE_WEBSERVER        1   // Turn on the internal webserver
-    #define ENABLE_NTP              1   // Set the clock from the web
-    #define ENABLE_OTA              0   // Accept over the air flash updates
-    #define ENABLE_REMOTE           0   // IR Remote Control
-    #define ENABLE_AUDIO            1   // Listen for audio from the microphone and process it
+    #define ENABLE_AUDIOSERIAL          0   // Report peaks at 2400baud on serial port for PETRock consumption
+    #define ENABLE_WIFI                 1   // Connect to WiFi
+    #define INCOMING_WIFI_ENABLED       1   // Accepting incoming color data and commands
+    #define WAIT_FOR_WIFI               0   // Hold in setup until we have WiFi - for strips without effects
+    #define TIME_BEFORE_LOCAL           2   // How many seconds before the lamp times out and shows local content
+    #define ENABLE_WEBSERVER            1   // Turn on the internal webserver
+    #define ENABLE_NTP                  1   // Set the clock from the web
+    #define ENABLE_OTA                  0   // Accept over the air flash updates
+    #define ENABLE_REMOTE               0   // IR Remote Control
+    #define ENABLE_AUDIO                1   // Listen for audio from the microphone and process it
+    #define COLORDATA_SERVER_ENABLED    0
 
     #if USE_PSRAM
         #define MAX_BUFFERS         500


### PR DESCRIPTION
## Description

This changes the feature flags of the Spectrum build configuration to allow the web server to be started and working - this currently doesn't work due to low memory conditions on some devices at least.

This is mainly for the purposes of the Web Installer; I consider it more likely that Web Installer users want to use the on-chip webserver than the services/features that have now been disabled. People who make and flash local builds can easily customize the build configuration in globals.h to their own liking, anyway.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).