### PR TITLE
Allow for web UI endpoints to be disabled during build

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -527,7 +527,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define INCOMING_WIFI_ENABLED       1   // Accepting incoming color data and commands
     #define WAIT_FOR_WIFI               0   // Hold in setup until we have WiFi - for strips without effects
     #define TIME_BEFORE_LOCAL           2   // How many seconds before the lamp times out and shows local content
-    #define ENABLE_WEBSERVER            1  // Turn on the internal webserver
+    #define ENABLE_WEBSERVER            1   // Turn on the internal webserver
     #define ENABLE_NTP                  1   // Set the clock from the web
     #define ENABLE_OTA                  1   // Accept over the air flash updates
     #define ENABLE_REMOTE               1   // IR Remote Control
@@ -1171,7 +1171,15 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 #endif
 
 #ifndef ENABLE_WEBSERVER
-#define ENABLE_WEBSERVER        0   // Chip provides a web server with controls to adjust effects
+    #define ENABLE_WEBSERVER        0   // Chip provides a web server with controls to adjust effects
+
+#endif
+
+
+#if ENABLE_WEBSERVER
+    #ifndef ENABLE_WEB_UI
+    #define ENABLE_WEB_UI           1   // Enable endpoints for the web UI
+    #endif
 #endif
 
 #ifndef ENABLE_OTA

--- a/include/globals.h
+++ b/include/globals.h
@@ -1171,14 +1171,12 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 #endif
 
 #ifndef ENABLE_WEBSERVER
-    #define ENABLE_WEBSERVER        0   // Chip provides a web server with controls to adjust effects
-
+#define ENABLE_WEBSERVER        0   // Chip provides a web server with controls to adjust effects
 #endif
-
 
 #if ENABLE_WEBSERVER
     #ifndef ENABLE_WEB_UI
-    #define ENABLE_WEB_UI           1   // Enable endpoints for the web UI
+    #define ENABLE_WEB_UI           1   // Enable HTTP pathnames for the web UI
     #endif
 #endif
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,7 +30,8 @@ extra_configs =
 ; Options that are used (or extended) in all device sections (and hence environments) are defined here
 
 [base]
-upload_port     =
+#upload_protocol = 
+#upload_port     = 
 monitor_port    =
 build_type      = release
 upload_speed    = 1500000
@@ -63,7 +64,6 @@ lib_deps        = crankyoldgit/IRremoteESP8266  @ ^2.7.20
 ; This partition table attempts to fit everything in 4M of flash.
 
 board_build.partitions = config/partitions_custom.csv
-
 
 ; =================================
 ; Build flags for enabling a remote
@@ -245,10 +245,14 @@ lib_extra_dirs  = ${PROJECT_DIR}/lib
 monitor_filters = esp32_exception_decoder
 extra_scripts   = pre:tools/bake_site.py
                   post:tools/merge_image.py
+
 board_build.embed_files = site/dist/index.html.gz
                           site/dist/index.js.gz
                           site/dist/favicon.ico.gz
+
 board_build.embed_txtfiles = config/timezones.json
+
+
 
 ; ================================================================
 ; Common project configurations

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,8 +30,7 @@ extra_configs =
 ; Options that are used (or extended) in all device sections (and hence environments) are defined here
 
 [base]
-#upload_protocol = 
-#upload_port     = 
+upload_port     =
 monitor_port    =
 build_type      = release
 upload_speed    = 1500000
@@ -64,6 +63,7 @@ lib_deps        = crankyoldgit/IRremoteESP8266  @ ^2.7.20
 ; This partition table attempts to fit everything in 4M of flash.
 
 board_build.partitions = config/partitions_custom.csv
+
 
 ; =================================
 ; Build flags for enabling a remote
@@ -245,14 +245,10 @@ lib_extra_dirs  = ${PROJECT_DIR}/lib
 monitor_filters = esp32_exception_decoder
 extra_scripts   = pre:tools/bake_site.py
                   post:tools/merge_image.py
-
 board_build.embed_files = site/dist/index.html.gz
                           site/dist/index.js.gz
                           site/dist/favicon.ico.gz
-
 board_build.embed_txtfiles = config/timezones.json
-
-
 
 ; ================================================================
 ; Common project configurations

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -134,17 +134,19 @@ void CWebServer::begin()
     debugI("Connecting Web Endpoints");
 
     // SPIFFS file requests
-    _server.on("/effectsConfig",         HTTP_GET,  [](AsyncWebServerRequest* pRequest) { pRequest->send(SPIFFS, EFFECTS_CONFIG_FILE,   "text/json"); });
 
