### PR TITLE
Force-initialize class members to zero in SM effects.

### DIFF
--- a/include/effects/matrix/PatternSMFire2021.h
+++ b/include/effects/matrix/PatternSMFire2021.h
@@ -52,7 +52,7 @@ class PatternSMFire2021 : public LEDStripEffect
 
     uint8_t pcnt;              // какой-то счётчик какого-то прогресса
     uint8_t deltaValue;        // просто повторно используемая переменная
-    uint16_t ff_x, ff_y, ff_z; // большие счётчики
+    uint16_t ff_x {0} , ff_y {0} , ff_z {0} ; // большие счётчики
     uint8_t step; // какой-нибудь счётчик кадров или последовательностей операций
 
     const TProgmemRGBPalette16 *curPalette;

--- a/include/effects/matrix/PatternSMHolidayLights.h
+++ b/include/effects/matrix/PatternSMHolidayLights.h
@@ -13,7 +13,7 @@ class PatternSMHolidayLights : public LEDStripEffect
   private:
 
     static constexpr int speed = (200 / (MATRIX_HEIGHT - 4));
-    byte hue;
+    byte hue {0};
     byte effId = 2; // 1 - 3
 
     const byte maxDim = max(MATRIX_WIDTH, MATRIX_HEIGHT);
@@ -22,8 +22,8 @@ class PatternSMHolidayLights : public LEDStripEffect
     const byte height_adj = (MATRIX_HEIGHT < MATRIX_WIDTH ? (MATRIX_WIDTH - MATRIX_HEIGHT) / 2 : 0);
     const bool glitch = abs(MATRIX_WIDTH - MATRIX_HEIGHT) >= minDim / 4;
 
-    byte density = 50;     //
-    byte fadingSpeed = 10; //
+    byte density = 50;
+    byte fadingSpeed = 10;
     byte updateFromRGBWeight = 10;
     const byte scaleToNumLeds = NUM_LEDS / 256;
 

--- a/include/effects/matrix/PatternSMHypnosis.h
+++ b/include/effects/matrix/PatternSMHypnosis.h
@@ -41,7 +41,7 @@ class PatternSMHypnosis : public LEDStripEffect
     }
 
     uint16_t t = 0;
