### PR TITLE
Add client response sequence, fix framerate on WiFi delivery

### DIFF
--- a/include/socketserver.h
+++ b/include/socketserver.h
@@ -65,6 +65,7 @@ bool ProcessIncomingData(std::unique_ptr<uint8_t []> & payloadData, size_t paylo
 struct SocketResponse
 {
     uint32_t    size;              // 4
+    uint64_t    sequence;          // 8 
     uint32_t    flashVersion;      // 4
     double      currentClock;      // 8
     double      oldestPacket;      // 8
@@ -75,7 +76,7 @@ struct SocketResponse
     uint32_t    bufferPos;         // 4
     uint32_t    fpsDrawing;        // 4
     uint32_t    watts;             // 4
-};
+} __attribute__((packed));
 
 static_assert(sizeof(double) == 8);             // SocketResponse on wire uses 8 byte floats
 static_assert(sizeof(float)  == 4);             // PeakData on wire uses 4 byte floats
@@ -85,7 +86,7 @@ static_assert(sizeof(float)  == 4);             // PeakData on wire uses 4 byte 
 // floats land on byte multiples of 8, otherwise you'll get packing bytes inserted.  Welcome to my world! Once upon
 // a time, I ported about a billion lines of x86 'pragma_pack(1)' code to the MIPS (davepl)!
 
-static_assert( sizeof(SocketResponse) == 64, "SocketResponse struct size is not what is expected - check alignment and float size" );
+static_assert( sizeof(SocketResponse) == 72, "SocketResponse struct size is not what is expected - check alignment and float size" );
 
 // SocketServer
 //

--- a/samples/videoserver/pcstats.py
+++ b/samples/videoserver/pcstats.py
@@ -23,13 +23,13 @@ import datetime
 
 # Constants
 
-MATRIX_WIDTH = 64*8
+MATRIX_WIDTH = 64
 MATRIX_HEIGHT = 32
-FUTURE_DELAY = 1
-ESP32_WIFI_ADDRESS = 'pi4-8g-02'
+FUTURE_DELAY = 3
+ESP32_WIFI_ADDRESS = '192.168.8.161'
 PORT = 49152
 WIFI_COMMAND_PIXELDATA64 = 3
-FPS = 120
+FPS = 60
 
 # connect_to_socket
 #
@@ -49,9 +49,9 @@ def connect_to_socket():
 def send_video_data():
 
     sock = None
-    future = datetime.datetime.now() + datetime.timedelta(seconds=FUTURE_DELAY)
-
     while True:
+        future = datetime.datetime.now() + datetime.timedelta(seconds=FUTURE_DELAY)
+
         # Connect to the socket if not already connected
         if sock is None:
             sock = connect_to_socket()
@@ -61,7 +61,7 @@ def send_video_data():
         pixels = contentimage.tobytes()
 
         # Advance timestamp by one frame's worth of time as we send each packet
-        future += datetime.timedelta(seconds = 1.0 / FPS)
+
         seconds = int(future.timestamp())
         microseconds = future.microsecond
 

--- a/src/ledmatrixgfx.cpp
+++ b/src/ledmatrixgfx.cpp
@@ -185,7 +185,7 @@ void LEDMatrixGFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixe
     debugV("MW: %d, Setting Scaled Brightness to: %d", g_Values.MatrixPowerMilliwatts, targetBrightness);
     pMatrix->SetBrightness(targetBrightness);
 
-    MatrixSwapBuffers((wifiPixelsDrawn == 0) && (g_ptrSystem->EffectManager().GetCurrentEffect().RequiresDoubleBuffering() || pMatrix->GetCaptionTransparency() > 0.0));
+    MatrixSwapBuffers((wifiPixelsDrawn > 0) || g_ptrSystem->EffectManager().GetCurrentEffect().RequiresDoubleBuffering() || pMatrix->GetCaptionTransparency() > 0.0);
 
     FastLED.countFPS();
 }

--- a/src/socketserver.cpp
+++ b/src/socketserver.cpp
@@ -244,7 +244,7 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
                 debugW("Unable to send response back to server.");
         }
 
-        delay(100);
+        delay(1);
 
     } while (true);
 

--- a/src/socketserver.cpp
+++ b/src/socketserver.cpp
@@ -222,11 +222,14 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
 
         if (bSendResponsePacket)
         {
+            static uint64_t sequence = 0;
+
             debugV("Sending Response Packet from Socket Server");
             auto& bufferManager = g_ptrSystem->BufferManagers()[0];
 
             SocketResponse response = {
                                         .size = sizeof(SocketResponse),
+                                        .sequence     = sequence++,
                                         .flashVersion = FLASH_VERSION,
                                         .currentClock = g_Values.AppTime.CurrentTime(),
                                         .oldestPacket = bufferManager.AgeOfOldestBuffer(),


### PR DESCRIPTION
## Description
Adds a new 64-bit sequence number to the response packet.
Fixes the WiFi delivery framerate issue that was limiting it to about 8fps

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).