### PR TITLE
Fix VU meter jitteriness in silent environments

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -138,8 +138,8 @@
 // NAME_OF with first character cut off - addresses underscore-prefixed (member) variables
 #define ACTUAL_NAME_OF(x)   ((#x) + 1)
 
-#define PERIOD_FROM_FREQ(f) (round(1000000 * (1.0 / f)))    // Calculate period in microseconds (us) from frequency in Hz
-#define FREQ_FROM_PERIOD(p) (1.0 / p * 1000000)             // Calculate frequency in Hz given the period in microseconds (us)
+#define PERIOD_FROM_FREQ(f) (round(1000000 * (1.0f / f)))    // Calculate period in microseconds (us) from frequency in Hz
+#define FREQ_FROM_PERIOD(p) (1.0f / p * 1000000)             // Calculate frequency in Hz given the period in microseconds (us)
 
 // I've built and run this on the Heltec Wifi 32 module and the M5StickC.  The
 // main difference is pinout and the OLED/LCD screen.  The presence of absence
@@ -566,7 +566,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
 
     // The mesmerizer mic isn't quite as sensitive as the M5 mic that the code was originally written for
     // so we adjust by a scalar to get the same effect.
-    
+
     #define AUDIO_MIC_SCALAR            1.5
 
     #define COLOR_ORDER                 EOrder::RGB
@@ -1061,7 +1061,7 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #endif
 
     #define DEFAULT_EFFECT_INTERVAL         0   // Do not auto-advance unless the button is presssed
-  
+
     #ifndef LED_PIN0
         #define LED_PIN0                    26
     #endif
@@ -1359,9 +1359,9 @@ extern RemoteDebug Debug;           // Let everyone in the project know about it
     #ifndef SPECTRUMBARBEAT_ENHANCE
         #define SPECTRUMBARBEAT_ENHANCE 0.75            // How much the SpectrumBar effect "pulses" with the music
     #endif
-    #ifndef VU_REACTIVITY_RATIO 
-        #define VU_REACTIVITY_RATIO 10.0                // How much the VU meter reacts to the music going up vs down
-    #endif        
+    #ifndef VU_REACTIVITY_RATIO
+        #define VU_REACTIVITY_RATIO 10.0f                // How much the VU meter reacts to the music going up vs down
+    #endif
 #endif
 
 
@@ -1689,13 +1689,12 @@ extern DRAM_ATTR const int g_aRingSizeTable[];
 // Given a time value for when the last frame took place and the current timestamp returns the number of
 // frames per second, as low as 0.  Never exceeds 999 so you can make some width assumptions.
 
-inline int FPS(uint32_t start, uint32_t end, uint32_t perSecond = MILLIS_PER_SECOND)
+inline int FPS(unsigned long duration, uint32_t perSecond = MILLIS_PER_SECOND)
 {
-    uint32_t duration = end - start;
     if (duration == 0)
         return 999;
 
-    float fpsf = 1.0f / (duration / (float) perSecond);
+    float fpsf = 1.0f / (duration / (float)perSecond);
     int FPS = (int)fpsf;
     if (FPS > 999)
         FPS = 999;

--- a/include/soundanalyzer.h
+++ b/include/soundanalyzer.h
@@ -158,13 +158,13 @@ public:
         }
         case M5PLUS2:
         {
-            static constexpr std::array<float, 16> Scalars16  = {0.5, 1.0, 2.5, 2.2, 1.5, 2.0, 2.0, 2.0, 1.5, 1.5, 1.5, 1.5, 1.0, 0.8, 1.0, 1.0}; 
+            static constexpr std::array<float, 16> Scalars16  = {0.5, 1.0, 2.5, 2.2, 1.5, 2.0, 2.0, 2.0, 1.5, 1.5, 1.5, 1.5, 1.0, 0.8, 1.0, 1.0};
             float result = (NUM_BANDS == 16) ? Scalars16[i] : 1.0;
             return result;
         }
         default:
         {
-            static constexpr std::array<float, 16> Scalars16  = {0.5, .5, 0.8, 1.0, 1.5, 1.2, 1.5, 1.6, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 5.0, 2.5}; 
+            static constexpr std::array<float, 16> Scalars16  = {0.5, .5, 0.8, 1.0, 1.5, 1.2, 1.5, 1.6, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 5.0, 2.5};
             float result = (NUM_BANDS == 16) ? Scalars16[i] : 1.0;
             return result;
         }
@@ -229,7 +229,7 @@ class SoundAnalyzer : public AudioVariables
     // GetBucketFrequency
     //
     // Given a bucket index, returns the frequency that bucket represents
