### PR TITLE
Fix OLED behavior on Heltec Wifi Kit 32 V2 and V3

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -1334,10 +1334,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 #define NUM_RINGS 1
 #endif
 
-#ifndef NUM_INFO_PAGES
-#define NUM_INFO_PAGES 2
-#endif
-
 #ifndef COLOR_ORDER
 #define COLOR_ORDER EOrder::GRB
 #endif
@@ -1480,6 +1476,10 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
 #endif // end USE_SCREEN
 
+#if USE_OLED
+    #define NUM_INFO_PAGES 1        // Only allow "Basic Info Summary" page on monochrome OLED screens
+#endif
+
 #if USE_LCD
     // These pins are based on the Espressif WROVER-KIT, which uses an ILI9314 chipset for its display
     // connected as follows:
@@ -1532,6 +1532,10 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
 #ifndef MATRIX_CENTER_Y
 #define MATRIX_CENTER_Y ((MATRIX_HEIGHT + 1) / 2)
+#endif
+
+#ifndef NUM_INFO_PAGES
+#define NUM_INFO_PAGES 2
 #endif
 
 // When you press a color button on the remote, the color is used to create a temporary fill effect, but

--- a/include/globals.h
+++ b/include/globals.h
@@ -1441,7 +1441,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
         #define USE_OLED 1                                    // Enable the Heltec's monochrome OLED
         #ifndef USE_SSD1306
-            #define NUM_INFO_PAGES 1        // Only allow "Basic Info Summary" page on monochrome OLED screens
+            #define NUM_INFO_PAGES 1        // Only display "BasicInfoSummary" if not SSD1306
         #endif
 
     #elif USE_M5                                        // screen definitions for m5stick-c-plus

--- a/include/globals.h
+++ b/include/globals.h
@@ -1440,7 +1440,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
                         // screen definations for heltec_wifi_kit_32 or heltec_wifi_kit_32_v2
 
         #define USE_OLED 1                                    // Enable the Heltec's monochrome OLED
-        #ifndef USE_SSD1306
+        #if !(USE_SSD1306)
             #define NUM_INFO_PAGES 1        // Only display "BasicInfoSummary" if not SSD1306
         #endif
 

--- a/include/globals.h
+++ b/include/globals.h
@@ -1436,15 +1436,13 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
 #if USE_SCREEN
 
-    #if ARDUINO_HELTEC_WIFI_KIT_32_V3
-
-        #define USE_OLED 1
-        #define USE_SSD1306 1
-
-    #elif ARDUINO_HELTEC_WIFI_KIT_32
+    #if ARDUINO_HELTEC_WIFI_KIT_32
                         // screen definations for heltec_wifi_kit_32 or heltec_wifi_kit_32_v2
 
         #define USE_OLED 1                                    // Enable the Heltec's monochrome OLED
+        #ifndef USE_SSD1306
+            #define NUM_INFO_PAGES 1        // Only allow "Basic Info Summary" page on monochrome OLED screens
+        #endif
 
     #elif USE_M5                                        // screen definitions for m5stick-c-plus
 
@@ -1475,10 +1473,6 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #endif
 
 #endif // end USE_SCREEN
-
-#if USE_OLED
-    #define NUM_INFO_PAGES 1        // Only allow "Basic Info Summary" page on monochrome OLED screens
-#endif
 
 #if USE_LCD
     // These pins are based on the Espressif WROVER-KIT, which uses an ILI9314 chipset for its display

--- a/include/screen.h
+++ b/include/screen.h
@@ -350,7 +350,7 @@ public:
 
     // SSD1306Screen
     //
-    // Display code for the SSD1306 display on the Heltect Wifi Kit 32 V3
+    // Display code for the SSD1306 display on supported Heltec ESP32 boards
 
     #include <U8g2lib.h>                // Library for monochrome displays
     #include <gfxfont.h>                // Adafruit GFX font structs

--- a/platformio.ini
+++ b/platformio.ini
@@ -121,7 +121,10 @@ build_flags     = -DUSE_SCREEN=1
 extends         = dev_heltec_wifi
 board           = heltec_wifi_kit_32_v2
 build_flags     = -DARDUINO_HELTEC_WIFI_KIT_32_V2=1
+                  -DUSE_SSD1306=1
                   ${dev_heltec_wifi.build_flags}
