### PR TITLE
Make it possible to override LED_PIN0 and enable all networking services from platformio.ini or command line 

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -1585,7 +1585,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 // $ PLATFORMIO_BUILD_FLAGS="-DLED_PIN0=14 -DUSE_ALL_NETWORKING" \
 //   pio run --target upload -e lilygo-tdisplay-s3-demo
 
-#ifdef USE_ALL_NETWORKING
+#if USE_ALL_NETWORKING
     #undef ENABLE_WIFI
     #define ENABLE_WIFI             1   // Connect to WiFi
 


### PR DESCRIPTION
## Description

    Make it possible to override LED_PIN0 from platformio.ini or command
    line in all cases, avoiding necessary undef/redefine cases or making
    another project that differs ONLY in the pin definition if it's not
    practical to change, such as having terminals being physically wired
    to specific pins.

## Contributing requirements

I have verified that LED_PIN and the new USE_ALL_NETWORKING can be successfully
used without warnings or errors.

PLATFORMIO_BUILD_FLAGS="-DLED_PIN0=14 -DUSE_ALL_NETWORKING" \
   pio run -v --target upload -e lilygo-tdisplay-s3-demo

Also Tested: Build buddy


========================= [SUCCESS] Took 35.26 seconds =========================

Environment               Status    Duration
------------------------  --------  ------------
demo                      SUCCESS   00:00:11.526
m5demo                    SUCCESS   00:00:33.872
m5plusdemo                SUCCESS   00:00:33.975
m5stackdemo               SUCCESS   00:00:34.103
heltecdemo                SUCCESS   00:00:30.212
heltecv2demo              SUCCESS   00:00:29.649
heltecv3demo              SUCCESS   00:00:30.161
helteclorav3demo          SUCCESS   00:00:30.798
lilygo-tdisplay-s3-demo   SUCCESS   00:00:12.679
demo_amoled               SUCCESS   00:00:33.494
ledstrip                  SUCCESS   00:00:29.569
ledstrip_feather          SUCCESS   00:00:29.486
ledstrip_feather_hexagon  SUCCESS   00:00:29.126
ledstrip_feather_wrover   SUCCESS   00:00:27.990
ledstriplite              SUCCESS   00:00:28.337
ledstrip_pico             SUCCESS   00:00:28.300
spectrum                  SUCCESS   00:00:35.583
spectrum2                 SUCCESS   00:00:35.363
helmet                    SUCCESS   00:00:34.758
spectrum_elecrow          SUCCESS   00:00:38.220
spectrumstack             SUCCESS   00:00:36.257
spectrumlite              SUCCESS   00:00:36.489
spectrum_wrover_kit       SUCCESS   00:00:29.450
mesmerizer                SUCCESS   00:00:18.042
mesmerizer_lolin          SUCCESS   00:00:32.301
laserline                 SUCCESS   00:00:14.970
lantern                   SUCCESS   00:00:33.843
pdpgrid                   SUCCESS   00:00:35.202
chieftain                 SUCCESS   00:00:29.126
umbrella                  SUCCESS   00:00:30.107
generic                   SUCCESS   00:00:27.851
panlee                    SUCCESS   00:00:29.962
ttgo                      SUCCESS   00:00:29.421
xmastrees                 SUCCESS   00:00:07.047
insulators                SUCCESS   00:00:35.080
magicmirror               SUCCESS   00:00:34.402
atomlight                 SUCCESS   00:00:30.899
spirallamp                SUCCESS   00:00:35.087
platecover                SUCCESS   00:00:34.338
fanset                    SUCCESS   00:00:35.126
cube                      SUCCESS   00:00:35.258
========================= 41 succeeded in 00:20:27.458 =========================

real        20m27.830s
user        79m54.048s
sys        61m5.998s
<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
