### PR TITLE
Don't define POWER_LIMIT_MW by default

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -264,8 +264,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define NUM_CHANNELS            1
     #define ENABLE_AUDIO            0
 
-    #define POWER_LIMIT_MW       12 * 10 * 1000   // 10 amp supply at 5 volts assumed
-
     // Once you have a working project, selectively enable various additional features by setting
     // them to 1 in the list below.  This DEMO config assumes no audio (mic), or screen, etc.
 
@@ -332,8 +330,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
     #define DEFAULT_EFFECT_INTERVAL     (60*60*24*5)
 
-    #define POWER_LIMIT_MW       12 * 10 * 1000   // 10 amp supply at 5 volts assumed
-
     #if M5STICKC || M5STICKCPLUS || M5STACKCORE2
         #define LED_PIN0 32
     #elif LILYGOTDISPLAYS3
@@ -376,8 +372,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define NUM_LEDS                (MATRIX_WIDTH*MATRIX_HEIGHT)
     #define NUM_CHANNELS            1
     #define ENABLE_AUDIO            1
-
-    #define POWER_LIMIT_MW       5000   // 1 amp supply at 5 volts assumed
 
     // Once you have a working project, selectively enable various additional features by setting
     // them to 1 in the list below.  This config assumes no audio (mic), or screen, etc.
@@ -439,7 +433,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define ENABLE_AUDIO      1                     // Listen for audio from the microphone and process it
     #define IR_REMOTE_PIN     25
     #define LED_FAN_OFFSET_BU 12
-    #define POWER_LIMIT_MW    20000
 
     #define TOGGLE_BUTTON  37
     #define NUM_INFO_PAGES 2
@@ -453,7 +446,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define NUM_RINGS               5
     #define RING_SIZE_0             24
 
-    #define POWER_LIMIT_MW       5000   // 1 amp supply at 5 volts assumed
     #define USE_LCD                 1
 
     #define ENABLE_WIFI             1   // Connect to WiFi
@@ -502,7 +494,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define FAN_SIZE        MATRIX_HEIGHT
     #define NUM_LEDS        (MATRIX_WIDTH*MATRIX_HEIGHT)
     #define LED_FAN_OFFSET_BU 6
-    #define POWER_LIMIT_MW  (8 * 5 * 1000)         // Expects at least a 5V, 20A supply (100W)
 
     #define TOGGLE_BUTTON_1 37
     #define TOGGLE_BUTTON_2 39
@@ -551,7 +542,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define IR_REMOTE_PIN               39
     #define INPUT_PIN                   36
     #define LED_FAN_OFFSET_BU           6
-    #define POWER_LIMIT_MW              (5 * 8 * 1000)         // Expects at least a 5V, 8A supply
 
     #define TOGGLE_BUTTON_1             0
 
@@ -591,7 +581,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define NUM_LEDS        (MATRIX_WIDTH*MATRIX_HEIGHT)
     #define IR_REMOTE_PIN   22
     #define LED_FAN_OFFSET_BU 6
-    #define POWER_LIMIT_MW  (1 * 5 * 1000)         // Expects at least a 5V, 1A supply
 
     #define TOGGLE_BUTTON_1         35
     #define NUM_INFO_PAGES          2
@@ -631,7 +620,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define NUM_LEDS        (MATRIX_WIDTH*MATRIX_HEIGHT)
     #define IR_REMOTE_PIN   25
     #define LED_FAN_OFFSET_BU 6
-    #define POWER_LIMIT_MW  (5 * 5 * 1000)         // Expects at least a 5V, 5A supply
 
     #define TOGGLE_BUTTON_1         37
     #define TOGGLE_BUTTON_2         39
@@ -666,8 +654,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define BONUS_PIXELS      0
 
     #define IR_REMOTE_PIN 15                        // Eric's is PIN 35
