### PR TITLE
Centralize port numbers in source

### DIFF
--- a/include/network.h
+++ b/include/network.h
@@ -33,6 +33,18 @@
     #include "socketserver.h"
 #endif
 
+    // For now, just a centralized location for the port numbers for our
+    // various services. Someday these might be configurable.
+    // This could be an enum class, but the static_cast<int> at the
+    // callers is ugly.
+    enum NetworkPort
+    {
+      ColorServer  = 12000,
+      IncomingWiFi  = 49152,
+      VICESocketServer = 25232,
+      Webserver  = 80
+    };
+
 #if ENABLE_WIFI
     enum class WiFiConnectResult
     {

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -50,8 +50,9 @@
 #include <ArduinoJson.h>
 #include <HTTPClient.h>
 #include "deviceconfig.h"
-#include "jsonbase.h"
 #include "effects.h"
+#include "jsonbase.h"
+#include "network.h"
 
 class CWebServer
 {
@@ -202,7 +203,7 @@ class CWebServer
   public:
 
     CWebServer()
-        : _server(80), _staticStats()
+        : _server(NetworkPort::Webserver), _staticStats()
     {}
 
     // begin - register page load handlers and start serving pages

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -36,6 +36,10 @@
 #include <esp_task_wdt.h>
 #include "soundanalyzer.h"
 
+#if ENABLE_VICE_SERVER
+#include "network.h"
+#endif
+
 // AudioSamplerTaskEntry
 // A background task that samples audio, computes the VU, stores it for effect use, etc.
 
@@ -224,14 +228,14 @@ void IRAM_ATTR AudioSerialTaskEntry(void *)
     SoundAnalyzer Analyzer;
 
 #if ENABLE_VICE_SERVER
-    VICESocketServer socketServer(25232);
+    VICESocketServer socketServer(NetworkPort::VICESocketServer);
     if (!socketServer.begin())
     {
-        debugE("Unable to start socket server for VICE!");
+        debugE("Unable to start socket server on port %u for VICE!", NetworkPort::VICESocketServer);
     }
     else
     {
-        debugW("Started socket server for VICE!");
+        debugW("Started socket server for VICE on port %u!", NetworkPort::VICESocketServer);
     }
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -371,7 +371,7 @@ void setup()
     #endif
 
     #if INCOMING_WIFI_ENABLED
-        g_ptrSystem->SetupSocketServer(49152, NUM_LEDS);  // $C000 is free RAM on the C64, fwiw!
+        g_ptrSystem->SetupSocketServer(NetworkPort::IncomingWiFi, NUM_LEDS);  // $C000 is free RAM on the C64, fwiw!
     #endif
 
     #if ENABLE_WIFI && ENABLE_WEBSERVER

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -639,11 +639,11 @@ bool WriteWiFiConfig(const String& WiFi_ssid, const String& WiFi_password)
 #if COLORDATA_SERVER_ENABLED
     // ColorDataTaskEntry
     //
-    // The thread which serves requests for color data on port 49153
-    
+    // The thread which serves requests for color data.
+
     void IRAM_ATTR ColorDataTaskEntry(void *)
     {
-        LEDViewer _viewer(12000);
+        LEDViewer _viewer(NetworkPort::ColorServer);
         int socket = -1;
 
         for(;;)


### PR DESCRIPTION
Instead of scattering port numbers in source, headers, or macros, we
stuff them into one grep-able enum.

Tested:
Touch test on (out-of-tree) Demo project with webserver, debugger turned on.
Successful buddybuild
Not tested:
Commodore pet rock. (Wat!?!)

## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
