### PR TITLE
Feature/weather fix tomorrow temps

### DIFF
--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -293,7 +293,7 @@ private:
         }
         else
         {
-            debugW("Error fetching forecast data for location: %s in country: %s", strLocation.c_str(), strCountryCode.c_str());
+            debugE("Error fetching forecast data for location: %s in country: %s", strLocation.c_str(), strCountryCode.c_str());
             http.end();
             return false;
         }
@@ -337,7 +337,7 @@ private:
         }
         else
         {
-            debugW("Error fetching Weather data for location: %s in country: %s", strLocation.c_str(), strCountryCode.c_str());
+            debugE("Error fetching Weather data for location: %s in country: %s", strLocation.c_str(), strCountryCode.c_str());
             http.end();
             return false;
         }
@@ -354,15 +354,7 @@ private:
         updateCoordinates();
 
         if (getWeatherData())
-        {
-            debugI("Got today's weather");
-            if (getTomorrowTemps(highTomorrow, loTomorrow))
-                debugI("Got tomorrow's weather");
-            else
-                debugW("Failed to get tomorrow's weather");
-        }
-        else
-            debugW("Failed to get today's weather");
+            getTomorrowTemps(highTomorrow, loTomorrow);
     }
 
     bool HasLocationChanged()

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -49,7 +49,10 @@
 #include "effects.h"
 #include "types.h"
 
-#define WEATHER_INTERVAL_SECONDS std::chrono::seconds{(10*60)}
+using namespace std::chrono;
+using namespace std::chrono_literals;
+
+#define WEATHER_INTERVAL_SECONDS 600s
 #define WEATHER_CHECK_WIFI_WAIT 5000
 
 extern const uint8_t brokenclouds_start[]           asm("_binary_assets_bmp_brokenclouds_jpg_start");
@@ -134,7 +137,7 @@ private:
 
     bool   dataReady          = false;
     size_t readerIndex = std::numeric_limits<size_t>::max();
-    std::chrono::system_clock::time_point latestUpdate = std::chrono::system_clock::from_time_t(0);
+    system_clock::time_point latestUpdate = system_clock::from_time_t(0);
 
     // The weather is obviously weather, and we don't want text overlaid on top of our text
 
@@ -235,8 +238,8 @@ private:
             JsonArray list = doc["list"];
 
             // Get tomorrow's date
-            auto tomorrow = std::chrono::system_clock::now() + std::chrono::hours{24};
-            auto tomorrow_timet = std::chrono::system_clock::to_time_t(tomorrow);
+            auto tomorrow = system_clock::now() + hours{24};
+            auto tomorrow_timet = system_clock::to_time_t(tomorrow);
             auto tomorrowTime = localtime(&tomorrow_timet);
             char dateStr[11];
             strftime(dateStr, sizeof(dateStr), "%Y-%m-%d", tomorrowTime);
@@ -406,13 +409,13 @@ public:
 
         g()->setFont(&Apple5x7);
 
-        auto now = std::chrono::system_clock::now();
+        auto now = system_clock::now();
 
         auto secondsSinceLastUpdate = now - latestUpdate;
 
         // If location and/or country have changed, trigger an update regardless of timer, but
         // not more than once every half a minute
-        if (secondsSinceLastUpdate >= WEATHER_INTERVAL_SECONDS || (HasLocationChanged() && secondsSinceLastUpdate >= std::chrono::seconds{30}))
+        if (secondsSinceLastUpdate >= WEATHER_INTERVAL_SECONDS || (HasLocationChanged() && secondsSinceLastUpdate >= 30s))
         {
             latestUpdate = now;
 

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -269,8 +269,7 @@ private:
 
                     // Identify the maximum of the 3 hour maximum temperature
                     float entryMaximum = main["temp_max"];
-                    if (entryMaximum > 0)
-                        dailyMaximum = std::max(dailyMaximum, entryMaximum);
+                    dailyMaximum = std::max(dailyMaximum, entryMaximum);
 
                     // Identify the minimum of the 3 hour mimimum temperatures
                     float entryMinimum = main["temp_min"];


### PR DESCRIPTION
## Description
This addresses a technical debt found in Issue [256](https://github.com/PlummersSoftwareLLC/NightDriverStrip/issues/256). 
Specifically:
- the tomorrow temperature range was not being correctly captured.  Neither was the weather icon for the day.
- several debug messages were improperly typed as warning or information
- all system time related code has been refactored to use std::chrono

Future work may include incorporating the new format libraries once the migration to C++ 20 is complete.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).