### PR TITLE
Fix Powder/PatternSMBlurringColors effect

### DIFF
--- a/include/effects/matrix/PatternSMBlurringColors.h
+++ b/include/effects/matrix/PatternSMBlurringColors.h
@@ -200,7 +200,15 @@ class PatternSMBlurringColors : public LEDStripEffect
                 // расстояния между 2мя соседними пикселями
 
         for (int i = 0; i < trackingOBJECT_MAX_COUNT; i++)
+        {
+            trackingObjectPosX[i] = 0;
+            trackingObjectPosY[i] = 0;
+            trackingObjectSpeedX[i] = 0;
+            trackingObjectSpeedY[i] = 0;
+            trackingObjectHue[i] = 0;
+            trackingObjectState[i] = 0;
             trackingObjectIsShift[i] = false;
+        }
 
         for (int j = 0; j < enlargedObjectNUM; j++)
         {


### PR DESCRIPTION
## Description

This fixes the Powder/`PatternSMBlurringColors` effect, which could get stuck with one color-fluctuating pixel in the lower-left corner of the matrix (technically the one pixel would "radiate" a little outwards, but who's looking that closely?)  
As with `PatternSMSupernova` before, the main issue seems to be that the effect needs to always start with an empty set of, in this case, `trackingObject...` arrays to ensure it has a usable working set of pixels to evolve. 

I note for the record that this effect would definitely benefit from an overall clean-up and OOP overhaul like the one that `PatternSMSupernova` received in #489. For the benefit of getting the effect to work the way it should as quickly as possible, in this PR I decided to focus purely on setting up the start-up conditions right.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).