### PR TITLE
Switch to ESP32Async/ESPAsyncWebserver

### DIFF
--- a/include/webserver.h
+++ b/include/webserver.h
@@ -59,7 +59,7 @@ class CWebServer
   private:
     // Template for param to value converter function, used by PushPostParamIfPresent()
     template<typename Tv>
-    using ParamValueGetter = std::function<Tv(AsyncWebParameter *param)>;
+    using ParamValueGetter = std::function<Tv(const AsyncWebParameter *param)>;
 
     // Template for value setting forwarding function, used by PushPostParamIfPresent()
     template<typename Tv>
@@ -106,14 +106,14 @@ class CWebServer
 
     // Convert param value to a specific type and forward it to a setter function that expects that type as an argument
     template<typename Tv>
-    static bool PushPostParamIfPresent(AsyncWebServerRequest * pRequest, const String & paramName, ValueSetter<Tv> setter, ParamValueGetter<Tv> getter)
+    static bool PushPostParamIfPresent(const AsyncWebServerRequest * pRequest, const String & paramName, ValueSetter<Tv> setter, ParamValueGetter<Tv> getter)
     {
         if (!pRequest->hasParam(paramName, true, false))
             return false;
 
         debugV("found %s", paramName.c_str());
 
-        AsyncWebParameter *param = pRequest->getParam(paramName, true, false);
+        const AsyncWebParameter *param = pRequest->getParam(paramName, true, false);
 
         // Extract the value and pass it off to the setter
         return setter(getter(param));
@@ -122,9 +122,9 @@ class CWebServer
     // Generic param value forwarder. The type argument must be implicitly convertable from String!
     //   Some specializations of this are included in the CPP file
     template<typename Tv>
-    static bool PushPostParamIfPresent(AsyncWebServerRequest * pRequest, const String & paramName, ValueSetter<Tv> setter)
+    static bool PushPostParamIfPresent(const AsyncWebServerRequest * pRequest, const String & paramName, ValueSetter<Tv> setter)
     {
-        return PushPostParamIfPresent<Tv>(pRequest, paramName, setter, [](AsyncWebParameter * param) { return param->value(); });
+        return PushPostParamIfPresent<Tv>(pRequest, paramName, setter, [](const AsyncWebParameter * param) { return param->value(); });
     }
 
     // AddCORSHeaderAndSend(OK)Response
@@ -190,7 +190,7 @@ class CWebServer
         _server.on(strUri, HTTP_GET, [strUri, file](AsyncWebServerRequest *request)
         {
             Serial.printf("GET for: %s\n", strUri);
-            AsyncWebServerResponse *response = request->beginResponse_P(200, file.type, file.contents, file.length);
+            AsyncWebServerResponse *response = request->beginResponse(200, file.type, file.contents, file.length);
             if (file.encoding)
             {
                 response->addHeader("Content-Encoding", file.encoding);

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -113,10 +113,8 @@ class CWebServer
 
         debugV("found %s", paramName.c_str());
 
-        const AsyncWebParameter *param = pRequest->getParam(paramName, true, false);
-
         // Extract the value and pass it off to the setter
-        return setter(getter(param));
+        return setter(getter(pRequest->getParam(paramName, true, false)));
     }
 
     // Generic param value forwarder. The type argument must be implicitly convertable from String!

--- a/platformio.ini
+++ b/platformio.ini
@@ -54,7 +54,6 @@ lib_deps        = crankyoldgit/IRremoteESP8266  @ ^2.7.20
                   adafruit/Adafruit GFX Library @ ^1.10.12
                   olikraus/U8g2                 @ ^2.28.8
                   kosme/arduinoFFT              @ ^1.5.6
-                  me-no-dev/AsyncTCP            @ ^1.1.1
                   esp32async/ESPAsyncWebServer  @ ^3.7.0
                   bblanchon/ArduinoJson         @ ^6.21.3
                   thomasfredericks/Bounce2      @ ^2.7.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -55,13 +55,14 @@ lib_deps        = crankyoldgit/IRremoteESP8266  @ ^2.7.20
                   olikraus/U8g2                 @ ^2.28.8
                   kosme/arduinoFFT              @ ^1.5.6
                   me-no-dev/AsyncTCP            @ ^1.1.1
-                  https://github.com/PlummersSoftwareLLC/ESPAsyncWebServer.git
+                  esp32async/ESPAsyncWebServer  @ ^3.7.0
                   bblanchon/ArduinoJson         @ ^6.21.3
                   thomasfredericks/Bounce2      @ ^2.7.0
                   https://github.com/PlummersSoftwareLLC/RemoteDebug
                   QRCode                        @ ^0.0.1
                   Bodmer/TJpg_Decoder           @ ^1.0.8
                   plageoj/UrlEncode             @ ^1.0.1
+#                  https://github.com/PlummersSoftwareLLC/ESPAsyncWebServer.git
 
 ; This partition table attempts to fit everything in 4M of flash.
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -62,7 +62,6 @@ lib_deps        = crankyoldgit/IRremoteESP8266  @ ^2.7.20
                   QRCode                        @ ^0.0.1
                   Bodmer/TJpg_Decoder           @ ^1.0.8
                   plageoj/UrlEncode             @ ^1.0.1
-#                  https://github.com/PlummersSoftwareLLC/ESPAsyncWebServer.git
 
 ; This partition table attempts to fit everything in 4M of flash.
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -53,9 +53,9 @@ std::vector<std::reference_wrapper<SettingSpec>> CWebServer::deviceSettingSpecs{
 
 // Push param that represents a bool. Values considered true are text "true" and any whole number not equal to 0
 template<>
-bool CWebServer::PushPostParamIfPresent<bool>(AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<bool> setter)
+bool CWebServer::PushPostParamIfPresent<bool>(const AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<bool> setter)
 {
-    return PushPostParamIfPresent<bool>(pRequest, paramName, std::move(setter), [](AsyncWebParameter * param) constexpr
+    return PushPostParamIfPresent<bool>(pRequest, paramName, std::move(setter), [](const AsyncWebParameter * param) constexpr
     {
         return BoolFromText(param->value());
     });
@@ -63,9 +63,9 @@ bool CWebServer::PushPostParamIfPresent<bool>(AsyncWebServerRequest * pRequest, 
 
 // Push param that represents a size_t
 template<>
-bool CWebServer::PushPostParamIfPresent<size_t>(AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<size_t> setter)
+bool CWebServer::PushPostParamIfPresent<size_t>(const AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<size_t> setter)
 {
-    return PushPostParamIfPresent<size_t>(pRequest, paramName, std::move(setter), [](AsyncWebParameter * param) constexpr
+    return PushPostParamIfPresent<size_t>(pRequest, paramName, std::move(setter), [](const AsyncWebParameter * param) constexpr -> size_t
     {
         return strtoul(param->value().c_str(), nullptr, 10);
     });
@@ -73,9 +73,9 @@ bool CWebServer::PushPostParamIfPresent<size_t>(AsyncWebServerRequest * pRequest
 
 // Push param that represents an int
 template<>
-bool CWebServer::PushPostParamIfPresent<int>(AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<int> setter)
+bool CWebServer::PushPostParamIfPresent<int>(const AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<int> setter)
 {
-    return PushPostParamIfPresent<int>(pRequest, paramName, std::move(setter), [](AsyncWebParameter * param) constexpr
+    return PushPostParamIfPresent<int>(pRequest, paramName, std::move(setter), [](const AsyncWebParameter * param) constexpr
     {
         return std::stoi(param->value().c_str());
     });
@@ -83,9 +83,9 @@ bool CWebServer::PushPostParamIfPresent<int>(AsyncWebServerRequest * pRequest, c
 
 // Push param that represents a color
 template<>
-bool CWebServer::PushPostParamIfPresent<CRGB>(AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<CRGB> setter)
+bool CWebServer::PushPostParamIfPresent<CRGB>(const AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<CRGB> setter)
 {
-    return PushPostParamIfPresent<CRGB>(pRequest, paramName, std::move(setter), [](AsyncWebParameter * param) constexpr
+    return PushPostParamIfPresent<CRGB>(pRequest, paramName, std::move(setter), [](const AsyncWebParameter * param) constexpr
     {
         return CRGB(strtoul(param->value().c_str(), nullptr, 10));
     });

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -65,7 +65,7 @@ bool CWebServer::PushPostParamIfPresent<bool>(const AsyncWebServerRequest * pReq
 template<>
 bool CWebServer::PushPostParamIfPresent<size_t>(const AsyncWebServerRequest * pRequest, const String &paramName, ValueSetter<size_t> setter)
 {
-    return PushPostParamIfPresent<size_t>(pRequest, paramName, std::move(setter), [](const AsyncWebParameter * param) constexpr -> size_t
+    return PushPostParamIfPresent<size_t>(pRequest, paramName, std::move(setter), [](const AsyncWebParameter * param) constexpr
     {
         return strtoul(param->value().c_str(), nullptr, 10);
     });


### PR DESCRIPTION
## Description

This changes the ESPAsyncWebserver web server dependency from a slightly modified version of the original version developed by [me-no-dev](https://github.com/me-no-dev/) (now archived) to the version maintained by the [ESP32Async](https://github.com/ESP32Async/) project. It also allows ESPAsyncWebserver to pull in its own version of AsyncTCP; that project also moved to ESP32Async.

Credits go to:

- @robertlipe for raising this in #690 
- @heidepiek for testing, and finding a completely unrelated bug in the process (see #694)

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).