### PR TITLE
Misc minor enhancements in gfxbase

### DIFF
--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -1128,38 +1128,38 @@ public:
 
     void BresenhamLine(int x0, int y0, int x1, int y1, CRGB color, bool bMerge = false) const
     {
-	int dx = abs(x1 - x0); // Delta in x direction
-	int dy = abs(y1 - y0); // Delta in y direction
-	int sx = (x0 < x1) ? 1 : -1; // Step in x direction
-	int sy = (y0 < y1) ? 1 : -1; // Step in y direction
+        int dx = abs(x1 - x0); // Delta in x direction
+        int dy = abs(y1 - y0); // Delta in y direction
+        int sx = (x0 < x1) ? 1 : -1; // Step in x direction
+        int sy = (y0 < y1) ? 1 : -1; // Step in y direction
 
-	int err = dx - dy; // Initial error term
+        int err = dx - dy; // Initial error term
 
-	while (true)
-	{
-	    int index = XY(x0, y0);
-	    if (isValidPixel(index))
-	    {
-		// Optimization opportunity: unswtitch bMerge into another function
-		leds[index] = bMerge ? leds[index] + color : color;
-	    }
+        while (true)
+        {
+            int index = XY(x0, y0);
+            if (isValidPixel(index))
+            {
+                // Optimization opportunity: unswtitch bMerge into another function
+                leds[index] = bMerge ? leds[index] + color : color;
+            }
 
-	    if (x0 == x1 && y0 == y1)
-		break; // Exit the loop once we've reached the destination
+            if (x0 == x1 && y0 == y1)
+                break; // Exit the loop once we've reached the destination
 
-	    int e2 = 2 * err; // Error term multiplied by 2 for efficiency. Saves second test for Y.
-	    if (e2 > -dy) // Move in the x direction if needed
-	    {
-		err -= dy;
-		x0 += sx;
-	    }
+            int e2 = 2 * err; // Error term multiplied by 2 for efficiency. Saves second test for Y.
+            if (e2 > -dy) // Move in the x direction if needed
+            {
+                err -= dy;
+                x0 += sx;
+            }
 
-	    if (e2 < dx) // Move in the y direction if needed
-	    {
-		err += dx;
-		y0 += sy;
-	    }
-	}
+            if (e2 < dx) // Move in the y direction if needed
+            {
+                err += dx;
+                y0 += sy;
+            }
+        }
     }
 
     void BresenhamLine(int x0, int y0, int x1, int y1, uint8_t colorIndex, bool bMerge = false) const

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -1126,7 +1126,7 @@ public:
         }
     }
 
