### PR TITLE
Add persisted "show VU" setting to web UI

### DIFF
--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -74,9 +74,7 @@ class DeviceConfig : public IJSONSerializable
     String  ntpServer = NTP_SERVER_DEFAULT;
     bool    rememberCurrentEffect = true;
     int     powerLimit = POWER_LIMIT_DEFAULT;
-    #if SHOW_VU_METER
     bool    showVUMeter = true;
-    #endif
     uint8_t brightness = BRIGHTNESS_MAX;
     CRGB    globalColor = CRGB::Red;
     bool    applyGlobalColors = false;
@@ -125,9 +123,7 @@ class DeviceConfig : public IJSONSerializable
     static constexpr const char * RememberCurrentEffectTag = NAME_OF(rememberCurrentEffect);
     static constexpr const char * PowerLimitTag = NAME_OF(powerLimit);
     static constexpr const char * BrightnessTag = NAME_OF(brightness);
-    #if SHOW_VU_METER
     static constexpr const char * ShowVUMeterTag = NAME_OF(showVUMeter);
-    #endif
     static constexpr const char * ClearGlobalColorTag = "clearGlobalColor";
     static constexpr const char * GlobalColorTag = NAME_OF(globalColor);
     static constexpr const char * ApplyGlobalColorsTag = NAME_OF(applyGlobalColors);
@@ -155,6 +151,7 @@ class DeviceConfig : public IJSONSerializable
         jsonDoc[NTPServerTag] = ntpServer;
         jsonDoc[RememberCurrentEffectTag] = rememberCurrentEffect;
         jsonDoc[PowerLimitTag] = powerLimit;
+        // Only serialize showVUMeter if it's enabled in the build
         #if SHOW_VU_METER
         jsonDoc[ShowVUMeterTag] = showVUMeter;
         #endif
@@ -190,6 +187,7 @@ class DeviceConfig : public IJSONSerializable
         SetIfPresentIn(jsonObject, rememberCurrentEffect, RememberCurrentEffectTag);
         SetIfPresentIn(jsonObject, powerLimit, PowerLimitTag);
         SetIfPresentIn(jsonObject, brightness, BrightnessTag);
+        // Only deserialize showVUMeter if it's enabled in the build
         #if SHOW_VU_METER
         SetIfPresentIn(jsonObject, showVUMeter, ShowVUMeterTag);
         #endif
@@ -296,6 +294,7 @@ class DeviceConfig : public IJSONSerializable
                 BRIGHTNESS_MAX
             ).HasValidation = true;
 
+            // Only publish the VU meter setting if it's enabled in the build
             #if SHOW_VU_METER
             settingSpecs.emplace_back(
                 ShowVUMeterTag,
@@ -470,7 +469,6 @@ class DeviceConfig : public IJSONSerializable
         SetAndSave(brightness, uint8_t(std::clamp<int>(newBrightness, BRIGHTNESS_MIN, BRIGHTNESS_MAX)));
     }
 
