### PR TITLE
Improve JSON serialization memory overflow handling

### DIFF
--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -222,9 +222,7 @@ class DeviceConfig : public IJSONSerializable
         if (includeSensitive)
             jsonDoc[OpenWeatherApiKeyTag] = openWeatherApiKey;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     bool DeserializeFromJSON(const JsonObjectConst& jsonObject) override

--- a/include/effects/matrix/PatternAnimatedGIF.h
+++ b/include/effects/matrix/PatternAnimatedGIF.h
@@ -233,8 +233,7 @@ public:
         jsonDoc[PTY_BKCOLOR]   = _bkColor;
         jsonDoc[PTY_PRECLEAR]  = _preClear;
 
-        assert(!jsonDoc.overflowed());
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     void Start() override

--- a/include/effects/matrix/PatternSMNoise.h
+++ b/include/effects/matrix/PatternSMNoise.h
@@ -390,9 +390,7 @@ class PatternSMNoise : public LEDStripEffect
 
         jsonDoc[PTY_EFFECT] = to_value(_effect);
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     void Start() override

--- a/include/effects/matrix/PatternSMPicasso3in1.h
+++ b/include/effects/matrix/PatternSMPicasso3in1.h
@@ -179,9 +179,7 @@ class PatternSMPicasso3in1 : public LEDStripEffect
 
         jsonDoc[PTY_SCALE] = _scale;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
 

--- a/include/effects/matrix/PatternStocks.h
+++ b/include/effects/matrix/PatternStocks.h
@@ -378,9 +378,7 @@ public:
         jsonDoc["sds"] = stockServer;
         jsonDoc["tsl"] = tickerSymbols;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
 
@@ -463,11 +461,11 @@ public:
             // We have the high and low data in the stock, but let's not trust it and calculate it ourselves
             // If this works, Davepl wrote it.  If not, Robert made me do it!
 
-            auto [minpoint, maxpoint] = 
-                std::minmax_element(currentStock.points.begin(), currentStock.points.end(), [](const StockPoint& a, const StockPoint& b) 
-                { 
-                        return a.val < b.val; 
-                }); 
+            auto [minpoint, maxpoint] =
+                std::minmax_element(currentStock.points.begin(), currentStock.points.end(), [](const StockPoint& a, const StockPoint& b)
+                {
+                        return a.val < b.val;
+                });
 
             // We're comparing against the previous day's close, so make sure we include that in the range
             float min = std::min(minpoint->val, currentStock.previousClose);
@@ -559,10 +557,7 @@ public:
         jsonDoc[NAME_OF(stockServer)] = stockServer;
         jsonDoc[NAME_OF(tickerSymbols)] = tickerSymbols;
 
-        if (jsonDoc.overflowed())
-            debugE("JSON buffer overflow while serializing settings for PatternStocks - object incomplete!");
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     // Extension override to accept our settings on top of those known by LEDStripEffect

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -195,9 +195,7 @@ class PatternSubscribers : public LEDStripEffect
         jsonDoc["bgc"] = backgroundColor;
         jsonDoc["boc"] = borderColor;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     bool RequiresDoubleBuffering() const override
@@ -264,10 +262,7 @@ class PatternSubscribers : public LEDStripEffect
         jsonDoc[NAME_OF(backgroundColor)] = backgroundColor;
         jsonDoc[NAME_OF(borderColor)] = borderColor;
 
-        if (jsonDoc.overflowed())
-            debugE("JSON buffer overflow while serializing settings for PatternSubscribers - object incomplete!");
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     // Extension override to accept our settings on top of those known by LEDStripEffect

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -72,9 +72,7 @@ class InsulatorSpectrumEffect : public LEDStripEffect, public BeatEffectBase, pu
 
         jsonDoc[PTY_PALETTE] = _Palette;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     virtual void Draw() override
@@ -155,7 +153,7 @@ class VUMeter
         const int MAX_FADE = 256;
 
         int xHalf = GFX[0]->width()/2-1;