-void BresenhamLine(int x0, int y0, int x1, int y1, CRGB color, bool bMerge = false) const
+    void BresenhamLine(int x0, int y0, int x1, int y1, CRGB color, bool bMerge = false) const
     {
 	int dx = abs(x1 - x0); // Delta in x direction
 	int dy = abs(y1 - y0); // Delta in y direction
@@ -1138,7 +1138,7 @@ void BresenhamLine(int x0, int y0, int x1, int y1, CRGB color, bool bMerge = fal
 	while (true)
 	{
 	    int index = XY(x0, y0);
-	    if (isValidPixel(index)
+	    if (isValidPixel(index))
 	    {
 		// Optimization opportunity: unswtitch bMerge into another function
 		leds[index] = bMerge ? leds[index] + color : color;

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -689,28 +689,24 @@ public:
 
     void setPalette(const String& paletteName)
     {
-        if (paletteName == "Rainbow")
-            loadPalette(0);
-        // else if (paletteName == "RainbowStripe")
-        //   loadPalette(1);
-        else if (paletteName == "Ocean")
-            loadPalette(1);
-        else if (paletteName == "Cloud")
-            loadPalette(2);
-        else if (paletteName == "Forest")
-            loadPalette(3);
-        else if (paletteName == "Party")
-            loadPalette(4);
-        else if (paletteName == "Grayscale")
-            loadPalette(5);
-        else if (paletteName == "Heat")
-            loadPalette(6);
-        else if (paletteName == "Lava")
-            loadPalette(7);
-        else if (paletteName == "Ice")
-            loadPalette(8);
-        else if (paletteName == "Random")
-            RandomPalette();
+        static const std::unordered_map<const char*, int> paletteMap = {
+            {"Rainbow", 0},
+            {"Ocean", 1},
+            {"Cloud", 2},
+            {"Forest", 3},
+            {"Party", 4},
+            {"Grayscale", 5},
+            {"Heat", 6},
+            {"Lava", 7},
+            {"Ice", 8}
+        };
+
+        auto it = paletteMap.find(paletteName.c_str());
+        if (it != paletteMap.end()) {
+            loadPalette(it->second);  // Found a matching palette, load it
+        } else if (paletteName == "Random") {
+            RandomPalette();  // Special case for "Random"
+        }
     }
 
     static void listPalettes()
@@ -1130,42 +1126,41 @@ public:
         }
     }
 
-    void BresenhamLine(int x0, int y0, int x1, int y1, CRGB color, bool bMerge = false) const
+void BresenhamLine(int x0, int y0, int x1, int y1, CRGB color, bool bMerge = false) const
     {
-        int dx = abs(x1 - x0), sx = x0 < x1 ? 1 : -1;
-        int dy = -abs(y1 - y0), sy = y0 < y1 ? 1 : -1;
+	int dx = abs(x1 - x0); // Delta in x direction
+	int dy = abs(y1 - y0); // Delta in y direction
+	int sx = (x0 < x1) ? 1 : -1; // Step in x direction
+	int sy = (y0 < y1) ? 1 : -1; // Step in y direction
 
-        int err = dx + dy;  // Error must be declared here
+	int err = dx - dy; // Initial error term
 
-        for (;;)
-        {
-            if (isValidPixel(x0, y0))
-                leds[XY(x0, y0)] = bMerge ? leds[XY(x0, y0)] + color : color;
+	while (true)
+	{
+	    int index = XY(x0, y0);
+	    if (isValidPixel(index)
+	    {
+		// Optimization opportunity: unswtitch bMerge into another function
+		leds[index] = bMerge ? leds[index] + color : color;
+	    }
 
-            if (x0 == x1 && y0 == y1)
-                break;
+	    if (x0 == x1 && y0 == y1)
+		break; // Exit the loop once we've reached the destination
 
-            int e2 = 2 * err;
-            if (e2 >= dy)
-            {
-                err += dy;
-                x0 += sx;
-            }
-            // Recheck after x-axis update
-            if (x0 == x1 && y0 == y1)
-                break;
+	    int e2 = 2 * err; // Error term multiplied by 2 for efficiency. Saves second test for Y.
+	    if (e2 > -dy) // Move in the x direction if needed
+	    {
+		err -= dy;
+		x0 += sx;
+	    }
 
-            if (e2 <= dx)
-            {
-                err += dx;
-                y0 += sy;
-            }
-            // Recheck after y-axis update
-            if (x0 == x1 && y0 == y1)
-                break;
-        }
+	    if (e2 < dx) // Move in the y direction if needed
+	    {
+		err += dx;
+		y0 += sy;
+	    }
+	}
     }
-
 
     void BresenhamLine(int x0, int y0, int x1, int y1, uint8_t colorIndex, bool bMerge = false) const
     {


### PR DESCRIPTION
Minor readability fixes in gfxbase.
    Minor readability fixes in gfxbase.

    setPalette: use STL to find entry in a table instead of nine separate
    string compares. The functions above and below really should be combined
    similarly.

    BresenhamLine():
      More faithful reproduction of published implementations.
      Computes pixel index only once.
      Since we're amplifying 'e2' term, no need to recheck y in each iteration.
      Keep sign of err in the most commonlhy used form instead of double negativ
e.

Tested:   Run all effects on Mesmerizer hardware, our most demanding build of   that code.**

## Description
I know this isn't your favorite tyep of PR, but technically it DOES improve
BlinkenPerBit by taking fewer bits to do the same thing. Use of STL maximixes
SWE brain cell consumption: find() finds things. Smarter data. Dumber code.ZZ

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