+    _server.on("/effectsConfig",         HTTP_GET,  [](AsyncWebServerRequest* pRequest) { pRequest->send(SPIFFS, EFFECTS_CONFIG_FILE,   "text/json"); });
     #if ENABLE_IMPROV_LOGGING
         _server.on(IMPROV_LOG_FILE,      HTTP_GET,  [](AsyncWebServerRequest* pRequest) { pRequest->send(SPIFFS, IMPROV_LOG_FILE,       "text/plain"); });
     #endif
 
     // Instance handler requests
+
     _server.on("/statistics",            HTTP_GET,  [this](AsyncWebServerRequest* pRequest) { this->GetStatistics(pRequest); });
     _server.on("/getStatistics",         HTTP_GET,  [this](AsyncWebServerRequest* pRequest) { this->GetStatistics(pRequest); });
 
     // Static handler requests
+
     _server.on("/effects",               HTTP_GET,  GetEffectListText);
     _server.on("/getEffectList",         HTTP_GET,  GetEffectListText);
     _server.on("/nextEffect",            HTTP_POST, NextEffect);
@@ -169,10 +171,11 @@ void CWebServer::begin()
     _server.on("/reset",                 HTTP_POST, Reset);
 
     // Embedded file requests
+
     ServeEmbeddedFile("/timezones.json", timezones_file);
 
     #if ENABLE_WEB_UI
-        debugI("Web UI Endpoints enabled");
+        debugI("Web UI URL pathnames enabled");
 
         ServeEmbeddedFile("/", html_file);
         ServeEmbeddedFile("/index.html", html_file);
@@ -181,6 +184,7 @@ void CWebServer::begin()
     #endif
 
     // Not found handler
+
     _server.onNotFound([](AsyncWebServerRequest *request)
     {
         if (request->method() == HTTP_OPTIONS) {

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -134,19 +134,17 @@ void CWebServer::begin()
     debugI("Connecting Web Endpoints");
 
     // SPIFFS file requests
-
     _server.on("/effectsConfig",         HTTP_GET,  [](AsyncWebServerRequest* pRequest) { pRequest->send(SPIFFS, EFFECTS_CONFIG_FILE,   "text/json"); });
+
     #if ENABLE_IMPROV_LOGGING
         _server.on(IMPROV_LOG_FILE,      HTTP_GET,  [](AsyncWebServerRequest* pRequest) { pRequest->send(SPIFFS, IMPROV_LOG_FILE,       "text/plain"); });
     #endif
 
     // Instance handler requests
-
     _server.on("/statistics",            HTTP_GET,  [this](AsyncWebServerRequest* pRequest) { this->GetStatistics(pRequest); });
     _server.on("/getStatistics",         HTTP_GET,  [this](AsyncWebServerRequest* pRequest) { this->GetStatistics(pRequest); });
 
     // Static handler requests
-
     _server.on("/effects",               HTTP_GET,  GetEffectListText);
     _server.on("/getEffectList",         HTTP_GET,  GetEffectListText);
     _server.on("/nextEffect",            HTTP_POST, NextEffect);
@@ -171,15 +169,18 @@ void CWebServer::begin()
     _server.on("/reset",                 HTTP_POST, Reset);
 
     // Embedded file requests
-
-    ServeEmbeddedFile("/", html_file);
-    ServeEmbeddedFile("/index.html", html_file);
-    ServeEmbeddedFile("/index.js", js_file);
-    ServeEmbeddedFile("/favicon.ico", ico_file);
     ServeEmbeddedFile("/timezones.json", timezones_file);
 
-    // Not found handler
+    #if ENABLE_WEB_UI
+        debugI("Web UI Endpoints enabled");
 
+        ServeEmbeddedFile("/", html_file);
+        ServeEmbeddedFile("/index.html", html_file);
+        ServeEmbeddedFile("/index.js", js_file);
+        ServeEmbeddedFile("/favicon.ico", ico_file);
+    #endif
+
+    // Not found handler
     _server.onNotFound([](AsyncWebServerRequest *request)
     {
         if (request->method() == HTTP_OPTIONS) {


### PR DESCRIPTION
## Description
- Adds build flags and a new base configuration to _optionally_ enable the React Web UI. 


When working with Heltec V3 boards, memory pressure is tight for HTTP requests memory due to the lack of PSRAM. The webserver is disabled by default but I figured it would be useful to allow users to be able to utilize the API endpoints without the need of the dedicated UI. 

(In my use-case I am building a standalone react app that can be self-hosted to manage many NightDriverStrip devices and I need API access but do not need the embedded UI)

I welcome any feedback on the platform IO build configuration as it is still pretty new to me and I want to make sure that I do not increase the build complexity too much

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).