### PR TITLE
Make IR remote OFF button dim gradually again on Mesmerizer

### DIFF
--- a/src/remotecontrol.cpp
+++ b/src/remotecontrol.cpp
@@ -93,7 +93,7 @@ void RemoteControl::handle()
     }
     else if (IR_OFF == result)
     {
-        #if HUB75
+        #if USE_HUB75
             deviceConfig.SetBrightness((int)deviceConfig.GetBrightness() - BRIGHTNESS_STEP);
         #else
             effectManager.ClearRemoteColor();


### PR DESCRIPTION
## Description

As discussed in #690, on all projects except Mesmerizer, the OFF button on the remote control should act as an effective OFF button, by turning the brightness to 0 on one press. On Mesmerizer, the OFF button should gradually decrease the brightness of the matrix - this was the behavior for all projects before #660 got merged. 

Due to a check for the wrong define being set (`HUB75` instead of `USE_HUB75`) the OFF button now also turns down the brightness all the way on Mesmerizer.

This PR fixes that.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).