### PR TITLE
Move Improv announcement from setup to loop

### DIFF
--- a/include/improvserial.h
+++ b/include/improvserial.h
@@ -83,9 +83,6 @@ public:
             SPIFFS.remove(IMPROV_LOG_FILE);
         #endif
 
-        debugI("Sending Improv packet to declare we're up. Ignore any IMPROV lines that follow this one.");
-        this->set_state_(improv::STATE_AUTHORIZED);
-
         log_write("Finished Improv setup");
     }
 
@@ -95,6 +92,13 @@ public:
 
     void loop()
     {
+        static bool announcedPresence = [&]
+        {
+            debugI("Sending Improv packet to declare we're up. Ignore any IMPROV lines that follow this one.");
+            this->set_state_(improv::STATE_AUTHORIZED);
+            return true;
+        }();
+
         const uint32_t now = millis();
         if (now - this->last_read_byte_ > 50)
         {


### PR DESCRIPTION
## Description

This fixes #596, which documents a case where the sending of the Improv state packet to indicate we're up blocks setup, and hence the starting of the blinking of LEDs. It does this by moving the one-time sending of the packet from `ImprovSerial::setup()` to `ImprovSerial::loop()`.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).