-    
+
     void Draw() override
     {
         t += 4;

--- a/include/effects/matrix/PatternSMNoise.h
+++ b/include/effects/matrix/PatternSMNoise.h
@@ -3,7 +3,7 @@
 #include "effectmanager.h"
 
 // Derived from https://editor.soulmatelights.com/gallery/1509-noise-palettes
-// Cycles through 17 effects if pallette noise, looking like a surreal topo.
+// Cycles through 17 effects of pallette noise, looking like a surreal topo.
 
 // Leave these as globals so they're kept in Flash.
 DEFINE_GRADIENT_PALETTE(temperature_gp){

--- a/include/effects/matrix/PatternSMPicasso3in1.h
+++ b/include/effects/matrix/PatternSMPicasso3in1.h
@@ -16,8 +16,7 @@ class PatternSMPicasso3in1 : public LEDStripEffect
                        // up. Scale -68 -2 == number of circles  *68=2, 69=3, 70=4, etc. 80
                        // up? SLOW
     static constexpr int trackingOBJECT_MAX_COUNT = 100U;
-    // максимальное количество отслеживаемых объектов (очень влияет на
-    // расход памяти)
+    // maximum number of tracked objects (greatly affects memory consumption)
     float trackingObjectPosX[trackingOBJECT_MAX_COUNT] {0};
     float trackingObjectPosY[trackingOBJECT_MAX_COUNT] {0};
     float trackingObjectSpeedX[trackingOBJECT_MAX_COUNT] {0};
@@ -27,11 +26,11 @@ class PatternSMPicasso3in1 : public LEDStripEffect
     uint8_t trackingObjectState[trackingOBJECT_MAX_COUNT] {0};
     bool trackingObjectIsShift[trackingOBJECT_MAX_COUNT] {0};
     static constexpr int enlargedOBJECT_MAX_COUNT = (MATRIX_WIDTH * 2);
-    // максимальное количество сложных отслеживаемых объектов
-    // (меньше, чем trackingOBJECT_MAX_COUNT)
+    // maximum number of complex tracked objects
+    // (less than trackingOBJECT_MAX_COUNT)
     uint8_t enlargedObjectNUM; // используемое в эффекте количество объектов
     long enlargedObjectTime[enlargedOBJECT_MAX_COUNT] {0};
-    int _scale{-1};
+    int _scale {-1};
 
     void PicassoGenerate(bool reset)
     {

--- a/include/effects/matrix/PatternSMRadialFire.h
+++ b/include/effects/matrix/PatternSMRadialFire.h
@@ -8,8 +8,8 @@ class PatternSMRadialFire : public LEDStripEffect
 {
   private:
 
-#define C_X (MATRIX_WIDTH / 2)
-#define C_Y (MATRIX_HEIGHT / 2)
+    static auto constexpr C_X = (MATRIX_WIDTH / 2);
+    static auto constexpr C_Y = (MATRIX_HEIGHT / 2);
     // BUGBUG: should probably be dynamically allocated into non-DMAable RAM.
     byte XY_angle[MATRIX_WIDTH][MATRIX_HEIGHT];
     byte XY_radius[MATRIX_WIDTH][MATRIX_HEIGHT];

--- a/include/effects/matrix/PatternSMRadialWave.h
+++ b/include/effects/matrix/PatternSMRadialWave.h
@@ -13,9 +13,9 @@ class PatternSMRadialWave : public LEDStripEffect
     // 22/05/22
 
     bool setupm = 1;
-    const uint8_t C_X = MATRIX_WIDTH / 2;
-    const uint8_t C_Y = MATRIX_HEIGHT / 2;
-    const uint8_t mapp = 255 / MATRIX_WIDTH;
+    static constexpr int8_t C_X = MATRIX_WIDTH / 2;
+    static constexpr int8_t C_Y = MATRIX_HEIGHT / 2;
+    static constexpr uint8_t mapp = 255 / MATRIX_WIDTH;
     // BUGBUG: should probably be allocated into slow RAM.
     struct
     {

--- a/include/effects/matrix/PatternSMRainbowTunnel.h
+++ b/include/effects/matrix/PatternSMRainbowTunnel.h
@@ -12,10 +12,9 @@ class PatternSMRainbowTunnel : public LEDStripEffect
     // Stepko and Sutaburosu
     // 23/12/21
 
-    bool setupm = 1;
-    const uint8_t C_X = MATRIX_WIDTH / 2;
-    const uint8_t C_Y = MATRIX_HEIGHT / 2;
-    const uint8_t mapp = 255 / MATRIX_WIDTH;
+    static constexpr uint8_t C_X = MATRIX_WIDTH / 2;
+    static constexpr uint8_t C_Y = MATRIX_HEIGHT / 2;
+    static constexpr uint8_t mapp = 255 / MATRIX_WIDTH;
 
     struct
     {

--- a/include/effects/matrix/PatternSMSmoke.h
+++ b/include/effects/matrix/PatternSMSmoke.h
@@ -7,14 +7,14 @@
 class PatternSMSmoke : public LEDStripEffect
 {
 private:
-  uint8_t Scale = 50; // 1-100. SettingA
+  static constexpr uint8_t Scale = 50; // 1-100. Setting
 
   static constexpr int WIDTH = MATRIX_WIDTH;
   static constexpr int HEIGHT = MATRIX_HEIGHT;
 
-  uint8_t hue, hue2;           // постепенный сдвиг оттенка или какой-нибудь другой
-                               // цикличный счётчик
-  uint8_t deltaHue, deltaHue2; // ещё пара таких же, когда нужно много
+  uint8_t hue {0}, hue2 {0};   // gradual shift in hue or some other
+                               // cyclic counter
+  uint8_t deltaHue {0}, deltaHue2 {0};
 
 public:
   PatternSMSmoke()

--- a/include/effects/matrix/PatternSMSpiroPulse.h
+++ b/include/effects/matrix/PatternSMSpiroPulse.h
@@ -12,15 +12,14 @@ class PatternSMSpiroPulse : public LEDStripEffect
   private:
     static constexpr int CenterX = ((MATRIX_WIDTH / 2) - 0.5);
     static constexpr int CenterY = ((MATRIX_HEIGHT / 2) - 0.5);
-    bool incenter;
-    byte AM = 1;
-    float Angle;
+    bool incenter {false};
+    byte AM {1};
+    float Angle {0.f};
     bool change = true;
 
     [[nodiscard]] CRGB getPixColorXY(uint8_t x, uint8_t y) const
     {
         return g()->leds[XY(x, MATRIX_HEIGHT - 1 - y)];
-        // return g()->leds[XY(x, y)];
     }
 
     void drawPixelXY(uint8_t x, int8_t y, CRGB color)
@@ -92,10 +91,10 @@ class PatternSMSpiroPulse : public LEDStripEffect
                 else if (AM >= (MATRIX_WIDTH + MATRIX_HEIGHT) / 2)
                     change = false;
             }
-            incenter = 1;
+            incenter = true;
         }
         else
-            incenter = 0;
+            incenter = false;
         // Originally /3. Let's go all the way to the edges.
         float radX = CalcRad * CenterY / 2;
         float radY = CalcRad * CenterY / 2;

--- a/include/effects/matrix/PatternSMStarDeep.h
+++ b/include/effects/matrix/PatternSMStarDeep.h
@@ -10,11 +10,8 @@ class PatternSMStarDeep : public LEDStripEffect
 {
   private:
 // Why are these named "bballs"? Probably reused effect innards.
-// const int bballsMaxNUM = 100U;  // the maximum number of tracked objects
-// (very affects memory consumption)
-#define bballsMaxNUM                                                                                                   \
-    100U // the maximum number of tracked objects (very affects memory
-         // consumption)
+   static constexpr int bballsMaxNUM = 100U; // the maximum number of tracked
+                                  // objects (very affects memory consumption)
     uint8_t bballsCOLOR[bballsMaxNUM]; // star color (reusing the Balls effect array)
     uint8_t bballsX[bballsMaxNUM];     // number of corners in the star (reusing the
                                        // Balls effect array
@@ -24,11 +21,11 @@ class PatternSMStarDeep : public LEDStripEffect
 
     float driftx, drifty;
     float cangle, sangle;
-    unsigned int counter; //, ringdelay;//, bringdelay, sumthum;
+    unsigned int counter { 0 };
     const TProgmemRGBPalette16 *curPalette = &PartyColors_p;
 
     const int STAR_BLENDER = 128U; // хз что это
-    const int CENTER_DRIFT_SPEED = 6U; // скорость перемещения плавающего центра возникновения звёзд
+    const int CENTER_DRIFT_SPEED = 6U; // speed of movement of the floating star emergence center
     const int WIDTH = MATRIX_WIDTH;
     const int HEIGHT = MATRIX_HEIGHT;
 

--- a/include/effects/matrix/PatternSMStrobeDiffusion.h
+++ b/include/effects/matrix/PatternSMStrobeDiffusion.h
@@ -20,8 +20,7 @@ class PatternSMStrobeDiffusion : public LEDStripEffect
 {
   private:
     uint8_t hue, hue2; // gradual hue shift or some other cyclic counter
-    uint8_t deltaHue;
-    uint8_t step; // some counter of frames or sequences of operations
+    uint8_t step { 0 }; // some counter of frames or sequences of operations
     std::bitset<MATRIX_WIDTH * MATRIX_HEIGHT> noise3d[MATRIX_WIDTH * MATRIX_HEIGHT]; // Locations of snowflakes.
     uint8_t Speed = 150;                                                             // 1-255 is speed
     uint8_t Scale = 90;                                                              // 1-100 is something parameter
@@ -159,7 +158,7 @@ class PatternSMStrobeDiffusion : public LEDStripEffect
         // Much of this could be calls to lineDraw() but maybe being able to do
         // both ends while iterating through the loop is a win.
         const uint8_t rows = (MATRIX_HEIGHT + 1) / 3U;
-        deltaHue = floor(Speed / 64) * 64;
+        uint8_t deltaHue = floor(Speed / 64) * 64;
         bool dir = false;
         for (uint8_t y = 0; y < rows; y++)
         {


### PR DESCRIPTION
Force initialization of anything in the SM patterns to zero.

## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
