### PR TITLE
Re-enable Fanset networking, move TTGO in web installer

### DIFF
--- a/config/web_projects.json
+++ b/config/web_projects.json
@@ -25,10 +25,6 @@
                     "name": "Ledstrip"
                 },
                 {
-                    "tag": "ttgo",
-                    "name": "TTGO"
-                },
-                {
                     "tag": "umbrella",
                     "name": "Umbrella"
                 }
@@ -87,6 +83,17 @@
                 {
                     "tag": "heltecv2demo",
                     "name":"Demo"
+                }
+            ]
+        },
+        {
+            "tag": "ttgo",
+            "chipfamily": "ESP32",
+            "name": "LilyGO TTGO",
+            "projects": [
+                {
+                    "tag": "ttgo",
+                    "name": "TTGO"
                 }
             ]
         },

--- a/include/globals.h
+++ b/include/globals.h
@@ -953,11 +953,11 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #endif
 
     #define ENABLE_AUDIOSERIAL          0   // Report peaks at 2400baud on serial port for PETRock consumption
-    #define ENABLE_WIFI                 0   // Connect to WiFi
+    #define ENABLE_WIFI                 1   // Connect to WiFi
     #define INCOMING_WIFI_ENABLED       0   // Accepting incoming color data and commands
     #define WAIT_FOR_WIFI               0   // Hold in setup until we have WiFi - for strips without effects
     #define TIME_BEFORE_LOCAL           2   // How many seconds before the lamp times out and shows local content
-    #define ENABLE_WEBSERVER            0   // Turn on the internal webserver
+    #define ENABLE_WEBSERVER            1   // Turn on the internal webserver
     #define ENABLE_NTP                  0   // Set the clock from the web
     #define ENABLE_OTA                  0   // Accept over the air flash updates
     #define ENABLE_REMOTE               1   // IR Remote Control


### PR DESCRIPTION
## Description

This:

- Re-enables networking and the webserver in the Fanset config. This is possible since some of the latest dependency updates have yielded back a big part of the RAM we've seen disappearing in recent times.
- Moves the TTGO config to its own device in the Web Installer, to avoid it being flashed on more generic ESP32 devices inadvertently.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).