### PR TITLE
Make secrets.h more immune to changes from secrets.example.h

### DIFF
--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -35,9 +35,12 @@
 #include <tuple>
 #include <algorithm>
 #include "jsonserializer.h"
+#include "types.h"
+
+// Make sure we have a secrets.h and that it contains everything we need.
 
 #if !__has_include("secrets.h")
-#error Copy include/secrets-example.h to include/secrets.h, edit to taste, and retry. Please see README.md
+#error Copy include/secrets.example.h to include/secrets.h, edit to taste, and retry. Please see README.md.
 #endif
 
 #include "secrets.h"
@@ -47,7 +50,7 @@
 #endif
 
 #if !defined(cszPassword)
-#error A definition for cszSSID is missing from secrets.h
+#error A definition for cszPassword is missing from secrets.h
 #endif
 
 #if !defined(cszHostname)
@@ -94,8 +97,9 @@
 //    (in deviceconfig.cpp)
 // 5. Adding (de)serialization logic for the setting to the SerializeToJSON()/DeserializeFromJSON() methods
 // 6. Adding a Get/Set method for the setting (and, where applicable, their implementation in deviceconfig.cpp)
-// 7. If you've added an entry to secrets.example.h add a test at the top of this file to confirm that the new #defines were found. This prevents drift when developers have an existing tree and don't know to refresh their modified version of secrets.h
-
+// 7. If you've added an entry to secrets.example.h to define a default value for your setting then add a
+//    test at the top of this file to confirm that the new #define is found. This prevents drift when users
+//    have an existing tree and don't know to refresh their modified version of secrets.h.
 //
 // For the first 5 points, a comment has been added to the respective place in the existing code.
 // Generally speaking, one will also want to add logic to the webserver to retrieve and set the setting.

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -35,7 +35,45 @@
 #include <tuple>
 #include <algorithm>
 #include "jsonserializer.h"
+
+#if !__has_include("secrets.h")
+#error Copy include/secrets-example.h to include/secrets.h, edit to taste, and retry. Please see README.md
+#endif
+
 #include "secrets.h"
+
+#if !defined(cszSSID)
+#error A definition for cszSSID is missing from secrets.h
+#endif
+
+#if !defined(cszPassword)
+#error A definition for cszSSID is missing from secrets.h
+#endif
+
+#if !defined(cszHostname)
+#error A definition for cszHostname is missing from secrets.h
+#endif
+
+#if !defined(cszOpenWeatherAPIKey)
+#error A definition for cszOpenWeatherAPIKey is missing from secrets.h
+#endif
+
+#if !defined(cszLocation)
+#error A definition for cszLocation is missing from secrets.h
+#endif
+
+#if !defined(bLocationIsZip)
+#error A definition for bLocationIsZip is missing from secrets.h
+#endif
+
+#if !defined(cszCountryCode)
+#error A definition for cszCountryCode is missing from secrets.h
+#endif
+
+#if !defined(cszTimeZone)
+#error A definition for cszTimeZone is missing from secrets.h
+#endif
+
 
 #define DEVICE_CONFIG_FILE "/device.cfg"
 #define NTP_SERVER_DEFAULT "0.pool.ntp.org"
@@ -56,6 +94,8 @@
 //    (in deviceconfig.cpp)
 // 5. Adding (de)serialization logic for the setting to the SerializeToJSON()/DeserializeFromJSON() methods
 // 6. Adding a Get/Set method for the setting (and, where applicable, their implementation in deviceconfig.cpp)
+// 7. If you've added an entry to secrets.example.h add a test at the top of this file to confirm that the new #defines were found. This prevents drift when developers have an existing tree and don't know to refresh their modified version of secrets.h
+
 //
 // For the first 5 points, a comment has been added to the respective place in the existing code.
 // Generally speaking, one will also want to add logic to the webserver to retrieve and set the setting.


### PR DESCRIPTION
When new fields are added in the example file, add a test in the
file that uses the real file to be sure the fields are present. This
is to solve the case where a developer has a checked-out, working tree
with a working secrets.h, syncs to head or another branch that adds
fields in secrets, and then incurs weird compilation errors when those
new fields aren't found.

This change leads the developer to the correct file and the doc
describing it for a better experience.

## Description

As discussed in #572.


## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
