### PR TITLE
Fix hang in `PreviousEffect()` (issue #583)

### DIFF
--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -82,11 +82,14 @@ class  EffectManager : public IJSONSerializable
         {
             _clearTempEffectWhenExpired = true;
 
-            // This is a hacky way to ensure that we start the correct effect after the temporary one.
+            // This ensures that we start the correct effect after the temporary one.
             //   The switching to the next effect is taken care of by NextEffect(), which starts with
-            //   increasing _iCurrentEffect. We therefore need to decrease it here, to make sure that
-            //   the first effect after the temporary one is the one we want (either the then current
-            //   one when the chip was powered off, or the one at index 0).
+            //   increasing _iCurrentEffect. We therefore need to set it to the previous effect, to
+            //   make sure that the first effect after the temporary one is the one we want (either the
+            //   then current one when the chip was powered off, or the one at index 0).
+            if (_iCurrentEffect == 0)
+                _iCurrentEffect = EffectCount();
+
             _iCurrentEffect--;
         }
     }


### PR DESCRIPTION
## Description

This fixes #583 by not lazily relying on an unsigned underflow when preparing `_iCurrentEffect` for the first "proper" effect after the splash logo.
 
## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).