### PR TITLE
Allow our network build to compile Arduino2 or Arduino 3

### DIFF
--- a/include/network.h
+++ b/include/network.h
@@ -28,6 +28,12 @@
 #pragma once
 
 #include <utility>
+// Retire this test once Arduino3 fully lands.
+#include <esp_arduino_version.h>
+#if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+   #include_next <Network.h> // For wl_status_t, etc. (case matters)
+#endif
+#include "esp_mac.h"
 
 #include "types.h"
 


### PR DESCRIPTION
Redo #733 in clean workspace.

We have a "network.h".
The Arduino system has a "Network.h"
__has_include can't distinguish between the two.

Our network.h uses some things that are only declared in the system network.h
so we really should be including it first. But we'd have to fix a bunch
of callers with ugly conditionals.

Weirdly, we have some OTA paths that can include (our) network.h
before Arduino.h, so we have to go get the version explicitly.

With exactly this change to this file, the network code can build on both.
Other pieces are forthcoming.

This PR probably took 500 builds to work through...The failures are WEIRD.

The inclusion of mac_addr was always technically required, but works in both.

<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).