-        int bars  = g_Analyzer._VURatioFade / 2.0 * xHalf; 
+        int bars  = g_Analyzer._VURatioFade / 2.0 * xHalf;
         bars = min(bars, xHalf);
 
         EraseVUMeter(GFX, bars, yVU);
@@ -184,7 +182,7 @@ class VUMeter
 
 class VUMeterVertical : public VUMeter
 {
-private:    
+private:
     virtual inline void EraseVUMeter(std::vector<std::shared_ptr<GFXBase>> & GFX, int start, int yVU) const
     {
         for (int i = start; i <= GFX[0]->width(); i++)
@@ -208,7 +206,7 @@ public:
         const int MAX_FADE = 256;
 
         int size = GFX[0]->width();
-        int bars  = g_Analyzer._VURatioFade / 2.0 * size; 
+        int bars  = g_Analyzer._VURatioFade / 2.0 * size;
         bars = min(bars, size);
 
         EraseVUMeter(GFX, bars, yVU);
@@ -232,7 +230,7 @@ public:
 
         for (int i = 0; i < bars; i++)
             DrawVUPixels(GFX, i, yVU, i > bars ? 255 : 0, pPalette);
-    }    
+    }
 };
 
 class VUMeterEffect : virtual public VUMeter, public LEDStripEffect
@@ -386,7 +384,7 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter
         if (_peak1DecayRate >= 0.0f)
         {
             xOffset = (xOffset - offset + MATRIX_WIDTH) % MATRIX_WIDTH;
-                
+
             if (_peak1DecayRate != _peak2DecayRate)
             {
                 const int PeakFadeTime_ms = 1000;
@@ -482,9 +480,7 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter
         jsonDoc["pd2"]                 = _peak2DecayRate;
         jsonDoc["scb"]                 = _bScrollBars;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     virtual void Start() override
@@ -583,9 +579,7 @@ class WaveformEffect : public LEDStripEffect
 
         jsonDoc["inc"] = _increment;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     void DrawSpike(int x, float v, bool bErase = true)
@@ -680,14 +674,12 @@ class GhostWave : public WaveformEffect
         jsonDoc[PTY_ERASE] = _erase;
         jsonDoc[PTY_FADE] = _fade;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     virtual bool RequiresDoubleBuffering() const override
     {
-        // MoveOutWardX in the main draw call uses the prior buffer 
+        // MoveOutWardX in the main draw call uses the prior buffer
         return true;
     }
 
@@ -769,9 +761,7 @@ class SpectrumBarEffect : public LEDStripEffect, public BeatEffectBase
         jsonDoc[PTY_DELTAHUE] = _hueIncrement;
         jsonDoc[PTY_HUESTEP]  = _hueStep;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     virtual size_t DesiredFramesPerSecond() const override
@@ -881,8 +871,7 @@ class AudioSpikeEffect : public LEDStripEffect
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
 
-        assert(!jsonDoc.overflowed());
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     virtual size_t DesiredFramesPerSecond() const override
@@ -893,11 +882,11 @@ class AudioSpikeEffect : public LEDStripEffect
     virtual void Draw() override
     {
         fadeAllChannelsToBlackBy(50);
-        
+
         static int colorOffset = 0;
         colorOffset+= 4;
 
-        static int offset = 2; 
+        static int offset = 2;
 
         const int16_t * data = g_Analyzer.GetSampleBuffer();
         int lastY = ::map(data[offset], 0, 2500, 0, MATRIX_HEIGHT);
@@ -907,7 +896,7 @@ class AudioSpikeEffect : public LEDStripEffect
             CRGB color = ColorFromPalette(spectrumBasicColors, (y1 * 4) + colorOffset, 255, NOBLEND);
             g()->drawLine(x, lastY, x+1, y1, color);
             lastY = y1;
-        }    
+        }
         offset += MATRIX_WIDTH;
         if (offset + MATRIX_WIDTH > g_Analyzer.GetSampleBufferSize())
             offset = 2;

--- a/include/effects/strip/bouncingballeffect.h
+++ b/include/effects/strip/bouncingballeffect.h
@@ -61,6 +61,7 @@ private:
 
     static constexpr float Gravity = -9.81f;
     static constexpr float StartHeight = 1.0f;
+    // Note: VSCode flags sqrt() for calling a non-constexpr builtin function, but it compiles and runs
     static constexpr float ImpactVelocityStart = sqrt(-2.0f * Gravity * StartHeight);
 
     std::vector<double> ClockTimeSinceLastBounce;
@@ -102,9 +103,7 @@ private:
         jsonDoc[PTY_MIRORRED] = _bMirrored;
         jsonDoc[PTY_ERASE] = _bErase;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     virtual size_t DesiredFramesPerSecond() const override

--- a/include/effects/strip/doublepaletteeffect.h
+++ b/include/effects/strip/doublepaletteeffect.h
@@ -67,9 +67,7 @@ class DoublePaletteEffect : public LEDStripEffect
         paletteObj = jsonDoc["pt2"].to<JsonObject>();
         _PaletteEffect2.SerializeToJSON(paletteObj);
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -704,9 +704,7 @@ public:
     jsonDoc["rpm"] = _bReplaceMagenta;
     jsonDoc["sch"] = _sparkleChance;
 
-    assert(!jsonDoc.overflowed());
-
-    return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+    return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
   }
 
   void Draw() override
