### PR TITLE
Update spectrumeffects.h to fix hightlight bar length

### DIFF
--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -396,11 +396,11 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter
                 float agePercent = (float) msPeakAge / (float) MS_PER_SECOND;
                 uint8_t fadeAmount = std::min(255.0f, agePercent * 256);
                 colorHighlight.fadeToBlackBy(fadeAmount);
-                pGFXChannel->drawLine(xOffset, max(0, yOffset-1), xOffset + barWidth, max(0, yOffset-1), colorHighlight);
+                pGFXChannel->drawLine(xOffset, max(0, yOffset-1), xOffset + barWidth - 1, max(0, yOffset-1), colorHighlight);
             }
             else
             {
-                pGFXChannel->drawLine(xOffset, max(0, yOffset2-1), xOffset + barWidth, max(0, yOffset2-1), colorHighlight);
+                pGFXChannel->drawLine(xOffset, max(0, yOffset2-1), xOffset + barWidth - 1, max(0, yOffset2-1), colorHighlight);
             }
         }
     }


### PR DESCRIPTION
This PR fixes the spectrum effects code where the white highlight bar is 1 pixel too long on all the spectrum effects that utilize it.


![Screen Shot 2025-05-07 at 9 30 58 AM](https://github.com/user-attachments/assets/2e77c758-9ab7-4878-bf39-85a9ec8db696)


* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).