### PR TITLE
psram mallocs in types.h use shared_ptr, so we need <memory>

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -32,7 +32,7 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <memory>                      // for std::shared_ptr^
+#include <memory>                      // for std::shared_ptr
 #include <optional>
 #include <sys/time.h>
 #include <WString.h>


### PR DESCRIPTION
Redo patch #734 via web editor. I surrender.

## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).