-    
+
     float GetBucketFrequency(int bin_index)
     {
         float bin_width = SAMPLING_FREQUENCY / (MAX_SAMPLES / 2);
@@ -503,9 +503,9 @@ public:
         free(_vPeaks);
     }
 
-    // These functions allow access to the last-acquired sample buffer and its size so that 
+    // These functions allow access to the last-acquired sample buffer and its size so that
     // effects can draw the waveform or do other things with the raw audio data
-    
+
     const int16_t * GetSampleBuffer() const
     {
         return ptrSampleBuffer.get();
@@ -543,8 +543,8 @@ public:
         M5.Speaker.setVolume(255);
         M5.Speaker.end();
         M5.Mic.begin();
-        
-    #elif ELECROW 
+
+    #elif ELECROW
 
         const i2s_config_t i2s_config = {
                 .mode = (i2s_mode_t) (I2S_MODE_MASTER | I2S_MODE_RX),
@@ -570,7 +570,7 @@ public:
             ESP_ERROR_CHECK( i2s_set_pin(I2S_NUM_0, &pin_config) );
             ESP_ERROR_CHECK( i2s_start(I2S_NUM_0) );
 
-    #elif TTGO || MESMERIZER || SPECTRUM_WROVER_KIT 
+    #elif TTGO || MESMERIZER || SPECTRUM_WROVER_KIT
 
         i2s_config_t i2s_config;
         i2s_config.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX | I2S_MODE_ADC_BUILT_IN);
@@ -657,7 +657,7 @@ public:
         {
             if (_Peaks[i] > _peak1Decay[i])
             {
-                const float maxIncrease = std::max(0.0, g_Values.AppTime.LastFrameTime() * _peak1DecayRate * VU_REACTIVITY_RATIO);  
+                const float maxIncrease = std::max(0.0, g_Values.AppTime.LastFrameTime() * _peak1DecayRate * VU_REACTIVITY_RATIO);
                 _peak1Decay[i] = std::min(_Peaks[i], _peak1Decay[i] + maxIncrease);
                 _lastPeak1Time[i] = millis();
             }

--- a/include/types.h
+++ b/include/types.h
@@ -60,8 +60,6 @@ class CAppTime
 
     void NewFrame()
     {
-        timeval tv;
-        gettimeofday(&tv, nullptr);
         double current = CurrentTime();
         _deltaTime = current - _lastFrame;
 
@@ -256,7 +254,7 @@ inline void * PreferPSRAMAlloc(size_t s)
         {
             debugE("RAM Allocation failed for %u bytes\n", s);
             throw std::bad_alloc();
-        }   
+        }
         return p;
     }
 }

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -63,7 +63,7 @@ void IRAM_ATTR AudioSamplerTaskEntry(void *)
         // VURatio with a fadeout
 
         static auto lastVU = 0.0f;
-        constexpr auto VU_DECAY_PER_SECOND = 4.0f;
+        constexpr auto VU_DECAY_PER_SECOND = 1.25f;
 
         // Get the elapsed time since the last frame. We'll calculate this at the right spot from the first loop onwards
         static auto frameDurationSeconds = (millis() - lastFrame) / 1000.0f;

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -69,7 +69,7 @@ void IRAM_ATTR AudioSamplerTaskEntry(void *)
         // which is controlled by this constant
 
         if (g_Analyzer._VURatio > lastVU)
-            lastVU += (millis() - lastFrame) / 1000.0 * VU_DECAY_PER_SECOND * VU_REACTIVITY_RATIO;
+            lastVU = g_Analyzer._VURatio;
         else
             lastVU -= (millis() - lastFrame) / 1000.0 * VU_DECAY_PER_SECOND;
 
@@ -80,7 +80,7 @@ void IRAM_ATTR AudioSamplerTaskEntry(void *)
         // Instantaneous VURatio
 
         assert(g_Analyzer._PeakVU >= g_Analyzer._MinVU);
-        
+
         g_Analyzer._VURatio = (g_Analyzer._PeakVU == g_Analyzer._MinVU) ?
                                 0.0 :
                                 (g_Analyzer._VU - g_Analyzer._MinVU) / std::max(g_Analyzer._PeakVU - g_Analyzer._MinVU, (float) MIN_VU) * 2.0f;


### PR DESCRIPTION
## Description

This fixes an issue where the VU meter on matrix projects (Mesmerizer specifically) would show excessive movement in silent environments. This was introduced with #660 and is discussed in #706.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).