### PR TITLE
Make Web Installer build and deploy on releases publication

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,51 +56,12 @@ jobs:
     - name: "Build environment: ${{ matrix.envname }}"
       run: pio run -e ${{ matrix.envname }}
 
-  build-and-publish-installer:
-    if: ( github.repository_owner == 'PlummersSoftwareLLC' && github.ref == 'refs/heads/main' ) || ( github.repository_owner == 'rbergen' && github.ref == 'refs/heads/staging' )
-
-    runs-on: ubuntu-latest
+  call-web-installer:
+    if: ( github.repository_owner == 'rbergen' && github.ref == 'refs/heads/staging' )
 
     needs: [build-environment]
 
-    env:
-      PLATFORMIO_CORE_DIR: ${{ github.workspace }}/.platformio
-
-    steps:
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-
-    - name: Maximize build space
-      uses: easimon/maximize-build-space@master
-      with:
-        remove-android: 'true'
-        remove-codeql: 'true'
-        remove-docker-images: 'true'
-        remove-dotnet: 'true'
-        remove-haskell: 'true'
-
-    - uses: actions/checkout@v4
-
-    - name: Install PlatformIO
-      run: |
-        curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py -o get-platformio.py
-        python get-platformio.py
-        echo "${PLATFORMIO_CORE_DIR}/penv/bin" >> $GITHUB_PATH
-
-    - name: Copy secrets and clear SSID
-      run: |
-        grep -v "^#define cszSSID" include/secrets.example.h > include/secrets.h
-        echo '#define cszSSID ""' >> include/secrets.h
-
-    - name: Build web installer environments and installer
-      run: |
-        python tools/bake_installer.py
-        touch WebInstaller/.nojekyll
-
-    - name: Push to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@v4
-      with:
-        branch: pages
-        folder: WebInstaller
+    uses: ./.github/workflows/web_installer.yml
+    with:
+      release-name: ${{ github.ref_name }} commit ${{ github.sha }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,12 @@
+name: Release actions
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  call-web-installer:
+    uses: ./.github/workflows/web_installer.yml
+    with:
+      release-name: ${{ github.event.release.name }}
+    secrets: inherit

--- a/.github/workflows/web_installer.yml
+++ b/.github/workflows/web_installer.yml
@@ -1,0 +1,55 @@
+name: Web Installer build and deploy
+
+on:
+  workflow_call:
+    inputs:
+      release-name:
+        description: 'Name of the Web Installer release'
+        required: true
+        type: string
+
+jobs:
+  build-and-publish-installer:
+    runs-on: ubuntu-latest
+
+    env:
+      PLATFORMIO_CORE_DIR: ${{ github.workspace }}/.platformio
+
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@master
+      with:
+        remove-android: 'true'
+        remove-codeql: 'true'
+        remove-docker-images: 'true'
+        remove-dotnet: 'true'
+        remove-haskell: 'true'
+
+    - uses: actions/checkout@v4
+
+    - name: Install PlatformIO
+      run: |
+        curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py -o get-platformio.py
+        python get-platformio.py
+        echo "${PLATFORMIO_CORE_DIR}/penv/bin" >> $GITHUB_PATH
+
+    - name: Copy secrets and clear SSID
+      run: |
+        grep -v "^#define cszSSID" include/secrets.example.h > include/secrets.h
+        echo '#define cszSSID ""' >> include/secrets.h
+
+    - name: Build web installer environments and installer
+      run: |
+        python tools/bake_installer.py ${{ inputs.release-name }}
+        touch WebInstaller/.nojekyll
+
+    - name: Push to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        branch: pages
+        folder: WebInstaller

--- a/.github/workflows/web_installer.yml
+++ b/.github/workflows/web_installer.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Build web installer environments and installer
       run: |
-        python tools/bake_installer.py ${{ inputs.release-name }}
+        python tools/bake_installer.py '${{ inputs.release-name }}'
         touch WebInstaller/.nojekyll
 
     - name: Push to GitHub Pages

--- a/config/installer_index.html
+++ b/config/installer_index.html
@@ -56,7 +56,7 @@ div#container {
       <img src="assets/NightDriverLogo-small.png" style="width: 640px; height: 380px" />
       <h1>NightDriverLED ESP32 Installation Wizard</h1>
 
-      <small>Release: $$RELEASE_NAME$$</small>
+      <em><small>Release: $$RELEASE_NAME$$</small></em>
 
       <br/><br/>
 

--- a/config/installer_index.html
+++ b/config/installer_index.html
@@ -55,6 +55,11 @@ div#container {
     <div class="content">
       <img src="assets/NightDriverLogo-small.png" style="width: 640px; height: 380px" />
       <h1>NightDriverLED ESP32 Installation Wizard</h1>
+
+      <small>Release: $$RELEASE_NAME$$</small>
+
+      <br/><br/>
+
       <label for="devices-dropdown">Select your device type:</label>
       <select id="devices-dropdown"></select>
 

--- a/tools/bake_installer.py
+++ b/tools/bake_installer.py
@@ -35,6 +35,7 @@ import glob
 import json
 import shutil
 import subprocess
+import sys
 import show_features
 
 class Dirs:
@@ -57,6 +58,7 @@ merged_image = 'merged_image.bin'
 globals_h = 'globals.h'
 index_template_file = 'installer_index.html'
 index_file = 'index.html'
+release_name = sys.argv[1] if len(sys.argv) > 1 else 'unnamed'
 
 # Do some ground work to set up the web installer directory, starting with the installer image assets...
 assets_target_dir = os.path.join(Dirs.webinstaller, Dirs.assets)
@@ -204,6 +206,9 @@ for feature_tag, feature in known_features.items():
 # Load template for index.html...
 with open(os.path.join(Dirs.config, index_template_file), "r", encoding='utf-8') as f:
     index_template = f.read()
+
+# ...then inject release name...
+index_template = index_template.replace('$$RELEASE_NAME$$', release_name)
 
 # ...and write it with the feature legend injected
 with open(os.path.join(Dirs.webinstaller, index_file), 'w', encoding='utf-8') as f:


### PR DESCRIPTION
## Description

This updates the GitHub workflows to build and deploy the production web installer only when a release is published, instead of on every push to the main branch. 

This is in preparation for the upcoming 1.0 release of NightDriverStrip.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).