### PR TITLE
Add section on COM problems to README

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       id: envs
       run: |
         if [[ $(< config/ci_exclude.json) != '[]' ]]; then echo "::warning title=Some environments were skipped::Environments not built: $(< config/ci_exclude.json)"; fi
-        echo "envs=$(tools/show_envs.py | jq -c --argfile ex config/ci_exclude.json '. - $ex')" >> $GITHUB_OUTPUT
+        echo "envs=$(tools/show_envs.py | jq -c --slurpfile ex config/ci_exclude.json '. - $ex[0]')" >> $GITHUB_OUTPUT
 
     outputs:
       envs: ${{ steps.envs.outputs.envs }}

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ cd tools
 
 Specifically on the Windows platform, there have been cases where people have experienced problems communicating to the serial port that the ESP32 device is connected to from PlatformIO, usually in the shape of PlatformIO showing messages that the COM port in question doesn't exist where it absolutely did before. This tends to be caused by the COM port being used by another process within PlatformIO (the monitor function being a known cause), or some other application effectively blocking the COM port in question. A confirmed example of the latter is Malwarebytes.
 
-If you run into problems of this nature, the tools in the Sysinternals toolkit (particularly Process Explorer and Portmon, available [from Microsoft](https://learn.microsoft.com/en-us/sysinternals/)) may be helpful towards finding the culprit.
+If you experience such difficulties accessing serial ports, the tools in the Sysinternals toolkit (particularly Process Explorer and Portmon, available [from Microsoft](https://learn.microsoft.com/en-us/sysinternals/)) may be helpful towards finding the culprit.
 
 ## Bonus exercise
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ _Davepl, 9/19/2021_
   - [Build commands](#build-commands)
 - [File system](#file-system)
 - [Tools](#tools)
+- [COM port problems](#com-port-problems)
 - [Bonus exercise](#bonus-exercise)
 - [Super Bonus Exercise](#super-bonus-exercise)
 - [Sample parts (Plummer's Software LLC Amazon affiliate links)](#sample-parts-plummers-software-llc-amazon-affiliate-links)
@@ -330,6 +331,12 @@ Instead of:
 cd tools
 ./buddybuild.sh
 ```
+
+## COM port problems
+
+Specifically on the Windows platform, there have been cases where people have experienced problems communicating to the serial port that the ESP32 device is connected to from PlatformIO, usually in the shape of PlatformIO showing messages that the COM port in question doesn't exist where it absolutely did before. This tends to be caused by the COM port being used by another process within PlatformIO (the monitor function being a known cause), or some other application effectively blocking the COM port in question. A confirmed example of the latter is Malwarebytes.
+
+If you run into problems of this nature, the tools in the Sysinternals toolkit (particularly Process Explorer and Portmon, available [from Microsoft](https://learn.microsoft.com/en-us/sysinternals/)) may be helpful towards finding the culprit.
 
 ## Bonus exercise
 


### PR DESCRIPTION
## Description

Adds a section to the README concerning COM port problems on the Windows platform.

It includes another minor change to the GitHub CI workflow file so it no longer uses jq's --argfile option, which is no longer available in jq on Ubuntu 24.04.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).