### PR TITLE
Tweaked ColorFillEffect to optionally ignore global color

### DIFF
--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -214,7 +214,7 @@ protected:
 //
 // Fills the pixels with a single color.
 // everyNth can be used to light some pixels with specified color, leaving the others unlit.
-// Unless a user chooses to ignor the global color, the glboal color will be used instead when
+// Unless a user chooses to ignore the global color, the global color will be used instead when
 // DeviceConfig().ApplyGlobalColors() returns true.
 
 class ColorFillEffect : public LEDStripEffect
@@ -267,7 +267,7 @@ protected:
     {
         if (_everyNth != 1)
           fillSolidOnAllChannels(CRGB::Black);
-        if (_ignoreGlobalColor == false && g_ptrSystem->DeviceConfig().ApplyGlobalColors() == true)
+        if (!_ignoreGlobalColor && g_ptrSystem->DeviceConfig().ApplyGlobalColors() == true)
           fillSolidOnAllChannels(g_ptrSystem->DeviceConfig().GlobalColor(), 0, NUM_LEDS, _everyNth);
         else
           fillSolidOnAllChannels(_color, 0, NUM_LEDS, _everyNth);

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -267,7 +267,7 @@ protected:
     {
         if (_everyNth != 1)
           fillSolidOnAllChannels(CRGB::Black);
-        if (!_ignoreGlobalColor && g_ptrSystem->DeviceConfig().ApplyGlobalColors() == true)
+        if (!_ignoreGlobalColor && g_ptrSystem->DeviceConfig().ApplyGlobalColors())
           fillSolidOnAllChannels(g_ptrSystem->DeviceConfig().GlobalColor(), 0, NUM_LEDS, _everyNth);
         else
           fillSolidOnAllChannels(_color, 0, NUM_LEDS, _everyNth);


### PR DESCRIPTION
Tweaked ColorFillEffect to optionally ignore global color

## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->
Instead of creating a new color fill effect that ignores the global color, I tweaked the existing effect to optionally ignore.
I also updated the label comment for the effect since it was wrong.

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).