@@ -780,9 +778,7 @@ public:
     jsonDoc[PTY_ORDER] = to_value(_order);
     jsonDoc["stp"] = _step;
 
-    assert(!jsonDoc.overflowed());
-
-    return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+    return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
   }
 
   void Draw() override
@@ -1044,9 +1040,7 @@ public:
     jsonDoc[PTY_ORDER] = to_value(Order);
     jsonDoc[PTY_MULTICOLOR] = bMulticolor ? 1 : 0;
 
-    assert(!jsonDoc.overflowed());
-
-    return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+    return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
   }
 
   CRGB GetBlackBodyHeatColorByte(uint8_t temp) const
@@ -1098,7 +1092,7 @@ public:
         if (random(255) < Sparking)
         {
           int y = CellCount() - 1 - random(SparkHeight * CellsPerLED);
-          abHeat[y] = ::min((long)MaxSparkTemp, abHeat[y] + random(0, MaxSparkTemp)); 
+          abHeat[y] = ::min((long)MaxSparkTemp, abHeat[y] + random(0, MaxSparkTemp));
         }
       }
     }

--- a/include/effects/strip/fireeffect.h
+++ b/include/effects/strip/fireeffect.h
@@ -116,9 +116,7 @@ class FireEffect : public LEDStripEffect
         jsonDoc[PTY_REVERSED] = bReversed;
         jsonDoc[PTY_MIRORRED] = bMirrored;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     virtual ~FireEffect()
@@ -251,9 +249,7 @@ public:
         jsonDoc[PTY_PALETTE] = _palette;
         jsonDoc[PTY_IGNOREGLOBALCOLOR] = _ignoreGlobalColor;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     virtual CRGB GetBlackBodyHeatColor(float temp) const override
@@ -368,9 +364,7 @@ public:
         jsonDoc[PTY_REVERSED] = _Reversed;
         jsonDoc[PTY_COOLING] = _Cooling;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     void Draw() override
@@ -537,9 +531,8 @@ public:
         jsonDoc["trb"] = _Turbo;
         jsonDoc[PTY_MIRORRED] = _Mirrored;
 
-        assert(!jsonDoc.overflowed());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
 
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
     }
 
     bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
@@ -707,9 +700,7 @@ class BaseFireEffect : public LEDStripEffect
         jsonDoc[PTY_LEDCOUNT] = LEDCount;
         jsonDoc["clc"] = CellCount;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     virtual CRGB MapHeatToColor(uint8_t temperature)

--- a/include/effects/strip/laserline.h
+++ b/include/effects/strip/laserline.h
@@ -101,9 +101,7 @@ class LaserLineEffect : public BeatEffectBase, public LEDStripEffect
         jsonDoc[PTY_SIZE] = _defaultSize;
         jsonDoc[PTY_SPEED] = _defaultSpeed;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override