-    #if SHOW_VU_METER
     bool ShowVUMeter() const
     {
         return showVUMeter;
@@ -478,9 +476,13 @@ class DeviceConfig : public IJSONSerializable
 
     void SetShowVUMeter(bool newShowVUMeter)
     {
+        // We only actually persist if the VU meter is enabled in the build
+        #if SHOW_VU_METER
         SetAndSave(showVUMeter, newShowVUMeter);
+        #else
+        showVUMeter = newShowVUMeter;
+        #endif
     }
-    #endif
 
     int GetPowerLimit() const
     {

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -123,7 +123,10 @@ class DeviceConfig : public IJSONSerializable
     static constexpr const char * RememberCurrentEffectTag = NAME_OF(rememberCurrentEffect);
     static constexpr const char * PowerLimitTag = NAME_OF(powerLimit);
     static constexpr const char * BrightnessTag = NAME_OF(brightness);
+    // No need to publish the show VU meter tag unless we're also publishing the setting
+    #if SHOW_VU_METER
     static constexpr const char * ShowVUMeterTag = NAME_OF(showVUMeter);
+    #endif
     static constexpr const char * ClearGlobalColorTag = "clearGlobalColor";
     static constexpr const char * GlobalColorTag = NAME_OF(globalColor);
     static constexpr const char * ApplyGlobalColorsTag = NAME_OF(applyGlobalColors);
@@ -140,7 +143,7 @@ class DeviceConfig : public IJSONSerializable
     {
         AllocatedJsonDocument jsonDoc(_jsonSize);
 
-        // Add serialization logic for additionl settings to this code
+        // Add serialization logic for additional settings to this code
         jsonDoc[HostnameTag] = hostname;
         jsonDoc[LocationTag] = location;
         jsonDoc[LocationIsZipTag] = locationIsZip;
@@ -151,7 +154,7 @@ class DeviceConfig : public IJSONSerializable
         jsonDoc[NTPServerTag] = ntpServer;
         jsonDoc[RememberCurrentEffectTag] = rememberCurrentEffect;
         jsonDoc[PowerLimitTag] = powerLimit;
-        // Only serialize showVUMeter if it's enabled in the build
+        // Only serialize showVUMeter if the VU meter is enabled in the build
         #if SHOW_VU_METER
         jsonDoc[ShowVUMeterTag] = showVUMeter;
         #endif
@@ -187,7 +190,7 @@ class DeviceConfig : public IJSONSerializable
         SetIfPresentIn(jsonObject, rememberCurrentEffect, RememberCurrentEffectTag);
         SetIfPresentIn(jsonObject, powerLimit, PowerLimitTag);
         SetIfPresentIn(jsonObject, brightness, BrightnessTag);
-        // Only deserialize showVUMeter if it's enabled in the build
+        // Only deserialize showVUMeter if the VU meter is enabled in the build
         #if SHOW_VU_METER
         SetIfPresentIn(jsonObject, showVUMeter, ShowVUMeterTag);
         #endif
@@ -263,13 +266,13 @@ class DeviceConfig : public IJSONSerializable
             settingSpecs.emplace_back(
                 Use24HourClockTag,
                 "Use 24 hour clock",
-                "A boolean that indicates if time should be shown in 24-hour format (yes if checked) or 12-hour AM/PM format.",
+                "Indicates if time should be shown in 24-hour format (yes if checked) or 12-hour AM/PM format.",
                 SettingSpec::SettingType::Boolean
             );
             settingSpecs.emplace_back(
                 UseCelsiusTag,
                 "Use degrees Celsius",
-                "A boolean that indicates if temperatures should be shown in degrees Celsius (yes if checked) or degrees Fahrenheit.",
+                "Indicates if temperatures should be shown in degrees Celsius (yes if checked) or degrees Fahrenheit.",
                 SettingSpec::SettingType::Boolean
             );
             settingSpecs.emplace_back(
@@ -281,7 +284,7 @@ class DeviceConfig : public IJSONSerializable
             settingSpecs.emplace_back(
                 RememberCurrentEffectTag,
                 "Remember current effect",
-                "A boolean that indicates if the current effect index should be saved after an effect transition, so the device resumes "
+                "Indicates if the current effect index should be saved after an effect transition, so the device resumes "
                 "from the same effect when restarted. Enabling this will lead to more wear on the flash chip of your device.",
                 SettingSpec::SettingType::Boolean
             );
@@ -294,7 +297,7 @@ class DeviceConfig : public IJSONSerializable
                 BRIGHTNESS_MAX
             ).HasValidation = true;
 
-            // Only publish the VU meter setting if it's enabled in the build
+            // Only publish the VU meter setting if the VU meter is enabled in the build
             #if SHOW_VU_METER
             settingSpecs.emplace_back(
                 ShowVUMeterTag,

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -74,6 +74,9 @@ class DeviceConfig : public IJSONSerializable
     String  ntpServer = NTP_SERVER_DEFAULT;
     bool    rememberCurrentEffect = true;
     int     powerLimit = POWER_LIMIT_DEFAULT;
+    #if SHOW_VU_METER
+    bool    showVUMeter = true;
+    #endif
     uint8_t brightness = BRIGHTNESS_MAX;
     CRGB    globalColor = CRGB::Red;
     bool    applyGlobalColors = false;
@@ -122,6 +125,9 @@ class DeviceConfig : public IJSONSerializable
     static constexpr const char * RememberCurrentEffectTag = NAME_OF(rememberCurrentEffect);
     static constexpr const char * PowerLimitTag = NAME_OF(powerLimit);
     static constexpr const char * BrightnessTag = NAME_OF(brightness);
+    #if SHOW_VU_METER
+    static constexpr const char * ShowVUMeterTag = NAME_OF(showVUMeter);
+    #endif
     static constexpr const char * ClearGlobalColorTag = "clearGlobalColor";
     static constexpr const char * GlobalColorTag = NAME_OF(globalColor);
     static constexpr const char * ApplyGlobalColorsTag = NAME_OF(applyGlobalColors);
@@ -149,6 +155,9 @@ class DeviceConfig : public IJSONSerializable
         jsonDoc[NTPServerTag] = ntpServer;
         jsonDoc[RememberCurrentEffectTag] = rememberCurrentEffect;
         jsonDoc[PowerLimitTag] = powerLimit;
+        #if SHOW_VU_METER
+        jsonDoc[ShowVUMeterTag] = showVUMeter;
+        #endif
         jsonDoc[BrightnessTag] = brightness;
         jsonDoc[GlobalColorTag] = globalColor;
         jsonDoc[ApplyGlobalColorsTag] = applyGlobalColors;
@@ -181,6 +190,9 @@ class DeviceConfig : public IJSONSerializable
         SetIfPresentIn(jsonObject, rememberCurrentEffect, RememberCurrentEffectTag);
         SetIfPresentIn(jsonObject, powerLimit, PowerLimitTag);
         SetIfPresentIn(jsonObject, brightness, BrightnessTag);
+        #if SHOW_VU_METER
+        SetIfPresentIn(jsonObject, showVUMeter, ShowVUMeterTag);
+        #endif
         SetIfPresentIn(jsonObject, globalColor, GlobalColorTag);
         SetIfPresentIn(jsonObject, applyGlobalColors, ApplyGlobalColorsTag);
         SetIfPresentIn(jsonObject, secondColor, SecondColorTag);
@@ -283,6 +295,15 @@ class DeviceConfig : public IJSONSerializable
                 BRIGHTNESS_MIN,
                 BRIGHTNESS_MAX
             ).HasValidation = true;
+
+            #if SHOW_VU_METER
+            settingSpecs.emplace_back(
+                ShowVUMeterTag,
+                "Show VU meter",
+                "Used to show (checked) or hide the VU meter at the top of the matrix.",
+                SettingSpec::SettingType::Boolean
+            );
+            #endif
 
             auto& powerLimitSpec = settingSpecs.emplace_back(
                 PowerLimitTag,
@@ -448,6 +469,18 @@ class DeviceConfig : public IJSONSerializable
     {
         SetAndSave(brightness, uint8_t(std::clamp<int>(newBrightness, BRIGHTNESS_MIN, BRIGHTNESS_MAX)));
     }
+
+    #if SHOW_VU_METER
+    bool ShowVUMeter() const
+    {
+        return showVUMeter;
+    }
+
+    void SetShowVUMeter(bool newShowVUMeter)
+    {
+        SetAndSave(showVUMeter, newShowVUMeter);
+    }
+    #endif
 
     int GetPowerLimit() const
     {

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -293,24 +293,8 @@ public:
     }
 
     // ShowVU - Control whether VU meter should be draw.  Returns the previous state when set.
-
-    virtual bool ShowVU(bool bShow)
-    {
-        bool bResult = _bShowVU;
-        debugI("Setting ShowVU to %d\n", bShow);
-        _bShowVU = bShow;
-
-        // Erase any exising pixels since effects don't all clear each frame
-        if (!bShow)
-            _gfx[0]->setPixelsF(0, MATRIX_WIDTH, CRGB::Black);
-
-        return bResult;
-    }
-
-    virtual bool IsVUVisible() const
-    {
-        return _bShowVU && GetCurrentEffect().CanDisplayVUMeter();
-    }
+    virtual bool ShowVU(bool bShow);
+    virtual bool IsVUVisible() const;
 
     // ApplyGlobalColor
     //
@@ -321,7 +305,7 @@ public:
     void ApplyGlobalPaletteColors();
 
     void ClearRemoteColor(bool retainRemoteEffect = false);
-    
+
     void StartEffect()
     {
         // If there's a temporary effect override from the remote control active, we start that, else

--- a/platformio.ini
+++ b/platformio.ini
@@ -500,7 +500,8 @@ debug_tool      = ftdi
 
 [env:mesmerizer_lolin]
 extends         = dev_lolin_d32_pro
-build_flags     = -Ofast
+build_flags     = -DSHOW_VU_METER=1
+                  -Ofast
                   ${mesmerizer_config.build_flags}
                   ${dev_lolin_d32_pro.build_flags}
 lib_deps        = ${dev_lolin_d32_pro.lib_deps}

--- a/platformio.ini
+++ b/platformio.ini
@@ -258,6 +258,7 @@ board_build.embed_txtfiles = config/timezones.json
 [mesmerizer_config]
 build_flags     = -DMESMERIZER=1
                   -DUSE_HUB75=1
+                  -DSHOW_VU_METER=1
                   ${psram_flags.build_flags}
                   ${remote_flags.build_flags}
 lib_deps        = https://github.com/PlummersSoftwareLLC/SmartMatrix.git
@@ -489,8 +490,7 @@ board_build.partitions = config/partitions_custom_noota.csv
 
 [env:mesmerizer]
 extends         = dev_mesmerizer
-build_flags     = -DSHOW_VU_METER=1
-                  -O3
+build_flags     = -O3
                   ${mesmerizer_config.build_flags}
                   ${dev_mesmerizer.build_flags}
 lib_deps        = ${dev_mesmerizer.lib_deps}
@@ -500,8 +500,7 @@ debug_tool      = ftdi
 
 [env:mesmerizer_lolin]
 extends         = dev_lolin_d32_pro
-build_flags     = -DSHOW_VU_METER=1
-                  -Ofast
+build_flags     = -Ofast
                   ${mesmerizer_config.build_flags}
                   ${dev_lolin_d32_pro.build_flags}
 lib_deps        = ${dev_lolin_d32_pro.lib_deps}

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -345,6 +345,26 @@ bool EffectManager::Init()
     return true;
 }
 
+bool EffectManager::ShowVU(bool bShow)
+{
+    auto& deviceConfig = g_ptrSystem->DeviceConfig();
+    bool bResult = deviceConfig.ShowVUMeter();
+    debugI("Setting ShowVU to %d\n", bShow);
+    deviceConfig.SetShowVUMeter(bShow);
+
+    // Erase any exising pixels since effects don't all clear each frame
+    if (!bShow)
+        _gfx[0]->setPixelsF(0, MATRIX_WIDTH, CRGB::Black);
+
+    return bResult;
+}
+
+bool EffectManager::IsVUVisible() const
+{
+    return g_ptrSystem->DeviceConfig().ShowVUMeter() && GetCurrentEffect().CanDisplayVUMeter();
+}
+
+
 void EffectManager::ClearRemoteColor(bool retainRemoteEffect)
 {
     if (!retainRemoteEffect)

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -502,8 +502,9 @@ void CWebServer::GetSettings(AsyncWebServerRequest * pRequest)
 void CWebServer::SetSettingsIfPresent(AsyncWebServerRequest * pRequest)
 {
     auto& deviceConfig = g_ptrSystem->DeviceConfig();
+    auto& effectManager = g_ptrSystem->EffectManager();
 
-    PushPostParamIfPresent<size_t>(pRequest,"effectInterval", SET_VALUE(g_ptrSystem->EffectManager().SetInterval(value)));
+    PushPostParamIfPresent<size_t>(pRequest,"effectInterval", SET_VALUE(effectManager.SetInterval(value)));
     PushPostParamIfPresent<String>(pRequest, DeviceConfig::HostnameTag, SET_VALUE(deviceConfig.SetHostname(value)));
     PushPostParamIfPresent<String>(pRequest, DeviceConfig::LocationTag, SET_VALUE(deviceConfig.SetLocation(value)));
     PushPostParamIfPresent<bool>(pRequest, DeviceConfig::LocationIsZipTag, SET_VALUE(deviceConfig.SetLocationIsZip(value)));
@@ -518,7 +519,7 @@ void CWebServer::SetSettingsIfPresent(AsyncWebServerRequest * pRequest)
     PushPostParamIfPresent<int>(pRequest, DeviceConfig::BrightnessTag, SET_VALUE(deviceConfig.SetBrightness(value)));
 
     #if SHOW_VU_METER
-    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::ShowVUMeterTag, SET_VALUE(deviceConfig.SetShowVUMeter(value)));
+    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::ShowVUMeterTag, SET_VALUE(effectManager.ShowVU(value)));
     #endif
 
     std::optional<CRGB> globalColor = {};

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -517,6 +517,10 @@ void CWebServer::SetSettingsIfPresent(AsyncWebServerRequest * pRequest)
     PushPostParamIfPresent<int>(pRequest, DeviceConfig::PowerLimitTag, SET_VALUE(deviceConfig.SetPowerLimit(value)));
     PushPostParamIfPresent<int>(pRequest, DeviceConfig::BrightnessTag, SET_VALUE(deviceConfig.SetBrightness(value)));
 
+    #if SHOW_VU_METER
+    PushPostParamIfPresent<bool>(pRequest, DeviceConfig::ShowVUMeterTag, SET_VALUE(deviceConfig.SetShowVUMeter(value)));
+    #endif
+
     std::optional<CRGB> globalColor = {};
     std::optional<CRGB> secondColor = {};
 


### PR DESCRIPTION
## Description

This adds a persisted device setting for showing or hiding the VU meter on matrix/audio builds, and exposes it via the web UI. This was suggested in #523, and mentioned in (an) earlier discussion(s). For completeness, the `SHOW_VU_METER` build flag is _not_ removed; the existing feature to toggle the VU meter via the IR remote control is now also available via the web UI and persisted across reboots.

In line with the original implementation in EffectManager, the show VU meter toggle can be (un)set without `SHOW_VU_METER` being defined, but persisting and publishing/showing it in the web UI only happens with that flag set.

Furthermore, `SHOW_VU_METER` is now also defined for the `mesmerizer_lolin` env in platformio.ini.

Tested on Mesmerizer.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).