### PR TITLE
Fix crash on "large" configurations, especially on ESP32-S3.

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -102,6 +102,8 @@
 
 #include <Arduino.h>
 
+//  See https://github.com/PlummersSoftwareLLC/NightDriverStrip/issues/515
+#define FASTLED_ESP32_FLASH_LOCK 1
 #define FASTLED_INTERNAL 1               // Suppresses build banners
 #include <FastLED.h>
 


### PR DESCRIPTION
- Fix crash on "large" configurations, especially on ESP32-S3.

## Description
See  https://github.com/PlummersSoftwareLLC/NightDriverStrip/issues/515 for the (painful) details.

Fixes #515.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
