### PR TITLE
Add global color settings

### DIFF
--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -121,6 +121,7 @@ class DeviceConfig : public IJSONSerializable
     static constexpr const char * RememberCurrentEffectTag = NAME_OF(rememberCurrentEffect);
     static constexpr const char * PowerLimitTag = NAME_OF(powerLimit);
     static constexpr const char * BrightnessTag = NAME_OF(brightness);
+    static constexpr const char * ClearGlobalColorTag = "clearGlobalColor";
     static constexpr const char * GlobalColorTag = NAME_OF(globalColor);
     static constexpr const char * ApplyGlobalColorTag = "applyGlobalColor";
     static constexpr const char * SecondColorTag = NAME_OF(secondColor);
@@ -291,6 +292,12 @@ class DeviceConfig : public IJSONSerializable
             powerLimitSpec.HasValidation = true;
 
             settingSpecs.emplace_back(
+                ClearGlobalColorTag,
+                "Clear global color",
+                "Stop applying the global color/derived palette. This takes precedence over the \"(Re)apply global color\" checkbox.",
+                SettingSpec::SettingType::Boolean
+            ).Access = SettingSpec::SettingAccess::WriteOnly;
+            settingSpecs.emplace_back(
                 GlobalColorTag,
                 "Global color",
                 "Main color that is applied to all those effects that support using it.",
@@ -299,7 +306,8 @@ class DeviceConfig : public IJSONSerializable
             settingSpecs.emplace_back(
                 ApplyGlobalColorTag,
                 "(Re)apply global color",
-                "You can use this to \"reselect\" and apply the current global color, to force the composition of the derived global palette.",
+                "You can use this to \"reselect\" and apply the current global color, to force the composition of the derived "
+                "global palette. This checkbox is ignored if the \"Clear global color\" checkbox is selected.",
                 SettingSpec::SettingType::Boolean
             ).Access = SettingSpec::SettingAccess::WriteOnly;
             settingSpecs.emplace_back(
@@ -477,4 +485,6 @@ class DeviceConfig : public IJSONSerializable
     {
         SetAndSave(secondColor, newSecondColor);
     }
+
+    void ApplyColorSettings(std::optional<CRGB> globalColor, std::optional<CRGB> secondColor, bool clearGlobalColor, bool applyGlobalColor);
 };

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -67,7 +67,6 @@ class  EffectManager : public IJSONSerializable
     uint _effectInterval = 0;
     bool _bPlayAll;
     bool _bShowVU = true;
-    CRGB lastManualColor = CRGB::Red;
     bool _clearTempEffectWhenExpired = false;
     bool _newFrameAvailable = false;
     int _effectSetVersion = 1;
@@ -319,6 +318,7 @@ public:
     // which takes drawing precedence
 
     void SetGlobalColor(CRGB color);
+    void ApplyGlobalPaletteColors();
 
     void ClearRemoteColor(bool retainRemoteEffect = false)
     {

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -312,12 +312,12 @@ public:
         return _bShowVU && GetCurrentEffect().CanDisplayVUMeter();
     }
 
-    // SetGlobalColor
+    // ApplyGlobalColor
     //
     // When a global color is set via the remote, we create a fill effect and assign it as the "remote effect"
     // which takes drawing precedence
 
-    void SetGlobalColor(CRGB color);
+    void ApplyGlobalColor(CRGB color);
     void ApplyGlobalPaletteColors();
 
     void ClearRemoteColor(bool retainRemoteEffect = false)
@@ -384,7 +384,7 @@ public:
             effect->SetEnabled(false);
 
             if (!AreEffectsEnabled())
-                SetGlobalColor(CRGB::Black);
+                ApplyGlobalColor(CRGB::Black);
 
             if (!skipSave)
                 SaveEffectManagerConfig();

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -319,14 +319,15 @@ std::shared_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color)
 
 #include "effects/strip/fireeffect.h"
 