-
-    #define POWER_LIMIT_MW (1000 * 8 * 5)           // 8 amps, 5 volts
 
     // Original Wiring:
     //   Fine red     = 3.3v
@@ -704,7 +690,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define ENABLE_AUDIO    1                     // Listen for audio from the microphone and process it
     #define MAX_BUFFERS     40
 
-    #define POWER_LIMIT_MW (1600 * 1000)                 // 100W transformer for an 8M strip max
     #define DEFAULT_EFFECT_INTERVAL     (1000*30 * 60)
 
 
@@ -751,8 +736,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
     #define LED_FAN_OFFSET_BU 6
 
-    #define POWER_LIMIT_MW 10000
-
 #elif HEXAGON
 
     // The LED strips I use for Christmas lights under my eaves
@@ -774,8 +757,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define ENABLE_REMOTE   0                     // IR Remote Control
     #define ENABLE_AUDIO    0                     // Listen for audio from the microphone and process it
     #define LED_PIN0        5
-
-    #define POWER_LIMIT_MW (INT_MAX)              // Unlimited power for long strips, up to you to limit here or supply enough!
 
     #define DEFAULT_EFFECT_INTERVAL     (1000*20)
 
@@ -808,8 +789,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define ENABLE_AUDIO    0                     // Listen for audio from the microphone and process it
     #define LED_PIN0        5
 
-    #define POWER_LIMIT_MW (INT_MAX)              // Unlimited power for long strips, up to you to limit here or supply enough!
-
     #define DEFAULT_EFFECT_INTERVAL     (1000*20)
 
     #define RING_SIZE_0 1
@@ -839,8 +818,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define ENABLE_AUDIO    1                     // Listen for audio from the microphone and process it
     #define LED_PIN0        5
 
-    #define POWER_LIMIT_MW (4500)                 // Assumes modern USB3 powered port or supply
-
     #define DEFAULT_EFFECT_INTERVAL     (1000*20)
 
     #define RING_SIZE_0 1
@@ -869,7 +846,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define ENABLE_REMOTE   0                     // IR Remote Control
     #define ENABLE_AUDIO    0                     // Listen for audio from the microphone and process it
     #define LED_PIN0        17
-    #define POWER_LIMIT_MW (3000)                 // 100W transformer for an 8M strip max
     #define DEFAULT_EFFECT_INTERVAL     (1000*60*60*24)
 
 #elif SPECTRUM
@@ -928,7 +904,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define NUM_BANDS                   16
     #define NUM_LEDS                    (MATRIX_WIDTH*MATRIX_HEIGHT)
     #define LED_FAN_OFFSET_BU           6
-    #define POWER_LIMIT_MW              (10 * 5 * 1000)         // Expects at least a 5V, 20A supply (100W)
 
     // The mic in the M5 is not quite the same as the Mesmerizer, so it gets a different minimum VU than default
 
@@ -981,7 +956,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define MATRIX_WIDTH                (NUM_FANS * FAN_SIZE + BONUS_PIXELS)
     #define NUM_LEDS                    (MATRIX_WIDTH)
     #define LED_FAN_OFFSET_BU           3
-    #define POWER_LIMIT_MW              8000
     #define MATRIX_HEIGHT               1
 
     // Being case-mounted normally, the FANSET needs a more sensitive mic so the NOISE_CUTOFF value is are lower than spectrum
@@ -1021,9 +995,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
     #define LED_FAN_OFFSET_BU 6
 
-    #define POWER_LIMIT_MW 10000
-
-
     #if M5STICKC
         #define LED_PIN0 26
     #else
@@ -1058,7 +1029,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define ENABLE_AUDIO      1                     // Listen for audio from the microphone and process it
     #define IR_REMOTE_PIN     26
     #define LED_FAN_OFFSET_BU 6
-    #define POWER_LIMIT_MW    50000
 
     #define TOGGLE_BUTTON_1 37
     #define TOGGLE_BUTTON_2 39
