### PR TITLE
Added heltec wifi lora v3 board

### DIFF
--- a/include/screen.h
+++ b/include/screen.h
@@ -314,7 +314,7 @@ public:
         U8G2_SSD1306_128X64_NONAME_F_HW_I2C oled;
 
     public:
-        #if ARDUINO_HELTEC_WIFI_LoRa_32_V3
+        #if ARDUINO_HELTEC_WIFI_LORA_32_V3
             OLEDScreen(int w, int h) : Screen(w, h), oled(U8G2_R2, /*reset*/ 21, /*clk*/ 18, /*data*/ 17)
         #else
             OLEDScreen(int w, int h) : Screen(w, h), oled(U8G2_R2, /*reset*/ 16, /*clk*/ 15, /*data*/ 4)

--- a/include/screen.h
+++ b/include/screen.h
@@ -364,8 +364,8 @@ public:
         SSD1306Screen(int w, int h) : Screen(w, h)
         {
             Heltec.begin(true /*DisplayEnable Enable*/, false /*LoRa Enable*/, false /*Serial Enable*/);
-            #ifdef SCREEN_ROTATION
-                Heltec.display->screenRotate(SCREEN_ROTATION);
+            #if ROTATE_SCREEN
+                Heltec.display->screenRotate(ANGLE_180_DEGREE);
             #endif
         }
 

--- a/include/screen.h
+++ b/include/screen.h
@@ -314,8 +314,11 @@ public:
         U8G2_SSD1306_128X64_NONAME_F_HW_I2C oled;
 
     public:
-
-        OLEDScreen(int w, int h) : Screen(w, h), oled(U8G2_R2, /*reset*/ 16, /*clk*/ 15, /*data*/ 4)
+        #if ARDUINO_HELTEC_WIFI_LoRa_32_V3
+            OLEDScreen(int w, int h) : Screen(w, h), oled(U8G2_R0, /*reset*/ 21, /*clk*/ 18, /*data*/ 17)
+        #else
+            OLEDScreen(int w, int h) : Screen(w, h), oled(U8G2_R2, /*reset*/ 16, /*clk*/ 15, /*data*/ 4)
+        #endif
         {
             oled.begin();
             oled.clear();

--- a/include/screen.h
+++ b/include/screen.h
@@ -360,7 +360,7 @@ public:
 
         SSD1306Screen(int w, int h) : Screen(w, h)
         {
-            Heltec.begin(true /*DisplayEnable Enable*/, true /*LoRa Disable*/, false /*Serial Enable*/);
+            Heltec.begin(true /*DisplayEnable Enable*/, true /*LoRa Enable*/, false /*Serial Enable*/);
             Heltec.display->screenRotate(ANGLE_180_DEGREE);
         }
 

--- a/include/screen.h
+++ b/include/screen.h
@@ -315,7 +315,7 @@ public:
 
     public:
         #if ARDUINO_HELTEC_WIFI_LoRa_32_V3
-            OLEDScreen(int w, int h) : Screen(w, h), oled(U8G2_R0, /*reset*/ 21, /*clk*/ 18, /*data*/ 17)
+            OLEDScreen(int w, int h) : Screen(w, h), oled(U8G2_R2, /*reset*/ 21, /*clk*/ 18, /*data*/ 17)
         #else
             OLEDScreen(int w, int h) : Screen(w, h), oled(U8G2_R2, /*reset*/ 16, /*clk*/ 15, /*data*/ 4)
         #endif
@@ -364,7 +364,9 @@ public:
         SSD1306Screen(int w, int h) : Screen(w, h)
         {
             Heltec.begin(true /*DisplayEnable Enable*/, false /*LoRa Enable*/, false /*Serial Enable*/);
-            Heltec.display->screenRotate(ANGLE_180_DEGREE);
+            #ifdef SCREEN_ROTATION
+                Heltec.display->screenRotate(SCREEN_ROTATION);
+            #endif
         }
 
         virtual void StartFrame() override

--- a/include/screen.h
+++ b/include/screen.h
@@ -360,7 +360,7 @@ public:
 
         SSD1306Screen(int w, int h) : Screen(w, h)
         {
-            Heltec.begin(true /*DisplayEnable Enable*/, true /*LoRa Enable*/, false /*Serial Enable*/);
+            Heltec.begin(true /*DisplayEnable Enable*/, false /*LoRa Enable*/, false /*Serial Enable*/);
             Heltec.display->screenRotate(ANGLE_180_DEGREE);
         }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -135,7 +135,7 @@ lib_deps        = ${dev_heltec_wifi.lib_deps}
 [dev_heltec_wifi_lora_v3]
 extends         = dev_heltec_wifi
 board           = heltec_wifi_lora_32_V3
-build_flags     = -DARDUINO_HELTEC_WIFI_LoRa_32_V3=1
+build_flags     = -DARDUINO_HELTEC_WIFI_LORA_32_V3=1
                   -DWIFI_LoRa_32_V3=1
                   ${dev_heltec_wifi.build_flags}
 lib_deps        = ${dev_heltec_wifi.lib_deps}

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@
 ; mesmerizer    HUB75 info panel with audio effects, weather, info, etc,
 
 [platformio]
-default_envs = helteclorav3demo
+default_envs = 
 build_cache_dir = .pio/build_cache
 extra_configs =
     custom_*.ini ; This file can be created in the root directory to store user defined devices and environments.
@@ -30,8 +30,8 @@ extra_configs =
 ; Options that are used (or extended) in all device sections (and hence environments) are defined here
 
 [base]
-upload_port     = COM7
-monitor_port    = COM7
+upload_port     = 
+monitor_port    = 
 build_type      = release
 upload_speed    = 2000000
 build_flags     = -std=gnu++2a
@@ -409,7 +409,6 @@ extends         = dev_heltec_wifi_lora_v3
 build_flags     = -DDEMO=1
                   -DENABLE_WIFI=1
                   -DUSE_SSD1306=1
-                  ;-DUSE_OLED=1
                   ${dev_heltec_wifi_lora_v3.build_flags}
 
 ; LILYGO T-Display-S3

--- a/platformio.ini
+++ b/platformio.ini
@@ -127,7 +127,7 @@ build_flags     = -DARDUINO_HELTEC_WIFI_KIT_32_V2=1
 extends         = dev_heltec_wifi
 board           = heltec_wifi_kit_32_V3
 build_flags     = -DARDUINO_HELTEC_WIFI_KIT_32_V3=1
-                  -DWIFI_Kit_32_V3=1
+                  -DUSE_SSD1306=1
                   ${dev_heltec_wifi.build_flags}
 lib_deps        = ${dev_heltec_wifi.lib_deps}
                   heltecautomation/Heltec ESP32 Dev-Boards @ ^1.1.1
@@ -136,7 +136,7 @@ lib_deps        = ${dev_heltec_wifi.lib_deps}
 extends         = dev_heltec_wifi
 board           = heltec_wifi_lora_32_V3
 build_flags     = -DARDUINO_HELTEC_WIFI_LORA_32_V3=1
-                  -DWIFI_LoRa_32_V3=1
+                  -DUSE_SSD1306=1
                   ${dev_heltec_wifi.build_flags}
 lib_deps        = ${dev_heltec_wifi.lib_deps}
                   heltecautomation/Heltec ESP32 Dev-Boards @ ^1.1.1
@@ -400,7 +400,7 @@ build_flags     = -DDEMO=1
 extends         = dev_heltec_wifi_v3
 build_flags     = -DDEMO=1
                   -DENABLE_WIFI=1
-                  -DUSE_SSD1306=1
+                  -DROTATE_SCREEN=1
                   ${dev_heltec_wifi_v3.build_flags}
 
 ; Heltec LoRa V3 board, which is an S3 with USB-C and LoRa
@@ -408,7 +408,6 @@ build_flags     = -DDEMO=1
 extends         = dev_heltec_wifi_lora_v3
 build_flags     = -DDEMO=1
                   -DENABLE_WIFI=1
-                  -DUSE_SSD1306=1
                   ${dev_heltec_wifi_lora_v3.build_flags}
 
 ; LILYGO T-Display-S3

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@
 ; mesmerizer    HUB75 info panel with audio effects, weather, info, etc,
 
 [platformio]
-default_envs =
+default_envs = helteclorav3demo
 build_cache_dir = .pio/build_cache
 extra_configs =
     custom_*.ini ; This file can be created in the root directory to store user defined devices and environments.
@@ -30,8 +30,8 @@ extra_configs =
 ; Options that are used (or extended) in all device sections (and hence environments) are defined here
 
 [base]
-upload_port     =
-monitor_port    =
+upload_port     = COM7
+monitor_port    = COM7
 build_type      = release
 upload_speed    = 2000000
 build_flags     = -std=gnu++2a
@@ -127,7 +127,16 @@ build_flags     = -DARDUINO_HELTEC_WIFI_KIT_32_V2=1
 extends         = dev_heltec_wifi
 board           = heltec_wifi_kit_32_V3
 build_flags     = -DARDUINO_HELTEC_WIFI_KIT_32_V3=1
-                  -DWIFI_Kit_32=1
+                  -DWIFI_Kit_32_V3=1
+                  ${dev_heltec_wifi.build_flags}
+lib_deps        = ${dev_heltec_wifi.lib_deps}
+                  heltecautomation/Heltec ESP32 Dev-Boards @ ^1.1.1
+
+[dev_heltec_wifi_lora_v3]
+extends         = dev_heltec_wifi
+board           = heltec_wifi_lora_32_V3
+build_flags     = -DARDUINO_HELTEC_WIFI_LoRa_32_V3=1
+                  -DWIFI_LoRa_32_V3=1
                   ${dev_heltec_wifi.build_flags}
 lib_deps        = ${dev_heltec_wifi.lib_deps}
                   heltecautomation/Heltec ESP32 Dev-Boards @ ^1.1.1
@@ -393,6 +402,15 @@ build_flags     = -DDEMO=1
                   -DENABLE_WIFI=1
                   -DUSE_SSD1306=1
                   ${dev_heltec_wifi_v3.build_flags}
+
+; Heltec LoRa V3 board, which is an S3 with USB-C and LoRa
+[env:helteclorav3demo]
+extends         = dev_heltec_wifi_lora_v3
+build_flags     = -DDEMO=1
+                  -DENABLE_WIFI=1
+                  -DUSE_SSD1306=1
+                  ;-DUSE_OLED=1
+                  ${dev_heltec_wifi_lora_v3.build_flags}
 
 ; LILYGO T-Display-S3
 [env:lilygo-tdisplay-s3-demo]

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -251,7 +251,11 @@ void CurrentEffectSummary(bool bRedraw)
     if (bRedraw)
         display.fillScreen(BLACK16);
 
-    uint16_t backColor = Screen::to16bit(CRGB(0, 0, 64));
+    #if ARDUINO_HELTEC_WIFI_LoRa_32_V3
+        uint16_t backColor = Screen::to16bit(CRGB(0, 0, 0));
+    #else
+        uint16_t backColor = Screen::to16bit(CRGB(0, 0, 64));
+    #endif
 
     // We only draw after a page flip or if anything has changed about the information that will be
     // shown in the page. This avoids flicker, but at the cost that we have to remember what we displayed

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -251,7 +251,7 @@ void CurrentEffectSummary(bool bRedraw)
     if (bRedraw)
         display.fillScreen(BLACK16);
 
-    #if ARDUINO_HELTEC_WIFI_LoRa_32_V3
+    #if ARDUINO_HELTEC_WIFI_LORA_32_V3
         uint16_t backColor = Screen::to16bit(CRGB(0, 0, 0));
     #else
         uint16_t backColor = Screen::to16bit(CRGB(0, 0, 64));


### PR DESCRIPTION
## Description
Added new dev_heltec_wifi_lora_v3 device and helteclorav3demo environment.
Changed build flag for dev_heltc_wifi_v3 from -DWIFI_Kit_32=1 to -DWIFI_Kit_32_V3.
Both flags do the same thing but passing the later may help compatibility in the future.
Fixed line in screen.h to disable LoRa by default.
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).