### PR TITLE
Replace unpkg with jsDelivr

### DIFF
--- a/site/src/index.html
+++ b/site/src/index.html
@@ -2,15 +2,15 @@
 <html lang="en">
 <head>
     <title>NightDriverStrip</title>
-    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js"></script>
+    <script crossorigin src="https://cdn.jsdelivr.net/npm/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://cdn.jsdelivr.net/npm/react-dom@18.2.0/umd/react-dom.production.min.js"></script>
     <!-- Material UI -->
-    <script crossorigin src="https://unpkg.com/@emotion/react@11.11.1/dist/emotion-react.umd.min.js"></script>
-    <script crossorigin src="https://unpkg.com/@emotion/styled@11.11.0/dist/emotion-styled.umd.min.js"></script>
-    <script crossorigin src="https://unpkg.com/@mui/material@5.14.9/umd/material-ui.development.js"></script>
-    <script crossorigin src="https://unpkg.com/html-react-parser@4.2.2/dist/html-react-parser.min.js"></script>
+    <script crossorigin src="https://cdn.jsdelivr.net/npm/@emotion/react@11.11.1/dist/emotion-react.umd.min.js"></script>
+    <script crossorigin src="https://cdn.jsdelivr.net/npm/@emotion/styled@11.11.0/dist/emotion-styled.umd.min.js"></script>
+    <script crossorigin src="https://cdn.jsdelivr.net/npm/@mui/material@5.14.9/umd/material-ui.development.js"></script>
+    <script crossorigin src="https://cdn.jsdelivr.net/npm/html-react-parser@4.2.2/dist/html-react-parser.min.js"></script>
     <!-- Proptype and Recharts for Recharts -->
-    <script src="https://unpkg.com/prop-types/prop-types.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prop-types/prop-types.min.js"></script>
     <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/recharts/2.3.2/Recharts.min.js" referrerpolicy="no-referrer"></script>
     <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
     <link crossorigin rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">


### PR DESCRIPTION
## Description

This switches from unpkg.com to jsdelivr.com for retrieval of on-board web UI JavaScript dependencies. Unpkg.com has become very unstable in the past few weeks, responding with various errors in the 5xx range and even temporarily not having a domain registration.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).