-void EffectManager::SetGlobalColor(CRGB color)
+void EffectManager::ApplyGlobalColor(CRGB color)
 {
     debugI("Setting Global Color");
 
     auto& deviceConfig = g_ptrSystem->DeviceConfig();
 
-    deviceConfig.SetSecondColor(deviceConfig.GlobalColor());
+    CRGB oldGlobalColor = deviceConfig.GlobalColor();
     deviceConfig.SetGlobalColor(color);
+    deviceConfig.SetSecondColor(oldGlobalColor);
 
     ApplyGlobalPaletteColors();
 }

--- a/src/remotecontrol.cpp
+++ b/src/remotecontrol.cpp
@@ -123,7 +123,7 @@ void RemoteControl::handle()
         if (RemoteColorCodes[i].code == result)
         {
             debugV("Changing Color via remote: %08X\n", (uint) RemoteColorCodes[i].color);
-            effectManager.SetGlobalColor(RemoteColorCodes[i].color);
+            effectManager.ApplyGlobalColor(RemoteColorCodes[i].color);
             return;
         }
     }

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -517,13 +517,15 @@ void CWebServer::SetSettingsIfPresent(AsyncWebServerRequest * pRequest)
     PushPostParamIfPresent<int>(pRequest, DeviceConfig::PowerLimitTag, SET_VALUE(deviceConfig.SetPowerLimit(value)));
     PushPostParamIfPresent<int>(pRequest, DeviceConfig::BrightnessTag, SET_VALUE(deviceConfig.SetBrightness(value)));
 
-    bool applyGlobalColor = PushPostParamIfPresent<CRGB>(pRequest, DeviceConfig::GlobalColorTag, SET_VALUE(deviceConfig.SetGlobalColor(value)))
-                            || IsPostParamTrue(pRequest, DeviceConfig::ApplyGlobalColorTag);
+    std::optional<CRGB> globalColor = {};
+    std::optional<CRGB> secondColor = {};
 
-    if (PushPostParamIfPresent<CRGB>(pRequest, DeviceConfig::SecondColorTag, SET_VALUE(deviceConfig.SetSecondColor(value))))
-        g_ptrSystem->EffectManager().ApplyGlobalPaletteColors();
-    else if (applyGlobalColor)
-        g_ptrSystem->EffectManager().SetGlobalColor(g_ptrSystem->DeviceConfig().GlobalColor());
+    PushPostParamIfPresent<CRGB>(pRequest, DeviceConfig::GlobalColorTag, SET_VALUE(globalColor = value));
+    PushPostParamIfPresent<CRGB>(pRequest, DeviceConfig::SecondColorTag, SET_VALUE(secondColor = value));
+
+    deviceConfig.ApplyColorSettings(globalColor, secondColor,
+                                    IsPostParamTrue(pRequest, DeviceConfig::ClearGlobalColorTag),
+                                    IsPostParamTrue(pRequest, DeviceConfig::ApplyGlobalColorTag));
 }
 
 // Set settings and return resulting config


### PR DESCRIPTION
## Description

This adds two persisted global color settings (global color and second palette color), and implements logic to apply one or both of the colors when set using the web UI. As the comment block above `DeviceConfig::ApplyColorSettings()` in deviceconfig.cpp explains, the logic effectively mimics the behavior of pressing a color button on the IR remote control when (only) the global color is set or (re)applied (for which a checkbox is available), but also allows the secondary global palette color to be specified directly. It also allows the global color/palette to be "unset", in accordance with the IR remote control.

The logic that was added in `DeviceConfig::ApplyColorSettings()` figures out how to prioritize and combine the values of (optional) settings; the actual logic for applying the correct color(s) and palette is still contained in a number of `EffectManager` member functions. The difference there is that the color settings are now pulled from and pushed to `DeviceConfig`, instead of (an) `EffectManager` instance variable(s).

With the previous being the case this fixes #479, as the brightness slider was already added in #494.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).