--- a/include/effects/strip/meteoreffect.h
+++ b/include/effects/strip/meteoreffect.h
@@ -203,9 +203,7 @@ class MeteorEffect : public LEDStripEffect
         jsonDoc[PTY_MINSPEED] = _meteorSpeedMin;
         jsonDoc[PTY_MAXSPEED] = _meteorSpeedMax;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -77,9 +77,7 @@ class SimpleRainbowTestEffect : public LEDStripEffect
         jsonDoc[PTY_EVERYNTH] = _EveryNth;
         jsonDoc[PTY_SPEEDDIVISOR] = _SpeedDivisor;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     void Draw() override
@@ -127,9 +125,7 @@ class RainbowTwinkleEffect : public LEDStripEffect
         jsonDoc[PTY_SPEEDDIVISOR] = _speedDivisor;
         jsonDoc[PTY_DELTAHUE] = _deltaHue;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     void Draw() override
@@ -196,9 +192,7 @@ protected:
         jsonDoc[PTY_DELTAHUE] = _deltaHue;
         jsonDoc[PTY_MIRRORED] = _mirrored;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     void Draw() override
@@ -273,9 +267,7 @@ protected:
         jsonDoc[PTY_COLOR] = _color;
         jsonDoc[PTY_IGNOREGLOBALCOLOR] = _ignoreGlobalColor;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     void Draw() override
@@ -385,9 +377,7 @@ class StatusEffect : public LEDStripEffect
         jsonDoc[PTY_EVERYNTH] = _everyNth;
         jsonDoc[PTY_COLOR] = _color;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     void Draw() override
@@ -464,9 +454,7 @@ class TwinkleEffect : public LEDStripEffect
         jsonDoc[PTY_FADE] = _fadeFactor;
         jsonDoc[PTY_SPEED] = _updateSpeed;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     const int Count = 99;

--- a/include/effects/strip/paletteeffect.h
+++ b/include/effects/strip/paletteeffect.h
@@ -106,9 +106,7 @@ class PaletteEffect : public LEDStripEffect
         jsonDoc[PTY_ERASE] = _bErase;
         jsonDoc["bns"] = _brightness;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     ~PaletteEffect()

--- a/include/effects/strip/particles.h
+++ b/include/effects/strip/particles.h
@@ -725,9 +725,7 @@ class MoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase, p
 
         jsonDoc[PTY_PALETTE] = _Palette;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
 
@@ -817,9 +815,7 @@ class NewMoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase
 
         jsonDoc[PTY_PALETTE] = _Palette;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     virtual void HandleBeat(bool bMajor, float elapsed, float span) override
@@ -905,9 +901,7 @@ class SparklySpinningMusicEffect : public LEDStripEffect, public BeatEffectBase,
 
         jsonDoc[PTY_PALETTE] = _Palette;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     virtual void HandleBeat(bool bMajor, float elapsed, float span) override

--- a/include/effects/strip/snakeeffect.h
+++ b/include/effects/strip/snakeeffect.h
@@ -90,9 +90,7 @@ class SnakeEffect : public LEDStripEffect
         jsonDoc[PTY_LEDCOUNT] = LEDCount;
         jsonDoc[PTY_SPEED] = SnakeSpeed;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     virtual ~SnakeEffect()

--- a/include/effects/strip/stareffect.h
+++ b/include/effects/strip/stareffect.h
@@ -484,9 +484,7 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
         jsonDoc["msf"] = _musicFactor;
         jsonDoc[PTY_COLOR] = _skyColor;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     virtual float StarSize()

--- a/include/jsonserializer.h
+++ b/include/jsonserializer.h
@@ -51,12 +51,12 @@ constexpr auto to_value(E e) noexcept
 
     struct JsonPsramAllocator : ArduinoJson::Allocator
     {
-        void* allocate(size_t size) override 
+        void* allocate(size_t size) override
         {
             return ps_malloc(size);
         }
 
-        void deallocate(void* pointer) override 
+        void deallocate(void* pointer) override
         {
             free(pointer);
         }
@@ -81,6 +81,21 @@ constexpr auto to_value(E e) noexcept
     }
 
 #endif