+lib_deps        = ${dev_heltec_wifi.lib_deps}
+                  heltecautomation/Heltec ESP32 Dev-Boards @ ^1.1.1
 
 [dev_heltec_wifi_v3]
 extends         = dev_heltec_wifi

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -251,7 +251,7 @@ void CurrentEffectSummary(bool bRedraw)
     if (bRedraw)
         display.fillScreen(BLACK16);
 
-    #if USE_SSD1306     // Set background color to black for monochrome SSD1306 screen
+    #if USE_SSD1306     // Set background color to black for monochrome SSD1306 OLED screen
         uint16_t backColor = Screen::to16bit(CRGB(0, 0, 0));
     #else
         uint16_t backColor = Screen::to16bit(CRGB(0, 0, 64));

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -251,7 +251,7 @@ void CurrentEffectSummary(bool bRedraw)
     if (bRedraw)
         display.fillScreen(BLACK16);
 
-    #if ARDUINO_HELTEC_WIFI_LORA_32_V3
+    #if USE_SSD1306     // Set background color to black for monochrome SSD1306 screen
         uint16_t backColor = Screen::to16bit(CRGB(0, 0, 0));
     #else
         uint16_t backColor = Screen::to16bit(CRGB(0, 0, 64));


### PR DESCRIPTION
## Description
Updated code to ensure consistent OLED display behavior among most supported Heltec boards.

## Overview
This code builds/works as expected for the following device models, with no local modifications except to create/populate a secrets.h file:

- Heltec Wifi Kit 32 (V2): pio run -e heltecv2demo -t upload
- Heltec Wifi Kit 32 (V3): pio run -e heltecv3demo -t upload
- Heltec Wifi LoRa 32 (V3): pio run -e helteclorav3demo -t upload

The "CurrentEffectSummary" screen now displays correctly (i.e., legible, but monochrome) on all three devices.

Prior to my changes, the code on the main branch resulted in different behavior for each device:

- Heltec Wifi Kit 32 (V2): Screen flashes solid blocks of pixels briefly on device boot or whenever any would-be-displayed data updates (this prompted my discussion #692 ).
- Heltec Wifi Kit 32 (V3): Screen remains on persistently, but displays only two solid blocks of pixels (similar to issue #667  for the LoRa 32).
- Heltec Wifi LoRa 32 (V3): Screen displays correctly and remains on persistently.

## Change Details

**platformio.ini**
I added the build_flag "-DUSE_SSD1306=1" and lib_dep "heltecautomation/Heltec ESP32 Dev-Boards @ ^1.1.1" to "[dev_heltec_wifi_v2]". Both had been added previously to the "wifi_v3" and "lora_v3" environments. This fixed the issue where the "CurrentEffectSummary" screen won't remain visible on the V2 board without constantly forcing a full redraw.

**globals.h**
I simplified the section under "#if ARDUINO_HELTEC_WIFI_KIT_32", now that 3 of 4 supported Heltec boards should all use a consistent config. Basically, everything with this flag should set "USE_OLED", and the only time we still want to reduce "NUM_INFO_PAGES" to '1' is when "USE_SSD1306" isn't set, i.e., for the original Heltec Wifi Kit 32.

I also moved the "default" setting of "NUM_INFO_PAGES" to a new location (line 1531) to avoid compiler warnings for a duplicate definition. My rationale for the new location is that this section seems to contain display-related defaults, vs. environment-related defaults.

**screen.h**
I changed a comment to reflect that the SSD1306Screen section already applies to multiple Heltec models.

**screen.cpp**
Here I changed the condition for setting the background of the "CurrentEffectSummary" screen to black. My thinking is that the reason for this conditional is a specific display type more than a specific board.

This alternative seems less elegant to me, but I don't know which is "better" in terms of proper scoping:
`#if ARDUINO_HELTEC_WIFI_KIT_32_V2 || ARDUINO_HELTEC_WIFI_KIT_32_V3 || ARDUINO_HELTEC_WIFI_LORA_32_V3`

## Questions

Is it worth trying to track down somebody with an original Heltec Wifi Kit 32 to see if we can make the display behavior consistent for all Heltec devices? The only reason I'm still including the conditional to set "NUM_INFO_PAGES" to '1' is that I don't have an original/"V1" Heltec to test with, and without testing, forcing the "BasicInfoSummary" screen seems like a "safer" option.

## Contribution Guidelines

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).