### PR TITLE
Bump to C++2a

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -32,8 +32,8 @@ upload_port     =
 monitor_port    =
 build_type      = release
 upload_speed    = 1500000
-build_flags     = -std=gnu++17
-                  -Dregister=                       ; Sinister: redefine 'register' so FastLED can use that keyword under C++17
+build_flags     = -std=gnu++2a
+                  -Dregister=                       ; Sinister: redefine 'register' so FastLED can use that keyword under C++17 and later
                   -g3
                   -Os
                   -ffunction-sections


### PR DESCRIPTION
## Description
Moves the roof of C++ support from C++17 to C++2a.

TLDR: Change the language and library policy from "<= GNU++17" to
"if it's supported by the provided toolchain, you can use it."

This obviously the minimal patch to allow for with, with the underlying
requirement having been previously chipped away for a while. Since this
one-liner takes 2+ hour of machine compile-time, it seems worth throwing
it into the next integration cycle.

Additional changes that actually allow use of C++20 and 23, as allowed by
GCC and Libg++ until the underlying ESP-IDF brings in even more, to come.

It's not my intention to go nuts replacing everything with modules and such,
but I would like toke advantage of std::format (not in our libg++
yet), ranges (a very natural way to express effects), concepts (better
template error message) and variadic templates (hello, str_sprintf),
span and view (pointer, length tuples, strongly supported by the libraries)
std::chrono to replace the awful C-era time functions,

We, of course, remain limited to what ESP-IDF gives us...which is annoyingly
behind the times but not drastically so. GCC 14 is currently in stabilization
branch and we're on 12.2, so a littel over a year behind, but enough for
std::format to be on on the wrong side of the split.

I decided to to go for '2a' isntead of '20' because the current G++ is
so old it doesn't understand "23" (for good reasons) of 23 that we can
use today (#elifdef, #elifndef, std::to_underlying, more constexpr 
(like unique_ptr) that are nice.


Tested:
Successful buddybuid.
[ ... ] 
Wrote 0x19f770 bytes to file ~/.pio/build/xmastrees/merged_image.bin, ready to flash to offset 0x0
======================== [SUCCESS] Took 135.78 seconds ========================

Environment    Status    Duration
-------------  --------  ------------
xmastrees      SUCCESS   00:02:15.784
========================= 1 succeeded in 00:02:15.784 =========================

As this is a policy change I consider it a worthy expemption for
blinkenbits because it opens the door for programmer producivity in
not havign to restrain ourselves to old practices.


<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
