### PR TITLE
Make demo config available for M5StickC Plus and M5Stack Core2

### DIFF
--- a/config/web_projects.json
+++ b/config/web_projects.json
@@ -98,6 +98,17 @@
             ]
         },
         {
+            "tag": "m5stack-core2",
+            "chipfamily": "ESP32",
+            "name": "M5Stack Core2",
+            "projects": [
+                {
+                    "tag": "m5stackdemo",
+                    "name":"Demo"
+                }
+            ]
+        },
+        {
             "tag": "m5stick-c",
             "chipfamily": "ESP32",
             "name": "M5StickC",

--- a/platformio.ini
+++ b/platformio.ini
@@ -356,6 +356,12 @@ board_build.partitions = config/partitions_custom_noota.csv
 
 ; This is largely the same as the m5demo above except it links to the PLUS version of the lib
 [env:m5plusdemo]
+extends         = dev_m5stick-c-plus
+build_flags     = -DM5DEMO=1
+                  ${dev_m5stick-c-plus.build_flags}
+
+; Also one for the M5Stack Core2
+[env:m5stackdemo]
 extends         = dev_m5stack
 build_flags     = -DM5DEMO=1
                   ${dev_m5stack.build_flags}


### PR DESCRIPTION
## Description

This makes the m5plusdemo config build for the M5StickC Plus once again, and adds a separate m5stackdemo config that targets the M5Stack Core2. Fixes #633.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).