@@ -1094,7 +1064,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define ENABLE_AUDIO      1                     // Listen for audio from the microphone and process it
     #define IR_REMOTE_PIN     26
     #define LED_FAN_OFFSET_BU 6
-    #define POWER_LIMIT_MW    5000
     #define ENABLE_OTA        0
 
     #define TOGGLE_BUTTON  37
@@ -1113,7 +1082,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #define NUM_CHANNELS            8
     #define NUM_RINGS               5
     #define RING_SIZE_0             24
-    #define POWER_LIMIT_MW          3 * 1000   // 3 watt power supply
 
     // Once you have a working project, selectively enable various additional features by setting
     // them to 1 in the list below.  This DEMO config assumes no audio (mic), or screen, etc.
@@ -1310,16 +1278,18 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 #define MATRIX_CALC_DIVIDER 3
 #endif
 
-
 // Power Limit
 //
-// The limit, in watts, that the power supply for your project can supply.  If your demands
-// exceed this, the code wil try to scale back brightness to hit this.  Don't rely on this
-// for safety, obviously, design your hardware to protect against it with a fuse, etc.
+// The maximum amount of power, in milliwatts, that you want your project to use, if you want to limit that.
+// If your demands exceed this in practice, the code will try to scale back brightness to hit this.
+// Don't rely on this for safety! Instead, design your hardware to protect against it with a fuse, etc.
+// Another way to limit power usage is through the Brightness setting that is contained by the DeviceConfig
+// class. Again, this should not be your primary/only means to protect against the overdraft of power.
+// If POWER_LIMIT_MW is unset and DeviceConfig's Brightness is set to maximum, the amount of power drawn will
+// not be limited at the software level.
 
-#ifndef POWER_LIMIT_MW
-#define POWER_LIMIT_MW 500*5                // Define for your power supply, default is a low 2500mA for USB
-#endif
+// #define POWER_LIMIT_MW 500*5                 // Define for your power draw limit. Example is a low 2500mA
+                                                // which may dim your LEDs quite a lot.
 
 // Display
 //

--- a/src/ledstripgfx.cpp
+++ b/src/ledstripgfx.cpp
@@ -53,7 +53,7 @@ void LEDStripGFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixel
 
     auto& effectManager = g_ptrSystem->EffectManager();
 
-    for (int i = 0; i < NUM_CHANNELS; i++) 
+    for (int i = 0; i < NUM_CHANNELS; i++)
     {
         FastLED[i].setLeds(effectManager.g(i)->leds, pixelsDrawn);
         fadeLightBy(FastLED[i].leds(), FastLED[i].size(), 255 - g_ptrSystem->DeviceConfig().GetBrightness());
@@ -61,6 +61,10 @@ void LEDStripGFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixel
     FastLED.show(g_Values.Fader); //Shows the pixels
 
     g_Values.FPS = FastLED.getFPS();
-    g_Values.Brite = 100.0 * calculate_max_brightness_for_power_mW(g_ptrSystem->DeviceConfig().GetBrightness(), POWER_LIMIT_MW) / 255;
+    #ifdef POWER_LIMIT_MW
+        g_Values.Brite = 100.0 * calculate_max_brightness_for_power_mW(g_ptrSystem->DeviceConfig().GetBrightness(), POWER_LIMIT_MW) / 255;
+    #else
+        g_Values.Brite = 100.0 * g_ptrSystem->DeviceConfig().GetBrightness() / 255;
+    #endif
     g_Values.Watts = calculate_unscaled_power_mW(effectManager.g()->leds, pixelsDrawn) / 1000; // 1000 for mw->W
 }


### PR DESCRIPTION
## Description

In follow up to a conversation in #601, this removes the definition of POWER_LIMIT_MW by default, and indeed allows it to not be set. 

If it is defined, it will still be respected in the same way it is now. 

If and when this PR is merged, it will replace and thus close #601.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).