+
+inline bool SetIfNotOverflowed(JsonDocument& jsonDoc, JsonObject& jsonObject, const char* location = nullptr)
+{
+    if (jsonDoc.overflowed())
+    {
+        if (location)
+            debugE("JSON document overflowed at: %s", location);
+        else
+            debugE("JSON document overflowed");
+
+        return false;
+    }
+
+    return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+}
 
 namespace ArduinoJson
 {
@@ -107,7 +122,7 @@ namespace ArduinoJson
     {
         return Converter<CRGB>::checkJson(src);
     }
-    
+
     template <>
     struct Converter<CRGBPalette16>
     {

--- a/include/ledstripeffect.h
+++ b/include/ledstripeffect.h
@@ -419,7 +419,7 @@ class LEDStripEffect : public IJSONSerializable
         for (auto& device : _GFX)
             device->setPixelsF(fPos, count, c, bMerge);
     }
-    
+
     // ClearFrameOnAllChannels
     //
     // Clears ALL the channels
@@ -545,9 +545,7 @@ class LEDStripEffect : public IJSONSerializable
         if (_coreEffect)
             jsonDoc[PTY_COREEFFECT] = 1;
 
-        assert(!jsonDoc.overflowed());
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     virtual bool IsEnabled() const
@@ -607,10 +605,7 @@ class LEDStripEffect : public IJSONSerializable
         jsonDoc[ACTUAL_NAME_OF(_maximumEffectTime)] = _maximumEffectTime;
         jsonDoc["hasMaximumEffectTime"] = HasMaximumEffectTime();
 
-        if (jsonDoc.overflowed())
-            debugE("JSON buffer overflow while serializing settings for LEDStripEffect - object incomplete!");
-
-        return jsonObject.set(jsonDoc.as<JsonObjectConst>());
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
     // Changes the value for one "known" effect setting. All setting values are passed to this

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -218,7 +218,11 @@ std::shared_ptr<LEDStripEffect> EffectManager::CopyEffect(size_t index)
     auto jsonDoc = CreateJsonDocument();
     auto jsonObject = jsonDoc.to<JsonObject>();
 
-    assert(sourceEffect->SerializeToJSON(jsonObject));
+    if (!sourceEffect->SerializeToJSON(jsonObject))
+    {
+        debugE("Could not serialize effect %s to JSON", sourceEffect->FriendlyName().c_str());
+        return nullptr;
+    }
 
     auto copiedEffect = factoryEntry->second(jsonDoc.as<JsonObjectConst>());
 

--- a/src/jsonserializer.cpp
+++ b/src/jsonserializer.cpp
@@ -51,8 +51,6 @@ bool LoadJSONFile(const String & fileName, JsonDocument& jsonDoc)
         {
             debugI("Attempting to read JSON file %s", fileName.c_str());
 
-            jsonDoc = CreateJsonDocument();
-
             DeserializationError error = deserializeJson(jsonDoc, file);
 
             if (error == DeserializationError::NoMemory)
@@ -79,7 +77,12 @@ bool SaveToJSONFile(const String & fileName, IJSONSerializable& object)
 {
     auto jsonDoc = CreateJsonDocument();
     auto jsonObject = jsonDoc.to<JsonObject>();
-    object.SerializeToJSON(jsonObject);
+
+    if (!object.SerializeToJSON(jsonObject))
+    {
+        debugE("Could not serialize object to JSON, skipping write to %s!", fileName.c_str());
+        return false;
+    }
 
     SPIFFS.remove(fileName);
 


### PR DESCRIPTION
## Description

This improves the handling of ArduinoJSON serialization memory overflows. Instead of triggering a device reset in case a JSON serialization memory overflow condition occurs, an error is logged and the failed serialization attempt is abandoned.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).