### PR TITLE
Remove tear/pepper in fire from SMSmoke

### DIFF
--- a/include/effects/matrix/PatternSMSmoke.h
+++ b/include/effects/matrix/PatternSMSmoke.h
@@ -64,18 +64,12 @@ public:
     // Two diagonal (note Y is used for height AND X offset)
     // "wipers", of different colors. Each leaves a
     // sky-written trailer of color.
-    // slew is used to make the lines look less mathematically diagonal
-    // and introduce some delay between color1 and color2. This gives a
-    // "tear" in the refresh and as a bonus, gives some 'pepper in fire'
-    // effect to he colors which gets quickly blended.
     for (uint8_t y = 0; y < HEIGHT; y++)
     {
-      uint8_t slew = random8(8) - 8/2 + 1;
-      uint8_t slew2 = random8(8) - 8/2 + 1;
-      g()->leds[XY((deltaHue + y + slew + 1U) % WIDTH, HEIGHT - 1U - y)] += color;
-      g()->leds[XY((deltaHue + y + slew2) % WIDTH, HEIGHT - 1U - y)] += color2; // color2
-      g()->leds[XY((deltaHue2 + y + slew2) % WIDTH, y)] += color;
-      g()->leds[XY((deltaHue2 + y + slew + 1U) % WIDTH, y)] += color2; // color2
+      g()->leds[XY((deltaHue + y + 1U) % WIDTH, HEIGHT - 1U - y)] += color;
+      g()->leds[XY((deltaHue + y) % WIDTH, HEIGHT - 1U - y)] += color2; // color2
+      g()->leds[XY((deltaHue2 + y) % WIDTH, y)] += color;
+      g()->leds[XY((deltaHue2 + y + 1U) % WIDTH, y)] += color2; // color2
     }
 
     EVERY_N_MILLISECONDS(100)


### PR DESCRIPTION
## Description

This updates the SMSmoke effect to remove the tear/"pepper in fire" that was added in #450. As such, fixes #486.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).