### PR TITLE
Remove outdated kludge for FastLED's use of register.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -35,7 +35,6 @@ monitor_port    =
 build_type      = release
 upload_speed    = 1500000
 build_flags     = -std=gnu++2a
-                  -Dregister=                       ; Sinister: redefine 'register' so FastLED can use that keyword under C++17 and later C++ versions
                   -g3
                   -Ofast
                   -ffunction-sections


### PR DESCRIPTION
Web-recreation of https://github.com/PlummersSoftwareLLC/NightDriverStrip/pull/658

FastLED used to use C style hints of 'register' that were deprecated long ago and the keyword was removed in C++17. There was a kludge that just defined register away.
FastLED was been updated (long ago) so this is no longer necessary. We can return this token to valid namespace.

This has been in my tree for many months and has survived buddybuilds and a variety of FastLED versions.

## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).