### PR TITLE
Fix Supernova effect

### DIFF
--- a/include/effects/matrix/PatternSMSupernova.h
+++ b/include/effects/matrix/PatternSMSupernova.h
@@ -24,9 +24,7 @@ public:
 
     void Start() override
     {
-        for (auto& debris_item : _debris_items)
-            debris_item.Clear();
-
+        std::for_each(_debris_items.begin(), _debris_items.end(), [](DebrisItem& debris_item) { debris_item.Clear(); });
         g()->Clear();
     }
 

--- a/include/effects/matrix/PatternSMSupernova.h
+++ b/include/effects/matrix/PatternSMSupernova.h
@@ -121,11 +121,12 @@ private:
             hue2 += 1;
         debris_item._position_x = MATRIX_WIDTH * 0.5;
         debris_item._position_y = MATRIX_HEIGHT * 0.5;
+
         debris_item._speed_x = (((float)random8() - 127.) / 512.);
         debris_item._speed_y = sqrtf(0.0626f - debris_item._speed_x * debris_item._speed_y);
-        if (random8(2U)) {
+        if (random8(2U))
             debris_item._speed_y = -debris_item._speed_y;
-        }
+        
         debris_item._state = random8(1, 250);
         debris_item._hue = hue2;
         debris_item._is_shift = true;

--- a/include/effects/matrix/PatternSMSupernova.h
+++ b/include/effects/matrix/PatternSMSupernova.h
@@ -24,8 +24,8 @@ public:
 
     void Start() override
     {
-        std::transform(_debris_items.begin(), _debris_items.end(), _debris_items.begin(),
-            [](DebrisItem &item) { item.Clear(); return item; });
+        for (auto& debris_item : _debris_items)
+            debris_item.Clear();
 
         g()->Clear();
     }

--- a/include/effects/matrix/PatternSMSupernova.h
+++ b/include/effects/matrix/PatternSMSupernova.h
@@ -138,9 +138,9 @@ private:
     void drawPixelXYF(float x, float y, CRGB color)
     {
         #if SHOW_VU_METER
-        static constexpr bool showingVuMeter = true;
+        static constexpr bool showingVUMeter = true;
         #else
-        static constexpr bool showingVuMeter = false;
+        static constexpr bool showingVUMeter = false;
         #endif
 
         const uint8_t xx = (x - (int)x) * 255, yy = (y - (int)y) * 255, ix = 255 - xx, iy = 255 - yy;
@@ -150,7 +150,7 @@ private:
             const int yn = y + ((i >> 1) & 1);
 
             // Make sure we're on the panel and leave the VU meter pixels alone, if we're showing it
-            if (!g()->isValidPixel(xn, yn) || (showingVuMeter && yn == (MATRIX_HEIGHT - 1)))
+            if (!g()->isValidPixel(xn, yn) || (showingVUMeter && yn == (MATRIX_HEIGHT - 1)))
                 continue;
 
             CRGB clr = g()->leds[XY(xn, MATRIX_HEIGHT - 1 - yn)];

--- a/include/effects/matrix/PatternSMSupernova.h
+++ b/include/effects/matrix/PatternSMSupernova.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "effectmanager.h"
+#include "systemcontainer.h"
 
 // Inspired by https://editor.soulmatelights.com/gallery/1923-supernova
 
@@ -105,9 +105,12 @@ private:
         const int x = debris_item._position_x += debris_item._speed_x;
         const int y = debris_item._position_y += debris_item._speed_y;
 
-        if (debris_item._state == 0 || x < 0 || x >= MATRIX_WIDTH ||
-                                 y < 0 || y >= MATRIX_HEIGHT)
+        if (debris_item._state == 0
+            || x < 0 || x >= MATRIX_WIDTH
+            || y < 0 || y >= MATRIX_HEIGHT)
+        {
             debris_item._is_shift = false;
+        }
 
         return debris_item._is_shift;
     }
@@ -135,12 +138,6 @@ private:
 
     void drawPixelXYF(float x, float y, CRGB color)
     {
-        #if SHOW_VU_METER
-        static constexpr bool showingVUMeter = true;
-        #else
-        static constexpr bool showingVUMeter = false;
-        #endif
-
         const uint8_t xx = (x - (int)x) * 255, yy = (y - (int)y) * 255, ix = 255 - xx, iy = 255 - yy;
         const uint8_t wu[4] = {WU_WEIGHT(ix, iy), WU_WEIGHT(xx, iy), WU_WEIGHT(ix, yy), WU_WEIGHT(xx, yy)};
         for (uint8_t i = 0; i < 4; i++) {
@@ -148,7 +145,7 @@ private:
             const int yn = y + ((i >> 1) & 1);
 
             // Make sure we're on the panel and leave the VU meter pixels alone, if we're showing it
-            if (!g()->isValidPixel(xn, yn) || (showingVUMeter && yn == (MATRIX_HEIGHT - 1)))
+            if (!g()->isValidPixel(xn, yn) || (g_ptrSystem->EffectManager().IsVUVisible() && yn == (MATRIX_HEIGHT - 1)))
                 continue;
 
             CRGB clr = g()->leds[XY(xn, MATRIX_HEIGHT - 1 - yn)];

--- a/include/effects/matrix/PatternSMSupernova.h
+++ b/include/effects/matrix/PatternSMSupernova.h
@@ -137,6 +137,12 @@ private:
 
     void drawPixelXYF(float x, float y, CRGB color)
     {
+        #if SHOW_VU_METER
+        static constexpr bool showingVuMeter = true;
+        #else
+        static constexpr bool showingVuMeter = false;
+        #endif
+
         const uint8_t xx = (x - (int)x) * 255, yy = (y - (int)y) * 255, ix = 255 - xx, iy = 255 - yy;
         const uint8_t wu[4] = {WU_WEIGHT(ix, iy), WU_WEIGHT(xx, iy), WU_WEIGHT(ix, yy), WU_WEIGHT(xx, yy)};
         for (uint8_t i = 0; i < 4; i++) {
@@ -144,7 +150,7 @@ private:
             const int yn = y + ((i >> 1) & 1);
 
             // Make sure we're on the panel and leave the VU meter pixels alone, if we're showing it
-            if (!g()->isValidPixel(xn, yn) || (SHOW_VU_METER && yn == (MATRIX_HEIGHT - 1)))
+            if (!g()->isValidPixel(xn, yn) || (showingVuMeter && yn == (MATRIX_HEIGHT - 1)))
                 continue;
 
             CRGB clr = g()->leds[XY(xn, MATRIX_HEIGHT - 1 - yn)];


### PR DESCRIPTION
## Description

This fixes #510. The main change is that the effect makes a clean start every run, as it used to before #489 was merged. I've also:

- Cleaned up a few (more) things that didn't seem to serve any purpose.
- Reinstated the use of `g()->isValidPixel()` to check if we're using sane x and y values, and skipping the draw otherwise.
- Added a check that only avoids sampling VU meter pixels if we're actually showing it.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).