### PR TITLE
Templates - Migrate macros to templates, simplify effects table, add effectId() to all derived effects

### DIFF
--- a/include/effectfactories.h
+++ b/include/effectfactories.h
@@ -95,7 +95,7 @@ class EffectFactories
       public:
         bool LoadDisabled = false;
 
-  NumberedFactory(int effectNumber, const DefaultEffectFactory& factory)
+        NumberedFactory(int effectNumber, const DefaultEffectFactory& factory)
           : effectNumber(effectNumber),
             factory(factory)
         {}

--- a/include/effectfactories.h
+++ b/include/effectfactories.h
@@ -41,8 +41,9 @@
 #include <esp_attr.h>
 #include "ledstripeffect.h"
 
-using DefaultEffectFactory = std::shared_ptr<LEDStripEffect>(*)();
-using JSONEffectFactory = std::shared_ptr<LEDStripEffect>(*)(const JsonObjectConst&);
+// Use std::function so factories can be capturing lambdas (needed for macro-free registration)
+using DefaultEffectFactory = std::function<std::shared_ptr<LEDStripEffect>()>;
+using JSONEffectFactory = std::function<std::shared_ptr<LEDStripEffect>(const JsonObjectConst&)>;
 
 // -----------------------------------------------------------------------------
 // Class: EffectFactories
@@ -94,7 +95,7 @@ class EffectFactories
       public:
         bool LoadDisabled = false;
 
-        NumberedFactory(int effectNumber, const DefaultEffectFactory& factory)
+  NumberedFactory(int effectNumber, const DefaultEffectFactory& factory)
           : effectNumber(effectNumber),
             factory(factory)
         {}

--- a/include/effects.h
+++ b/include/effects.h
@@ -43,130 +43,140 @@
 // to a mismatch between effect JSON blobs for the "old" effect and the "new" effect
 // class.
 
-// Strip effects
-#define EFFECT_STRIP_BOUNCING_BALL                       1
-#define EFFECT_STRIP_DOUBLE_PALETTE                      2
-#define EFFECT_STRIP_PALETTE_SPIN                        3
-#define EFFECT_STRIP_COLOR_CYCLE                         4
-#define EFFECT_STRIP_FIRE_FAN                            5
-#define EFFECT_STRIP_RING_TEST                           6
-#define EFFECT_STRIP_LANTERN                             7
-#define EFFECT_STRIP_FIRE                                8
-#define EFFECT_STRIP_CLASSIC_FIRE                        9
-#define EFFECT_STRIP_SMOOTH_FIRE                        10
-#define EFFECT_STRIP_BASE_FIRE                          11
-#define EFFECT_STRIP_LASER_LINE                         12
-#define EFFECT_STRIP_METEOR                             13
-#define EFFECT_STRIP_SIMPLE_RAINBOW_TEST                14
-#define EFFECT_STRIP_RAINBOW_TWINKLE                    15
-#define EFFECT_STRIP_RAINBOW_FILL                       16
-#define EFFECT_STRIP_COLOR_FILL                         17
-#define EFFECT_STRIP_STATUS                             18
-#define EFFECT_STRIP_TWINKLE                            19
-#define EFFECT_STRIP_SIMPLE_COLOR_BEAT                  20
-#define EFFECT_STRIP_PALETTE                            21
-#define EFFECT_STRIP_COLOR_BEAT_WITH_FLASH              22
-#define EFFECT_STRIP_COLOR_BEAT_OVER_RED                23
-#define EFFECT_STRIP_MOLTEN_GLASS_ON_VIOLET_BKGND       24
-#define EFFECT_STRIP_NEW_MOLTEN_GLASS_ON_VIOLET_BKGND   25
-#define EFFECT_STRIP_SPARKLY_SPINNING_MUSIC             26
-#define EFFECT_STRIP_MUSICAL_HOT_WHITE_INSULATOR        27
-#define EFFECT_STRIP_SNAKE                              28
-#define EFFECT_STRIP_PALETTE_FLAME                      29
-#define EFFECT_STRIP_MUSICAL_PALETTE_FIRE               30
-#define EFFECT_STRIP_STARRY_NIGHT                       31
-#define EFFECT_STRIP_TWINKLE_STAR                       32
-#define EFFECT_STRIP_SIMPLE_INSULATOR_BEAT              33
-#define EFFECT_STRIP_SIMPLE_INSULATOR_BEAT2             34
-#define EFFECT_STRIP_PALETTE_REEL                       35
-#define EFFECT_STRIP_TAPE_REEL                          36
-#define EFFECT_STRIP_FAN_BEAT                           37
-#define EFFECT_STRIP_SPLASH_LOGO                        38
-#define EFFECT_STRIP_VUMETER                            39
-#define EFFECT_STRIP_VUMETER_VERTICAL                   40
+// Effect identifiers (preserve existing numeric values for JSON compatibility)
+enum EffectId
+{
+	// Strip effects
+	idStripBouncingBall                     = 1,
+	idStripDoublePalette                    = 2,
+	idStripPaletteSpin                      = 3,
+	idStripColorCycle                       = 4,
+	idStripFireFan                          = 5,
+	idStripRingTest                         = 6,
+	idStripLantern                          = 7,
+	idStripFire                             = 8,
+	idStripClassicFire                      = 9,
+	idStripSmoothFire                       = 10,
+	idStripBaseFire                         = 11,
+	idStripLaserLine                        = 12,
+	idStripMeteor                           = 13,
+	idStripSimpleRainbowTest                = 14,
+	idStripRainbowTwinkle                   = 15,
+	idStripRainbowFill                      = 16,
+	idStripColorFill                        = 17,
+	idStripStatus                           = 18,
+	idStripTwinkle                          = 19,
+	idStripSimpleColorBeat                  = 20,
+	idStripPalette                          = 21,
+	idStripColorBeatWithFlash               = 22,
+	idStripColorBeatOverRed                 = 23,
+	idStripMoltenGlassOnVioletBkgnd         = 24,
+	idStripNewMoltenGlassOnVioletBkgnd      = 25,
+	idStripSparklySpinningMusic             = 26,
+	idStripMusicalHotWhiteInsulator         = 27,
+	idStripSnake                            = 28,
+	idStripPaletteFlame                     = 29,
+	idStripMusicalPaletteFire               = 30,
+	idStripStarryNight                      = 31,
+	idStripTwinkleStar                      = 32,
+	idStripSimpleInsulatorBeat              = 33,
+	idStripSimpleInsulatorBeat2             = 34,
+	idStripPaletteReel                      = 35,
+	idStripTapeReel                         = 36,
+	idStripFanBeat                          = 37,
+	idStripSplashLogo                       = 38,
+	idStripVUMeter                          = 39,
+	idStripVUMeterVertical                  = 40,
 
-// Matrix effects
-#define EFFECT_MATRIX_ALIEN_TEXT                       101
-#define EFFECT_MATRIX_BOUNCE                           102
-#define EFFECT_MATRIX_CIRCUIT                          103
-#define EFFECT_MATRIX_CLOCK                            104
-#define EFFECT_MATRIX_CUBE                             105
-// Was #define EFFECT_MATRIX_FLOW_FIELD                106
-#define EFFECT_MATRIX_LIFE                             107
-#define EFFECT_MATRIX_MANDALA                          108
-#define EFFECT_MATRIX_SUNBURST                         109
-#define EFFECT_MATRIX_ROSE                             110
-#define EFFECT_MATRIX_PINWHEEL                         111
-#define EFFECT_MATRIX_INFINITY                         112
-#define EFFECT_MATRIX_MUNCH                            113
-// Was EFFECT_MATRIX_CURTAIN                           114
-// Was EFFECT_MATRIX_GRID_LIGHTS                       115
-// Was EFFECT_MATRIX_PALETTE_SMEAR                     116
-#define EFFECT_MATRIX_RAINBOW_FLAG                     117
-#define EFFECT_MATRIX_PONG_CLOCK                       118
-#define EFFECT_MATRIX_PULSE                            119
-#define EFFECT_MATRIX_PULSAR                           120
-#define EFFECT_MATRIX_QR                               121
-#define EFFECT_MATRIX_RADAR                            122
-#define EFFECT_MATRIX_SERENDIPITY                      123
-// Was #define EFFECT_MATRIX_SPARK                     124
-#define EFFECT_MATRIX_SPIN                             125
-#define EFFECT_MATRIX_SPIRO                            126
-#define EFFECT_MATRIX_SUBSCRIBERS                      127
-#define EFFECT_MATRIX_SWIRL                            128
-#define EFFECT_MATRIX_WAVE                             129
-#define EFFECT_MATRIX_WEATHER                          130
-#define EFFECT_MATRIX_INSULATOR_SPECTRUM               131
-#define EFFECT_MATRIX_SPECTRUM_ANALYZER                132
-#define EFFECT_MATRIX_WAVEFORM                         133
-#define EFFECT_MATRIX_GHOST_WAVE                       134
-#define EFFECT_MATRIX_MAZE                             135
-#define EFFECT_MATRIX_SPECTRUMBAR                      136
+	// Matrix effects
+	idMatrixAlienText                       = 101,
+	idMatrixBounce                          = 102,
+	idMatrixCircuit                         = 103,
+	idMatrixClock                           = 104,
+	idMatrixCube                            = 105,
+	// 106 was Flow Field (unused)
+	idMatrixLife                            = 107,
+	idMatrixMandala                         = 108,
+	idMatrixSunburst                        = 109,
+	idMatrixRose                            = 110,
+	idMatrixPinwheel                        = 111,
+	idMatrixInfinity                        = 112,
+	idMatrixMunch                           = 113,
+	// 114 was Curtain (unused)
+	// 115 was Grid Lights (unused)
+	// 116 was Palette Smear (unused)
+	idMatrixRainbowFlag                     = 117,
+	idMatrixPongClock                       = 118,
+	idMatrixPulse                           = 119,
+	idMatrixPulsar                          = 120,
+	idMatrixQR                              = 121,
+	idMatrixRadar                           = 122,
+	idMatrixSerendipity                     = 123,
+	// 124 was Spark (unused)
+	idMatrixSpin                            = 125,
+	idMatrixSpiro                           = 126,
+	idMatrixSubscribers                     = 127,
+	idMatrixSwirl                           = 128,
+	idMatrixWave                            = 129,
+	idMatrixWeather                         = 130,
+	idMatrixInsulatorSpectrum               = 131,
+	idMatrixSpectrumAnalyzer                = 132,
+	idMatrixWaveform                        = 133,
+	idMatrixGhostWave                       = 134,
+	idMatrixMaze                            = 135,
+	idMatrixSpectrumBar                     = 136,
 
-#define EFFECT_MATRIX_SM2DDPR                          137
-#define EFFECT_MATRIX_SMAMBERRAIN                      138
-#define EFFECT_MATRIX_SMBLURRING_COLORS                139
-#define EFFECT_MATRIX_SMFIRE2021                       140
-#define EFFECT_MATRIX_SMFLOW_FIELDS                    141
-#define EFFECT_MATRIX_SMGAMMA                          142
-#define EFFECT_MATRIX_SMHOLIDAY_LIGHTS                 143
-#define EFFECT_MATRIX_SMHYPNOSIS                       144
-#define EFFECT_MATRIX_SMMETA_BALLS                     145
-#define EFFECT_MATRIX_SMNOISE                          146
-#define EFFECT_MATRIX_SMPICASSO3IN1                    147
-#define EFFECT_MATRIX_SMRADIAL_FIRE                    148
-#define EFFECT_MATRIX_SMRADIAL_WAVE                    149
-#define EFFECT_MATRIX_SMRAINBOW_TUNNEL                 150
-#define EFFECT_MATRIX_SMSMOKE                          151
-#define EFFECT_MATRIX_SMSPIRO_PULSE                    152
-#define EFFECT_MATRIX_SMSTARDEEP                       153
-#define EFFECT_MATRIX_SMSTROBE_DIFFUSION               154
-#define EFFECT_MATRIX_SMSUPERNOVA                      155
-#define EFFECT_MATRIX_SMTWISTER                        156
-#define EFFECT_MATRIX_SMWALKING_MACHINE                157
-#define EFFECT_MATRIX_ANIMATEDGIF                      158
-#define EFFECT_MATRIX_STOCKS                           159
-#define EFFECT_MATRIX_SILON                            160
-#define EFFECT_MATRIX_PDPGRID                          161
-#define EFFECT_MATRIX_AUDIOSPIKE                       162
-#define EFFECT_MATRIX_PDPCMX                           163     
-// Hexagon Effects
-#define EFFECT_HEXAGON_OUTER_RING                      201
+	idMatrixSM2DDPR                         = 137,
+	idMatrixSMAmberRain                     = 138,
+	idMatrixSMBlurringColors                = 139,
+	idMatrixSMFire2021                      = 140,
+	idMatrixSMFlowFields                    = 141,
+	idMatrixSMGamma                         = 142,
+	idMatrixSMHolidayLights                 = 143,
+	idMatrixSMHypnosis                      = 144,
+	idMatrixSMMetaBalls                     = 145,
+	idMatrixSMNoise                         = 146,
+	idMatrixSMPicasso3in1                   = 147,
+	idMatrixSMRadialFire                    = 148,
+	idMatrixSMRadialWave                    = 149,
+	idMatrixSMRainbowTunnel                 = 150,
+	idMatrixSMSmoke                         = 151,
+	idMatrixSMSpiroPulse                    = 152,
+	idMatrixSMStarDeep                      = 153,
+	idMatrixSMStrobeDiffusion               = 154,
+	idMatrixSMSupernova                     = 155,
+	idMatrixSMTwister                       = 156,
+	idMatrixSMWalkingMachine                = 157,
+	idMatrixAnimatedGIF                     = 158,
+	idMatrixStocks                          = 159,
+	idMatrixSilon                           = 160,
+	idMatrixPDPGrid                         = 161,
+	idMatrixAudioSpike                      = 162,
+	idMatrixPDPCMX                          = 163,
+
+	// Hexagon effects
+	idHexagonOuterRing                      = 201
+};
 
 // Starry Night star variations
-#define EFFECT_STAR                                      1
-#define EFFECT_STAR_RANDOM_PALETTE_COLOR                 2
-#define EFFECT_STAR_LONG_LIFE_SPARKLE                    3
-#define EFFECT_STAR_COLOR                                4
-#define EFFECT_STAR_MUSIC                                5
-#define EFFECT_STAR_MUSIC_PULSE                          6
-#define EFFECT_STAR_QUIET                                7
-#define EFFECT_STAR_BUBBLY                               8
-#define EFFECT_STAR_FLASH                                9
-#define EFFECT_STAR_COLOR_CYCLE                         10
-#define EFFECT_STAR_MULTI_COLOR                         11
-#define EFFECT_STAR_CHRISTMAS                           12
-#define EFFECT_STAR_HOT_WHITE                           13
+enum StarId
+{
+	idStar                                  = 1,
+	idStarRandomPaletteColor                = 2,
+	idStarLongLifeSparkle                   = 3,
+	idStarColor                             = 4,
+	idStarMusic                             = 5,
+	idStarMusicPulse                        = 6,
+	idStarQuiet                             = 7,
+	idStarBubbly                            = 8,
+	idStarFlash                             = 9,
+	idStarColorCycle                        = 10,
+	idStarMultiColor                        = 11,
+	idStarChristmas                         = 12,
+	idStarHotWhite                          = 13
+};
+
+// Legacy EFFECT_* macro aliases were removed after migration to enum-based ids.
 
 // Some common JSON properties to prevent typos. By project convention JSON properties
 // at the LEDStripEffect level have a length of 2 characters, and JSON properties

--- a/include/effects.h
+++ b/include/effects.h
@@ -26,6 +26,7 @@
 //    Defines for effect (sub)types numbers and common JSON property names
 //
 // History:     Apr-05-2023         Rbergen      Created for NightDriverStrip
+//              Aug-17-2025         Davepl       Converted to enums
 //
 //---------------------------------------------------------------------------
 #pragma once
@@ -87,6 +88,17 @@ enum EffectId
 	idStripSplashLogo                       = 38,
 	idStripVUMeter                          = 39,
 	idStripVUMeterVertical                  = 40,
+	idStripVUInsulators                     = 41,
+	idStripCount                            = 42,
+	idStripColorCycleBottomUp               = 43,
+	idStripColorCycleTopDown                = 44,
+	idStripColorCycleSequential             = 45,
+	idStripColorCycleRightLeft              = 46,
+	idStripColorCycleLeftRight              = 47,
+	idStripFireFanBlue                      = 48,
+	idStripFireFanGreen                     = 49,
+	idStripRGBRollAround                    = 50,
+	idStripHueTest                          = 51,
 
 	// Matrix effects
 	idMatrixAlienText                       = 101,

--- a/include/effects/matrix/PatternAlienText.h
+++ b/include/effects/matrix/PatternAlienText.h
@@ -73,7 +73,7 @@
 
 class PatternAlienText : public LEDStripEffect
 {
-  public:
+public:
   static constexpr EffectId kId = idMatrixAlienText;
 
 private:

--- a/include/effects/matrix/PatternAlienText.h
+++ b/include/effects/matrix/PatternAlienText.h
@@ -75,7 +75,8 @@ class PatternAlienText : public LEDStripEffect
 {
 public:
   static constexpr EffectId kId = idMatrixAlienText;
-
+  EffectId effectId() const override { return kId; }
+  
 private:
   const int charWidth = 6;
   const int charHeight = 6;

--- a/include/effects/matrix/PatternAlienText.h
+++ b/include/effects/matrix/PatternAlienText.h
@@ -73,6 +73,9 @@
 
 class PatternAlienText : public LEDStripEffect
 {
+  public:
+  static constexpr EffectId kId = idMatrixAlienText;
+
 private:
   const int charWidth = 6;
   const int charHeight = 6;

--- a/include/effects/matrix/PatternAlienText.h
+++ b/include/effects/matrix/PatternAlienText.h
@@ -83,7 +83,7 @@ private:
 
 public:
 
-  PatternAlienText() : LEDStripEffect(EFFECT_MATRIX_ALIEN_TEXT, "AlienText")
+  PatternAlienText() : LEDStripEffect(idMatrixAlienText, "AlienText")
   {
   }
 

--- a/include/effects/matrix/PatternAnimatedGIF.h
+++ b/include/effects/matrix/PatternAnimatedGIF.h
@@ -136,8 +136,10 @@ const std::unique_ptr<GifDecoder<MATRIX_WIDTH, MATRIX_HEIGHT, 16, true>> g_ptrGI
 //
 // Draws a cycling animated GIF on the LED matrix.  Use GifDecoder to do the heavy lifting behind the scenes.
 
-class PatternAnimatedGIF : public LEDStripEffect
-{
+class PatternAnimatedGIF : public LEDStripEffect {
+    public:
+        static constexpr EffectId kId = idMatrixAnimatedGIF;
+
 private:
 
     GIFIdentifier _gifIndex  = GIFIdentifier::INVALID;

--- a/include/effects/matrix/PatternAnimatedGIF.h
+++ b/include/effects/matrix/PatternAnimatedGIF.h
@@ -207,7 +207,7 @@ private:
 public:
 
     PatternAnimatedGIF(const String & friendlyName, GIFIdentifier gifIndex, bool preClear = false, CRGB bkColor = CRGB::Black) :
-        LEDStripEffect(EFFECT_MATRIX_ANIMATEDGIF, friendlyName),
+    LEDStripEffect(idMatrixAnimatedGIF, friendlyName),
         _preClear(preClear),
         _gifIndex(gifIndex),
         _bkColor(bkColor)

--- a/include/effects/matrix/PatternAnimatedGIF.h
+++ b/include/effects/matrix/PatternAnimatedGIF.h
@@ -136,11 +136,13 @@ const std::unique_ptr<GifDecoder<MATRIX_WIDTH, MATRIX_HEIGHT, 16, true>> g_ptrGI
 //
 // Draws a cycling animated GIF on the LED matrix.  Use GifDecoder to do the heavy lifting behind the scenes.
 
-class PatternAnimatedGIF : public LEDStripEffect {
-    public:
-        static constexpr EffectId kId = idMatrixAnimatedGIF;
+class PatternAnimatedGIF : public LEDStripEffect 
+{
+  public:
+    static constexpr EffectId kId = idMatrixAnimatedGIF;
+    EffectId effectId() const override { return kId; }
 
-private:
+  private:
 
     GIFIdentifier _gifIndex  = GIFIdentifier::INVALID;
     CRGB _bkColor            = BLACK16;

--- a/include/effects/matrix/PatternBounce.h
+++ b/include/effects/matrix/PatternBounce.h
@@ -81,7 +81,7 @@ private:
     PVector gravity = PVector(0, 0.0125);
 
 public:
-    PatternBounce() : LEDStripEffect(EFFECT_MATRIX_BOUNCE, "Bounce")
+    PatternBounce() : LEDStripEffect(idMatrixBounce, "Bounce")
     {
     }
 

--- a/include/effects/matrix/PatternBounce.h
+++ b/include/effects/matrix/PatternBounce.h
@@ -82,6 +82,7 @@ private:
 
 public:
     static constexpr EffectId kId = idMatrixBounce;
+    EffectId effectId() const override { return kId; }
 
     PatternBounce() : LEDStripEffect(kId, "Bounce")
     {

--- a/include/effects/matrix/PatternBounce.h
+++ b/include/effects/matrix/PatternBounce.h
@@ -81,7 +81,9 @@ private:
     PVector gravity = PVector(0, 0.0125);
 
 public:
-    PatternBounce() : LEDStripEffect(idMatrixBounce, "Bounce")
+    static constexpr EffectId kId = idMatrixBounce;
+
+    PatternBounce() : LEDStripEffect(kId, "Bounce")
     {
     }
 

--- a/include/effects/matrix/PatternCircuit.h
+++ b/include/effects/matrix/PatternCircuit.h
@@ -191,7 +191,8 @@ private:
 
 public:
     static constexpr EffectId kId = idMatrixCircuit;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternCircuit() : LEDStripEffect(idMatrixCircuit, "Circuit") { construct(); }
     PatternCircuit(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject) { construct(); }
     ~PatternCircuit() { free(snakes); }

--- a/include/effects/matrix/PatternCircuit.h
+++ b/include/effects/matrix/PatternCircuit.h
@@ -190,7 +190,7 @@ private:
     }
 
 public:
-    PatternCircuit() : LEDStripEffect(EFFECT_MATRIX_CIRCUIT, "Circuit")
+    PatternCircuit() : LEDStripEffect(idMatrixCircuit, "Circuit")
     {
         construct();
     }

--- a/include/effects/matrix/PatternCircuit.h
+++ b/include/effects/matrix/PatternCircuit.h
@@ -190,20 +190,11 @@ private:
     }
 
 public:
-    PatternCircuit() : LEDStripEffect(idMatrixCircuit, "Circuit")
-    {
-        construct();
-    }
+    static constexpr EffectId kId = idMatrixCircuit;
 
-    PatternCircuit(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
-    {
-        construct();
-    }
-
-    ~PatternCircuit()
-    {
-        free(snakes);
-    }
+    PatternCircuit() : LEDStripEffect(idMatrixCircuit, "Circuit") { construct(); }
+    PatternCircuit(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject) { construct(); }
+    ~PatternCircuit() { free(snakes); }
 
     unsigned long msStart;
 

--- a/include/effects/matrix/PatternClock.h
+++ b/include/effects/matrix/PatternClock.h
@@ -49,7 +49,8 @@ class PatternClock : public LEDStripEffect
   public:
 
     static constexpr EffectId kId = idMatrixClock;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternClock() : LEDStripEffect(kId, "Clock")
     {
     }

--- a/include/effects/matrix/PatternClock.h
+++ b/include/effects/matrix/PatternClock.h
@@ -48,7 +48,9 @@ class PatternClock : public LEDStripEffect
 
   public:
 
-    PatternClock() : LEDStripEffect(idMatrixClock, "Clock")
+    static constexpr EffectId kId = idMatrixClock;
+
+    PatternClock() : LEDStripEffect(kId, "Clock")
     {
     }
 

--- a/include/effects/matrix/PatternClock.h
+++ b/include/effects/matrix/PatternClock.h
@@ -48,7 +48,7 @@ class PatternClock : public LEDStripEffect
 
   public:
 
-    PatternClock() : LEDStripEffect(EFFECT_MATRIX_CLOCK, "Clock")
+    PatternClock() : LEDStripEffect(idMatrixClock, "Clock")
     {
     }
 

--- a/include/effects/matrix/PatternCube.h
+++ b/include/effects/matrix/PatternCube.h
@@ -214,9 +214,10 @@ class PatternCube : public LEDStripEffect
     }
 
   public:
-  static constexpr EffectId kId = idMatrixCube;
-
-  PatternCube() : LEDStripEffect(kId, "Cubes")
+    static constexpr EffectId kId = idMatrixCube;
+    EffectId effectId() const override { return kId; }
+    
+    PatternCube() : LEDStripEffect(kId, "Cubes")
     {
       construct();
     }

--- a/include/effects/matrix/PatternCube.h
+++ b/include/effects/matrix/PatternCube.h
@@ -214,7 +214,7 @@ class PatternCube : public LEDStripEffect
     }
 
   public:
-    PatternCube() : LEDStripEffect(EFFECT_MATRIX_CUBE, "Cubes")
+  PatternCube() : LEDStripEffect(idMatrixCube, "Cubes")
     {
       construct();
     }

--- a/include/effects/matrix/PatternCube.h
+++ b/include/effects/matrix/PatternCube.h
@@ -214,7 +214,9 @@ class PatternCube : public LEDStripEffect
     }
 
   public:
-  PatternCube() : LEDStripEffect(idMatrixCube, "Cubes")
+  static constexpr EffectId kId = idMatrixCube;
+
+  PatternCube() : LEDStripEffect(kId, "Cubes")
     {
       construct();
     }

--- a/include/effects/matrix/PatternLife.h
+++ b/include/effects/matrix/PatternLife.h
@@ -235,7 +235,9 @@ private:
 
 public:
 
-    PatternLife() : LEDStripEffect(idMatrixLife, "Life")
+    static constexpr EffectId kId = idMatrixLife;
+
+    PatternLife() : LEDStripEffect(kId, "Life")
     {
     }
 

--- a/include/effects/matrix/PatternLife.h
+++ b/include/effects/matrix/PatternLife.h
@@ -236,7 +236,8 @@ private:
 public:
 
     static constexpr EffectId kId = idMatrixLife;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternLife() : LEDStripEffect(kId, "Life")
     {
     }

--- a/include/effects/matrix/PatternLife.h
+++ b/include/effects/matrix/PatternLife.h
@@ -235,7 +235,7 @@ private:
 
 public:
 
-    PatternLife() : LEDStripEffect(EFFECT_MATRIX_LIFE, "Life")
+    PatternLife() : LEDStripEffect(idMatrixLife, "Life")
     {
     }
 

--- a/include/effects/matrix/PatternMandala.h
+++ b/include/effects/matrix/PatternMandala.h
@@ -93,7 +93,7 @@ private:
     int16_t dsy;
 
 public:
-    PatternMandala() : LEDStripEffect(EFFECT_MATRIX_MANDALA, "MRI")
+    PatternMandala() : LEDStripEffect(idMatrixMandala, "MRI")
     {
     }
 

--- a/include/effects/matrix/PatternMandala.h
+++ b/include/effects/matrix/PatternMandala.h
@@ -94,7 +94,8 @@ private:
 
 public:
     static constexpr EffectId kId = idMatrixMandala;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternMandala() : LEDStripEffect(kId, "MRI")
     {
     }

--- a/include/effects/matrix/PatternMandala.h
+++ b/include/effects/matrix/PatternMandala.h
@@ -93,7 +93,9 @@ private:
     int16_t dsy;
 
 public:
-    PatternMandala() : LEDStripEffect(idMatrixMandala, "MRI")
+    static constexpr EffectId kId = idMatrixMandala;
+
+    PatternMandala() : LEDStripEffect(kId, "MRI")
     {
     }
 

--- a/include/effects/matrix/PatternMaze.h
+++ b/include/effects/matrix/PatternMaze.h
@@ -276,7 +276,7 @@ private:
 
 public:
 
-    PatternMaze() : LEDStripEffect(EFFECT_MATRIX_MAZE, "Maze")
+    PatternMaze() : LEDStripEffect(idMatrixMaze, "Maze")
     {
     }
 

--- a/include/effects/matrix/PatternMaze.h
+++ b/include/effects/matrix/PatternMaze.h
@@ -85,8 +85,10 @@
 //   grid, and managing cell progression.
 
 
-class PatternMaze : public LEDStripEffect
-{
+class PatternMaze : public LEDStripEffect {
+    public:
+        static constexpr EffectId kId = idMatrixMaze;
+
 private:
     enum Directions {
         None = 0,

--- a/include/effects/matrix/PatternMaze.h
+++ b/include/effects/matrix/PatternMaze.h
@@ -88,7 +88,8 @@
 class PatternMaze : public LEDStripEffect {
 public:
     static constexpr EffectId kId = idMatrixMaze;
-
+    EffectId effectId() const override { return kId; }
+    
 private:
     enum Directions {
         None = 0,

--- a/include/effects/matrix/PatternMaze.h
+++ b/include/effects/matrix/PatternMaze.h
@@ -86,8 +86,8 @@
 
 
 class PatternMaze : public LEDStripEffect {
-    public:
-        static constexpr EffectId kId = idMatrixMaze;
+public:
+    static constexpr EffectId kId = idMatrixMaze;
 
 private:
     enum Directions {

--- a/include/effects/matrix/PatternMisc.h
+++ b/include/effects/matrix/PatternMisc.h
@@ -62,7 +62,7 @@ class PatternSunburst : public LEDStripEffect
 {
   public:
 
-    PatternSunburst() : LEDStripEffect(EFFECT_MATRIX_SUNBURST, "Sunburst")
+    PatternSunburst() : LEDStripEffect(idMatrixSunburst, "Sunburst")
     {
     }
 
@@ -103,7 +103,7 @@ class PatternRose : public LEDStripEffect
 {
   public:
 
-    PatternRose() : LEDStripEffect(EFFECT_MATRIX_ROSE, "Rose")
+    PatternRose() : LEDStripEffect(idMatrixRose, "Rose")
     {
     }
 
@@ -157,7 +157,7 @@ class PatternPinwheel : public LEDStripEffect
 {
   public:
 
-    PatternPinwheel() : LEDStripEffect(EFFECT_MATRIX_PINWHEEL, "Pinwheel")
+    PatternPinwheel() : LEDStripEffect(idMatrixPinwheel, "Pinwheel")
     {
     }
 
@@ -201,7 +201,7 @@ class PatternInfinity : public LEDStripEffect
 {
 public:
 
-    PatternInfinity() : LEDStripEffect(EFFECT_MATRIX_INFINITY, "Infinity")
+    PatternInfinity() : LEDStripEffect(idMatrixInfinity, "Infinity")
     {
     }
 
@@ -266,7 +266,7 @@ private:
     uint8_t generation = 0;
 
 public:
-    PatternMunch() : LEDStripEffect(EFFECT_MATRIX_MUNCH, "Munch")
+    PatternMunch() : LEDStripEffect(idMatrixMunch, "Munch")
     {
     }
 

--- a/include/effects/matrix/PatternMisc.h
+++ b/include/effects/matrix/PatternMisc.h
@@ -62,7 +62,9 @@ class PatternSunburst : public LEDStripEffect
 {
   public:
 
-    PatternSunburst() : LEDStripEffect(idMatrixSunburst, "Sunburst")
+    static constexpr EffectId kId = idMatrixSunburst;
+
+    PatternSunburst() : LEDStripEffect(kId, "Sunburst")
     {
     }
 
@@ -103,7 +105,9 @@ class PatternRose : public LEDStripEffect
 {
   public:
 
-    PatternRose() : LEDStripEffect(idMatrixRose, "Rose")
+    static constexpr EffectId kId = idMatrixRose;
+
+    PatternRose() : LEDStripEffect(kId, "Rose")
     {
     }
 
@@ -157,7 +161,9 @@ class PatternPinwheel : public LEDStripEffect
 {
   public:
 
-    PatternPinwheel() : LEDStripEffect(idMatrixPinwheel, "Pinwheel")
+    static constexpr EffectId kId = idMatrixPinwheel;
+
+    PatternPinwheel() : LEDStripEffect(kId, "Pinwheel")
     {
     }
 
@@ -201,7 +207,9 @@ class PatternInfinity : public LEDStripEffect
 {
 public:
 
-    PatternInfinity() : LEDStripEffect(idMatrixInfinity, "Infinity")
+    static constexpr EffectId kId = idMatrixInfinity;
+
+    PatternInfinity() : LEDStripEffect(kId, "Infinity")
     {
     }
 
@@ -266,7 +274,9 @@ private:
     uint8_t generation = 0;
 
 public:
-    PatternMunch() : LEDStripEffect(idMatrixMunch, "Munch")
+    static constexpr EffectId kId = idMatrixMunch;
+
+    PatternMunch() : LEDStripEffect(kId, "Munch")
     {
     }
 

--- a/include/effects/matrix/PatternMisc.h
+++ b/include/effects/matrix/PatternMisc.h
@@ -63,6 +63,7 @@ class PatternSunburst : public LEDStripEffect
   public:
 
     static constexpr EffectId kId = idMatrixSunburst;
+    EffectId effectId() const override { return kId; }
 
     PatternSunburst() : LEDStripEffect(kId, "Sunburst")
     {
@@ -106,7 +107,8 @@ class PatternRose : public LEDStripEffect
   public:
 
     static constexpr EffectId kId = idMatrixRose;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternRose() : LEDStripEffect(kId, "Rose")
     {
     }
@@ -162,6 +164,7 @@ class PatternPinwheel : public LEDStripEffect
   public:
 
     static constexpr EffectId kId = idMatrixPinwheel;
+    EffectId effectId() const override { return kId; }
 
     PatternPinwheel() : LEDStripEffect(kId, "Pinwheel")
     {
@@ -208,6 +211,7 @@ class PatternInfinity : public LEDStripEffect
 public:
 
     static constexpr EffectId kId = idMatrixInfinity;
+    EffectId effectId() const override { return kId; }
 
     PatternInfinity() : LEDStripEffect(kId, "Infinity")
     {
@@ -275,7 +279,8 @@ private:
 
 public:
     static constexpr EffectId kId = idMatrixMunch;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternMunch() : LEDStripEffect(kId, "Munch")
     {
     }

--- a/include/effects/matrix/PatternNoiseSmearing.h
+++ b/include/effects/matrix/PatternNoiseSmearing.h
@@ -61,7 +61,7 @@
 class PatternRainbowFlag : public LEDStripEffect
 {
 public:
-  PatternRainbowFlag() : LEDStripEffect(EFFECT_MATRIX_RAINBOW_FLAG, "RainbowFlag")
+  PatternRainbowFlag() : LEDStripEffect(idMatrixRainbowFlag, "RainbowFlag")
   {
   }
 

--- a/include/effects/matrix/PatternPongClock.h
+++ b/include/effects/matrix/PatternPongClock.h
@@ -74,9 +74,11 @@
 #define SPEEDUP 1.15
 #define MAXSPEED 4.0f
 
-class PatternPongClock : public LEDStripEffect
-{
-  private:
+class PatternPongClock : public LEDStripEffect {
+    public:
+        static constexpr EffectId kId = idMatrixPongClock;
+
+    private:
     float ballpos_x, ballpos_y;
     uint8_t erase_x = 10; // holds ball old pos so we can erase it, set to blank area of screen initially.
     uint8_t erase_y = 10;

--- a/include/effects/matrix/PatternPongClock.h
+++ b/include/effects/matrix/PatternPongClock.h
@@ -74,11 +74,13 @@
 #define SPEEDUP 1.15
 #define MAXSPEED 4.0f
 
-class PatternPongClock : public LEDStripEffect {
-    public:
-        static constexpr EffectId kId = idMatrixPongClock;
-
-    private:
+class PatternPongClock : public LEDStripEffect 
+{
+  public:
+    static constexpr EffectId kId = idMatrixPongClock;
+    EffectId effectId() const override { return kId; }
+  
+  private:
     float ballpos_x, ballpos_y;
     uint8_t erase_x = 10; // holds ball old pos so we can erase it, set to blank area of screen initially.
     uint8_t erase_y = 10;

--- a/include/effects/matrix/PatternPongClock.h
+++ b/include/effects/matrix/PatternPongClock.h
@@ -95,7 +95,7 @@ class PatternPongClock : public LEDStripEffect
 
   public:
 
-    PatternPongClock() : LEDStripEffect(EFFECT_MATRIX_PONG_CLOCK, "PongClock")
+    PatternPongClock() : LEDStripEffect(idMatrixPongClock, "PongClock")
     {
     }
 

--- a/include/effects/matrix/PatternPulse.h
+++ b/include/effects/matrix/PatternPulse.h
@@ -121,9 +121,11 @@ class PatternPulse : public LEDStripEffect
         // effects.standardNoiseSmearing();
     }
 };
-class PatternPulsar : public BeatEffectBase, public LEDStripEffect
-{
-  private:
+class PatternPulsar : public BeatEffectBase, public LEDStripEffect {
+    public:
+        static constexpr EffectId kId = idMatrixPulsar;
+
+    private:
 
     struct PulsePop
     {

--- a/include/effects/matrix/PatternPulse.h
+++ b/include/effects/matrix/PatternPulse.h
@@ -124,7 +124,8 @@ class PatternPulse : public LEDStripEffect
 class PatternPulsar : public BeatEffectBase, public LEDStripEffect {
     public:
         static constexpr EffectId kId = idMatrixPulsar;
-
+        EffectId effectId() const override { return kId; }
+        
     private:
 
     struct PulsePop

--- a/include/effects/matrix/PatternPulse.h
+++ b/include/effects/matrix/PatternPulse.h
@@ -72,7 +72,7 @@ class PatternPulse : public LEDStripEffect
 
   public:
 
-    PatternPulse() : LEDStripEffect(EFFECT_MATRIX_PULSE, "Pulse")
+    PatternPulse() : LEDStripEffect(idMatrixPulse, "Pulse")
     {
     }
 
@@ -145,7 +145,7 @@ class PatternPulsar : public BeatEffectBase, public LEDStripEffect
 
     PatternPulsar() :
         BeatEffectBase(1.5, 0.25 ),
-        LEDStripEffect(EFFECT_MATRIX_PULSAR, "Pulsars")
+    LEDStripEffect(idMatrixPulsar, "Pulsars")
     {
     }
 

--- a/include/effects/matrix/PatternQR.h
+++ b/include/effects/matrix/PatternQR.h
@@ -51,7 +51,7 @@ protected:
 
 public:
 
-    PatternQR() : LEDStripEffect(EFFECT_MATRIX_QR, "QR")
+    PatternQR() : LEDStripEffect(idMatrixQR, "QR")
     {
         construct();
     }

--- a/include/effects/matrix/PatternRadar.h
+++ b/include/effects/matrix/PatternRadar.h
@@ -62,7 +62,8 @@ private:
 
 public:
   static constexpr EffectId kId = idMatrixRadar;
-
+  EffectId effectId() const override { return kId; }
+  
   PatternRadar() : LEDStripEffect(kId, "Radar")
   {
   }

--- a/include/effects/matrix/PatternRadar.h
+++ b/include/effects/matrix/PatternRadar.h
@@ -61,7 +61,9 @@ private:
   uint8_t hueoffset = 0;
 
 public:
-  PatternRadar() : LEDStripEffect(idMatrixRadar, "Radar")
+  static constexpr EffectId kId = idMatrixRadar;
+
+  PatternRadar() : LEDStripEffect(kId, "Radar")
   {
   }
 

--- a/include/effects/matrix/PatternRadar.h
+++ b/include/effects/matrix/PatternRadar.h
@@ -61,7 +61,7 @@ private:
   uint8_t hueoffset = 0;
 
 public:
-  PatternRadar() : LEDStripEffect(EFFECT_MATRIX_RADAR, "Radar")
+  PatternRadar() : LEDStripEffect(idMatrixRadar, "Radar")
   {
   }
 

--- a/include/effects/matrix/PatternSM2DDPR.h
+++ b/include/effects/matrix/PatternSM2DDPR.h
@@ -9,7 +9,8 @@
 class PatternSM2DDPR : public LEDStripEffect {
     public:
         static constexpr EffectId kId = idMatrixSM2DDPR;
-
+        EffectId effectId() const override { return kId; }
+        
     private:
     uint8_t ZVoffset = 0;
 

--- a/include/effects/matrix/PatternSM2DDPR.h
+++ b/include/effects/matrix/PatternSM2DDPR.h
@@ -6,9 +6,11 @@
 // Looks best on a square display, but OK on rectangles.
 // I'll admit this math may as well be magic, but it's pretty.
 
-class PatternSM2DDPR : public LEDStripEffect
-{
-  private:
+class PatternSM2DDPR : public LEDStripEffect {
+    public:
+        static constexpr EffectId kId = idMatrixSM2DDPR;
+
+    private:
     uint8_t ZVoffset = 0;
 
     const int Scale = 127;

--- a/include/effects/matrix/PatternSM2DDPR.h
+++ b/include/effects/matrix/PatternSM2DDPR.h
@@ -21,7 +21,7 @@ class PatternSM2DDPR : public LEDStripEffect
     //   byte effect = 1;
 
   public:
-    PatternSM2DDPR() : LEDStripEffect(EFFECT_MATRIX_SM2DDPR, "Crystallize")
+    PatternSM2DDPR() : LEDStripEffect(idMatrixSM2DDPR, "Crystallize")
     {
     }
 

--- a/include/effects/matrix/PatternSMAmberRain.h
+++ b/include/effects/matrix/PatternSMAmberRain.h
@@ -85,7 +85,8 @@ class PatternSMAmberRain : public LEDStripEffect
 
   public:
     static constexpr EffectId kId = idMatrixSMAmberRain;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternSMAmberRain() : LEDStripEffect(kId, "Color Rain")
     {
     }

--- a/include/effects/matrix/PatternSMAmberRain.h
+++ b/include/effects/matrix/PatternSMAmberRain.h
@@ -84,7 +84,7 @@ class PatternSMAmberRain : public LEDStripEffect
     }
 
   public:
-    PatternSMAmberRain() : LEDStripEffect(EFFECT_MATRIX_SMAMBERRAIN, "Color Rain")
+    PatternSMAmberRain() : LEDStripEffect(idMatrixSMAmberRain, "Color Rain")
     {
     }
 

--- a/include/effects/matrix/PatternSMAmberRain.h
+++ b/include/effects/matrix/PatternSMAmberRain.h
@@ -84,7 +84,9 @@ class PatternSMAmberRain : public LEDStripEffect
     }
 
   public:
-    PatternSMAmberRain() : LEDStripEffect(idMatrixSMAmberRain, "Color Rain")
+    static constexpr EffectId kId = idMatrixSMAmberRain;
+
+    PatternSMAmberRain() : LEDStripEffect(kId, "Color Rain")
     {
     }
 

--- a/include/effects/matrix/PatternSMBlurringColors.h
+++ b/include/effects/matrix/PatternSMBlurringColors.h
@@ -192,14 +192,11 @@ class PatternSMBlurringColors : public LEDStripEffect
         powder_item._is_shift = true; // particle->isAlive
     }
 
-  public:
-    PatternSMBlurringColors() : LEDStripEffect(idMatrixSMBlurringColors, "Powder")
-    {
-    }
+    public:
+        static constexpr EffectId kId = idMatrixSMBlurringColors;
 
-    PatternSMBlurringColors(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+        PatternSMBlurringColors() : LEDStripEffect(idMatrixSMBlurringColors, "Powder") {}
+        PatternSMBlurringColors(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject) {}
 
     void Start() override
     {

--- a/include/effects/matrix/PatternSMBlurringColors.h
+++ b/include/effects/matrix/PatternSMBlurringColors.h
@@ -192,11 +192,13 @@ class PatternSMBlurringColors : public LEDStripEffect
         powder_item._is_shift = true; // particle->isAlive
     }
 
-    public:
-        static constexpr EffectId kId = idMatrixSMBlurringColors;
+  public:
 
-        PatternSMBlurringColors() : LEDStripEffect(idMatrixSMBlurringColors, "Powder") {}
-        PatternSMBlurringColors(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject) {}
+    static constexpr EffectId kId = idMatrixSMBlurringColors;
+    EffectId effectId() const override { return kId; }
+    
+    PatternSMBlurringColors() : LEDStripEffect(idMatrixSMBlurringColors, "Powder") {}
+    PatternSMBlurringColors(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject) {}
 
     void Start() override
     {

--- a/include/effects/matrix/PatternSMBlurringColors.h
+++ b/include/effects/matrix/PatternSMBlurringColors.h
@@ -193,7 +193,7 @@ class PatternSMBlurringColors : public LEDStripEffect
     }
 
   public:
-    PatternSMBlurringColors() : LEDStripEffect(EFFECT_MATRIX_SMBLURRING_COLORS, "Powder")
+    PatternSMBlurringColors() : LEDStripEffect(idMatrixSMBlurringColors, "Powder")
     {
     }
 

--- a/include/effects/matrix/PatternSMFire2021.h
+++ b/include/effects/matrix/PatternSMFire2021.h
@@ -6,10 +6,11 @@
 
 class PatternSMFire2021 : public LEDStripEffect
 {
-    public:
-        static constexpr EffectId kId = idMatrixSMFire2021;
+  public:
+    static constexpr EffectId kId = idMatrixSMFire2021;
+    EffectId effectId() const override { return kId; }
 
-    private:
+  private:
     uint8_t Speed = 150; // 1-252 ...why is not 255?! // Setting
     uint8_t Scale = 9;   // 1-99 is palette and scale // Setting
 

--- a/include/effects/matrix/PatternSMFire2021.h
+++ b/include/effects/matrix/PatternSMFire2021.h
@@ -18,7 +18,7 @@ class PatternSMFire2021 : public LEDStripEffect
     const TProgmemRGBPalette16 *curPalette;
 
   public:
-    PatternSMFire2021() : LEDStripEffect(EFFECT_MATRIX_SMFIRE2021, "Fireplace")
+    PatternSMFire2021() : LEDStripEffect(idMatrixSMFire2021, "Fireplace")
     {
     }
 

--- a/include/effects/matrix/PatternSMFire2021.h
+++ b/include/effects/matrix/PatternSMFire2021.h
@@ -6,7 +6,10 @@
 
 class PatternSMFire2021 : public LEDStripEffect
 {
-  private:
+    public:
+        static constexpr EffectId kId = idMatrixSMFire2021;
+
+    private:
     uint8_t Speed = 150; // 1-252 ...why is not 255?! // Setting
     uint8_t Scale = 9;   // 1-99 is palette and scale // Setting
 

--- a/include/effects/matrix/PatternSMFlowFields.h
+++ b/include/effects/matrix/PatternSMFlowFields.h
@@ -78,7 +78,7 @@ class PatternSMFlowFields : public LEDStripEffect
     uint16_t scale = 30;
 
   public:
-    PatternSMFlowFields() : LEDStripEffect(EFFECT_MATRIX_SMFLOW_FIELDS, "Liquidflow")
+    PatternSMFlowFields() : LEDStripEffect(idMatrixSMFlowFields, "Liquidflow")
     {
     }
 

--- a/include/effects/matrix/PatternSMFlowFields.h
+++ b/include/effects/matrix/PatternSMFlowFields.h
@@ -78,6 +78,8 @@ class PatternSMFlowFields : public LEDStripEffect
     uint16_t scale = 30;
 
   public:
+    static constexpr EffectId kId = idMatrixSMFlowFields;
+
     PatternSMFlowFields() : LEDStripEffect(idMatrixSMFlowFields, "Liquidflow")
     {
     }

--- a/include/effects/matrix/PatternSMFlowFields.h
+++ b/include/effects/matrix/PatternSMFlowFields.h
@@ -79,7 +79,8 @@ class PatternSMFlowFields : public LEDStripEffect
 
   public:
     static constexpr EffectId kId = idMatrixSMFlowFields;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternSMFlowFields() : LEDStripEffect(idMatrixSMFlowFields, "Liquidflow")
     {
     }

--- a/include/effects/matrix/PatternSMGamma.h
+++ b/include/effects/matrix/PatternSMGamma.h
@@ -7,15 +7,13 @@
 
 class PatternSMGamma : public LEDStripEffect
 {
-  private:
   public:
-    PatternSMGamma() : LEDStripEffect(idMatrixSMGamma, "Gamma")
-    {
-    }
+    static constexpr EffectId kId = idMatrixSMGamma;
 
-    PatternSMGamma(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    PatternSMGamma() : LEDStripEffect(idMatrixSMGamma, "Gamma") {}
+    PatternSMGamma(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject) {}
+
+  private:
 
     void Start() override
     {

--- a/include/effects/matrix/PatternSMGamma.h
+++ b/include/effects/matrix/PatternSMGamma.h
@@ -9,7 +9,7 @@ class PatternSMGamma : public LEDStripEffect
 {
   private:
   public:
-    PatternSMGamma() : LEDStripEffect(EFFECT_MATRIX_SMGAMMA, "Gamma")
+    PatternSMGamma() : LEDStripEffect(idMatrixSMGamma, "Gamma")
     {
     }
 

--- a/include/effects/matrix/PatternSMGamma.h
+++ b/include/effects/matrix/PatternSMGamma.h
@@ -9,7 +9,8 @@ class PatternSMGamma : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idMatrixSMGamma;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternSMGamma() : LEDStripEffect(idMatrixSMGamma, "Gamma") {}
     PatternSMGamma(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject) {}
 

--- a/include/effects/matrix/PatternSMHolidayLights.h
+++ b/include/effects/matrix/PatternSMHolidayLights.h
@@ -8,11 +8,13 @@
 //@stepko
 // Merry Christmas and Happy New Year
 
-class PatternSMHolidayLights : public LEDStripEffect {
-    public:
-        static constexpr EffectId kId = idMatrixSMHolidayLights;
-
-    private:
+class PatternSMHolidayLights : public LEDStripEffect 
+{
+  public:
+    static constexpr EffectId kId = idMatrixSMHolidayLights;
+    EffectId effectId() const override { return kId; }
+  
+  private:
 
     static constexpr int speed = (200 / (MATRIX_HEIGHT - 4));
     uint8_t hue {0};

--- a/include/effects/matrix/PatternSMHolidayLights.h
+++ b/include/effects/matrix/PatternSMHolidayLights.h
@@ -8,9 +8,11 @@
 //@stepko
 // Merry Christmas and Happy New Year
 
-class PatternSMHolidayLights : public LEDStripEffect
-{
-  private:
+class PatternSMHolidayLights : public LEDStripEffect {
+    public:
+        static constexpr EffectId kId = idMatrixSMHolidayLights;
+
+    private:
 
     static constexpr int speed = (200 / (MATRIX_HEIGHT - 4));
     uint8_t hue {0};

--- a/include/effects/matrix/PatternSMHolidayLights.h
+++ b/include/effects/matrix/PatternSMHolidayLights.h
@@ -129,7 +129,7 @@ void spruce()
 
 
   public:
-    PatternSMHolidayLights() : LEDStripEffect(EFFECT_MATRIX_SMHOLIDAY_LIGHTS, "Tannenbaum")
+    PatternSMHolidayLights() : LEDStripEffect(idMatrixSMHolidayLights, "Tannenbaum")
     {
     }
 

--- a/include/effects/matrix/PatternSMHypnosis.h
+++ b/include/effects/matrix/PatternSMHypnosis.h
@@ -18,7 +18,7 @@ class PatternSMHypnosis : public LEDStripEffect
     } rMap[MATRIX_WIDTH][MATRIX_HEIGHT];
 
   public:
-    PatternSMHypnosis() : LEDStripEffect(EFFECT_MATRIX_SMHYPNOSIS, "Hypnosis")
+    PatternSMHypnosis() : LEDStripEffect(idMatrixSMHypnosis, "Hypnosis")
     {
     }
 

--- a/include/effects/matrix/PatternSMHypnosis.h
+++ b/include/effects/matrix/PatternSMHypnosis.h
@@ -19,7 +19,8 @@ class PatternSMHypnosis : public LEDStripEffect
 
   public:
     static constexpr EffectId kId = idMatrixSMHypnosis;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternSMHypnosis() : LEDStripEffect(kId, "Hypnosis")
     {
     }

--- a/include/effects/matrix/PatternSMHypnosis.h
+++ b/include/effects/matrix/PatternSMHypnosis.h
@@ -18,7 +18,9 @@ class PatternSMHypnosis : public LEDStripEffect
     } rMap[MATRIX_WIDTH][MATRIX_HEIGHT];
 
   public:
-    PatternSMHypnosis() : LEDStripEffect(idMatrixSMHypnosis, "Hypnosis")
+    static constexpr EffectId kId = idMatrixSMHypnosis;
+
+    PatternSMHypnosis() : LEDStripEffect(kId, "Hypnosis")
     {
     }
 

--- a/include/effects/matrix/PatternSMMetaBalls.h
+++ b/include/effects/matrix/PatternSMMetaBalls.h
@@ -25,7 +25,9 @@ class PatternSMMetaBalls : public LEDStripEffect
     }
 
   public:
-    PatternSMMetaBalls() : LEDStripEffect(idMatrixSMMetaBalls, "MetaBalls")
+    static constexpr EffectId kId = idMatrixSMMetaBalls;
+
+    PatternSMMetaBalls() : LEDStripEffect(kId, "MetaBalls")
     {
     }
 

--- a/include/effects/matrix/PatternSMMetaBalls.h
+++ b/include/effects/matrix/PatternSMMetaBalls.h
@@ -25,7 +25,7 @@ class PatternSMMetaBalls : public LEDStripEffect
     }
 
   public:
-    PatternSMMetaBalls() : LEDStripEffect(EFFECT_MATRIX_SMMETA_BALLS, "MetaBalls")
+    PatternSMMetaBalls() : LEDStripEffect(idMatrixSMMetaBalls, "MetaBalls")
     {
     }
 

--- a/include/effects/matrix/PatternSMMetaBalls.h
+++ b/include/effects/matrix/PatternSMMetaBalls.h
@@ -26,7 +26,8 @@ class PatternSMMetaBalls : public LEDStripEffect
 
   public:
     static constexpr EffectId kId = idMatrixSMMetaBalls;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternSMMetaBalls() : LEDStripEffect(kId, "MetaBalls")
     {
     }

--- a/include/effects/matrix/PatternSMNoise.h
+++ b/include/effects/matrix/PatternSMNoise.h
@@ -364,15 +364,16 @@ class PatternSMNoise : public LEDStripEffect
     };
 
     static constexpr EffectId kId = idMatrixSMNoise;
+    EffectId effectId() const override { return kId; }
 
     PatternSMNoise(const String& name, EffectType effect)
-    : LEDStripEffect(kId, name),
+      : LEDStripEffect(kId, name),
         _effect(effect)
     {
     }
 
     PatternSMNoise()
-    : LEDStripEffect(kId, "Lava Lamp"),
+      : LEDStripEffect(kId, "Lava Lamp"),
         _effect(EffectType::Unknown)
     {
     }

--- a/include/effects/matrix/PatternSMNoise.h
+++ b/include/effects/matrix/PatternSMNoise.h
@@ -363,14 +363,16 @@ class PatternSMNoise : public LEDStripEffect
         ColorCube_t
     };
 
+    static constexpr EffectId kId = idMatrixSMNoise;
+
     PatternSMNoise(const String& name, EffectType effect)
-    : LEDStripEffect(idMatrixSMNoise, name),
+    : LEDStripEffect(kId, name),
         _effect(effect)
     {
     }
 
     PatternSMNoise()
-    : LEDStripEffect(idMatrixSMNoise, "Lava Lamp"),
+    : LEDStripEffect(kId, "Lava Lamp"),
         _effect(EffectType::Unknown)
     {
     }

--- a/include/effects/matrix/PatternSMNoise.h
+++ b/include/effects/matrix/PatternSMNoise.h
@@ -364,13 +364,13 @@ class PatternSMNoise : public LEDStripEffect
     };
 
     PatternSMNoise(const String& name, EffectType effect)
-      : LEDStripEffect(EFFECT_MATRIX_SMNOISE, name),
+    : LEDStripEffect(idMatrixSMNoise, name),
         _effect(effect)
     {
     }
 
     PatternSMNoise()
-      : LEDStripEffect(EFFECT_MATRIX_SMNOISE, "Lava Lamp"),
+    : LEDStripEffect(idMatrixSMNoise, "Lava Lamp"),
         _effect(EffectType::Unknown)
     {
     }

--- a/include/effects/matrix/PatternSMPicasso3in1.h
+++ b/include/effects/matrix/PatternSMPicasso3in1.h
@@ -4,9 +4,11 @@
 
 // Inspired by https://editor.soulmatelights.com/gallery/1177-picasso-3in1
 
-class PatternSMPicasso3in1 : public LEDStripEffect
-{
-  private:
+class PatternSMPicasso3in1 : public LEDStripEffect {
+    public:
+        static constexpr EffectId kId = idMatrixSMPicasso3in1;
+
+    private:
     // Suggested values for Mesmerizer w/ 1/2 HUB75 panel: 10, 36, 70
     uint8_t Scale = 2; // 1-100 is image type and count. THis should be a Setting 0-33 = P1,
                        // 34-68 = P2, 68-99 = Picasso3 P1 - Scale is number of independent
@@ -220,7 +222,7 @@ class PatternSMPicasso3in1 : public LEDStripEffect
 
 	    Scale = _scale;
 
-        if (Scale < 34U) // если масштаб до 34
+        if (Scale < 34U) // если масштаб до 34 
             PicassoRoutine1();
         else if (Scale > 67U) // если масштаб больше 67
             PicassoRoutine3();

--- a/include/effects/matrix/PatternSMPicasso3in1.h
+++ b/include/effects/matrix/PatternSMPicasso3in1.h
@@ -4,11 +4,15 @@
 
 // Inspired by https://editor.soulmatelights.com/gallery/1177-picasso-3in1
 
-class PatternSMPicasso3in1 : public LEDStripEffect {
-    public:
-        static constexpr EffectId kId = idMatrixSMPicasso3in1;
+class PatternSMPicasso3in1 : public LEDStripEffect 
+{
+  public:
+  
+    static constexpr EffectId kId = idMatrixSMPicasso3in1;
+    EffectId effectId() const override { return kId; }
+    
+  private:
 
-    private:
     // Suggested values for Mesmerizer w/ 1/2 HUB75 panel: 10, 36, 70
     uint8_t Scale = 2; // 1-100 is image type and count. THis should be a Setting 0-33 = P1,
                        // 34-68 = P2, 68-99 = Picasso3 P1 - Scale is number of independent
@@ -154,13 +158,13 @@ class PatternSMPicasso3in1 : public LEDStripEffect {
 
   public:
     PatternSMPicasso3in1()
-    : LEDStripEffect(idMatrixSMPicasso3in1, "Picasso"),
+      : LEDStripEffect(idMatrixSMPicasso3in1, "Picasso"),
         _scale(-1)
     {
     }
 
     PatternSMPicasso3in1(const String& name, int scale)
-    : LEDStripEffect(idMatrixSMPicasso3in1, name),
+      : LEDStripEffect(idMatrixSMPicasso3in1, name),
         _scale(scale)
     {
     }
@@ -204,7 +208,7 @@ class PatternSMPicasso3in1 : public LEDStripEffect {
     void Start() override
     {
         g()->Clear();
-	Scale = _scale;
+	    Scale = _scale;
         RecalibrateDrawnObjects();
     }
 
@@ -222,11 +226,11 @@ class PatternSMPicasso3in1 : public LEDStripEffect {
 
 	    Scale = _scale;
 
-        if (Scale < 34U) // если масштаб до 34 
-            PicassoRoutine1();
-        else if (Scale > 67U) // если масштаб больше 67
-            PicassoRoutine3();
-        else // для масштабов посередине
-            PicassoRoutine2();
+        if (Scale < 34U) 
+            PicassoRoutine1();  // Scale is less than 34
+        else if (Scale > 67U) 
+            PicassoRoutine3();  // Scale is greater than 67
+        else 
+            PicassoRoutine2();  // Scale is between 34 and 67
     }
 };

--- a/include/effects/matrix/PatternSMPicasso3in1.h
+++ b/include/effects/matrix/PatternSMPicasso3in1.h
@@ -152,13 +152,13 @@ class PatternSMPicasso3in1 : public LEDStripEffect
 
   public:
     PatternSMPicasso3in1()
-      : LEDStripEffect(EFFECT_MATRIX_SMPICASSO3IN1, "Picasso"),
+    : LEDStripEffect(idMatrixSMPicasso3in1, "Picasso"),
         _scale(-1)
     {
     }
 
     PatternSMPicasso3in1(const String& name, int scale)
-      : LEDStripEffect(EFFECT_MATRIX_SMPICASSO3IN1, name),
+    : LEDStripEffect(idMatrixSMPicasso3in1, name),
         _scale(scale)
     {
     }

--- a/include/effects/matrix/PatternSMRadialFire.h
+++ b/include/effects/matrix/PatternSMRadialFire.h
@@ -31,7 +31,7 @@ public:
                 XY_radius_buf[idx] = hypot(x, y); // thanks Sutaburosu
             }
         }
-        return true;
+        return LEDStripEffect::Init(gfx);
     }
 
     void Start() override

--- a/include/effects/matrix/PatternSMRadialFire.h
+++ b/include/effects/matrix/PatternSMRadialFire.h
@@ -8,6 +8,7 @@ class PatternSMRadialFire : public LEDStripEffect
 {
 public:
     static constexpr EffectId kId = idMatrixSMRadialFire;
+    EffectId effectId() const override { return kId; }
 
     PatternSMRadialFire() : LEDStripEffect(idMatrixSMRadialFire, "RadialFire") {}
     PatternSMRadialFire(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject) {}

--- a/include/effects/matrix/PatternSMRadialFire.h
+++ b/include/effects/matrix/PatternSMRadialFire.h
@@ -6,7 +6,7 @@
 
 class PatternSMRadialFire : public LEDStripEffect
 {
-  public:
+public:
     static constexpr EffectId kId = idMatrixSMRadialFire;
 
     PatternSMRadialFire() : LEDStripEffect(idMatrixSMRadialFire, "RadialFire") {}

--- a/include/effects/matrix/PatternSMRadialFire.h
+++ b/include/effects/matrix/PatternSMRadialFire.h
@@ -15,7 +15,7 @@ class PatternSMRadialFire : public LEDStripEffect
     uint8_t XY_radius[MATRIX_WIDTH][MATRIX_HEIGHT];
 
   public:
-    PatternSMRadialFire() : LEDStripEffect(EFFECT_MATRIX_SMRADIAL_FIRE, "RadialFire")
+    PatternSMRadialFire() : LEDStripEffect(idMatrixSMRadialFire, "RadialFire")
     {
     }
 

--- a/include/effects/matrix/PatternSMRadialFire.h
+++ b/include/effects/matrix/PatternSMRadialFire.h
@@ -15,21 +15,27 @@ class PatternSMRadialFire : public LEDStripEffect
   private:
     static auto constexpr C_X = (MATRIX_WIDTH / 2);
     static auto constexpr C_Y = (MATRIX_HEIGHT / 2);
-    // BUGBUG: should probably be dynamically allocated into non-DMAable RAM.
-    uint8_t XY_angle[MATRIX_WIDTH][MATRIX_HEIGHT];
-    uint8_t XY_radius[MATRIX_WIDTH][MATRIX_HEIGHT];
+    
+    std::unique_ptr<uint8_t[]> XY_angle_buf;
+    std::unique_ptr<uint8_t[]> XY_radius_buf;
+
+    bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
+    {
+        XY_angle_buf = make_unique_psram<uint8_t[]>(MATRIX_WIDTH * MATRIX_HEIGHT);
+        XY_radius_buf = make_unique_psram<uint8_t[]>(MATRIX_WIDTH * MATRIX_HEIGHT);
+        for (int8_t x = -C_X; x < C_X + (MATRIX_WIDTH % 2); x++) {
+            for (int8_t y = -C_Y; y < C_Y + (MATRIX_HEIGHT % 2); y++) {
+                int idx = (x + C_X) + MATRIX_WIDTH * (y + C_Y);
+                XY_angle_buf[idx] = 128 * (atan2(y, x) / PI);
+                XY_radius_buf[idx] = hypot(x, y); // thanks Sutaburosu
+            }
+        }
+        return true;
+    }
 
     void Start() override
     {
         g()->Clear();
-        for (int8_t x = -C_X; x < C_X + (MATRIX_WIDTH % 2); x++)
-        {
-            for (int8_t y = -C_Y; y < C_Y + (MATRIX_HEIGHT % 2); y++)
-            {
-                XY_angle[x + C_X][y + C_Y] = 128 * (atan2(y, x) / PI);
-                XY_radius[x + C_X][y + C_Y] = hypot(x, y); // thanks Sutaburosu
-            }
-        }
     }
 
     void Draw() override
@@ -40,14 +46,14 @@ class PatternSMRadialFire : public LEDStripEffect
         static uint8_t speed = 24;
         static uint32_t t;
         t += speed;
-        for (uint8_t x = 0; x < MATRIX_WIDTH; x++)
-        {
-            for (uint8_t y = 0; y < MATRIX_HEIGHT; y++)
-            {
-                uint8_t angle = XY_angle[x][y];
-                uint8_t radius = XY_radius[x][y];
+        for (uint8_t x = 0; x < MATRIX_WIDTH; x++) {
+            for (uint8_t y = 0; y < MATRIX_HEIGHT; y++) {
+                int idx = x + MATRIX_WIDTH * y;
+                uint8_t angle = XY_angle_buf[idx];
+                uint8_t radius = XY_radius_buf[idx];
                 int16_t Bri = inoise8(angle * scaleX, (radius * scaleY) - t) - radius * (255 / MATRIX_HEIGHT);
                 uint8_t Col = Bri;
+                
                 if (Bri < 0)
                     Bri = 0;
                 if (Bri != 0)
@@ -55,6 +61,7 @@ class PatternSMRadialFire : public LEDStripEffect
 
                 // If the palette is paused, we use it to color the fire, otherwise we just use red
                 // Step 1: Calculate normalized color value
+
                 float normalizedCol = Col / 255.0f;
 
                 // Step 2: Choose base color depending on palette state

--- a/include/effects/matrix/PatternSMRadialWave.h
+++ b/include/effects/matrix/PatternSMRadialWave.h
@@ -7,10 +7,11 @@
 
 class PatternSMRadialWave : public LEDStripEffect
 {
-    public:
-        static constexpr EffectId kId = idMatrixSMRadialWave;
-
-    private:
+  public:
+    static constexpr EffectId kId = idMatrixSMRadialWave;
+    EffectId effectId() const override { return kId; }
+  
+  private:
     // RadialWave
     // Stepko and Sutaburosu
     // 22/05/22

--- a/include/effects/matrix/PatternSMRadialWave.h
+++ b/include/effects/matrix/PatternSMRadialWave.h
@@ -7,7 +7,10 @@
 
 class PatternSMRadialWave : public LEDStripEffect
 {
-  private:
+    public:
+        static constexpr EffectId kId = idMatrixSMRadialWave;
+
+    private:
     // RadialWave
     // Stepko and Sutaburosu
     // 22/05/22

--- a/include/effects/matrix/PatternSMRadialWave.h
+++ b/include/effects/matrix/PatternSMRadialWave.h
@@ -24,7 +24,7 @@ class PatternSMRadialWave : public LEDStripEffect
     } rMap[MATRIX_WIDTH][MATRIX_HEIGHT];
 
   public:
-    PatternSMRadialWave() : LEDStripEffect(EFFECT_MATRIX_SMRADIAL_WAVE, "RadialWave")
+    PatternSMRadialWave() : LEDStripEffect(idMatrixSMRadialWave, "RadialWave")
     {
     }
 

--- a/include/effects/matrix/PatternSMRainbowTunnel.h
+++ b/include/effects/matrix/PatternSMRainbowTunnel.h
@@ -23,6 +23,8 @@ class PatternSMRainbowTunnel : public LEDStripEffect
     } rMap[MATRIX_WIDTH][MATRIX_HEIGHT];
 
   public:
+    static constexpr EffectId kId = idMatrixSMRainbowTunnel;
+
     PatternSMRainbowTunnel() : LEDStripEffect(idMatrixSMRainbowTunnel, "Colorspin")
     {
     }

--- a/include/effects/matrix/PatternSMRainbowTunnel.h
+++ b/include/effects/matrix/PatternSMRainbowTunnel.h
@@ -24,6 +24,7 @@ class PatternSMRainbowTunnel : public LEDStripEffect
 
   public:
     static constexpr EffectId kId = idMatrixSMRainbowTunnel;
+    EffectId effectId() const override { return kId; }
 
     PatternSMRainbowTunnel() : LEDStripEffect(idMatrixSMRainbowTunnel, "Colorspin")
     {

--- a/include/effects/matrix/PatternSMRainbowTunnel.h
+++ b/include/effects/matrix/PatternSMRainbowTunnel.h
@@ -23,7 +23,7 @@ class PatternSMRainbowTunnel : public LEDStripEffect
     } rMap[MATRIX_WIDTH][MATRIX_HEIGHT];
 
   public:
-    PatternSMRainbowTunnel() : LEDStripEffect(EFFECT_MATRIX_SMRAINBOW_TUNNEL, "Colorspin")
+    PatternSMRainbowTunnel() : LEDStripEffect(idMatrixSMRainbowTunnel, "Colorspin")
     {
     }
 

--- a/include/effects/matrix/PatternSMSmoke.h
+++ b/include/effects/matrix/PatternSMSmoke.h
@@ -6,7 +6,7 @@
 
 class PatternSMSmoke : public LEDStripEffect
 {
-  public:
+public:
   static constexpr EffectId kId = idMatrixSMSmoke;
 
 private:

--- a/include/effects/matrix/PatternSMSmoke.h
+++ b/include/effects/matrix/PatternSMSmoke.h
@@ -6,6 +6,9 @@
 
 class PatternSMSmoke : public LEDStripEffect
 {
+  public:
+  static constexpr EffectId kId = idMatrixSMSmoke;
+
 private:
   static constexpr uint8_t Scale = 50; // 1-100. Setting
 

--- a/include/effects/matrix/PatternSMSmoke.h
+++ b/include/effects/matrix/PatternSMSmoke.h
@@ -8,6 +8,7 @@ class PatternSMSmoke : public LEDStripEffect
 {
 public:
   static constexpr EffectId kId = idMatrixSMSmoke;
+  EffectId effectId() const override { return kId; }
 
 private:
   static constexpr uint8_t Scale = 50; // 1-100. Setting
@@ -21,12 +22,12 @@ private:
 
 public:
   PatternSMSmoke()
-  : LEDStripEffect(idMatrixSMSmoke, "Smoke")
+    : LEDStripEffect(idMatrixSMSmoke, "Smoke")
   {
   }
 
   PatternSMSmoke(const JsonObjectConst &jsonObject)
-      : LEDStripEffect(jsonObject)
+    : LEDStripEffect(jsonObject)
   {
   }
 

--- a/include/effects/matrix/PatternSMSmoke.h
+++ b/include/effects/matrix/PatternSMSmoke.h
@@ -18,7 +18,7 @@ private:
 
 public:
   PatternSMSmoke()
-      : LEDStripEffect(EFFECT_MATRIX_SMSMOKE, "Smoke")
+  : LEDStripEffect(idMatrixSMSmoke, "Smoke")
   {
   }
 

--- a/include/effects/matrix/PatternSMSpiroPulse.h
+++ b/include/effects/matrix/PatternSMSpiroPulse.h
@@ -61,7 +61,8 @@ class PatternSMSpiroPulse : public LEDStripEffect
 
   public:
     static constexpr EffectId kId = idMatrixSMSpiroPulse;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternSMSpiroPulse() : LEDStripEffect(idMatrixSMSpiroPulse, "Spiro")
     {
     }

--- a/include/effects/matrix/PatternSMSpiroPulse.h
+++ b/include/effects/matrix/PatternSMSpiroPulse.h
@@ -60,6 +60,8 @@ class PatternSMSpiroPulse : public LEDStripEffect
     }
 
   public:
+    static constexpr EffectId kId = idMatrixSMSpiroPulse;
+
     PatternSMSpiroPulse() : LEDStripEffect(idMatrixSMSpiroPulse, "Spiro")
     {
     }

--- a/include/effects/matrix/PatternSMSpiroPulse.h
+++ b/include/effects/matrix/PatternSMSpiroPulse.h
@@ -60,7 +60,7 @@ class PatternSMSpiroPulse : public LEDStripEffect
     }
 
   public:
-    PatternSMSpiroPulse() : LEDStripEffect(EFFECT_MATRIX_SMSPIRO_PULSE, "Spiro")
+    PatternSMSpiroPulse() : LEDStripEffect(idMatrixSMSpiroPulse, "Spiro")
     {
     }
 

--- a/include/effects/matrix/PatternSMStarDeep.h
+++ b/include/effects/matrix/PatternSMStarDeep.h
@@ -44,7 +44,8 @@ class PatternSMStarDeep : public LEDStripEffect
 
   public:
     static constexpr EffectId kId = idMatrixSMStarDeep;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternSMStarDeep() : LEDStripEffect(kId, "Star Deep")
     {
     }

--- a/include/effects/matrix/PatternSMStarDeep.h
+++ b/include/effects/matrix/PatternSMStarDeep.h
@@ -43,7 +43,7 @@ class PatternSMStarDeep : public LEDStripEffect
     const int spirocenterY = CENTER_Y_MINOR;
 
   public:
-    PatternSMStarDeep() : LEDStripEffect(EFFECT_MATRIX_SMSTARDEEP, "Star Deep")
+    PatternSMStarDeep() : LEDStripEffect(idMatrixSMStarDeep, "Star Deep")
     {
     }
 

--- a/include/effects/matrix/PatternSMStarDeep.h
+++ b/include/effects/matrix/PatternSMStarDeep.h
@@ -43,7 +43,9 @@ class PatternSMStarDeep : public LEDStripEffect
     const int spirocenterY = CENTER_Y_MINOR;
 
   public:
-    PatternSMStarDeep() : LEDStripEffect(idMatrixSMStarDeep, "Star Deep")
+    static constexpr EffectId kId = idMatrixSMStarDeep;
+
+    PatternSMStarDeep() : LEDStripEffect(kId, "Star Deep")
     {
     }
 

--- a/include/effects/matrix/PatternSMStrobeDiffusion.h
+++ b/include/effects/matrix/PatternSMStrobeDiffusion.h
@@ -35,7 +35,8 @@ class PatternSMStrobeDiffusion : public LEDStripEffect
 
   public:
     static constexpr EffectId kId = idMatrixSMStrobeDiffusion;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternSMStrobeDiffusion()
         :
 #if ENABLE_AUDIO

--- a/include/effects/matrix/PatternSMStrobeDiffusion.h
+++ b/include/effects/matrix/PatternSMStrobeDiffusion.h
@@ -34,12 +34,14 @@ class PatternSMStrobeDiffusion : public LEDStripEffect
 #endif
 
   public:
+    static constexpr EffectId kId = idMatrixSMStrobeDiffusion;
+
     PatternSMStrobeDiffusion()
         :
 #if ENABLE_AUDIO
           BeatEffectBase(1.50, 0.05),
 #endif
-          LEDStripEffect(idMatrixSMStrobeDiffusion, "Diffusion")
+          LEDStripEffect(kId, "Diffusion")
     {
     }
 

--- a/include/effects/matrix/PatternSMStrobeDiffusion.h
+++ b/include/effects/matrix/PatternSMStrobeDiffusion.h
@@ -39,7 +39,7 @@ class PatternSMStrobeDiffusion : public LEDStripEffect
 #if ENABLE_AUDIO
           BeatEffectBase(1.50, 0.05),
 #endif
-          LEDStripEffect(EFFECT_MATRIX_SMSTROBE_DIFFUSION, "Diffusion")
+          LEDStripEffect(idMatrixSMStrobeDiffusion, "Diffusion")
     {
     }
 

--- a/include/effects/matrix/PatternSMSupernova.h
+++ b/include/effects/matrix/PatternSMSupernova.h
@@ -9,7 +9,8 @@ class PatternSMSupernova : public LEDStripEffect
 {
 public:
     static constexpr EffectId kId = idMatrixSMSupernova;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternSMSupernova() : LEDStripEffect(idMatrixSMSupernova, "Supernova"), hue(0), hue2(0), step(0) {}
     PatternSMSupernova(const JsonObjectConst &jsonDebrisItem) : LEDStripEffect(jsonDebrisItem) {}
 

--- a/include/effects/matrix/PatternSMSupernova.h
+++ b/include/effects/matrix/PatternSMSupernova.h
@@ -8,14 +8,10 @@
 class PatternSMSupernova : public LEDStripEffect
 {
 public:
+    static constexpr EffectId kId = idMatrixSMSupernova;
 
-    PatternSMSupernova() : LEDStripEffect(idMatrixSMSupernova, "Supernova"), hue(0), hue2(0), step(0)
-    {
-    }
-
-    PatternSMSupernova(const JsonObjectConst &jsonDebrisItem) : LEDStripEffect(jsonDebrisItem)
-    {
-    }
+    PatternSMSupernova() : LEDStripEffect(idMatrixSMSupernova, "Supernova"), hue(0), hue2(0), step(0) {}
+    PatternSMSupernova(const JsonObjectConst &jsonDebrisItem) : LEDStripEffect(jsonDebrisItem) {}
 
     virtual size_t DesiredFramesPerSecond() const override
     {

--- a/include/effects/matrix/PatternSMSupernova.h
+++ b/include/effects/matrix/PatternSMSupernova.h
@@ -9,7 +9,7 @@ class PatternSMSupernova : public LEDStripEffect
 {
 public:
 
-    PatternSMSupernova() : LEDStripEffect(EFFECT_MATRIX_SMSUPERNOVA, "Supernova"), hue(0), hue2(0), step(0)
+    PatternSMSupernova() : LEDStripEffect(idMatrixSMSupernova, "Supernova"), hue(0), hue2(0), step(0)
     {
     }
 

--- a/include/effects/matrix/PatternSMTwister.h
+++ b/include/effects/matrix/PatternSMTwister.h
@@ -32,7 +32,7 @@ class PatternSMTwister : public LEDStripEffect
     }
 
   public:
-    PatternSMTwister() : LEDStripEffect(EFFECT_MATRIX_SMTWISTER, "Twister")
+    PatternSMTwister() : LEDStripEffect(idMatrixSMTwister, "Twister")
     {
     }
 

--- a/include/effects/matrix/PatternSMTwister.h
+++ b/include/effects/matrix/PatternSMTwister.h
@@ -32,7 +32,9 @@ class PatternSMTwister : public LEDStripEffect
     }
 
   public:
-    PatternSMTwister() : LEDStripEffect(idMatrixSMTwister, "Twister")
+    static constexpr EffectId kId = idMatrixSMTwister;
+
+    PatternSMTwister() : LEDStripEffect(kId, "Twister")
     {
     }
 

--- a/include/effects/matrix/PatternSMTwister.h
+++ b/include/effects/matrix/PatternSMTwister.h
@@ -33,7 +33,8 @@ class PatternSMTwister : public LEDStripEffect
 
   public:
     static constexpr EffectId kId = idMatrixSMTwister;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternSMTwister() : LEDStripEffect(kId, "Twister")
     {
     }

--- a/include/effects/matrix/PatternSMWalkingMachine.h
+++ b/include/effects/matrix/PatternSMWalkingMachine.h
@@ -90,7 +90,7 @@ class PatternSMWalkingMachine : public LEDStripEffect
     } dot[7];
 
   public:
-    PatternSMWalkingMachine() : LEDStripEffect(EFFECT_MATRIX_SMWALKING_MACHINE, "Machine")
+    PatternSMWalkingMachine() : LEDStripEffect(idMatrixSMWalkingMachine, "Machine")
     {
     }
 

--- a/include/effects/matrix/PatternSMWalkingMachine.h
+++ b/include/effects/matrix/PatternSMWalkingMachine.h
@@ -6,10 +6,11 @@
 
 class PatternSMWalkingMachine : public LEDStripEffect
 {
-    public:
-        static constexpr EffectId kId = idMatrixSMWalkingMachine;
-
-    private:
+public:
+    static constexpr EffectId kId = idMatrixSMWalkingMachine;
+    EffectId effectId() const override { return kId; }
+    
+  private:
     // Walking machine
     // St3p40 aka Stepko
     // 11.04.23

--- a/include/effects/matrix/PatternSMWalkingMachine.h
+++ b/include/effects/matrix/PatternSMWalkingMachine.h
@@ -6,7 +6,10 @@
 
 class PatternSMWalkingMachine : public LEDStripEffect
 {
-  private:
+    public:
+        static constexpr EffectId kId = idMatrixSMWalkingMachine;
+
+    private:
     // Walking machine
     // St3p40 aka Stepko
     // 11.04.23

--- a/include/effects/matrix/PatternSerendipity.h
+++ b/include/effects/matrix/PatternSerendipity.h
@@ -95,7 +95,8 @@ private:
 
 public:
     static constexpr EffectId kId = idMatrixSerendipity;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternSerendipity() : LEDStripEffect(kId, "Serendipiti")
     {
     }

--- a/include/effects/matrix/PatternSerendipity.h
+++ b/include/effects/matrix/PatternSerendipity.h
@@ -94,7 +94,7 @@ private:
     }
 
 public:
-    PatternSerendipity() : LEDStripEffect(EFFECT_MATRIX_SERENDIPITY, "Serendipiti")
+    PatternSerendipity() : LEDStripEffect(idMatrixSerendipity, "Serendipiti")
     {
     }
 

--- a/include/effects/matrix/PatternSerendipity.h
+++ b/include/effects/matrix/PatternSerendipity.h
@@ -94,7 +94,9 @@ private:
     }
 
 public:
-    PatternSerendipity() : LEDStripEffect(idMatrixSerendipity, "Serendipiti")
+    static constexpr EffectId kId = idMatrixSerendipity;
+
+    PatternSerendipity() : LEDStripEffect(kId, "Serendipiti")
     {
     }
 

--- a/include/effects/matrix/PatternSpin.h
+++ b/include/effects/matrix/PatternSpin.h
@@ -58,7 +58,8 @@ class PatternSpin : public LEDStripEffect
 {
 public:
     static constexpr EffectId kId = idMatrixSpin;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternSpin() : LEDStripEffect(kId, "Spin")
     {
     }

--- a/include/effects/matrix/PatternSpin.h
+++ b/include/effects/matrix/PatternSpin.h
@@ -57,7 +57,9 @@
 class PatternSpin : public LEDStripEffect
 {
 public:
-    PatternSpin() : LEDStripEffect(idMatrixSpin, "Spin")
+    static constexpr EffectId kId = idMatrixSpin;
+
+    PatternSpin() : LEDStripEffect(kId, "Spin")
     {
     }
 

--- a/include/effects/matrix/PatternSpin.h
+++ b/include/effects/matrix/PatternSpin.h
@@ -57,11 +57,11 @@
 class PatternSpin : public LEDStripEffect
 {
 public:
-    PatternSpin() : LEDStripEffect(EFFECT_MATRIX_SPIN, "Spin")
+    PatternSpin() : LEDStripEffect(idMatrixSpin, "Spin")
     {
     }
 
-    PatternSpin(const char   * pszFriendlyName) : LEDStripEffect(EFFECT_MATRIX_SPIN, pszFriendlyName)
+    PatternSpin(const char   * pszFriendlyName) : LEDStripEffect(idMatrixSpin, pszFriendlyName)
     {
     }
 

--- a/include/effects/matrix/PatternSpiro.h
+++ b/include/effects/matrix/PatternSpiro.h
@@ -81,7 +81,7 @@ private:
   boolean handledChange = false;
 
 public:
-  PatternSpiro() : LEDStripEffect(EFFECT_MATRIX_SPIRO, "Spiro")
+  PatternSpiro() : LEDStripEffect(idMatrixSpiro, "Spiro")
   {
   }
 

--- a/include/effects/matrix/PatternStocks.h
+++ b/include/effects/matrix/PatternStocks.h
@@ -351,7 +351,7 @@ private:
 
 public:
 
-    PatternStocks() : LEDStripEffect(EFFECT_MATRIX_STOCKS, "Stocks")
+    PatternStocks() : LEDStripEffect(idMatrixStocks, "Stocks")
     {
     }
 

--- a/include/effects/matrix/PatternStocks.h
+++ b/include/effects/matrix/PatternStocks.h
@@ -351,7 +351,9 @@ private:
 
 public:
 
-    PatternStocks() : LEDStripEffect(idMatrixStocks, "Stocks")
+    static constexpr EffectId kId = idMatrixStocks;
+
+    PatternStocks() : LEDStripEffect(kId, "Stocks")
     {
     }
 

--- a/include/effects/matrix/PatternStocks.h
+++ b/include/effects/matrix/PatternStocks.h
@@ -352,7 +352,8 @@ private:
 public:
 
     static constexpr EffectId kId = idMatrixStocks;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternStocks() : LEDStripEffect(kId, "Stocks")
     {
     }

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -162,7 +162,8 @@ class PatternSubscribers : public LEDStripEffect
   public:
 
     static constexpr EffectId kId = idMatrixSubscribers;
-
+    EffectId effectId() const override { return kId; }
+    
     PatternSubscribers() : LEDStripEffect(kId, "Subs")
     {
     }

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -161,7 +161,7 @@ class PatternSubscribers : public LEDStripEffect
 
   public:
 
-    PatternSubscribers() : LEDStripEffect(EFFECT_MATRIX_SUBSCRIBERS, "Subs")
+    PatternSubscribers() : LEDStripEffect(idMatrixSubscribers, "Subs")
     {
     }
 

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -161,7 +161,9 @@ class PatternSubscribers : public LEDStripEffect
 
   public:
 
-    PatternSubscribers() : LEDStripEffect(idMatrixSubscribers, "Subs")
+    static constexpr EffectId kId = idMatrixSubscribers;
+
+    PatternSubscribers() : LEDStripEffect(kId, "Subs")
     {
     }
 

--- a/include/effects/matrix/PatternSwirl.h
+++ b/include/effects/matrix/PatternSwirl.h
@@ -59,6 +59,9 @@
 
 class PatternSwirl : public LEDStripEffect
 {
+    public:
+        static constexpr EffectId kId = idMatrixSwirl;
+
 private:
     const uint8_t borderWidth = 2;
 

--- a/include/effects/matrix/PatternSwirl.h
+++ b/include/effects/matrix/PatternSwirl.h
@@ -59,10 +59,11 @@
 
 class PatternSwirl : public LEDStripEffect
 {
-    public:
-        static constexpr EffectId kId = idMatrixSwirl;
+  public:
+    static constexpr EffectId kId = idMatrixSwirl;
+    EffectId effectId() const override { return kId; }
 
-private:
+  private:
     const uint8_t borderWidth = 2;
 
 public:

--- a/include/effects/matrix/PatternSwirl.h
+++ b/include/effects/matrix/PatternSwirl.h
@@ -63,7 +63,7 @@ private:
     const uint8_t borderWidth = 2;
 
 public:
-    PatternSwirl() : LEDStripEffect(EFFECT_MATRIX_SWIRL, "Swirl")
+    PatternSwirl() : LEDStripEffect(idMatrixSwirl, "Swirl")
     {
     }
 

--- a/include/effects/matrix/PatternWave.h
+++ b/include/effects/matrix/PatternWave.h
@@ -86,7 +86,7 @@ private:
 
 
 public:
-    PatternWave() : LEDStripEffect(EFFECT_MATRIX_WAVE, "Wave")
+    PatternWave() : LEDStripEffect(idMatrixWave, "Wave")
     {
         construct();
     }

--- a/include/effects/matrix/PatternWave.h
+++ b/include/effects/matrix/PatternWave.h
@@ -60,8 +60,8 @@
 
 class PatternWave : public LEDStripEffect
 {
-    public:
-        static constexpr EffectId kId = idMatrixWave;
+public:
+    static constexpr EffectId kId = idMatrixWave;
 
 private:
     uint8_t thetaUpdate = 4;

--- a/include/effects/matrix/PatternWave.h
+++ b/include/effects/matrix/PatternWave.h
@@ -60,6 +60,9 @@
 
 class PatternWave : public LEDStripEffect
 {
+    public:
+        static constexpr EffectId kId = idMatrixWave;
+
 private:
     uint8_t thetaUpdate = 4;
     uint8_t thetaUpdateFrequency = 0;

--- a/include/effects/matrix/PatternWave.h
+++ b/include/effects/matrix/PatternWave.h
@@ -60,10 +60,11 @@
 
 class PatternWave : public LEDStripEffect
 {
-public:
+  public:
     static constexpr EffectId kId = idMatrixWave;
+    EffectId effectId() const override { return kId; }
 
-private:
+  private:
     uint8_t thetaUpdate = 4;
     uint8_t thetaUpdateFrequency = 0;
     uint8_t theta = 0;

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -123,10 +123,11 @@ static std::map<const String, EmbeddedFile, std::less<const String>, psram_alloc
  */
 class PatternWeather : public LEDStripEffect
 {
-    public:
-        static constexpr EffectId kId = idMatrixWeather;
+  public:
+    static constexpr EffectId kId = idMatrixWeather;
+    EffectId effectId() const override { return kId; }
 
-private:
+  private:
 
     String strLocationName    = "";
     String strLocation        = "";

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -439,7 +439,7 @@ public:
      * @brief Construct a new Pattern Weather object
      *
      */
-    PatternWeather() : LEDStripEffect(EFFECT_MATRIX_WEATHER, "Weather")
+    PatternWeather() : LEDStripEffect(idMatrixWeather, "Weather")
     {
     }
 

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -123,6 +123,8 @@ static std::map<const String, EmbeddedFile, std::less<const String>, psram_alloc
  */
 class PatternWeather : public LEDStripEffect
 {
+    public:
+        static constexpr EffectId kId = idMatrixWeather;
 
 private:
 

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -46,9 +46,11 @@ class InsulatorSpectrumEffect : public LEDStripEffect, public BeatEffectBase, pu
     CRGB _baseColor = CRGB::Black;
 
   public:
+    static constexpr EffectId kId = idMatrixInsulatorSpectrum;
+    EffectId effectId() const override { return kId; }
 
     InsulatorSpectrumEffect(const String & strName, const CRGBPalette16 & Palette) :
-        LEDStripEffect(idMatrixInsulatorSpectrum, strName),
+        LEDStripEffect(strName),
         BeatEffectBase(1.50, 0.25),
         ParticleSystem<SpinningPaletteRingParticle>(),
         _Palette(Palette)
@@ -237,12 +239,14 @@ public:
 class VUMeterEffect : virtual public VUMeter, public LEDStripEffect
 {
 public:
+    static constexpr EffectId kId = idStripVUMeter;
+    EffectId effectId() const override { return kId; }
     virtual void Draw() override
     {
         DrawVUMeter(g_ptrSystem->EffectManager().GetBaseGraphics(), 0);
     }
 
-    VUMeterEffect() : LEDStripEffect(idStripVUMeter, "VUMeter")
+    VUMeterEffect() : LEDStripEffect("VUMeter")
     {
     }
 
@@ -260,12 +264,14 @@ public:
 class VUMeterVerticalEffect : virtual public VUMeterVertical, public LEDStripEffect
 {
 public:
+    static constexpr EffectId kId = idStripVUMeterVertical;
+    EffectId effectId() const override { return kId; }
     virtual void Draw() override
     {
         DrawVUMeter(g_ptrSystem->EffectManager().GetBaseGraphics(), 0);
     }
 
-    VUMeterVerticalEffect() : LEDStripEffect(idStripVUMeterVertical, "Vertical VUMeter")
+    VUMeterVerticalEffect() : LEDStripEffect("Vertical VUMeter")
     {
     }
 
@@ -286,10 +292,12 @@ public:
 
 class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter 
 {
-    public:
-        static constexpr EffectId kId = idMatrixSpectrumAnalyzer;
+  public:
+  
+    static constexpr EffectId kId = idMatrixSpectrumAnalyzer;
+    EffectId effectId() const override { return kId; }
 
-    protected:
+  protected:
 
     uint8_t   _numBars;
     uint8_t   _colorOffset;
@@ -348,7 +356,6 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter
             value2 = g_Analyzer.Peak2Decay(iBand) *  pGFXChannel->height();
         }
 
-        debugV("Band: %d, Value: %f\n", iBar, g_Analyzer.Peak2Decay(iBar) );
 
         if (value > pGFXChannel->height())
             value = pGFXChannel->height();
@@ -420,7 +427,7 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter
                            float           peak1DecayRate = 1.0,
                            float           peak2DecayRate = 1.0,
                            bool              bScrollBars  = false)
-    : LEDStripEffect(idMatrixSpectrumAnalyzer, pszFriendlyName),
+    : LEDStripEffect(pszFriendlyName),
           _numBars(cNumBars),
           _colorOffset(0),
           _colorScrollSpeed(scrollSpeed),
@@ -440,7 +447,7 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter
                            float            peak1DecayRate = 1.0,
                            float            peak2DecayRate = 1.0,
                            bool                bScrollBars = false)
-    : LEDStripEffect(idMatrixSpectrumAnalyzer, pszFriendlyName),
+    : LEDStripEffect(pszFriendlyName),
           _numBars(cNumBars),
           _colorOffset(0),
           _colorScrollSpeed(0),
@@ -552,39 +559,38 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter
 //
 // Draws a colorful scrolling waveform driven by instantaneous VU as it scrolls
 
-class WaveformEffect : public LEDStripEffect {
+class WaveformEffect : public LEDStripEffect 
+{
     public:
+ 
         static constexpr EffectId kId = idMatrixWaveform;
+        EffectId effectId() const override { return kId; }
 
     protected:
-    uint8_t                      _iColorOffset = 0;
-    uint8_t                      _increment = 0;
-    float                        _iPeakVUy = 0;
-    unsigned long                _msPeakVU = 0;
+        uint8_t                      _iColorOffset = 0;
+        uint8_t                      _increment = 0;
+        float                        _iPeakVUy = 0;
+        unsigned long                _msPeakVU = 0;
 
-  public:
+    public:
+        WaveformEffect(const String & pszFriendlyName, uint8_t increment = 0)
+            : LEDStripEffect(pszFriendlyName),
+                    _increment(increment)
+        {
+        }
 
-    WaveformEffect(const String & pszFriendlyName, uint8_t increment = 0)
-    : LEDStripEffect(idMatrixWaveform, pszFriendlyName),
-          _increment(increment)
-    {
-    }
-
-    WaveformEffect(const JsonObjectConst& jsonObject)
-        : LEDStripEffect(jsonObject),
-          _increment(jsonObject["inc"])
-    {
-    }
+        WaveformEffect(const JsonObjectConst& jsonObject)
+            : LEDStripEffect(jsonObject),
+                    _increment(jsonObject["inc"])
+        {
+        }
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {
         auto jsonDoc = CreateJsonDocument();
-
         JsonObject root = jsonDoc.to<JsonObject>();
         LEDStripEffect::SerializeToJSON(root);
-
         jsonDoc["inc"] = _increment;
-
         return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
@@ -641,18 +647,14 @@ class WaveformEffect : public LEDStripEffect {
 
 class GhostWave : public WaveformEffect
 {
-    public:
-        static constexpr EffectId kId = idMatrixGhostWave;
-
-        uint8_t                   _blur     = 0;
-        bool                      _erase    = true;
-        int                       _fade     = 0;
-
-        void construct()
-    {
-        _effectNumber = idMatrixGhostWave;
-    }
   public:
+    static constexpr EffectId kId = idMatrixGhostWave;
+    
+    EffectId effectId() const override { return kId; }
+    
+    uint8_t                   _blur     = 0;
+    bool                      _erase    = true;
+    int                       _fade     = 0;
 
     GhostWave(const String & pszFriendlyName, uint8_t increment = 0, uint8_t blur = 0, bool erase = true, int fade = 0)
         : WaveformEffect(pszFriendlyName, increment),
@@ -660,7 +662,6 @@ class GhostWave : public WaveformEffect
           _erase(erase),
           _fade(fade)
     {
-        construct();
     }
 
     GhostWave(const JsonObjectConst& jsonObject)
@@ -669,7 +670,6 @@ class GhostWave : public WaveformEffect
           _erase(jsonObject[PTY_ERASE]),
           _fade(jsonObject[PTY_FADE])
     {
-        construct();
     }
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
@@ -732,22 +732,16 @@ class GhostWave : public WaveformEffect
 
 class SpectrumBarEffect : public LEDStripEffect, public BeatEffectBase
 {
-    public:
-        static constexpr EffectId kId = idMatrixSpectrumBar;
+  public:
+    static constexpr EffectId kId = idMatrixSpectrumBar;
+    EffectId effectId() const override { return kId; }
 
-        uint8_t _hueIncrement = 0;
-        uint8_t _scrollIncrement = 0;
-        uint8_t _hueStep = 0;
-
-        void construct()
-    {
-        _effectNumber = idMatrixSpectrumBar;
-    }
-
-    public:
+    uint8_t _hueIncrement = 0;
+    uint8_t _scrollIncrement = 0;
+    uint8_t _hueStep = 0;
 
     SpectrumBarEffect(const char   * pszFriendlyName, uint8_t hueStep = 16, uint8_t hueIncrement = 4, uint8_t scrollIncrement = 0)
-      : LEDStripEffect(idMatrixSpectrumBar, pszFriendlyName),
+    : LEDStripEffect(pszFriendlyName),
         _hueIncrement(hueIncrement),
         _scrollIncrement(scrollIncrement),
         _hueStep(hueStep)
@@ -861,12 +855,12 @@ class SpectrumBarEffect : public LEDStripEffect, public BeatEffectBase
 
 class AudioSpikeEffect : public LEDStripEffect
 {
-  protected:
-
   public:
+    static constexpr EffectId kId = idMatrixAudioSpike;
+    EffectId effectId() const override { return kId; }
 
     AudioSpikeEffect(const String & pszFriendlyName)
-    : LEDStripEffect(idMatrixAudioSpike, pszFriendlyName)
+    : LEDStripEffect(pszFriendlyName)
     {
     }
 

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -284,9 +284,11 @@ public:
 // An effect that draws an audio spectrum analyzer on a matrix.  It is assumed that the
 // matrix is 48x16 using LED Channel 0 only.   Has a VU meter up top and 16 bands.
 
-class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter
-{
-  protected:
+class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter {
+    public:
+        static constexpr EffectId kId = idMatrixSpectrumAnalyzer;
+
+    protected:
 
     uint8_t   _numBars;
     uint8_t   _colorOffset;
@@ -549,9 +551,11 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter
 //
 // Draws a colorful scrolling waveform driven by instantaneous VU as it scrolls
 
-class WaveformEffect : public LEDStripEffect
-{
-  protected:
+class WaveformEffect : public LEDStripEffect {
+    public:
+        static constexpr EffectId kId = idMatrixWaveform;
+
+    protected:
     uint8_t                      _iColorOffset = 0;
     uint8_t                      _increment = 0;
     float                        _iPeakVUy = 0;
@@ -636,11 +640,14 @@ class WaveformEffect : public LEDStripEffect
 
 class GhostWave : public WaveformEffect
 {
-    uint8_t                   _blur     = 0;
-    bool                      _erase    = true;
-    int                       _fade     = 0;
+    public:
+        static constexpr EffectId kId = idMatrixGhostWave;
 
-    void construct()
+        uint8_t                   _blur     = 0;
+        bool                      _erase    = true;
+        int                       _fade     = 0;
+
+        void construct()
     {
     _effectNumber = idMatrixGhostWave;
     }
@@ -724,11 +731,14 @@ class GhostWave : public WaveformEffect
 
 class SpectrumBarEffect : public LEDStripEffect, public BeatEffectBase
 {
-    uint8_t _hueIncrement = 0;
-    uint8_t _scrollIncrement = 0;
-    uint8_t _hueStep = 0;
+    public:
+        static constexpr EffectId kId = idMatrixSpectrumBar;
 
-    void construct()
+        uint8_t _hueIncrement = 0;
+        uint8_t _scrollIncrement = 0;
+        uint8_t _hueStep = 0;
+
+        void construct()
     {
     _effectNumber = idMatrixSpectrumBar;
     }

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -48,7 +48,7 @@ class InsulatorSpectrumEffect : public LEDStripEffect, public BeatEffectBase, pu
   public:
 
     InsulatorSpectrumEffect(const String & strName, const CRGBPalette16 & Palette) :
-        LEDStripEffect(EFFECT_MATRIX_INSULATOR_SPECTRUM, strName),
+    LEDStripEffect(idMatrixInsulatorSpectrum, strName),
         BeatEffectBase(1.50, 0.25),
         ParticleSystem<SpinningPaletteRingParticle>(),
         _Palette(Palette)
@@ -242,7 +242,7 @@ public:
         DrawVUMeter(g_ptrSystem->EffectManager().GetBaseGraphics(), 0);
     }
 
-    VUMeterEffect() : LEDStripEffect(EFFECT_STRIP_VUMETER, "VUMeter")
+    VUMeterEffect() : LEDStripEffect(idStripVUMeter, "VUMeter")
     {
     }
 
@@ -265,7 +265,7 @@ public:
         DrawVUMeter(g_ptrSystem->EffectManager().GetBaseGraphics(), 0);
     }
 
-    VUMeterVerticalEffect() : LEDStripEffect(EFFECT_STRIP_VUMETER_VERTICAL, "Vertical VUMeter")
+    VUMeterVerticalEffect() : LEDStripEffect(idStripVUMeterVertical, "Vertical VUMeter")
     {
     }
 
@@ -417,7 +417,7 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter
                            float           peak1DecayRate = 1.0,
                            float           peak2DecayRate = 1.0,
                            bool              bScrollBars  = false)
-        : LEDStripEffect(EFFECT_MATRIX_SPECTRUM_ANALYZER, pszFriendlyName),
+    : LEDStripEffect(idMatrixSpectrumAnalyzer, pszFriendlyName),
           _numBars(cNumBars),
           _colorOffset(0),
           _colorScrollSpeed(scrollSpeed),
@@ -437,7 +437,7 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter
                            float            peak1DecayRate = 1.0,
                            float            peak2DecayRate = 1.0,
                            bool                bScrollBars = false)
-        : LEDStripEffect(EFFECT_MATRIX_SPECTRUM_ANALYZER, pszFriendlyName),
+    : LEDStripEffect(idMatrixSpectrumAnalyzer, pszFriendlyName),
           _numBars(cNumBars),
           _colorOffset(0),
           _colorScrollSpeed(0),
@@ -560,7 +560,7 @@ class WaveformEffect : public LEDStripEffect
   public:
 
     WaveformEffect(const String & pszFriendlyName, uint8_t increment = 0)
-        : LEDStripEffect(EFFECT_MATRIX_WAVEFORM, pszFriendlyName),
+    : LEDStripEffect(idMatrixWaveform, pszFriendlyName),
           _increment(increment)
     {
     }
@@ -642,7 +642,7 @@ class GhostWave : public WaveformEffect
 
     void construct()
     {
-        _effectNumber = EFFECT_MATRIX_GHOST_WAVE;
+    _effectNumber = idMatrixGhostWave;
     }
   public:
 
@@ -730,13 +730,13 @@ class SpectrumBarEffect : public LEDStripEffect, public BeatEffectBase
 
     void construct()
     {
-        _effectNumber = EFFECT_MATRIX_SPECTRUMBAR;
+    _effectNumber = idMatrixSpectrumBar;
     }
 
     public:
 
     SpectrumBarEffect(const char   * pszFriendlyName, uint8_t hueStep = 16, uint8_t hueIncrement = 4, uint8_t scrollIncrement = 0)
-        :LEDStripEffect(EFFECT_MATRIX_SPECTRUMBAR, pszFriendlyName),
+    :LEDStripEffect(idMatrixSpectrumBar, pszFriendlyName),
         _hueIncrement(hueIncrement),
         _scrollIncrement(scrollIncrement),
         _hueStep(hueStep)
@@ -855,7 +855,7 @@ class AudioSpikeEffect : public LEDStripEffect
   public:
 
     AudioSpikeEffect(const String & pszFriendlyName)
-        : LEDStripEffect(EFFECT_MATRIX_AUDIOSPIKE, pszFriendlyName)
+    : LEDStripEffect(idMatrixAudioSpike, pszFriendlyName)
     {
     }
 

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -48,7 +48,7 @@ class InsulatorSpectrumEffect : public LEDStripEffect, public BeatEffectBase, pu
   public:
 
     InsulatorSpectrumEffect(const String & strName, const CRGBPalette16 & Palette) :
-    LEDStripEffect(idMatrixInsulatorSpectrum, strName),
+        LEDStripEffect(idMatrixInsulatorSpectrum, strName),
         BeatEffectBase(1.50, 0.25),
         ParticleSystem<SpinningPaletteRingParticle>(),
         _Palette(Palette)
@@ -284,7 +284,8 @@ public:
 // An effect that draws an audio spectrum analyzer on a matrix.  It is assumed that the
 // matrix is 48x16 using LED Channel 0 only.   Has a VU meter up top and 16 bands.
 
-class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter {
+class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter 
+{
     public:
         static constexpr EffectId kId = idMatrixSpectrumAnalyzer;
 
@@ -649,7 +650,7 @@ class GhostWave : public WaveformEffect
 
         void construct()
     {
-    _effectNumber = idMatrixGhostWave;
+        _effectNumber = idMatrixGhostWave;
     }
   public:
 
@@ -740,13 +741,13 @@ class SpectrumBarEffect : public LEDStripEffect, public BeatEffectBase
 
         void construct()
     {
-    _effectNumber = idMatrixSpectrumBar;
+        _effectNumber = idMatrixSpectrumBar;
     }
 
     public:
 
     SpectrumBarEffect(const char   * pszFriendlyName, uint8_t hueStep = 16, uint8_t hueIncrement = 4, uint8_t scrollIncrement = 0)
-    :LEDStripEffect(idMatrixSpectrumBar, pszFriendlyName),
+      : LEDStripEffect(idMatrixSpectrumBar, pszFriendlyName),
         _hueIncrement(hueIncrement),
         _scrollIncrement(scrollIncrement),
         _hueStep(hueStep)

--- a/include/effects/strip/bouncingballeffect.h
+++ b/include/effects/strip/bouncingballeffect.h
@@ -74,7 +74,7 @@ private:
   public:
 
     BouncingBallEffect(size_t ballCount = 3, bool bMirrored = true, bool bErase = false, int ballSize = 5)
-        : LEDStripEffect(EFFECT_STRIP_BOUNCING_BALL, "Bouncing Balls"),
+    : LEDStripEffect(idStripBouncingBall, "Bouncing Balls"),
           _cBalls(ballCount),
           _cBallSize(ballSize),
           _bMirrored(bMirrored),

--- a/include/effects/strip/bouncingballeffect.h
+++ b/include/effects/strip/bouncingballeffect.h
@@ -74,6 +74,7 @@ class BouncingBallEffect : public LEDStripEffect
   public:
 
     static constexpr EffectId kId = idStripBouncingBall;
+    EffectId effectId() const override { return kId; }
 
     BouncingBallEffect(size_t ballCount = 3, bool bMirrored = true, bool bErase = false, int ballSize = 5)
         : LEDStripEffect(idStripBouncingBall, "Bouncing Balls"),

--- a/include/effects/strip/bouncingballeffect.h
+++ b/include/effects/strip/bouncingballeffect.h
@@ -49,9 +49,7 @@ static constexpr auto ballColors = to_array(
 
 class BouncingBallEffect : public LEDStripEffect
 {
-    public:
-        static constexpr EffectId kId = idStripBouncingBall;
-private:
+  private:
 
     size_t  _iOffset;
     size_t  _cLength;
@@ -75,8 +73,10 @@ private:
 
   public:
 
+    static constexpr EffectId kId = idStripBouncingBall;
+
     BouncingBallEffect(size_t ballCount = 3, bool bMirrored = true, bool bErase = false, int ballSize = 5)
-    : LEDStripEffect(idStripBouncingBall, "Bouncing Balls"),
+        : LEDStripEffect(idStripBouncingBall, "Bouncing Balls"),
           _cBalls(ballCount),
           _cBallSize(ballSize),
           _bMirrored(bMirrored),

--- a/include/effects/strip/bouncingballeffect.h
+++ b/include/effects/strip/bouncingballeffect.h
@@ -49,6 +49,8 @@ static constexpr auto ballColors = to_array(
 
 class BouncingBallEffect : public LEDStripEffect
 {
+    public:
+        static constexpr EffectId kId = idStripBouncingBall;
 private:
 
     size_t  _iOffset;

--- a/include/effects/strip/doublepaletteeffect.h
+++ b/include/effects/strip/doublepaletteeffect.h
@@ -42,7 +42,7 @@ class DoublePaletteEffect : public LEDStripEffect
   public:
 
     DoublePaletteEffect()
-     :  LEDStripEffect(EFFECT_STRIP_DOUBLE_PALETTE, "Double Palette"),
+  :  LEDStripEffect(idStripDoublePalette, "Double Palette"),
         _PaletteEffect1(RainbowColors_p, 1.0,  0.03,  4.0, 3, 3, LINEARBLEND, false, 0.5),
         _PaletteEffect2(RainbowColors_p, 1.0, -0.03, -4.0, 3, 3, LINEARBLEND, false, 0.5)
     {

--- a/include/effects/strip/doublepaletteeffect.h
+++ b/include/effects/strip/doublepaletteeffect.h
@@ -36,6 +36,8 @@ class DoublePaletteEffect : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripDoublePalette;
+    EffectId effectId() const override { return kId; }
+
   private:
 
     PaletteEffect   _PaletteEffect1;
@@ -44,7 +46,7 @@ class DoublePaletteEffect : public LEDStripEffect
   public:
 
     DoublePaletteEffect()
-  :  LEDStripEffect(idStripDoublePalette, "Double Palette"),
+  :  LEDStripEffect("Double Palette"),
         _PaletteEffect1(RainbowColors_p, 1.0,  0.03,  4.0, 3, 3, LINEARBLEND, false, 0.5),
         _PaletteEffect2(RainbowColors_p, 1.0, -0.03, -4.0, 3, 3, LINEARBLEND, false, 0.5)
     {

--- a/include/effects/strip/doublepaletteeffect.h
+++ b/include/effects/strip/doublepaletteeffect.h
@@ -34,6 +34,8 @@
 
 class DoublePaletteEffect : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripDoublePalette;
   private:
 
     PaletteEffect   _PaletteEffect1;

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -378,6 +378,8 @@ class EmptyEffect : public LEDStripEffect
 
 class FanBeatEffect : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripFanBeat;
 public:
 
   FanBeatEffect(const String & strName) : LEDStripEffect(idStripFanBeat, strName)
@@ -448,6 +450,8 @@ public:
 
 class CountEffect : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripCount;
   using LEDStripEffect::LEDStripEffect;
 
   const int DRAW_LEN = 16;
@@ -481,6 +485,8 @@ class CountEffect : public LEDStripEffect
 
 class TapeReelEffect : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripTapeReel;
 private:
   float ReelPos[NUM_FANS] = {0};
   float ReelDir[NUM_FANS] = {0};
@@ -567,6 +573,8 @@ public:
 
 class PaletteReelEffect : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripPaletteReel;
 private:
   float ReelPos[NUM_FANS] = {0};
   float ReelDir[NUM_FANS] = {0};
@@ -666,6 +674,8 @@ public:
 
 class PaletteSpinEffect : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripPaletteSpin;
   const CRGBPalette16 _Palette;
   bool _bReplaceMagenta;
   float _sparkleChance;
@@ -746,6 +756,8 @@ public:
 };
 class ColorCycleEffect : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripColorCycle;
   PixelOrder _order;
   int _step;
 
@@ -800,6 +812,8 @@ public:
 
 class ColorCycleEffectBottomUp : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripColorCycleBottomUp;
 public:
   using LEDStripEffect::LEDStripEffect;
 
@@ -824,6 +838,8 @@ public:
 
 class ColorCycleEffectTopDown : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripColorCycleTopDown;
 public:
   using LEDStripEffect::LEDStripEffect;
 
@@ -848,6 +864,8 @@ public:
 
 class ColorCycleEffectSequential : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripColorCycleSequential;
 public:
   using LEDStripEffect::LEDStripEffect;
 
@@ -895,6 +913,8 @@ public:
 
 class ColorCycleEffectRightLeft : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripColorCycleRightLeft;
 public:
   using LEDStripEffect::LEDStripEffect;
 
@@ -917,6 +937,8 @@ public:
 
 class ColorCycleEffectLeftRight : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripColorCycleLeftRight;
 public:
   using LEDStripEffect::LEDStripEffect;
 
@@ -939,6 +961,8 @@ public:
 
 class FireFanEffect : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripFireFan;
 protected:
   CRGBPalette16 Palette;
   int LEDCount; // Number of LEDs total
@@ -1135,6 +1159,8 @@ public:
 
 class BlueFireFanEffect : public FireFanEffect
 {
+  public:
+    static constexpr EffectId kId = idStripFireFanBlue;
   using FireFanEffect::FireFanEffect;
 
   virtual CRGB MapHeatToColor(uint8_t temperature, int iChannel = 0)
@@ -1152,6 +1178,8 @@ class BlueFireFanEffect : public FireFanEffect
 
 class GreenFireFanEffect : public FireFanEffect
 {
+  public:
+    static constexpr EffectId kId = idStripFireFanGreen;
   using FireFanEffect::FireFanEffect;
 
   virtual CRGB MapHeatToColor(uint8_t temperature, int iChannel = 0)
@@ -1169,6 +1197,8 @@ class GreenFireFanEffect : public FireFanEffect
 
 class RGBRollAround : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripRGBRollAround;
   int iRotate = 0;
 
 public:
@@ -1192,6 +1222,8 @@ public:
 
 class HueTest : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripHueTest;
   int iRotate = 0;
 
 public:
@@ -1210,6 +1242,8 @@ public:
 
 class RingTestEffect : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripRingTest;
 private:
 public:
   RingTestEffect() : LEDStripEffect(idStripRingTest, "Ring Test")
@@ -1396,6 +1430,8 @@ public:
 
 class LanternEffect : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripLantern;
   static const int _maxParticles = 1;
 
 private:

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -380,7 +380,7 @@ class FanBeatEffect : public LEDStripEffect
 {
 public:
 
-  FanBeatEffect(const String & strName) : LEDStripEffect(EFFECT_STRIP_FAN_BEAT, strName)
+  FanBeatEffect(const String & strName) : LEDStripEffect(idStripFanBeat, strName)
   {
   }
 
@@ -486,7 +486,7 @@ private:
   float ReelDir[NUM_FANS] = {0};
 
 public:
-  TapeReelEffect(const String & strName) : LEDStripEffect(EFFECT_STRIP_TAPE_REEL, strName)
+  TapeReelEffect(const String & strName) : LEDStripEffect(idStripTapeReel, strName)
   {
   }
 
@@ -573,7 +573,7 @@ private:
   int ColorOffset[NUM_FANS] = {0};
 
 public:
-  PaletteReelEffect(const String & strName) : LEDStripEffect(EFFECT_STRIP_PALETTE_REEL, strName)
+  PaletteReelEffect(const String & strName) : LEDStripEffect(idStripPaletteReel, strName)
   {
   }
 
@@ -676,7 +676,7 @@ private:
 
 public:
   PaletteSpinEffect(const String &strName, const CRGBPalette16 &palette, bool bReplace, float sparkleChance = 0.0)
-      : LEDStripEffect(EFFECT_STRIP_PALETTE_SPIN, strName),
+  : LEDStripEffect(idStripPaletteSpin, strName),
         _Palette(palette),
         _bReplaceMagenta(bReplace),
         _sparkleChance(sparkleChance)
@@ -753,7 +753,7 @@ public:
   using LEDStripEffect::LEDStripEffect;
 
   ColorCycleEffect(PixelOrder order = Sequential, int step = 8)
-    : LEDStripEffect(EFFECT_STRIP_COLOR_CYCLE, "ColorCylceEffect"),
+  : LEDStripEffect(idStripColorCycle, "ColorCylceEffect"),
       _order(order),
       _step(step)
   {
@@ -981,7 +981,7 @@ public:
                 bool bmirrored = false,
                 bool bmulticolor = false,
                 uint8_t maxSparkTemp = 255)
-      : LEDStripEffect(EFFECT_STRIP_FIRE_FAN, "FireFanEffect"),
+  : LEDStripEffect(idStripFireFan, "FireFanEffect"),
         Palette(palette),
         LEDCount(ledCount),
         CellsPerLED(cellsPerLED),
@@ -1212,7 +1212,7 @@ class RingTestEffect : public LEDStripEffect
 {
 private:
 public:
-  RingTestEffect() : LEDStripEffect(EFFECT_STRIP_RING_TEST, "Ring Test")
+  RingTestEffect() : LEDStripEffect(idStripRingTest, "Ring Test")
   {
   }
 
@@ -1402,7 +1402,7 @@ private:
   LanternParticle _particles[_maxParticles];
 
 public:
-  LanternEffect() : LEDStripEffect(EFFECT_STRIP_LANTERN, "LanternEffect")
+  LanternEffect() : LEDStripEffect(idStripLantern, "LanternEffect")
   {
   }
 

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -380,6 +380,8 @@ class FanBeatEffect : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripFanBeat;
+    EffectId effectId() const override { return kId; }
+
 public:
 
   FanBeatEffect(const String & strName) : LEDStripEffect(idStripFanBeat, strName)
@@ -452,6 +454,8 @@ class CountEffect : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripCount;
+    EffectId effectId() const override { return kId; }
+
   using LEDStripEffect::LEDStripEffect;
 
   const int DRAW_LEN = 16;
@@ -487,6 +491,8 @@ class TapeReelEffect : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripTapeReel;
+    EffectId effectId() const override { return kId; }
+
 private:
   float ReelPos[NUM_FANS] = {0};
   float ReelDir[NUM_FANS] = {0};
@@ -575,6 +581,8 @@ class PaletteReelEffect : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripPaletteReel;
+    EffectId effectId() const override { return kId; }
+
 private:
   float ReelPos[NUM_FANS] = {0};
   float ReelDir[NUM_FANS] = {0};
@@ -676,13 +684,15 @@ class PaletteSpinEffect : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripPaletteSpin;
-  const CRGBPalette16 _Palette;
-  bool _bReplaceMagenta;
-  float _sparkleChance;
+    EffectId effectId() const override { return kId; }
+
+    const CRGBPalette16 _Palette;
+    bool _bReplaceMagenta;
+    float _sparkleChance;
 
 private:
-  float ReelPos[NUM_FANS] = {0};
-  int ColorOffset[NUM_FANS] = {0};
+    float ReelPos[NUM_FANS] = {0};
+    int ColorOffset[NUM_FANS] = {0};
 
 public:
   PaletteSpinEffect(const String &strName, const CRGBPalette16 &palette, bool bReplace, float sparkleChance = 0.0)
@@ -758,6 +768,8 @@ class ColorCycleEffect : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripColorCycle;
+    EffectId effectId() const override { return kId; }
+
   PixelOrder _order;
   int _step;
 
@@ -814,6 +826,8 @@ class ColorCycleEffectBottomUp : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripColorCycleBottomUp;
+    EffectId effectId() const override { return kId; }
+
 public:
   using LEDStripEffect::LEDStripEffect;
 
@@ -840,6 +854,8 @@ class ColorCycleEffectTopDown : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripColorCycleTopDown;
+    EffectId effectId() const override { return kId; }
+
 public:
   using LEDStripEffect::LEDStripEffect;
 
@@ -866,6 +882,8 @@ class ColorCycleEffectSequential : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripColorCycleSequential;
+    EffectId effectId() const override { return kId; }
+
 public:
   using LEDStripEffect::LEDStripEffect;
 
@@ -915,6 +933,8 @@ class ColorCycleEffectRightLeft : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripColorCycleRightLeft;
+    EffectId effectId() const override { return kId; }
+
 public:
   using LEDStripEffect::LEDStripEffect;
 
@@ -939,6 +959,8 @@ class ColorCycleEffectLeftRight : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripColorCycleLeftRight;
+    EffectId effectId() const override { return kId; }
+
 public:
   using LEDStripEffect::LEDStripEffect;
 
@@ -963,6 +985,8 @@ class FireFanEffect : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripFireFan;
+    EffectId effectId() const override { return kId; }
+
 protected:
   CRGBPalette16 Palette;
   int LEDCount; // Number of LEDs total
@@ -1161,6 +1185,8 @@ class BlueFireFanEffect : public FireFanEffect
 {
   public:
     static constexpr EffectId kId = idStripFireFanBlue;
+    EffectId effectId() const override { return kId; }
+
   using FireFanEffect::FireFanEffect;
 
   virtual CRGB MapHeatToColor(uint8_t temperature, int iChannel = 0)
@@ -1180,6 +1206,8 @@ class GreenFireFanEffect : public FireFanEffect
 {
   public:
     static constexpr EffectId kId = idStripFireFanGreen;
+    EffectId effectId() const override { return kId; }
+
   using FireFanEffect::FireFanEffect;
 
   virtual CRGB MapHeatToColor(uint8_t temperature, int iChannel = 0)
@@ -1199,7 +1227,9 @@ class RGBRollAround : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripRGBRollAround;
-  int iRotate = 0;
+    EffectId effectId() const override { return kId; }
+  
+    int iRotate = 0;
 
 public:
   using LEDStripEffect::LEDStripEffect;
@@ -1224,7 +1254,9 @@ class HueTest : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripHueTest;
-  int iRotate = 0;
+    EffectId effectId() const override { return kId; }
+
+    int iRotate = 0;
 
 public:
   using LEDStripEffect::LEDStripEffect;
@@ -1244,26 +1276,26 @@ class RingTestEffect : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripRingTest;
-private:
-public:
-  RingTestEffect() : LEDStripEffect(idStripRingTest, "Ring Test")
-  {
-  }
+    EffectId effectId() const override { return kId; }
 
-  RingTestEffect(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
-  {
-  }
-
-  void Draw() override
-  {
-    for (int i = 0; i < NUM_FANS; i++)
+    RingTestEffect() : LEDStripEffect(idStripRingTest, "Ring Test")
     {
-      for (int c = 0; c < NUM_RINGS; c++)
+    }
+
+    RingTestEffect(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
+    {
+    }
+
+    void Draw() override
+    {
+      for (int i = 0; i < NUM_FANS; i++)
       {
-        FillRingPixels(CRGB(CHSV(c * 16, 255, 255)), i, c);
+        for (int c = 0; c < NUM_RINGS; c++)
+        {
+          FillRingPixels(CRGB(CHSV(c * 16, 255, 255)), i, c);
+        }
       }
     }
-  }
 };
 
 /*
@@ -1432,7 +1464,9 @@ class LanternEffect : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripLantern;
-  static const int _maxParticles = 1;
+    EffectId effectId() const override { return kId; }
+    
+    static const int _maxParticles = 1;
 
 private:
   LanternParticle _particles[_maxParticles];

--- a/include/effects/strip/fireeffect.h
+++ b/include/effects/strip/fireeffect.h
@@ -39,8 +39,10 @@
 
 class FireEffect : public LEDStripEffect
 {
-    public:
-        static constexpr EffectId kId = idStripFire;
+  public:
+    static constexpr EffectId kId = idStripFire;
+    EffectId effectId() const override { return kId; }
+
     void construct()
     {
         heat.reset( psram_allocator<uint8_t>().allocate(CellCount()) );
@@ -73,7 +75,7 @@ class FireEffect : public LEDStripEffect
   public:
 
     FireEffect(const String & strName, int ledCount = NUM_LEDS, int cellsPerLED = 1, int cooling = 20, int sparking = 100, int sparks = 3, int sparkHeight = 4,  bool breversed = false, bool bmirrored = false)
-    : LEDStripEffect(idStripFire, strName),
+    : LEDStripEffect(strName),
           LEDCount(ledCount),
           CellsPerLED(cellsPerLED),
           Cooling(cooling),
@@ -209,13 +211,10 @@ class PaletteFlameEffect : public FireEffect
 {
     public:
         static constexpr EffectId kId = idStripPaletteFlame;
-    CRGBPalette16 _palette;
-    bool _ignoreGlobalColor;
-
-    void construct()
-    {
-    _effectNumber = idStripPaletteFlame;
-    }
+        EffectId effectId() const override { return kId; }
+    
+        CRGBPalette16 _palette;
+        bool _ignoreGlobalColor;
 
 public:
     PaletteFlameEffect(const String & strName,
@@ -233,7 +232,6 @@ public:
           _palette(palette),
           _ignoreGlobalColor(ignoreGlobalColor)
     {
-        construct();
     }
 
     PaletteFlameEffect(const JsonObjectConst& jsonObject)
@@ -241,7 +239,6 @@ public:
         _palette(jsonObject[PTY_PALETTE].as<CRGBPalette16>()),
         _ignoreGlobalColor(jsonObject[PTY_IGNOREGLOBALCOLOR])
     {
-        construct();
     }
 
     bool SerializeToJSON(JsonObject& jsonObject) override
@@ -280,10 +277,7 @@ class MusicalPaletteFire : public PaletteFlameEffect, protected BeatEffectBase
 {
     public:
         static constexpr EffectId kId = idStripMusicalPaletteFire;
-    void construct()
-    {
-    _effectNumber = idStripMusicalPaletteFire;
-    }
+    EffectId effectId() const override { return kId; }
 
   public:
 
@@ -303,7 +297,6 @@ class MusicalPaletteFire : public PaletteFlameEffect, protected BeatEffectBase
 
 
     {
-        construct();
     }
 
     MusicalPaletteFire(const JsonObjectConst& jsonObject)
@@ -311,7 +304,6 @@ class MusicalPaletteFire : public PaletteFlameEffect, protected BeatEffectBase
           BeatEffectBase(1.00, 0.01)
 
     {
-        construct();
     }
 
   protected:
@@ -338,8 +330,9 @@ class MusicalPaletteFire : public PaletteFlameEffect, protected BeatEffectBase
 
 class ClassicFireEffect : public LEDStripEffect
 {
-    public:
-        static constexpr EffectId kId = idStripClassicFire;
+  public:
+    static constexpr EffectId kId = idStripClassicFire;
+    EffectId effectId() const override { return kId; }
     bool _Mirrored;
     bool _Reversed;
     int  _Cooling;
@@ -347,7 +340,7 @@ class ClassicFireEffect : public LEDStripEffect
 public:
 
     ClassicFireEffect(bool mirrored = false, bool reversed = false, int cooling = 5)
-    : LEDStripEffect(idStripClassicFire, "Classic Fire"),
+    : LEDStripEffect("Classic Fire"),
           _Mirrored(mirrored),
           _Reversed(reversed),
           _Cooling(cooling)
@@ -472,8 +465,10 @@ public:
 
 class SmoothFireEffect : public LEDStripEffect
 {
-    public:
-        static constexpr EffectId kId = idStripSmoothFire;
+  public:
+    static constexpr EffectId kId = idStripSmoothFire;
+    EffectId effectId() const override { return kId; }
+
 private:
     bool _Reversed;
     float _Cooling;
@@ -632,8 +627,10 @@ public:
 
 class BaseFireEffect : public LEDStripEffect
 {
-    public:
-        static constexpr EffectId kId = idStripBaseFire;
+  public:
+    static constexpr EffectId kId = idStripBaseFire;
+    EffectId effectId() const override { return kId; }
+
     void construct()
     {
         heat = std::make_unique<uint8_t []>(CellCount);

--- a/include/effects/strip/fireeffect.h
+++ b/include/effects/strip/fireeffect.h
@@ -384,7 +384,7 @@ public:
 
     void Fire(int Cooling, int Sparking, int Sparks)
     {
-        static std::unique_ptr<uint8_t []> heat = make_unique_psram_array<uint8_t>(NUM_LEDS);
+        static std::unique_ptr<uint8_t[]> heat = make_unique_psram<uint8_t[]>(NUM_LEDS);
         setAllOnAllChannels(0,0,0);
 
         // Step 1.  Cool down every cell a little

--- a/include/effects/strip/fireeffect.h
+++ b/include/effects/strip/fireeffect.h
@@ -39,6 +39,8 @@
 
 class FireEffect : public LEDStripEffect
 {
+    public:
+        static constexpr EffectId kId = idStripFire;
     void construct()
     {
         heat.reset( psram_allocator<uint8_t>().allocate(CellCount()) );
@@ -205,6 +207,8 @@ class FireEffect : public LEDStripEffect
 
 class PaletteFlameEffect : public FireEffect
 {
+    public:
+        static constexpr EffectId kId = idStripPaletteFlame;
     CRGBPalette16 _palette;
     bool _ignoreGlobalColor;
 
@@ -274,6 +278,8 @@ public:
 #if ENABLE_AUDIO
 class MusicalPaletteFire : public PaletteFlameEffect, protected BeatEffectBase
 {
+    public:
+        static constexpr EffectId kId = idStripMusicalPaletteFire;
     void construct()
     {
     _effectNumber = idStripMusicalPaletteFire;
@@ -332,6 +338,8 @@ class MusicalPaletteFire : public PaletteFlameEffect, protected BeatEffectBase
 
 class ClassicFireEffect : public LEDStripEffect
 {
+    public:
+        static constexpr EffectId kId = idStripClassicFire;
     bool _Mirrored;
     bool _Reversed;
     int  _Cooling;
@@ -464,6 +472,8 @@ public:
 
 class SmoothFireEffect : public LEDStripEffect
 {
+    public:
+        static constexpr EffectId kId = idStripSmoothFire;
 private:
     bool _Reversed;
     float _Cooling;
@@ -622,6 +632,8 @@ public:
 
 class BaseFireEffect : public LEDStripEffect
 {
+    public:
+        static constexpr EffectId kId = idStripBaseFire;
     void construct()
     {
         heat = std::make_unique<uint8_t []>(CellCount);
@@ -653,7 +665,7 @@ class BaseFireEffect : public LEDStripEffect
   public:
 
     BaseFireEffect(int ledCount, int cellsPerLED = 1, int cooling = 20, int sparking = 100, int sparks = 3, int sparkHeight = 4, bool breversed = false, bool bmirrored = false)
-    : LEDStripEffect(idStripBaseFire, "BaseFireEffect"),
+        : LEDStripEffect(idStripBaseFire, "BaseFireEffect"),
           Cooling(cooling),
           Sparks(sparks),
           SparkHeight(sparkHeight),

--- a/include/effects/strip/fireeffect.h
+++ b/include/effects/strip/fireeffect.h
@@ -71,7 +71,7 @@ class FireEffect : public LEDStripEffect
   public:
 
     FireEffect(const String & strName, int ledCount = NUM_LEDS, int cellsPerLED = 1, int cooling = 20, int sparking = 100, int sparks = 3, int sparkHeight = 4,  bool breversed = false, bool bmirrored = false)
-        : LEDStripEffect(EFFECT_STRIP_FIRE, strName),
+    : LEDStripEffect(idStripFire, strName),
           LEDCount(ledCount),
           CellsPerLED(cellsPerLED),
           Cooling(cooling),
@@ -210,7 +210,7 @@ class PaletteFlameEffect : public FireEffect
 
     void construct()
     {
-        _effectNumber = EFFECT_STRIP_PALETTE_FLAME;
+    _effectNumber = idStripPaletteFlame;
     }
 
 public:
@@ -276,7 +276,7 @@ class MusicalPaletteFire : public PaletteFlameEffect, protected BeatEffectBase
 {
     void construct()
     {
-        _effectNumber = EFFECT_STRIP_MUSICAL_PALETTE_FIRE;
+    _effectNumber = idStripMusicalPaletteFire;
     }
 
   public:
@@ -339,7 +339,7 @@ class ClassicFireEffect : public LEDStripEffect
 public:
 
     ClassicFireEffect(bool mirrored = false, bool reversed = false, int cooling = 5)
-        : LEDStripEffect(EFFECT_STRIP_CLASSIC_FIRE, "Classic Fire"),
+    : LEDStripEffect(idStripClassicFire, "Classic Fire"),
           _Mirrored(mirrored),
           _Reversed(reversed),
           _Cooling(cooling)
@@ -491,7 +491,7 @@ public:
                      bool turbo = false,
                      bool mirrored = false)
 
-        : LEDStripEffect(EFFECT_STRIP_SMOOTH_FIRE, "Fire Sound Effect v2"),
+    : LEDStripEffect(idStripSmoothFire, "Fire Sound Effect v2"),
           _Reversed(reversed),
           _Cooling(cooling),
           _Sparks(sparks),
@@ -653,7 +653,7 @@ class BaseFireEffect : public LEDStripEffect
   public:
 
     BaseFireEffect(int ledCount, int cellsPerLED = 1, int cooling = 20, int sparking = 100, int sparks = 3, int sparkHeight = 4, bool breversed = false, bool bmirrored = false)
-        : LEDStripEffect(EFFECT_STRIP_BASE_FIRE, "BaseFireEffect"),
+    : LEDStripEffect(idStripBaseFire, "BaseFireEffect"),
           Cooling(cooling),
           Sparks(sparks),
           SparkHeight(sparkHeight),

--- a/include/effects/strip/laserline.h
+++ b/include/effects/strip/laserline.h
@@ -67,6 +67,8 @@ public:
 
 class LaserLineEffect : public BeatEffectBase, public LEDStripEffect
 {
+    public:
+        static constexpr EffectId kId = idStripLaserLine;
   private:
     std::vector<LaserShot>      _shots;
     std::shared_ptr<GFXBase>    _gfx;

--- a/include/effects/strip/laserline.h
+++ b/include/effects/strip/laserline.h
@@ -67,9 +67,11 @@ public:
 
 class LaserLineEffect : public BeatEffectBase, public LEDStripEffect
 {
-    public:
-        static constexpr EffectId kId = idStripLaserLine;
-  private:
+  public:
+    static constexpr EffectId kId = idStripLaserLine;
+    EffectId effectId() const override { return kId; }
+
+    private:
     std::vector<LaserShot>      _shots;
     std::shared_ptr<GFXBase>    _gfx;
     float                      _defaultSize;

--- a/include/effects/strip/laserline.h
+++ b/include/effects/strip/laserline.h
@@ -77,7 +77,7 @@ class LaserLineEffect : public BeatEffectBase, public LEDStripEffect
 
     LaserLineEffect(float speed, float size)
         : BeatEffectBase(1.50, 0.00),
-          LEDStripEffect(EFFECT_STRIP_LASER_LINE, "LaserLine"),
+          LEDStripEffect(idStripLaserLine, "LaserLine"),
           _defaultSize(size),
           _defaultSpeed(speed)
     {

--- a/include/effects/strip/meteoreffect.h
+++ b/include/effects/strip/meteoreffect.h
@@ -162,6 +162,8 @@ public:
 
 class MeteorEffect : public LEDStripEffect
 {
+    public:
+        static constexpr EffectId kId = idStripMeteor;
   private:
     std::vector<MeteorChannel> _Meteors;
 

--- a/include/effects/strip/meteoreffect.h
+++ b/include/effects/strip/meteoreffect.h
@@ -162,8 +162,10 @@ public:
 
 class MeteorEffect : public LEDStripEffect
 {
-    public:
-        static constexpr EffectId kId = idStripMeteor;
+  public:
+    static constexpr EffectId kId = idStripMeteor;
+    EffectId effectId() const override { return kId; }
+  
   private:
     std::vector<MeteorChannel> _Meteors;
 

--- a/include/effects/strip/meteoreffect.h
+++ b/include/effects/strip/meteoreffect.h
@@ -174,7 +174,7 @@ class MeteorEffect : public LEDStripEffect
   public:
 
     MeteorEffect(int cMeteors = 4, uint size = 4, uint decay = 3, float minSpeed = 0.2, float maxSpeed = 0.2)
-        : LEDStripEffect(EFFECT_STRIP_METEOR, "Color Meteors"),
+    : LEDStripEffect(idStripMeteor, "Color Meteors"),
           _Meteors(),
           _cMeteors(cMeteors),
           _meteorSize(size),

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -58,6 +58,7 @@ class SimpleRainbowTestEffect : public LEDStripEffect
     {
         debugV("SimpleRainbowTestEffect constructor");
     }
+    static constexpr EffectId kId = idStripSimpleRainbowTest;
 
     SimpleRainbowTestEffect(const JsonObjectConst& jsonObject)
       : LEDStripEffect(jsonObject),
@@ -106,6 +107,7 @@ class RainbowTwinkleEffect : public LEDStripEffect
     {
         debugV("RainbowFill constructor");
     }
+    static constexpr EffectId kId = idStripRainbowTwinkle;
 
     RainbowTwinkleEffect(const JsonObjectConst& jsonObject)
       : LEDStripEffect(jsonObject),
@@ -153,6 +155,8 @@ class RainbowTwinkleEffect : public LEDStripEffect
 
 class RainbowFillEffect : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripRainbowFill;
   private:
 
 protected:
@@ -237,6 +241,7 @@ protected:
     {
         debugV("Color Fill constructor");
     }
+    static constexpr EffectId kId = idStripColorFill;
 
     ColorFillEffect(CRGB color = CRGB(246,200,160), int everyNth = 10, bool ignoreGlobalColor = false)
   : LEDStripEffect(idStripColorFill, "Color Fill"),
@@ -303,6 +308,7 @@ class SplashLogoEffect : public LEDStripEffect
     {
         debugV("Splash logo constructor");
     }
+    static constexpr EffectId kId = idStripSplashLogo;
 
     SplashLogoEffect(const JsonObjectConst& jsonObject)
       : LEDStripEffect(jsonObject),
@@ -358,6 +364,7 @@ class StatusEffect : public LEDStripEffect
     {
         debugV("Status Fill constructor");
     }
+    static constexpr EffectId kId = idStripStatus;
 
     StatusEffect(const JsonObjectConst& jsonObject)     // Warmer: CRGB(246,200,160)
       : LEDStripEffect(jsonObject),
@@ -434,6 +441,7 @@ class TwinkleEffect : public LEDStripEffect
         _updateSpeed(updateSpeed)
     {
     }
+    static constexpr EffectId kId = idStripTwinkle;
 
     TwinkleEffect(const JsonObjectConst& jsonObject)
       : LEDStripEffect(jsonObject),
@@ -517,6 +525,7 @@ class SilonEffect : public LEDStripEffect
   SilonEffect() : LEDStripEffect(idMatrixSilon, "SilonEffect")
     {
     }
+    static constexpr EffectId kId = idMatrixSilon;
 
     SilonEffect(const JsonObjectConst& jsonObject)
       : LEDStripEffect(jsonObject)
@@ -565,6 +574,7 @@ class PDPGridEffect : public LEDStripEffect
   PDPGridEffect() : LEDStripEffect(idMatrixPDPGrid, "PDPGridEffect")
     {
     }
+    static constexpr EffectId kId = idMatrixPDPGrid;
 
     PDPGridEffect(const JsonObjectConst& jsonObject)
       : LEDStripEffect(jsonObject)
@@ -660,6 +670,7 @@ class PDPCMXEffect : public LEDStripEffect
   PDPCMXEffect() : LEDStripEffect(idMatrixPDPCMX, "PDPCMXEffect")
     {
     }
+    static constexpr EffectId kId = idMatrixPDPCMX;
 
     PDPCMXEffect(const JsonObjectConst& jsonObject)
       : LEDStripEffect(jsonObject)
@@ -712,6 +723,7 @@ class OuterHexRingEffect : public LEDStripEffect
   OuterHexRingEffect() : LEDStripEffect(idHexagonOuterRing, "OuterRingHexEffect")
     {
     }
+    static constexpr EffectId kId = idHexagonOuterRing;
 
     OuterHexRingEffect(const JsonObjectConst& jsonObject)
       : LEDStripEffect(jsonObject)

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -59,6 +59,7 @@ class SimpleRainbowTestEffect : public LEDStripEffect
         debugV("SimpleRainbowTestEffect constructor");
     }
     static constexpr EffectId kId = idStripSimpleRainbowTest;
+    EffectId effectId() const override { return kId; }
 
     SimpleRainbowTestEffect(const JsonObjectConst& jsonObject)
       : LEDStripEffect(jsonObject),
@@ -108,6 +109,7 @@ class RainbowTwinkleEffect : public LEDStripEffect
         debugV("RainbowFill constructor");
     }
     static constexpr EffectId kId = idStripRainbowTwinkle;
+    EffectId effectId() const override { return kId; }
 
     RainbowTwinkleEffect(const JsonObjectConst& jsonObject)
       : LEDStripEffect(jsonObject),
@@ -157,9 +159,9 @@ class RainbowFillEffect : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripRainbowFill;
-  private:
-
-protected:
+    EffectId effectId() const override { return kId; }
+  
+    protected:
 
     float _speedDivisor;
     int   _deltaHue;
@@ -242,6 +244,7 @@ protected:
         debugV("Color Fill constructor");
     }
     static constexpr EffectId kId = idStripColorFill;
+    EffectId effectId() const override { return kId; }
 
     ColorFillEffect(CRGB color = CRGB(246,200,160), int everyNth = 10, bool ignoreGlobalColor = false)
   : LEDStripEffect(idStripColorFill, "Color Fill"),
@@ -309,6 +312,7 @@ class SplashLogoEffect : public LEDStripEffect
         debugV("Splash logo constructor");
     }
     static constexpr EffectId kId = idStripSplashLogo;
+    EffectId effectId() const override { return kId; }
 
     SplashLogoEffect(const JsonObjectConst& jsonObject)
       : LEDStripEffect(jsonObject),
@@ -365,6 +369,7 @@ class StatusEffect : public LEDStripEffect
         debugV("Status Fill constructor");
     }
     static constexpr EffectId kId = idStripStatus;
+    EffectId effectId() const override { return kId; }
 
     StatusEffect(const JsonObjectConst& jsonObject)     // Warmer: CRGB(246,200,160)
       : LEDStripEffect(jsonObject),
@@ -442,6 +447,7 @@ class TwinkleEffect : public LEDStripEffect
     {
     }
     static constexpr EffectId kId = idStripTwinkle;
+    EffectId effectId() const override { return kId; }
 
     TwinkleEffect(const JsonObjectConst& jsonObject)
       : LEDStripEffect(jsonObject),
@@ -526,6 +532,7 @@ class SilonEffect : public LEDStripEffect
     {
     }
     static constexpr EffectId kId = idMatrixSilon;
+    EffectId effectId() const override { return kId; }
 
     SilonEffect(const JsonObjectConst& jsonObject)
       : LEDStripEffect(jsonObject)
@@ -575,6 +582,7 @@ class PDPGridEffect : public LEDStripEffect
     {
     }
     static constexpr EffectId kId = idMatrixPDPGrid;
+    EffectId effectId() const override { return kId; }
 
     PDPGridEffect(const JsonObjectConst& jsonObject)
       : LEDStripEffect(jsonObject)
@@ -671,6 +679,7 @@ class PDPCMXEffect : public LEDStripEffect
     {
     }
     static constexpr EffectId kId = idMatrixPDPCMX;
+    EffectId effectId() const override { return kId; }
 
     PDPCMXEffect(const JsonObjectConst& jsonObject)
       : LEDStripEffect(jsonObject)
@@ -724,6 +733,7 @@ class OuterHexRingEffect : public LEDStripEffect
     {
     }
     static constexpr EffectId kId = idHexagonOuterRing;
+    EffectId effectId() const override { return kId; }
 
     OuterHexRingEffect(const JsonObjectConst& jsonObject)
       : LEDStripEffect(jsonObject)

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -52,7 +52,7 @@ class SimpleRainbowTestEffect : public LEDStripEffect
   public:
 
     SimpleRainbowTestEffect(uint8_t speedDivisor = 8, uint8_t everyNthPixel = 12)
-      : LEDStripEffect(EFFECT_STRIP_SIMPLE_RAINBOW_TEST, "Simple Rainbow"),
+  : LEDStripEffect(idStripSimpleRainbowTest, "Simple Rainbow"),
           _EveryNth(everyNthPixel),
           _SpeedDivisor(speedDivisor)
     {
@@ -100,7 +100,7 @@ class RainbowTwinkleEffect : public LEDStripEffect
   public:
 
     RainbowTwinkleEffect(float speedDivisor = 12.0f, int deltaHue = 14)
-      : LEDStripEffect(EFFECT_STRIP_RAINBOW_TWINKLE, "Rainbow Twinkle"),
+  : LEDStripEffect(idStripRainbowTwinkle, "Rainbow Twinkle"),
         _speedDivisor(speedDivisor),
         _deltaHue(deltaHue)
     {
@@ -164,7 +164,7 @@ protected:
   public:
 
     RainbowFillEffect(float speedDivisor = 12.0f, int deltaHue = 14, bool mirrored = false)
-      : LEDStripEffect(EFFECT_STRIP_RAINBOW_FILL, "RainbowFill Rainbow"),
+  : LEDStripEffect(idStripRainbowFill, "RainbowFill Rainbow"),
         _speedDivisor(speedDivisor),
         _deltaHue(deltaHue),
         _mirrored(mirrored)
@@ -230,7 +230,7 @@ protected:
   public:
 
     ColorFillEffect(const String &name, CRGB color = CRGB(246,200,160), int everyNth = 10, bool ignoreGlobalColor = false)
-      : LEDStripEffect(EFFECT_STRIP_COLOR_FILL, name),
+  : LEDStripEffect(idStripColorFill, name),
         _everyNth(everyNth),
         _color(color),
         _ignoreGlobalColor(ignoreGlobalColor)
@@ -239,7 +239,7 @@ protected:
     }
 
     ColorFillEffect(CRGB color = CRGB(246,200,160), int everyNth = 10, bool ignoreGlobalColor = false)
-      : LEDStripEffect(EFFECT_STRIP_COLOR_FILL, "Color Fill"),
+  : LEDStripEffect(idStripColorFill, "Color Fill"),
         _everyNth(everyNth),
         _color(color),
         _ignoreGlobalColor(ignoreGlobalColor)
@@ -298,7 +298,7 @@ class SplashLogoEffect : public LEDStripEffect
   public:
 
     SplashLogoEffect()
-      : LEDStripEffect(EFFECT_STRIP_SPLASH_LOGO, "Mesmerizer"),
+  : LEDStripEffect(idStripSplashLogo, "Mesmerizer"),
         logo(logo_start, logo_end)
     {
         debugV("Splash logo constructor");
@@ -352,7 +352,7 @@ class StatusEffect : public LEDStripEffect
   public:
 
     StatusEffect(CRGB color = CRGB(255,255,255), int everyNth = 10)     // Warmer: CRGB(246,200,160)
-      : LEDStripEffect(EFFECT_STRIP_STATUS, "Status Fill"),
+  : LEDStripEffect(idStripStatus, "Status Fill"),
         _everyNth(everyNth),
         _color(color)
     {
@@ -428,7 +428,7 @@ class TwinkleEffect : public LEDStripEffect
   public:
 
     TwinkleEffect(int countToDraw = NUM_LEDS / 2, uint8_t fadeFactor = 10, int updateSpeed = 10)
-      : LEDStripEffect(EFFECT_STRIP_TWINKLE, "Twinkle"),
+  : LEDStripEffect(idStripTwinkle, "Twinkle"),
         _countToDraw(countToDraw),
         _fadeFactor(fadeFactor),
         _updateSpeed(updateSpeed)
@@ -514,7 +514,7 @@ class SilonEffect : public LEDStripEffect
 {
   public:
 
-    SilonEffect() : LEDStripEffect(EFFECT_MATRIX_SILON, "SilonEffect")
+  SilonEffect() : LEDStripEffect(idMatrixSilon, "SilonEffect")
     {
     }
 
@@ -562,7 +562,7 @@ class PDPGridEffect : public LEDStripEffect
 {
   public:
 
-    PDPGridEffect() : LEDStripEffect(EFFECT_MATRIX_PDPGRID, "PDPGridEffect")
+  PDPGridEffect() : LEDStripEffect(idMatrixPDPGrid, "PDPGridEffect")
     {
     }
 
@@ -657,7 +657,7 @@ class PDPCMXEffect : public LEDStripEffect
 
   public:
 
-    PDPCMXEffect() : LEDStripEffect(EFFECT_MATRIX_PDPCMX, "PDPCMXEffect")
+  PDPCMXEffect() : LEDStripEffect(idMatrixPDPCMX, "PDPCMXEffect")
     {
     }
 
@@ -709,7 +709,7 @@ class OuterHexRingEffect : public LEDStripEffect
 {
   public:
 
-    OuterHexRingEffect() : LEDStripEffect(EFFECT_HEXAGON_OUTER_RING, "OuterRingHexEffect")
+  OuterHexRingEffect() : LEDStripEffect(idHexagonOuterRing, "OuterRingHexEffect")
     {
     }
 

--- a/include/effects/strip/musiceffect.h
+++ b/include/effects/strip/musiceffect.h
@@ -189,7 +189,7 @@ class SimpleColorBeat : public BeatEffectBase, public LEDStripEffect
   public:
 
     SimpleColorBeat(const String & strName)
-      : BeatEffectBase(0.5, 0.25), LEDStripEffect(EFFECT_STRIP_SIMPLE_COLOR_BEAT, strName)
+        : BeatEffectBase(0.5, 0.25), LEDStripEffect(idStripSimpleColorBeat, strName)
     {
     }
 

--- a/include/effects/strip/musiceffect.h
+++ b/include/effects/strip/musiceffect.h
@@ -128,6 +128,10 @@ class BeatEffectBase
 
 class SimpleColorBeat : public BeatEffectBase, public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripSimpleColorBeat;
+    EffectId effectId() const override { return kId; }
+
   protected:
 
     int _iLastInsulator = -1;
@@ -189,7 +193,7 @@ class SimpleColorBeat : public BeatEffectBase, public LEDStripEffect
   public:
 
     SimpleColorBeat(const String & strName)
-        : BeatEffectBase(0.5, 0.25), LEDStripEffect(idStripSimpleColorBeat, strName)
+  : BeatEffectBase(0.5, 0.25), LEDStripEffect(strName)
     {
     }
 

--- a/include/effects/strip/paletteeffect.h
+++ b/include/effects/strip/paletteeffect.h
@@ -36,6 +36,8 @@ class PaletteEffect : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripPalette;
+    EffectId effectId() const override { return kId; }
+    
   private:
 
     float _startIndex;
@@ -61,7 +63,7 @@ class PaletteEffect : public LEDStripEffect
                   TBlendType blend = LINEARBLEND,
                   bool  bErase = true,
                   float brightness = 1.0)
-  : LEDStripEffect(idStripPalette, "Palette Effect"),
+  : LEDStripEffect("Palette Effect"),
         _startIndex(0.0f),
         _paletteIndex(0.0f),
         _palette(palette),

--- a/include/effects/strip/paletteeffect.h
+++ b/include/effects/strip/paletteeffect.h
@@ -34,6 +34,8 @@
 
 class PaletteEffect : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripPalette;
   private:
 
     float _startIndex;

--- a/include/effects/strip/paletteeffect.h
+++ b/include/effects/strip/paletteeffect.h
@@ -59,7 +59,7 @@ class PaletteEffect : public LEDStripEffect
                   TBlendType blend = LINEARBLEND,
                   bool  bErase = true,
                   float brightness = 1.0)
-      : LEDStripEffect(EFFECT_STRIP_PALETTE, "Palette Effect"),
+  : LEDStripEffect(idStripPalette, "Palette Effect"),
         _startIndex(0.0f),
         _paletteIndex(0.0f),
         _palette(palette),

--- a/include/effects/strip/particles.h
+++ b/include/effects/strip/particles.h
@@ -35,6 +35,13 @@
 #include <deque>
 
 #include "effects.h"
+// Needed for FillRingPixels, DrawRingPixels, and fan/ring utilities
+#include "faneffects.h"
+
+#if ENABLE_AUDIO
+// Needed for BeatEffectBase and audio-driven particle effects
+#include "musiceffect.h"
+#endif
 
 // Lifespan
 //
@@ -384,7 +391,7 @@ class ColorBeatWithFlash : public BeatEffectBase, public ParticleSystem<RingPart
 
   public:
 
-    ColorBeatWithFlash(const String & strName) : BeatEffectBase(), ParticleSystem<RingParticle>(), LEDStripEffect(EFFECT_STRIP_COLOR_BEAT_WITH_FLASH, strName)
+    ColorBeatWithFlash(const String & strName) : BeatEffectBase(), ParticleSystem<RingParticle>(), LEDStripEffect(idStripColorBeatWithFlash, strName)
     {
     }
 
@@ -440,7 +447,7 @@ class ColorBeatOverRed : public LEDStripEffect, public BeatEffectBase, public Pa
   public:
 
     ColorBeatOverRed(const String & strName)
-      : LEDStripEffect(EFFECT_STRIP_COLOR_BEAT_OVER_RED, strName),
+  : LEDStripEffect(idStripColorBeatOverRed, strName),
         BeatEffectBase(1.75, 0.2),
         ParticleSystem<RingParticle>()
     {
@@ -701,7 +708,7 @@ class MoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase, p
   public:
 
     MoltenGlassOnVioletBkgnd(const String & strName, const CRGBPalette16 & Palette)
-      : LEDStripEffect(EFFECT_STRIP_MOLTEN_GLASS_ON_VIOLET_BKGND, strName),
+  : LEDStripEffect(idStripMoltenGlassOnVioletBkgnd, strName),
         BeatEffectBase(1.50, 0.05),
         ParticleSystem<SpinningPaletteRingParticle>(),
         _Palette(Palette)
@@ -791,7 +798,7 @@ class NewMoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase
   public:
 
     NewMoltenGlassOnVioletBkgnd(const String & strName, const CRGBPalette16 & Palette)
-      : LEDStripEffect(EFFECT_STRIP_NEW_MOLTEN_GLASS_ON_VIOLET_BKGND, strName),
+  : LEDStripEffect(idStripNewMoltenGlassOnVioletBkgnd, strName),
         BeatEffectBase(1.0, 0.25 ),
         ParticleSystem<SpinningPaletteRingParticle>(),
         _Palette(Palette)
@@ -880,7 +887,7 @@ class SparklySpinningMusicEffect : public LEDStripEffect, public BeatEffectBase,
   public:
 
     SparklySpinningMusicEffect(const String & strName, const CRGBPalette16 & Palette)
-      : LEDStripEffect(EFFECT_STRIP_SPARKLY_SPINNING_MUSIC, strName), BeatEffectBase(), ParticleSystem<SpinningPaletteRingParticle>(), _Palette(Palette)
+  : LEDStripEffect(idStripSparklySpinningMusic, strName), BeatEffectBase(), ParticleSystem<SpinningPaletteRingParticle>(), _Palette(Palette)
     {
     }
 
@@ -941,7 +948,7 @@ class MusicalHotWhiteInsulatorEffect : public LEDStripEffect, public BeatEffectB
 
   public:
 
-    MusicalHotWhiteInsulatorEffect(const String & strName) : LEDStripEffect(EFFECT_STRIP_MUSICAL_HOT_WHITE_INSULATOR, strName), BeatEffectBase(), ParticleSystem<HotWhiteRingParticle>()
+  MusicalHotWhiteInsulatorEffect(const String & strName) : LEDStripEffect(idStripMusicalHotWhiteInsulator, strName), BeatEffectBase(), ParticleSystem<HotWhiteRingParticle>()
     {
     }
 

--- a/include/effects/strip/snakeeffect.h
+++ b/include/effects/strip/snakeeffect.h
@@ -36,8 +36,11 @@
 
 class SnakeEffect : public LEDStripEffect
 {
-    public:
-        static constexpr EffectId kId = idStripSnake;
+  public:
+  
+    static constexpr EffectId kId = idStripSnake;
+    EffectId effectId() const override { return kId; }
+    
     void construct()
     {
         lastLEDIndex = LEDCount - 1;

--- a/include/effects/strip/snakeeffect.h
+++ b/include/effects/strip/snakeeffect.h
@@ -36,6 +36,8 @@
 
 class SnakeEffect : public LEDStripEffect
 {
+    public:
+        static constexpr EffectId kId = idStripSnake;
     void construct()
     {
         lastLEDIndex = LEDCount - 1;

--- a/include/effects/strip/snakeeffect.h
+++ b/include/effects/strip/snakeeffect.h
@@ -65,7 +65,7 @@ class SnakeEffect : public LEDStripEffect
   public:
 
     SnakeEffect(const char * strName, int ledCount = NUM_LEDS, int snakeSpeed = dSnakeSpeed)
-        : LEDStripEffect(EFFECT_STRIP_SNAKE, strName),
+    : LEDStripEffect(idStripSnake, strName),
           LEDCount(ledCount),
           SnakeSpeed(snakeSpeed)
     {

--- a/include/effects/strip/stareffect.h
+++ b/include/effects/strip/stareffect.h
@@ -46,7 +46,7 @@ class Star : public MovingFadingPaletteObject, public ObjectSize
 
     static int GetStarTypeNumber()
     {
-    return idStar;
+        return idStar;
     }
 
     virtual float GetStarSize()
@@ -114,7 +114,7 @@ class ColorStar : public MovingFadingColoredObject, public ObjectSize
 
     static int GetStarTypeNumber()
     {
-    return idStarColor;
+        return idStarColor;
     }
 
     virtual float GetStarSize()
@@ -135,7 +135,7 @@ class QuietStar : public RandomPaletteColorStar
 
     static int GetStarTypeNumber()
     {
-    return idStarQuiet;
+        return idStarQuiet;
     }
 
     QuietStar(const CRGBPalette16 & palette, TBlendType blendType = NOBLEND, float maxSpeed = 10.0, float starSize = 1)
@@ -161,7 +161,7 @@ class MusicStar : public Star
 
     static int GetStarTypeNumber()
     {
-    return idStarMusic;
+        return idStarMusic;
     }
 
     virtual float PreignitionTime() const      { return 0.0f;  }
@@ -187,7 +187,7 @@ class MusicPulseStar : public Star
 
     static int GetStarTypeNumber()
     {
-    return idStarMusicPulse;
+        return idStarMusicPulse;
     }
 
     virtual float PreignitionTime() const { return 0.00f;  }
@@ -217,7 +217,7 @@ class BubblyStar : public Star
 
     static int GetStarTypeNumber()
     {
-    return idStarBubbly;
+        return idStarBubbly;
     }
 
     float GetStarSize() override
@@ -243,7 +243,7 @@ class FlashStar : public Star
 
     static int GetStarTypeNumber()
     {
-    return idStarFlash;
+        return idStarFlash;
     }
 
     float PreignitionTime() const override  { return 0.00f; }
@@ -267,7 +267,7 @@ class ColorCycleStar : public Star
 
     static int GetStarTypeNumber()
     {
-    return idStarColorCycle;
+        return idStarColorCycle;
     }
 
     virtual CRGB Render(TBlendType blend)
@@ -340,7 +340,7 @@ class ChristmasLightStar : public Star
 
     static int GetStarTypeNumber()
     {
-    return idStarChristmas;
+        return idStarChristmas;
     }
 
     float PreignitionTime() const override { return 0.20f; }
@@ -366,7 +366,7 @@ class HotWhiteStar : public Star
 
     static int GetStarTypeNumber()
     {
-    return idStarHotWhite;
+        return idStarHotWhite;
     }
 
     float PreignitionTime() const override { return 0.00f;  }
@@ -432,6 +432,10 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
 
   public:
 
+        // All StarryNight variants share the same EffectId; star type is encoded separately
+        static constexpr EffectId kId = idStripStarryNight;
+        EffectId effectId() const override { return kId; }
+
 
     StarryNightEffect<StarType>(const String & strName,
                                 const CRGBPalette16& palette,
@@ -442,7 +446,7 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
                                 float blurFactor = 0.0,
                                 float musicFactor = 1.0,
                                 CRGB skyColor = CRGB::Black)
-    : LEDStripEffect(idStripStarryNight, strName),
+    : LEDStripEffect(strName),
         _palette(palette),
         _newStarProbability(probability),
         _starSize(starSize),
@@ -588,14 +592,17 @@ template <typename StarType> class BlurStarEffect : public StarryNightEffect<Sta
 
 class TwinkleStarEffect : public LEDStripEffect
 {
-    public:
-        static constexpr EffectId kId = idStripTwinkleStar;
+  public:
+
+    static constexpr EffectId kId = idStripTwinkleStar;
+    EffectId effectId() const override { return kId; }
+  
     #define NUM_TWINKLES 100
     int buffer[NUM_TWINKLES];
 
 public:
 
-    TwinkleStarEffect() : LEDStripEffect(idStripTwinkleStar, "Twinkle Star")
+    TwinkleStarEffect() : LEDStripEffect("Twinkle Star")
     {
     }
 
@@ -613,12 +620,8 @@ public:
 
     void Draw() override
     {
-
-        // Init all the memory slots to -1 which means "empty slot"
-
-
         // Rotate the buffer
-        //memmove(buffer, buffer + 1, std::size(buffer) * (Count - 1));
+
         for (int i = 0; i < NUM_TWINKLES - 1; i++)
             buffer[i] = buffer[i + 1];
 
@@ -628,6 +631,7 @@ public:
             setPixelsOnAllChannels(buffer[0], 0, 0, 0);
 
         // Pick a random pixel and put it in the TOP slot
+
         int iNew = (int) random_range(0U, _cLEDs);
         setPixelOnAllChannels(iNew, RandomRainbowColor());
         buffer[NUM_TWINKLES - 1] = iNew;

--- a/include/effects/strip/stareffect.h
+++ b/include/effects/strip/stareffect.h
@@ -588,6 +588,8 @@ template <typename StarType> class BlurStarEffect : public StarryNightEffect<Sta
 
 class TwinkleStarEffect : public LEDStripEffect
 {
+    public:
+        static constexpr EffectId kId = idStripTwinkleStar;
     #define NUM_TWINKLES 100
     int buffer[NUM_TWINKLES];
 

--- a/include/effects/strip/stareffect.h
+++ b/include/effects/strip/stareffect.h
@@ -46,7 +46,7 @@ class Star : public MovingFadingPaletteObject, public ObjectSize
 
     static int GetStarTypeNumber()
     {
-        return EFFECT_STAR;
+    return idStar;
     }
 
     virtual float GetStarSize()
@@ -67,7 +67,7 @@ class RandomPaletteColorStar : public MovingFadingPaletteObject, public ObjectSi
 
     static int GetStarTypeNumber()
     {
-        return EFFECT_STAR_RANDOM_PALETTE_COLOR;
+    return idStarRandomPaletteColor;
     }
 
     virtual float GetStarSize()
@@ -93,7 +93,7 @@ class LongLifeSparkleStar : public MovingFadingPaletteObject, public ObjectSize
 
     static int GetStarTypeNumber()
     {
-        return EFFECT_STAR_LONG_LIFE_SPARKLE;
+    return idStarLongLifeSparkle;
     }
 
     virtual float GetStarSize()
@@ -114,7 +114,7 @@ class ColorStar : public MovingFadingColoredObject, public ObjectSize
 
     static int GetStarTypeNumber()
     {
-        return EFFECT_STAR_COLOR;
+    return idStarColor;
     }
 
     virtual float GetStarSize()
@@ -135,7 +135,7 @@ class QuietStar : public RandomPaletteColorStar
 
     static int GetStarTypeNumber()
     {
-        return EFFECT_STAR_QUIET;
+    return idStarQuiet;
     }
 
     QuietStar(const CRGBPalette16 & palette, TBlendType blendType = NOBLEND, float maxSpeed = 10.0, float starSize = 1)
@@ -161,7 +161,7 @@ class MusicStar : public Star
 
     static int GetStarTypeNumber()
     {
-        return EFFECT_STAR_MUSIC;
+    return idStarMusic;
     }
 
     virtual float PreignitionTime() const      { return 0.0f;  }
@@ -187,7 +187,7 @@ class MusicPulseStar : public Star
 
     static int GetStarTypeNumber()
     {
-        return EFFECT_STAR_MUSIC_PULSE;
+    return idStarMusicPulse;
     }
 
     virtual float PreignitionTime() const { return 0.00f;  }
@@ -217,7 +217,7 @@ class BubblyStar : public Star
 
     static int GetStarTypeNumber()
     {
-        return EFFECT_STAR_BUBBLY;
+    return idStarBubbly;
     }
 
     float GetStarSize() override
@@ -243,7 +243,7 @@ class FlashStar : public Star
 
     static int GetStarTypeNumber()
     {
-        return EFFECT_STAR_FLASH;
+    return idStarFlash;
     }
 
     float PreignitionTime() const override  { return 0.00f; }
@@ -267,7 +267,7 @@ class ColorCycleStar : public Star
 
     static int GetStarTypeNumber()
     {
-        return EFFECT_STAR_COLOR_CYCLE;
+    return idStarColorCycle;
     }
 
     virtual CRGB Render(TBlendType blend)
@@ -313,7 +313,7 @@ class MultiColorStar : public Star
 
     static int GetStarTypeNumber()
     {
-        return EFFECT_STAR_MULTI_COLOR;
+    return idStarMultiColor;
     }
 
     float PreignitionTime() const override { return 2.0f; }
@@ -340,7 +340,7 @@ class ChristmasLightStar : public Star
 
     static int GetStarTypeNumber()
     {
-        return EFFECT_STAR_CHRISTMAS;
+    return idStarChristmas;
     }
 
     float PreignitionTime() const override { return 0.20f; }
@@ -366,7 +366,7 @@ class HotWhiteStar : public Star
 
     static int GetStarTypeNumber()
     {
-        return EFFECT_STAR_HOT_WHITE;
+    return idStarHotWhite;
     }
 
     float PreignitionTime() const override { return 0.00f;  }
@@ -442,7 +442,7 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
                                 float blurFactor = 0.0,
                                 float musicFactor = 1.0,
                                 CRGB skyColor = CRGB::Black)
-      : LEDStripEffect(EFFECT_STRIP_STARRY_NIGHT, strName),
+    : LEDStripEffect(idStripStarryNight, strName),
         _palette(palette),
         _newStarProbability(probability),
         _starSize(starSize),
@@ -593,7 +593,7 @@ class TwinkleStarEffect : public LEDStripEffect
 
 public:
 
-    TwinkleStarEffect() : LEDStripEffect(EFFECT_STRIP_TWINKLE_STAR, "Twinkle Star")
+    TwinkleStarEffect() : LEDStripEffect(idStripTwinkleStar, "Twinkle Star")
     {
     }
 

--- a/include/effects/strip/tempeffect.h
+++ b/include/effects/strip/tempeffect.h
@@ -37,6 +37,8 @@
 
 class SimpleInsulatorBeatEffect : public LEDStripEffect, public BeatEffectBase
 {
+  public:
+    static constexpr EffectId kId = idStripSimpleInsulatorBeat;
   protected:
 
     std::deque<int> _lit;
@@ -80,6 +82,8 @@ class SimpleInsulatorBeatEffect : public LEDStripEffect, public BeatEffectBase
 
 class SimpleInsulatorBeatEffect2 : public LEDStripEffect, public BeatEffectBase
 {
+  public:
+    static constexpr EffectId kId = idStripSimpleInsulatorBeat2;
   protected:
 
     std::deque<int> _lit;
@@ -120,6 +124,8 @@ class SimpleInsulatorBeatEffect2 : public LEDStripEffect, public BeatEffectBase
 
 class VUInsulatorsEffect : public LEDStripEffect
 {
+  public:
+    static constexpr EffectId kId = idStripVUInsulators;
     int _last = 1;
 
     using LEDStripEffect::LEDStripEffect;

--- a/include/effects/strip/tempeffect.h
+++ b/include/effects/strip/tempeffect.h
@@ -39,6 +39,8 @@ class SimpleInsulatorBeatEffect : public LEDStripEffect, public BeatEffectBase
 {
   public:
     static constexpr EffectId kId = idStripSimpleInsulatorBeat;
+    EffectId effectId() const override { return kId; }
+
   protected:
 
     std::deque<int> _lit;
@@ -84,6 +86,8 @@ class SimpleInsulatorBeatEffect2 : public LEDStripEffect, public BeatEffectBase
 {
   public:
     static constexpr EffectId kId = idStripSimpleInsulatorBeat2;
+    EffectId effectId() const override { return kId; }
+
   protected:
 
     std::deque<int> _lit;
@@ -126,6 +130,8 @@ class VUInsulatorsEffect : public LEDStripEffect
 {
   public:
     static constexpr EffectId kId = idStripVUInsulators;
+    EffectId effectId() const override { return kId; }
+    
     int _last = 1;
 
     using LEDStripEffect::LEDStripEffect;

--- a/include/effects/strip/tempeffect.h
+++ b/include/effects/strip/tempeffect.h
@@ -67,7 +67,7 @@ class SimpleInsulatorBeatEffect : public LEDStripEffect, public BeatEffectBase
     using BeatEffectBase::BeatEffectBase;
 
     SimpleInsulatorBeatEffect(const String & strName)
-      : LEDStripEffect(EFFECT_STRIP_SIMPLE_INSULATOR_BEAT, strName), BeatEffectBase(0.5, 0.01)
+  : LEDStripEffect(idStripSimpleInsulatorBeat, strName), BeatEffectBase(0.5, 0.01)
     {
     }
 
@@ -108,7 +108,7 @@ class SimpleInsulatorBeatEffect2 : public LEDStripEffect, public BeatEffectBase
   public:
 
     SimpleInsulatorBeatEffect2(const String & strName)
-      : LEDStripEffect(EFFECT_STRIP_SIMPLE_INSULATOR_BEAT2, strName), BeatEffectBase()
+  : LEDStripEffect(idStripSimpleInsulatorBeat2, strName), BeatEffectBase()
     {
     }
 

--- a/include/effectsupport.h
+++ b/include/effectsupport.h
@@ -280,5 +280,5 @@ inline auto Disabled(F adder)
 
 // Defines used by some StarryNightEffect instances
 
-#define STARRYNIGHT_PROBABILITY 1.0
-#define STARRYNIGHT_MUSICFACTOR 1.0
+constexpr float kStarryNightProbability = 1.0f;
+constexpr float kStarryNightMusicFactor = 1.0f;

--- a/include/effectsupport.h
+++ b/include/effectsupport.h
@@ -33,6 +33,8 @@
 #pragma once
 
 #include "globals.h"
+// Needed for StarryNightEffect used by helpers below
+#include "effects/strip/stareffect.h"
 
 // Palettes used by a number of effects
 
@@ -186,36 +188,94 @@ const CRGBPalette16 rainbowPalette(RainbowColors_p);
 
 extern DRAM_ATTR std::unique_ptr<EffectFactories> g_ptrEffectFactories;
 
+// --- Macro-free helpers for concise, type-safe effect registration ---
+
 // Adds a default and JSON effect factory for a specific effect number and type.
-//   All parameters beyond effectNumber and effectType will be passed on to the default effect constructor.
-#define ADD_EFFECT(effectNumber, effectType, ...) \
-    g_ptrEffectFactories->AddEffect(effectNumber, \
-        []()                                 ->std::shared_ptr<LEDStripEffect> { return make_shared_psram<effectType>(__VA_ARGS__); }, \
-        [](const JsonObjectConst& jsonObject)->std::shared_ptr<LEDStripEffect> { return make_shared_psram<effectType>(jsonObject); }\
-    )
+// All parameters beyond effectNumber and effect type are forwarded to the default constructor.
+template<typename TEffect, typename... Args>
+inline EffectFactories::NumberedFactory& AddEffect(EffectFactories& factories, int effectNumber, Args&&... args)
+{
+    return factories.AddEffect(
+        effectNumber,
+        [=]() -> std::shared_ptr<LEDStripEffect> { return make_shared_psram<TEffect>(args...); },
+        [](const JsonObjectConst& jsonObject) -> std::shared_ptr<LEDStripEffect> { return make_shared_psram<TEffect>(jsonObject); }
+    );
+}
 
-// Adds a default and JSON effect factory for a specific effect number/type.
-//   All parameters beyond effectNumber and effectType will be passed on to the default effect constructor.
-//   The default effect will be disabled upon creation, so will not show until enabled.
-#define ADD_EFFECT_DISABLED(effectNumber, effectType, ...) \
-    ADD_EFFECT(effectNumber, effectType, __VA_ARGS__).LoadDisabled = true
+// Adds a default and JSON effect factory, but the default effect will be disabled upon creation.
+template<typename TEffect, typename... Args>
+inline EffectFactories::NumberedFactory& AddEffectDisabled(EffectFactories& factories, int effectNumber, Args&&... args)
+{
+    auto& nf = AddEffect<TEffect>(factories, effectNumber, std::forward<Args>(args)...);
+    nf.LoadDisabled = true;
+    return nf;
+}
 
-// Used by ADD_STARRY_NIGHT_EFFECT
+// Used by Starry Night helper
 std::shared_ptr<LEDStripEffect> CreateStarryNightEffectFromJSON(const JsonObjectConst& jsonObject);
 
 // Adds a default and JSON effect factory for a StarryNightEffect with a specific star type.
-//   All parameters beyond starType will be passed on to the default StarryNightEffect constructor for the indicated star type.
-#define ADD_STARRY_NIGHT_EFFECT(starType, ...) \
-    g_ptrEffectFactories->AddEffect(EFFECT_STRIP_STARRY_NIGHT, \
-        []()                                 ->std::shared_ptr<LEDStripEffect> { return make_shared_psram<StarryNightEffect<starType>>(__VA_ARGS__); }, \
-        [](const JsonObjectConst& jsonObject)->std::shared_ptr<LEDStripEffect> { return CreateStarryNightEffectFromJSON(jsonObject); }\
-    )
+template<typename TStar, typename... Args>
+inline EffectFactories::NumberedFactory& AddStarryNightEffect(EffectFactories& factories, Args&&... args)
+{
+    return factories.AddEffect(
+    idStripStarryNight,
+        [=]() -> std::shared_ptr<LEDStripEffect> { return make_shared_psram<StarryNightEffect<TStar>>(args...); },
+        [](const JsonObjectConst& jsonObject) -> std::shared_ptr<LEDStripEffect> { return CreateStarryNightEffectFromJSON(jsonObject); }
+    );
+}
 
-// Adds a default and JSON effect factory for a StarryNightEffect with a specific star type.
-//   All parameters beyond starType will be passed on to the default StarryNightEffect constructor for the indicated star type.
-//   The default effect will be disabled upon creation, so will not show until enabled.
-#define ADD_STARRY_NIGHT_EFFECT_DISABLED(starType, ...) \
-    ADD_STARRY_NIGHT_EFFECT(starType, __VA_ARGS__).LoadDisabled = true
+// Disabled-on-load variant for Starry Night
+template<typename TStar, typename... Args>
+inline EffectFactories::NumberedFactory& AddStarryNightEffectDisabled(EffectFactories& factories, Args&&... args)
+{
+    auto& nf = AddStarryNightEffect<TStar>(factories, std::forward<Args>(args)...);
+    nf.LoadDisabled = true;
+    return nf;
+}
+
+// Fold-expression helper to register many at once with brief syntax:
+//   RegisterAll(*g_ptrEffectFactories,
+//       Effect<idStripPalette, MyEffect>(args...),
+//       Starry<MyStar>(args...),
+//       Disabled(Effect<idStripColorFill, OtherEffect>(args...)));
+template<typename... Adders>
+inline void RegisterAll(EffectFactories& factories, Adders&&... adders)
+{
+    (static_cast<void>(adders(factories)), ...);
+}
+
+// Builder for a single effect entry used with RegisterAll
+template<int EffectNumber, typename TEffect, typename... Args>
+inline auto Effect(Args&&... args)
+{
+    return [=](EffectFactories& factories) -> EffectFactories::NumberedFactory&
+    {
+        return AddEffect<TEffect>(factories, EffectNumber, args...);
+    };
+}
+
+// Builder for a Starry Night entry used with RegisterAll
+template<typename TStar, typename... Args>
+inline auto Starry(Args&&... args)
+{
+    return [=](EffectFactories& factories) -> EffectFactories::NumberedFactory&
+    {
+        return AddStarryNightEffect<TStar>(factories, args...);
+    };
+}
+
+// Decorator to mark an entry disabled-on-load when using RegisterAll
+template<typename F>
+inline auto Disabled(F adder)
+{
+    return [=](EffectFactories& factories) -> EffectFactories::NumberedFactory&
+    {
+        auto& nf = adder(factories);
+        nf.LoadDisabled = true;
+        return nf;
+    };
+}
 
 // Defines used by some StarryNightEffect instances
 

--- a/include/globals.h
+++ b/include/globals.h
@@ -896,16 +896,14 @@ constexpr std::array<T, N> to_array(const T (&arr)[N]) {
 
 // Provide a single-parameter std::accumulate overload for ranges/containers
 // This allows: auto total = std::accumulate(container);
-namespace std {
-    template <typename Range>
-    inline auto accumulate(const Range& r)
-        -> std::remove_cv_t<std::remove_reference_t<decltype(*std::begin(r))>>
-    {
-        using T = std::remove_cv_t<std::remove_reference_t<decltype(*std::begin(r))>>;
-        T total{};
-        for (const auto& v : r) total += v;
-        return total;
-    }
+template <typename Range>
+inline auto accumulate(const Range& r)
+    -> std::remove_cv_t<std::remove_reference_t<decltype(*std::begin(r))>>
+{
+    using T = std::remove_cv_t<std::remove_reference_t<decltype(*std::begin(r))>>;
+    T total{};
+    for (const auto& v : r) total += v;
+    return total;
 }
 
 // 16-bit (5:6:5) color definitions for common colors

--- a/include/soundanalyzer.h
+++ b/include/soundanalyzer.h
@@ -933,7 +933,7 @@ class SoundAnalyzer : public ISoundAnalyzer
         _msLastRemoteAudio = millis();
         _Peaks = peaks;
         _vPeaks = _Peaks;
-        float sum = std::accumulate(_vPeaks);
+        float sum = accumulate(_vPeaks);
         UpdateVU(sum / NUM_BANDS);
     }
 
@@ -993,7 +993,7 @@ class SoundAnalyzer : public ISoundAnalyzer
         else
         {
             // Using remote data - just update VU from existing peaks
-            float sum = std::accumulate(_Peaks);
+            float sum = accumulate(_Peaks);
             UpdateVU(sum / NUM_BANDS);
         }
     }

--- a/include/soundanalyzer.h
+++ b/include/soundanalyzer.h
@@ -813,7 +813,7 @@ class SoundAnalyzer : public ISoundAnalyzer
         M5.Mic.config(cfg);
         M5.Mic.begin();
 
-#elif ELECROW || USE_I2S_AUDIO
+#elif USE_I2S_AUDIO
 
         const i2s_config_t i2s_config = {.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_RX),
                                          .sample_rate = SAMPLING_FREQUENCY,
@@ -935,22 +935,6 @@ class SoundAnalyzer : public ISoundAnalyzer
         _vPeaks = _Peaks;
         float sum = accumulate(_vPeaks);
         UpdateVU(sum / NUM_BANDS);
-    }
-
-    // Expose computed band start indices (inclusive) for diagnostics.
-    // Length is NUM_BANDS; pairs with BandBinEnds().
-
-    inline const int *BandBinStarts() const
-    {
-        return _bandBinStart.data();
-    }
-
-    // Expose computed band end indices (exclusive) for diagnostics.
-    // Length is NUM_BANDS; pairs with BandBinStarts().
-
-    inline const int * BandBinEnds() const
-    {
-        return _bandBinEnd.data();
     }
 
 #if ENABLE_AUDIO_DEBUG

--- a/platformio.ini
+++ b/platformio.ini
@@ -40,6 +40,7 @@ build_flags     = -std=gnu++2a
                   -Ofast
                   -ffunction-sections
                   -fdata-sections
+                  -include string.h
 
 build_src_flags = -Wformat=2                        ; Warnings for our code only, excluding libraries
                   -Wformat-truncation
@@ -353,7 +354,7 @@ build_flags     = -DPROJECT_NAME="\"Mesmerizer\""
                   -DMESMERIZER=1
                   -DUSE_HUB75=1
                   -DSHOW_VU_METER=1
-                  -DEFFECTS_FULL=1
+                  -DEFFECTS_FULLMATRIX=1
                   -DCOLOR_ORDER=EOrder::RGB
                   -DENABLE_WIFI=1
                   -DINCOMING_WIFI_ENABLED=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -1015,24 +1015,6 @@ build_flags     = -DHEXAGON=1
                   -DHEX_HALF_DIMENSION=10
                   ${dev_esp32.build_flags}
 
-[env:belt]
-extends         = dev_esp32
-build_flags     = -DBELT=1
-                  -DEFFECTS_MINIMAL=1
-                  -DPROJECT_NAME="\"Belt\""
-                  -DENABLE_WIFI=0
-                  -DINCOMING_WIFI_ENABLED=0
-                  -DWAIT_FOR_WIFI=0
-                  -DTIME_BEFORE_LOCAL=1
-                  -DNUM_CHANNELS=1
-                  -DMATRIX_WIDTH=1*144
-                  -DMATRIX_HEIGHT=1
-                  -DENABLE_REMOTE=0
-                  -DENABLE_AUDIO=0
-                  -DLED_PIN0=17
-                  -DDEFAULT_EFFECT_INTERVAL=1000*60*60*24
-                  ${dev_esp32.build_flags}
-
 [env:generic]
 extends         = dev_esp32
 build_flags     = -DGENERIC=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -760,6 +760,7 @@ build_flags     = -DSPECTRUM=1
                   -DSHOW_VU_METER=1
                   -DENABLE_AUDIO=1
                   -DELECROW=1
+                  -DUSE_I2S_AUDIO=1
                   -DUSE_SCREEN=1
                   -DTFT_WIDTH=320
                   -DTFT_HEIGHT=480

--- a/src/deviceconfig.cpp
+++ b/src/deviceconfig.cpp
@@ -89,7 +89,7 @@ bool DeviceConfig::SetTimeZone(const String& newTimeZone, bool skipWrite)
 
         size_t length = end - start;
 
-        std::unique_ptr<char[]> value = make_unique_psram_array<char>(length + 1);
+        std::unique_ptr<char[]> value = make_unique_psram<char[]>(length + 1);
         strncpy(value.get(), start, length);
         value[length] = 0;
 

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -214,7 +214,7 @@ std::shared_ptr<LEDStripEffect> EffectManager::CopyEffect(size_t index)
     auto& sourceEffect = _vEffects[index];
 
     auto jsonEffectFactories = g_ptrEffectFactories->GetJSONFactories();
-    auto factoryEntry = jsonEffectFactories.find(sourceEffect->EffectNumber());
+    auto factoryEntry = jsonEffectFactories.find(static_cast<int>(sourceEffect->effectId()));
 
     if (factoryEntry == jsonEffectFactories.end())
         return nullptr;

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -37,7 +37,7 @@
 #include "effects/strip/doublepaletteeffect.h"  // double palette effect
 #include "effects/strip/meteoreffect.h"         // meteor blend effect
 #include "effects/strip/stareffect.h"           // star effects
-#include "effects/strip/bouncingballeffect.h"   // bouncing ball effectsenable+
+#include "effects/strip/bouncingballeffect.h"   // bouncing ball effects
 #include "effects/strip/tempeffect.h"
 #include "effects/strip/stareffect.h"
 #include "effects/strip/laserline.h"
@@ -206,7 +206,7 @@ void LoadEffectFactories()
             Effect<FireEffect>("Medium Fire", NUM_LEDS, 1, 3, 100, 3, 4, true, true),
             Effect<BouncingBallEffect>(3, true, true, 1),
             Effect<MeteorEffect>(4, 4, 10, 2.0, 2.0),
-            Starry<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
+            Starry<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, kStarryNightProbability, 1, LINEARBLEND, 2.0, 0.0, kStarryNightMusicFactor),
             Effect<PaletteEffect>(RainbowColors_p)
         );
     #endif
@@ -227,27 +227,19 @@ void LoadEffectFactories()
             Effect<BouncingBallEffect>(8, true, true, 1),
             Effect<MeteorEffect>(4, 4, 10, 2.0, 2.0),
             Effect<MeteorEffect>(2, 4, 10, 2.0, 2.0),
-            Starry<QuietStar>("Red Twinkle Stars",    RedColors_p,   1.0, 1, LINEARBLEND, 2.0),
-            Starry<QuietStar>("Green Twinkle Stars",  GreenColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
-            Starry<Star>("Blue Sparkle Stars",        BlueColors_p,  STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
-            Starry<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR)
-        );
-
-        #if ENABLE_AUDIO
-        RegisterAll(*g_ptrEffectFactories,
-            Starry<MusicStar>("RGB Music Blend Stars", RGBColors_p, 0.2, 1, NOBLEND, 5.0, 0.1, 2.0)
-        );
-        #endif
-
-        RegisterAll(*g_ptrEffectFactories,
+            Starry<QuietStar>("Red Twinkle Stars", RedColors_p,   1.0, 1, LINEARBLEND, 2.0),
+            Starry<QuietStar>("Green Twinkle Stars", GreenColors_p, kStarryNightProbability, 1, LINEARBLEND, 2.0, 0.0, kStarryNightMusicFactor),
+            Starry<Star>("Blue Sparkle Stars", BlueColors_p,  kStarryNightProbability, 1, LINEARBLEND, 2.0, 0.0, kStarryNightMusicFactor),
+            Starry<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, kStarryNightProbability, 1, LINEARBLEND, 2.0, 0.0, kStarryNightMusicFactor),
             Effect<TwinkleEffect>(NUM_LEDS / 2, 20, 50),
             Effect<PaletteEffect>(RainbowColors_p, .25, 1, 0, 1.0, 0.0, LINEARBLEND, true, 1.0),
             Effect<PaletteEffect>(RainbowColors_p)
         );
-        
+
         #if ENABLE_AUDIO
         RegisterAll(*g_ptrEffectFactories,
-            Starry<MusicStar>("Rainbow Twinkle Stars", RainbowColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 0.0, 0.0, STARRYNIGHT_MUSICFACTOR)
+            Starry<MusicStar>("RGB Music Blend Stars", RGBColors_p, 0.2, 1, NOBLEND, 5.0, 0.1, 2.0),
+            Starry<MusicStar>("Rainbow Twinkle Stars", RainbowColors_p, kStarryNightProbability, 1, LINEARBLEND, 0.0, 0.0, kStarryNightMusicFactor)
         );
         #endif
     #endif
@@ -411,14 +403,14 @@ void LoadEffectFactories()
             Effect<MeteorEffect>(10, 1, 20, 1.5, 1.5),
             Effect<MeteorEffect>(25, 1, 40, 1.0, 1.0),
             Effect<MeteorEffect>(50, 1, 50, 0.5, 0.5),
-            Starry<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
+            Starry<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, kStarryNightProbability, 1, LINEARBLEND, 2.0, 0.0, kStarryNightMusicFactor),
             Starry<MusicStar>("RGB Music Blend Stars", RGBColors_p, 0.8, 1, NOBLEND, 15.0, 0.1, 10.0),
             Starry<MusicStar>("Rainbow Music Stars", RainbowColors_p, 2.0, 2, LINEARBLEND, 5.0, 0.0, 10.0),
-            Starry<BubblyStar>("Little Blooming Rainbow Stars", BlueColors_p, STARRYNIGHT_PROBABILITY, 4, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
-            Starry<QuietStar>("Green Twinkle Stars", GreenColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
-            Starry<Star>("Blue Sparkle Stars", BlueColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
+            Starry<BubblyStar>("Little Blooming Rainbow Stars", BlueColors_p, kStarryNightProbability, 4, LINEARBLEND, 2.0, 0.0, kStarryNightMusicFactor),
+            Starry<QuietStar>("Green Twinkle Stars", GreenColors_p, kStarryNightProbability, 1, LINEARBLEND, 2.0, 0.0, kStarryNightMusicFactor),
+            Starry<Star>("Blue Sparkle Stars", BlueColors_p, kStarryNightProbability, 1, LINEARBLEND, 2.0, 0.0, kStarryNightMusicFactor),
             Starry<QuietStar>("Red Twinkle Stars", RedColors_p, 1.0, 1, LINEARBLEND, 2.0),
-            Starry<Star>("Lava Stars", LavaColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
+            Starry<Star>("Lava Stars", LavaColors_p, kStarryNightProbability, 1, LINEARBLEND, 2.0, 0.0, kStarryNightMusicFactor),
             Effect<PaletteEffect>(RainbowColors_p),
             Effect<PaletteEffect>(RainbowColors_p, 1.0, 1.0),
             Effect<PaletteEffect>(RainbowColors_p, .25)
@@ -568,14 +560,14 @@ void LoadEffectFactories()
             Effect<RainbowFillEffect>(120, 0),
             Effect<PaletteEffect>(RainbowColors_p, 4, 0.1, 0.0, 1.0, 0.0),
             Effect<BouncingBallEffect>(3, true, true, 8),
-            Starry<MusicStar>("Rainbow Twinkle Stars", RainbowColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 0.0, 0.0, STARRYNIGHT_MUSICFACTOR),
-            Starry<Star>("Rainbow Twinkle Stars", RainbowColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
-            Starry<Star>("Red Sparkle Stars",     RedColors_p,   STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
-            Starry<MusicStar>("Red Stars",        RedColors_p,   STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
-            Starry<Star>("Blue Sparkle Stars",    BlueColors_p,  STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
-            Starry<MusicStar>("Blue Stars",       BlueColors_p,  STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
-            Starry<Star>("Green Sparkle Stars",   GreenColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
-            Starry<MusicStar>("Green Stars",      GreenColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
+            Starry<MusicStar>("Rainbow Twinkle Stars", RainbowColors_p, kStarryNightProbability, 1, LINEARBLEND, 0.0, 0.0, kStarryNightMusicFactor),
+            Starry<Star>("Rainbow Twinkle Stars", RainbowColors_p, kStarryNightProbability, 1, LINEARBLEND, 2.0, 0.0, kStarryNightMusicFactor),
+            Starry<Star>("Red Sparkle Stars", RedColors_p,   kStarryNightProbability, 1, LINEARBLEND, 2.0, 0.0, kStarryNightMusicFactor),
+            Starry<MusicStar>("Red Stars", RedColors_p,   kStarryNightProbability, 1, LINEARBLEND, 2.0, 0.0, kStarryNightMusicFactor),
+            Starry<Star>("Blue Sparkle Stars", BlueColors_p,  kStarryNightProbability, 1, LINEARBLEND, 2.0, 0.0, kStarryNightMusicFactor),
+            Starry<MusicStar>("Blue Stars", BlueColors_p,  kStarryNightProbability, 1, LINEARBLEND, 2.0, 0.0, kStarryNightMusicFactor),
+            Starry<Star>("Green Sparkle Stars", GreenColors_p, kStarryNightProbability, 1, LINEARBLEND, 2.0, 0.0, kStarryNightMusicFactor),
+            Starry<MusicStar>("Green Stars", GreenColors_p, kStarryNightProbability, 1, LINEARBLEND, 2.0, 0.0, kStarryNightMusicFactor),
             Effect<TwinkleEffect>(NUM_LEDS / 2, 20, 50),
             Effect<PaletteEffect>(RainbowColors_p, .25, 1, 0, 1.0, 0.0, LINEARBLEND, true, 1.0),
             Effect<PaletteEffect>(RainbowColors_p)

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -497,13 +497,6 @@ void LoadEffectFactories()
         );
     #endif
 
-    #if defined(EFFECTS_BELT)
-        // LED belt effect set
-        RegisterAll(*g_ptrEffectFactories,
-            Effect<TwinkleEffect>(NUM_LEDS / 4, 10)
-        );
-    #endif
-
     #if defined(EFFECTS_MAGICMIRROR)
         // Magic mirror effect set
         RegisterAll(*g_ptrEffectFactories,

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -195,38 +195,38 @@ void LoadEffectFactories()
     #if defined(EFFECTS_MINIMAL)
         // Minimal effect set for projects with limited memory/space
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idStripStatus,      StatusEffect>(CRGB::White),
-            Effect<idStripRainbowFill, RainbowFillEffect>(6, 2)
+            Effect<StatusEffect>(CRGB::White),
+            Effect<RainbowFillEffect>(6, 2)
         );
     #endif
     
     #if defined(EFFECTS_SIMPLE)
         // Simple effect set for basic LED strip projects
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idStripFire,           FireEffect>("Medium Fire", NUM_LEDS, 1, 3, 100, 3, 4, true, true),
-            Effect<idStripBouncingBall,  BouncingBallEffect>(3, true, true, 1),
-            Effect<idStripMeteor,         MeteorEffect>(4, 4, 10, 2.0, 2.0),
+            Effect<FireEffect>("Medium Fire", NUM_LEDS, 1, 3, 100, 3, 4, true, true),
+            Effect<BouncingBallEffect>(3, true, true, 1),
+            Effect<MeteorEffect>(4, 4, 10, 2.0, 2.0),
             Starry<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
-            Effect<idStripPalette,        PaletteEffect>(RainbowColors_p)
+            Effect<PaletteEffect>(RainbowColors_p)
         );
     #endif
 
     #if defined(EFFECTS_PDPWOPR)
         // PDPWOPR project effects
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idMatrixPDPCMX, PDPCMXEffect>(),
-            Effect<idMatrixPDPGrid, PDPGridEffect>()
+            Effect<PDPCMXEffect>(),
+            Effect<PDPGridEffect>()
         );
     #endif
 
     #if defined(EFFECTS_DEMO)
         // Demo effect set for M5 demos and similar
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idStripFire,           FireEffect>("Medium Fire", NUM_LEDS, 1, 3, 100, 3, 4, true, true),
-            Effect<idStripBouncingBall,  BouncingBallEffect>(3, true, true, 1),
-            Effect<idStripBouncingBall,  BouncingBallEffect>(8, true, true, 1),
-            Effect<idStripMeteor,         MeteorEffect>(4, 4, 10, 2.0, 2.0),
-            Effect<idStripMeteor,         MeteorEffect>(2, 4, 10, 2.0, 2.0),
+            Effect<FireEffect>("Medium Fire", NUM_LEDS, 1, 3, 100, 3, 4, true, true),
+            Effect<BouncingBallEffect>(3, true, true, 1),
+            Effect<BouncingBallEffect>(8, true, true, 1),
+            Effect<MeteorEffect>(4, 4, 10, 2.0, 2.0),
+            Effect<MeteorEffect>(2, 4, 10, 2.0, 2.0),
             Starry<QuietStar>("Red Twinkle Stars",    RedColors_p,   1.0, 1, LINEARBLEND, 2.0),
             Starry<QuietStar>("Green Twinkle Stars",  GreenColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
             Starry<Star>("Blue Sparkle Stars",        BlueColors_p,  STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
@@ -240,9 +240,9 @@ void LoadEffectFactories()
         #endif
 
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idStripTwinkle,  TwinkleEffect>(NUM_LEDS / 2, 20, 50),
-            Effect<idStripPalette,  PaletteEffect>(RainbowColors_p, .25, 1, 0, 1.0, 0.0, LINEARBLEND, true, 1.0),
-            Effect<idStripPalette,  PaletteEffect>(RainbowColors_p)
+            Effect<TwinkleEffect>(NUM_LEDS / 2, 20, 50),
+            Effect<PaletteEffect>(RainbowColors_p, .25, 1, 0, 1.0, 0.0, LINEARBLEND, true, 1.0),
+            Effect<PaletteEffect>(RainbowColors_p)
         );
         
         #if ENABLE_AUDIO
@@ -255,162 +255,162 @@ void LoadEffectFactories()
     #if defined(EFFECTS_FAN)
         // Fan-specific effects for fan projects
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idStripRainbowFill,  RainbowFillEffect>(24, 0),
-            Effect<idStripColorCycle,   ColorCycleEffect>(BottomUp),
-            Effect<idStripColorCycle,   ColorCycleEffect>(TopDown),
-            Effect<idStripColorCycle,   ColorCycleEffect>(LeftRight),
-            Effect<idStripColorCycle,   ColorCycleEffect>(RightLeft),
-            Effect<idStripPaletteReel,  PaletteReelEffect>("PaletteReelEffect"),
-            Effect<idStripMeteor,        MeteorEffect>(),
-            Effect<idStripTapeReel,     TapeReelEffect>("TapeReelEffect"),
+            Effect<RainbowFillEffect>(24, 0),
+            Effect<ColorCycleEffect>(BottomUp),
+            Effect<ColorCycleEffect>(TopDown),
+            Effect<ColorCycleEffect>(LeftRight),
+            Effect<ColorCycleEffect>(RightLeft),
+            Effect<PaletteReelEffect>("PaletteReelEffect"),
+            Effect<MeteorEffect>(),
+            Effect<TapeReelEffect>("TapeReelEffect"),
             Starry<MusicStar>("RGB Music Blend Stars", RGBColors_p, 0.8, 1, NOBLEND, 15.0, 0.1, 10.0),
             Starry<MusicStar>("Rainbow Music Stars", RainbowColors_p, 2.0, 2, LINEARBLEND, 5.0, 0.0, 10.0),
-            Effect<idStripFanBeat,      FanBeatEffect>("FanBeat"),
+            Effect<FanBeatEffect>("FanBeat"),
             Starry<BubblyStar>("Little Blooming Rainbow Stars", BlueColors_p, 8.0, 4, LINEARBLEND, 2.0, 0.0, 1.0),
             Starry<BubblyStar>("Big Blooming Rainbow Stars", RainbowColors_p, 2, 12, LINEARBLEND, 1.0),
             Starry<BubblyStar>("Neon Bars", RainbowColors_p, 0.5, 64, NOBLEND, 0),
-            Effect<idStripFireFan,      FireFanEffect>(GreenHeatColors_p, NUM_LEDS, 3, 7, 400, 2, NUM_LEDS / 2, Sequential, false, true),
-            Effect<idStripFireFan,      FireFanEffect>(GreenHeatColors_p, NUM_LEDS, 3, 8, 600, 2, NUM_LEDS / 2, Sequential, false, true),
-            Effect<idStripFireFan,      FireFanEffect>(GreenHeatColors_p, NUM_LEDS, 2, 10, 800, 2, NUM_LEDS / 2, Sequential, false, true),
-            Effect<idStripFireFan,      FireFanEffect>(GreenHeatColors_p, NUM_LEDS, 1, 12, 1000, 2, NUM_LEDS / 2, Sequential, false, true),
-            Effect<idStripFireFan,      FireFanEffect>(BlueHeatColors_p,  NUM_LEDS, 3, 7, 400, 2, NUM_LEDS / 2, Sequential, false, true),
-            Effect<idStripFireFan,      FireFanEffect>(BlueHeatColors_p,  NUM_LEDS, 3, 8, 600, 2, NUM_LEDS / 2, Sequential, false, true),
-            Effect<idStripFireFan,      FireFanEffect>(BlueHeatColors_p,  NUM_LEDS, 2, 10, 800, 2, NUM_LEDS / 2, Sequential, false, true),
-            Effect<idStripFireFan,      FireFanEffect>(BlueHeatColors_p,  NUM_LEDS, 1, 12, 1000, 2, NUM_LEDS / 2, Sequential, false, true),
-            Effect<idStripFireFan,      FireFanEffect>(HeatColors_p,      NUM_LEDS, 3, 7, 400, 2, NUM_LEDS / 2, Sequential, false, true),
-            Effect<idStripFireFan,      FireFanEffect>(HeatColors_p,      NUM_LEDS, 3, 8, 600, 2, NUM_LEDS / 2, Sequential, false, true),
-            Effect<idStripFireFan,      FireFanEffect>(HeatColors_p,      NUM_LEDS, 2, 10, 800, 2, NUM_LEDS / 2, Sequential, false, true),
-            Effect<idStripFireFan,      FireFanEffect>(HeatColors_p,      NUM_LEDS, 1, 12, 1000, 2, NUM_LEDS / 2, Sequential, false, true)
+            Effect<FireFanEffect>(GreenHeatColors_p, NUM_LEDS, 3, 7, 400, 2, NUM_LEDS / 2, Sequential, false, true),
+            Effect<FireFanEffect>(GreenHeatColors_p, NUM_LEDS, 3, 8, 600, 2, NUM_LEDS / 2, Sequential, false, true),
+            Effect<FireFanEffect>(GreenHeatColors_p, NUM_LEDS, 2, 10, 800, 2, NUM_LEDS / 2, Sequential, false, true),
+            Effect<FireFanEffect>(GreenHeatColors_p, NUM_LEDS, 1, 12, 1000, 2, NUM_LEDS / 2, Sequential, false, true),
+            Effect<FireFanEffect>(BlueHeatColors_p,  NUM_LEDS, 3, 7, 400, 2, NUM_LEDS / 2, Sequential, false, true),
+            Effect<FireFanEffect>(BlueHeatColors_p,  NUM_LEDS, 3, 8, 600, 2, NUM_LEDS / 2, Sequential, false, true),
+            Effect<FireFanEffect>(BlueHeatColors_p,  NUM_LEDS, 2, 10, 800, 2, NUM_LEDS / 2, Sequential, false, true),
+            Effect<FireFanEffect>(BlueHeatColors_p,  NUM_LEDS, 1, 12, 1000, 2, NUM_LEDS / 2, Sequential, false, true),
+            Effect<FireFanEffect>(HeatColors_p,      NUM_LEDS, 3, 7, 400, 2, NUM_LEDS / 2, Sequential, false, true),
+            Effect<FireFanEffect>(HeatColors_p,      NUM_LEDS, 3, 8, 600, 2, NUM_LEDS / 2, Sequential, false, true),
+            Effect<FireFanEffect>(HeatColors_p,      NUM_LEDS, 2, 10, 800, 2, NUM_LEDS / 2, Sequential, false, true),
+            Effect<FireFanEffect>(HeatColors_p,      NUM_LEDS, 1, 12, 1000, 2, NUM_LEDS / 2, Sequential, false, true)
         );
     #endif
 
     #if defined(EFFECTS_LASERLINE)
         // Laser line effect set
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idStripLaserLine, LaserLineEffect>(500, 20)
+            Effect<LaserLineEffect>(500, 20)
         );
     #endif
 
     #if defined(EFFECTS_CHIEFTAIN)
         // Chieftain lantern effect set
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idStripLantern,      LanternEffect>(),
-            Effect<idStripPalette,      PaletteEffect>(RainbowColors_p, 2.0f, 0.1, 0.0, 1.0, 0.0, LINEARBLEND, true, 1.0),
-            Effect<idStripRainbowFill,  RainbowFillEffect>(10, 32)
+            Effect<LanternEffect>(),
+            Effect<PaletteEffect>(RainbowColors_p, 2.0f, 0.1, 0.0, 1.0, 0.0, LINEARBLEND, true, 1.0),
+            Effect<RainbowFillEffect>(10, 32)
         );
     #endif
 
     #if defined(EFFECTS_PDPGRID)
         // PDP grid matrix effect set
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idMatrixPDPCMX,  PDPCMXEffect>(),
-            Effect<idMatrixPDPGrid, PDPGridEffect>()
+            Effect<PDPCMXEffect>(),
+            Effect<PDPGridEffect>()
         );
     #endif
 
     #if defined(EFFECTS_LANTERN)
         // Lantern effect set
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idStripFire, FireEffect>("Calm Fire", NUM_LEDS, 40, 5, 50, 3, 3, true, true)
+            Effect<FireEffect>("Calm Fire", NUM_LEDS, 40, 5, 50, 3, 3, true, true)
         );
     #endif
 
     #if defined(EFFECTS_FULLMATRIX)
         // Full matrix effect set for advanced displays (Mesmerizer, etc.)
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idMatrixSpectrumBar,       SpectrumBarEffect>("Audiograph", 16, 4, 0),
-            Effect<idMatrixSpectrumAnalyzer, SpectrumAnalyzerEffect>("Spectrum", NUM_BANDS, spectrumAltColors, false, 0, 0, 1.6, 1.6),
-            Effect<idMatrixSpectrumAnalyzer, SpectrumAnalyzerEffect>("AudioWave", MATRIX_WIDTH, CRGB(0,0,40), 0, 1.25, 1.25, true),
-            Effect<idMatrixSMRadialWave,     PatternSMRadialWave>(),
-            Effect<idMatrixAnimatedGIF,       PatternAnimatedGIF>("Fire Log", GIFIdentifier::Firelog),
-            Effect<idMatrixAnimatedGIF,       PatternAnimatedGIF>("Pacman", GIFIdentifier::Pacman),
-            Effect<idMatrixPongClock,        PatternPongClock>(),
-            Effect<idMatrixAnimatedGIF,       PatternAnimatedGIF>("Colorball", GIFIdentifier::ColorSphere),
-            Effect<idMatrixSMFire2021,        PatternSMFire2021>(),
-            Effect<idMatrixGhostWave,        GhostWave>("GhostWave", 0, 30, false, 10),
-            Effect<idMatrixSMGamma,           PatternSMGamma>(),
-            Effect<idMatrixAnimatedGIF,       PatternAnimatedGIF>("Rings", GIFIdentifier::ThreeRings),
-            Effect<idMatrixAnimatedGIF,       PatternAnimatedGIF>("Atomic", GIFIdentifier::Atomic),
-            Effect<idMatrixAnimatedGIF,       PatternAnimatedGIF>("Bananaman", GIFIdentifier::Banana, true, CRGB::DarkBlue),
-            Effect<idMatrixSMMetaBalls,      PatternSMMetaBalls>(),
-            Effect<idMatrixSMSupernova,       PatternSMSupernova>(),
-            Effect<idMatrixCube,              PatternCube>(),
-            Effect<idMatrixAnimatedGIF,       PatternAnimatedGIF>("Tesseract", GIFIdentifier::Tesseract),
-            Effect<idMatrixAnimatedGIF,       PatternAnimatedGIF>("Nyancat", GIFIdentifier::Nyancat),
-            Effect<idMatrixLife,              PatternLife>(),
-            Effect<idMatrixCircuit,           PatternCircuit>(),
-            Effect<idMatrixSpectrumAnalyzer, SpectrumAnalyzerEffect>("USA", NUM_BANDS, USAColors_p, true, 0, 0, 0.75, 0.75),
-            Effect<idMatrixSpectrumAnalyzer, SpectrumAnalyzerEffect>("Spectrum 2", 32, spectrumBasicColors, false, 100, 0, 0.75, 0.75),
-            Effect<idMatrixSpectrumAnalyzer, SpectrumAnalyzerEffect>("Spectrum++", NUM_BANDS, spectrumBasicColors, false, 0, 40, -1.0, 2.0),
-            Effect<idMatrixWaveform,          WaveformEffect>("WaveIn", 8),
-            Effect<idMatrixGhostWave,        GhostWave>("WaveOut", 0, 0, true, 0),
+            Effect<SpectrumBarEffect>("Audiograph", 16, 4, 0),
+            Effect<SpectrumAnalyzerEffect>("Spectrum", NUM_BANDS, spectrumAltColors, false, 0, 0, 1.6, 1.6),
+            Effect<SpectrumAnalyzerEffect>("AudioWave", MATRIX_WIDTH, CRGB(0,0,40), 0, 1.25, 1.25, true),
+            Effect<PatternSMRadialWave>(),
+            Effect<PatternAnimatedGIF>("Fire Log", GIFIdentifier::Firelog),
+            Effect<PatternAnimatedGIF>("Pacman", GIFIdentifier::Pacman),
+            Effect<PatternPongClock>(),
+            Effect<PatternAnimatedGIF>("Colorball", GIFIdentifier::ColorSphere),
+            Effect<PatternSMFire2021>(),
+            Effect<GhostWave>("GhostWave", 0, 30, false, 10),
+            Effect<PatternSMGamma>(),
+            Effect<PatternAnimatedGIF>("Rings", GIFIdentifier::ThreeRings),
+            Effect<PatternAnimatedGIF>("Atomic", GIFIdentifier::Atomic),
+            Effect<PatternAnimatedGIF>("Bananaman", GIFIdentifier::Banana, true, CRGB::DarkBlue),
+            Effect<PatternSMMetaBalls>(),
+            Effect<PatternSMSupernova>(),
+            Effect<PatternCube>(),
+            Effect<PatternAnimatedGIF>("Tesseract", GIFIdentifier::Tesseract),
+            Effect<PatternAnimatedGIF>("Nyancat", GIFIdentifier::Nyancat),
+            Effect<PatternLife>(),
+            Effect<PatternCircuit>(),
+            Effect<SpectrumAnalyzerEffect>("USA", NUM_BANDS, USAColors_p, true, 0, 0, 0.75, 0.75),
+            Effect<SpectrumAnalyzerEffect>("Spectrum 2", 32, spectrumBasicColors, false, 100, 0, 0.75, 0.75),
+            Effect<SpectrumAnalyzerEffect>("Spectrum++", NUM_BANDS, spectrumBasicColors, false, 0, 40, -1.0, 2.0),
+            Effect<WaveformEffect>("WaveIn", 8),
+            Effect<GhostWave>("WaveOut", 0, 0, true, 0),
             Starry<MusicStar>("Stars", RainbowColors_p, 1.0, 1, LINEARBLEND, 2.0, 0.5, 10.0)
         );
 
         #if ENABLE_WIFI
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idMatrixStocks,      PatternStocks>(),
-            Effect<idMatrixSubscribers, PatternSubscribers>(),
-            Effect<idMatrixWeather,     PatternWeather>()
+            Effect<PatternStocks>(),
+            Effect<PatternSubscribers>(),
+            Effect<PatternWeather>()
         );
         #endif
 
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idMatrixSMSmoke,            PatternSMSmoke>(),
-            Effect<idMatrixGhostWave,         GhostWave>("PlasmaWave", 0, 255, false),
-            Effect<idMatrixSMNoise,            PatternSMNoise>("Shikon", PatternSMNoise::EffectType::Shikon_t),
-            Effect<idMatrixSMRadialFire,      PatternSMRadialFire>(),
-            Effect<idMatrixSMFlowFields,      PatternSMFlowFields>(),
-            Effect<idMatrixSMBlurringColors,  PatternSMBlurringColors>(),
-            Effect<idMatrixSMWalkingMachine,  PatternSMWalkingMachine>(),
-            Effect<idMatrixSMHypnosis,         PatternSMHypnosis>(),
-            Effect<idMatrixSMStarDeep,         PatternSMStarDeep>(),
-            Effect<idMatrixSM2DDPR,            PatternSM2DDPR>(),
-            Effect<idMatrixSMPicasso3in1,      PatternSMPicasso3in1>("Lines", 38),
-            Effect<idMatrixSMPicasso3in1,      PatternSMPicasso3in1>("Circles", 73),
-            Effect<idMatrixSMAmberRain,        PatternSMAmberRain>(),
-            Effect<idMatrixSMStrobeDiffusion, PatternSMStrobeDiffusion>(),
-            Effect<idMatrixSMRainbowTunnel,   PatternSMRainbowTunnel>(),
-            Effect<idMatrixSMSpiroPulse,      PatternSMSpiroPulse>(),
-            Effect<idMatrixSMTwister,          PatternSMTwister>(),
-            Effect<idMatrixSMHolidayLights,   PatternSMHolidayLights>(),
-            Effect<idMatrixRose,               PatternRose>(),
-            Effect<idMatrixPinwheel,           PatternPinwheel>(),
-            Effect<idMatrixSunburst,           PatternSunburst>(),
-            Effect<idMatrixClock,              PatternClock>(),
-            Effect<idMatrixAlienText,         PatternAlienText>(),
-            Effect<idMatrixPulsar,             PatternPulsar>(),
-            Effect<idMatrixBounce,             PatternBounce>(),
-            Effect<idMatrixWave,               PatternWave>(),
-            Effect<idMatrixSwirl,              PatternSwirl>(),
-            Effect<idMatrixSerendipity,        PatternSerendipity>(),
-            Effect<idMatrixMandala,            PatternMandala>(),
-            Effect<idMatrixMunch,              PatternMunch>(),
-            Effect<idMatrixMaze,               PatternMaze>()
+            Effect<PatternSMSmoke>(),
+            Effect<GhostWave>("PlasmaWave", 0, 255, false),
+            Effect<PatternSMNoise>("Shikon", PatternSMNoise::EffectType::Shikon_t),
+            Effect<PatternSMRadialFire>(),
+            Effect<PatternSMFlowFields>(),
+            Effect<PatternSMBlurringColors>(),
+            Effect<PatternSMWalkingMachine>(),
+            Effect<PatternSMHypnosis>(),
+            Effect<PatternSMStarDeep>(),
+            Effect<PatternSM2DDPR>(),
+            Effect<PatternSMPicasso3in1>("Lines", 38),
+            Effect<PatternSMPicasso3in1>("Circles", 73),
+            Effect<PatternSMAmberRain>(),
+            Effect<PatternSMStrobeDiffusion>(),
+            Effect<PatternSMRainbowTunnel>(),
+            Effect<PatternSMSpiroPulse>(),
+            Effect<PatternSMTwister>(),
+            Effect<PatternSMHolidayLights>(),
+            Effect<PatternRose>(),
+            Effect<PatternPinwheel>(),
+            Effect<PatternSunburst>(),
+            Effect<PatternClock>(),
+            Effect<PatternAlienText>(),
+            Effect<PatternPulsar>(),
+            Effect<PatternBounce>(),
+            Effect<PatternWave>(),
+            Effect<PatternSwirl>(),
+            Effect<PatternSerendipity>(),
+            Effect<PatternMandala>(),
+            Effect<PatternMunch>(),
+            Effect<PatternMaze>()
         );
     #endif
 
     #if defined(EFFECTS_UMBRELLA)
         // Umbrella-specific effects
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idStripFire,                FireEffect>("Calm Fire", NUM_LEDS, 2, 2, 75, 3, 10, true, false),
-            Effect<idStripFire,                FireEffect>("Medium Fire", NUM_LEDS, 1, 5, 100, 3, 4, true, false),
-            Effect<idStripMusicalPaletteFire, MusicalPaletteFire>("Musical Red Fire", HeatColors_p, NUM_LEDS, 1, 8, 50, 1, 24, true, false),
-            Effect<idStripMusicalPaletteFire, MusicalPaletteFire>("Purple Fire", CRGBPalette16(CRGB::Black, CRGB::Purple, CRGB::MediumPurple, CRGB::LightPink), NUM_LEDS, 2, 3, 150, 3, 10, true, false),
-            Effect<idStripMusicalPaletteFire, MusicalPaletteFire>("Purple Fire", CRGBPalette16(CRGB::Black, CRGB::Purple, CRGB::MediumPurple, CRGB::LightPink), NUM_LEDS, 1, 7, 150, 3, 10, true, false),
-            Effect<idStripMusicalPaletteFire, MusicalPaletteFire>("Musical Purple Fire", CRGBPalette16(CRGB::Black, CRGB::Purple, CRGB::MediumPurple, CRGB::LightPink), NUM_LEDS, 1, 8, 50, 1, 24, true, false),
-            Effect<idStripMusicalPaletteFire, MusicalPaletteFire>("Blue Fire", CRGBPalette16(CRGB::Black, CRGB::DarkBlue, CRGB::Blue, CRGB::LightSkyBlue), NUM_LEDS, 2, 3, 150, 3, 10, true, false),
-            Effect<idStripMusicalPaletteFire, MusicalPaletteFire>("Blue Fire", CRGBPalette16(CRGB::Black, CRGB::DarkBlue, CRGB::Blue, CRGB::LightSkyBlue), NUM_LEDS, 1, 7, 150, 3, 10, true, false),
-            Effect<idStripMusicalPaletteFire, MusicalPaletteFire>("Musical Blue Fire", CRGBPalette16(CRGB::Black, CRGB::DarkBlue, CRGB::Blue, CRGB::LightSkyBlue), NUM_LEDS, 1, 8, 50, 1, 24, true, false),
-            Effect<idStripMusicalPaletteFire, MusicalPaletteFire>("Green Fire", CRGBPalette16(CRGB::Black, CRGB::DarkGreen, CRGB::Green, CRGB::LimeGreen), NUM_LEDS, 2, 3, 150, 3, 10, true, false),
-            Effect<idStripMusicalPaletteFire, MusicalPaletteFire>("Green Fire", CRGBPalette16(CRGB::Black, CRGB::DarkGreen, CRGB::Green, CRGB::LimeGreen), NUM_LEDS, 1, 7, 150, 3, 10, true, false),
-            Effect<idStripMusicalPaletteFire, MusicalPaletteFire>("Musical Green Fire", CRGBPalette16(CRGB::Black, CRGB::DarkGreen, CRGB::Green, CRGB::LimeGreen), NUM_LEDS, 1, 8, 50, 1, 24, true, false),
-            Effect<idStripBouncingBall,       BouncingBallEffect>(),
-            Effect<idStripDoublePalette,      DoublePaletteEffect>(),
-            Effect<idStripMeteor,              MeteorEffect>(4, 4, 10, 2.0, 2.0),
-            Effect<idStripMeteor,              MeteorEffect>(10, 1, 20, 1.5, 1.5),
-            Effect<idStripMeteor,              MeteorEffect>(25, 1, 40, 1.0, 1.0),
-            Effect<idStripMeteor,              MeteorEffect>(50, 1, 50, 0.5, 0.5),
+            Effect<FireEffect>("Calm Fire", NUM_LEDS, 2, 2, 75, 3, 10, true, false),
+            Effect<FireEffect>("Medium Fire", NUM_LEDS, 1, 5, 100, 3, 4, true, false),
+            Effect<MusicalPaletteFire>("Musical Red Fire", HeatColors_p, NUM_LEDS, 1, 8, 50, 1, 24, true, false),
+            Effect<MusicalPaletteFire>("Purple Fire", CRGBPalette16(CRGB::Black, CRGB::Purple, CRGB::MediumPurple, CRGB::LightPink), NUM_LEDS, 2, 3, 150, 3, 10, true, false),
+            Effect<MusicalPaletteFire>("Purple Fire", CRGBPalette16(CRGB::Black, CRGB::Purple, CRGB::MediumPurple, CRGB::LightPink), NUM_LEDS, 1, 7, 150, 3, 10, true, false),
+            Effect<MusicalPaletteFire>("Musical Purple Fire", CRGBPalette16(CRGB::Black, CRGB::Purple, CRGB::MediumPurple, CRGB::LightPink), NUM_LEDS, 1, 8, 50, 1, 24, true, false),
+            Effect<MusicalPaletteFire>("Blue Fire", CRGBPalette16(CRGB::Black, CRGB::DarkBlue, CRGB::Blue, CRGB::LightSkyBlue), NUM_LEDS, 2, 3, 150, 3, 10, true, false),
+            Effect<MusicalPaletteFire>("Blue Fire", CRGBPalette16(CRGB::Black, CRGB::DarkBlue, CRGB::Blue, CRGB::LightSkyBlue), NUM_LEDS, 1, 7, 150, 3, 10, true, false),
+            Effect<MusicalPaletteFire>("Musical Blue Fire", CRGBPalette16(CRGB::Black, CRGB::DarkBlue, CRGB::Blue, CRGB::LightSkyBlue), NUM_LEDS, 1, 8, 50, 1, 24, true, false),
+            Effect<MusicalPaletteFire>("Green Fire", CRGBPalette16(CRGB::Black, CRGB::DarkGreen, CRGB::Green, CRGB::LimeGreen), NUM_LEDS, 2, 3, 150, 3, 10, true, false),
+            Effect<MusicalPaletteFire>("Green Fire", CRGBPalette16(CRGB::Black, CRGB::DarkGreen, CRGB::Green, CRGB::LimeGreen), NUM_LEDS, 1, 7, 150, 3, 10, true, false),
+            Effect<MusicalPaletteFire>("Musical Green Fire", CRGBPalette16(CRGB::Black, CRGB::DarkGreen, CRGB::Green, CRGB::LimeGreen), NUM_LEDS, 1, 8, 50, 1, 24, true, false),
+            Effect<BouncingBallEffect>(),
+            Effect<DoublePaletteEffect>(),
+            Effect<MeteorEffect>(4, 4, 10, 2.0, 2.0),
+            Effect<MeteorEffect>(10, 1, 20, 1.5, 1.5),
+            Effect<MeteorEffect>(25, 1, 40, 1.0, 1.0),
+            Effect<MeteorEffect>(50, 1, 50, 0.5, 0.5),
             Starry<QuietStar>("Rainbow Twinkle Stars", RainbowColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
             Starry<MusicStar>("RGB Music Blend Stars", RGBColors_p, 0.8, 1, NOBLEND, 15.0, 0.1, 10.0),
             Starry<MusicStar>("Rainbow Music Stars", RainbowColors_p, 2.0, 2, LINEARBLEND, 5.0, 0.0, 10.0),
@@ -419,88 +419,88 @@ void LoadEffectFactories()
             Starry<Star>("Blue Sparkle Stars", BlueColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
             Starry<QuietStar>("Red Twinkle Stars", RedColors_p, 1.0, 1, LINEARBLEND, 2.0),
             Starry<Star>("Lava Stars", LavaColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
-            Effect<idStripPalette,             PaletteEffect>(RainbowColors_p),
-            Effect<idStripPalette,             PaletteEffect>(RainbowColors_p, 1.0, 1.0),
-            Effect<idStripPalette,             PaletteEffect>(RainbowColors_p, .25)
+            Effect<PaletteEffect>(RainbowColors_p),
+            Effect<PaletteEffect>(RainbowColors_p, 1.0, 1.0),
+            Effect<PaletteEffect>(RainbowColors_p, .25)
         );
     #endif
 
     #if defined(EFFECTS_SPECTRUM)
         // Spectrum analyzer effect set
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idMatrixSpectrumAnalyzer, SpectrumAnalyzerEffect>("Spectrum Standard", NUM_BANDS, spectrumAltColors, false, 0, 0, 0.5, 1.5),
-            Effect<idMatrixSpectrumAnalyzer, SpectrumAnalyzerEffect>("Spectrum Standard", 24, spectrumAltColors, false, 0, 0, 1.25, 1.25),
-            Effect<idMatrixSpectrumAnalyzer, SpectrumAnalyzerEffect>("Spectrum Standard", 24, spectrumAltColors, false, 0, 0, 0.25, 1.25),
-            Effect<idMatrixSpectrumAnalyzer, SpectrumAnalyzerEffect>("Spectrum Standard", 16, spectrumAltColors, false, 0, 0, 1.0, 1.0),
-            Effect<idMatrixSpectrumAnalyzer, SpectrumAnalyzerEffect>("Spectrum Standard", 48, CRGB(0,0,4), 0, 1.25, 1.25),
-            Effect<idMatrixGhostWave,        GhostWave>("GhostWave", 0, 16, false, 15),
-            Effect<idMatrixSpectrumAnalyzer, SpectrumAnalyzerEffect>("Spectrum USA", 16, USAColors_p, true, 0),
-            Effect<idMatrixGhostWave,        GhostWave>("GhostWave Rainbow", 8),
-            Effect<idMatrixSpectrumAnalyzer, SpectrumAnalyzerEffect>("Spectrum Fade", 24, RainbowColors_p, false, 50, 70, -1.0, 2.0),
-            Effect<idMatrixGhostWave,        GhostWave>("GhostWave Blue", 0),
-            Effect<idMatrixSpectrumAnalyzer, SpectrumAnalyzerEffect>("Spectrum Standard", 24, RainbowColors_p, false),
-            Effect<idMatrixGhostWave,        GhostWave>("GhostWave One", 4)
+            Effect<SpectrumAnalyzerEffect>("Spectrum Standard", NUM_BANDS, spectrumAltColors, false, 0, 0, 0.5, 1.5),
+            Effect<SpectrumAnalyzerEffect>("Spectrum Standard", 24, spectrumAltColors, false, 0, 0, 1.25, 1.25),
+            Effect<SpectrumAnalyzerEffect>("Spectrum Standard", 24, spectrumAltColors, false, 0, 0, 0.25, 1.25),
+            Effect<SpectrumAnalyzerEffect>("Spectrum Standard", 16, spectrumAltColors, false, 0, 0, 1.0, 1.0),
+            Effect<SpectrumAnalyzerEffect>("Spectrum Standard", 48, CRGB(0,0,4), 0, 1.25, 1.25),
+            Effect<GhostWave>("GhostWave", 0, 16, false, 15),
+            Effect<SpectrumAnalyzerEffect>("Spectrum USA", 16, USAColors_p, true, 0),
+            Effect<GhostWave>("GhostWave Rainbow", 8),
+            Effect<SpectrumAnalyzerEffect>("Spectrum Fade", 24, RainbowColors_p, false, 50, 70, -1.0, 2.0),
+            Effect<GhostWave>("GhostWave Blue", 0),
+            Effect<SpectrumAnalyzerEffect>("Spectrum Standard", 24, RainbowColors_p, false),
+            Effect<GhostWave>("GhostWave One", 4)
         );
     #endif
 
     #if defined(EFFECTS_HELMET)
         // Helmet display effect set
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idMatrixSilon,              SilonEffect>(),
-            Effect<idMatrixSpectrumAnalyzer,  SpectrumAnalyzerEffect>("Spectrum Standard", NUM_BANDS, spectrumAltColors, false, 0, 0, 0.5, 1.5)
+            Effect<SilonEffect>(),
+            Effect<SpectrumAnalyzerEffect>("Spectrum Standard", NUM_BANDS, spectrumAltColors, false, 0, 0, 0.5, 1.5)
         );
     #endif
 
     #if defined(EFFECTS_TTGO)
         // TTGO display effect set
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idMatrixSpectrumAnalyzer, SpectrumAnalyzerEffect>("Spectrum Fade", 12, spectrumBasicColors, false, 50, 70, -1.0, 3.0)
+            Effect<SpectrumAnalyzerEffect>("Spectrum Fade", 12, spectrumBasicColors, false, 50, 70, -1.0, 3.0)
         );
     #endif
 
     #if defined(EFFECTS_WROVERKIT)
         // Wrover Kit effect set
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idStripPalette, PaletteEffect>(rainbowPalette, 256 / 16, .2, 0)
+            Effect<PaletteEffect>(rainbowPalette, 256 / 16, .2, 0)
         );
     #endif
 
     #if defined(EFFECTS_XMASTREES)
         // Christmas trees effect set
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idStripColorBeatOverRed, ColorBeatOverRed>("ColorBeatOverRed"),
-            Effect<idStripColorCycle,         ColorCycleEffect>(BottomUp, 6),
-            Effect<idStripColorCycle,         ColorCycleEffect>(BottomUp, 2),
-            Effect<idStripRainbowFill,        RainbowFillEffect>(48, 0),
-            Effect<idStripColorCycle,         ColorCycleEffect>(BottomUp, 3),
-            Effect<idStripColorCycle,         ColorCycleEffect>(BottomUp, 1),
+            Effect<ColorBeatOverRed>("ColorBeatOverRed"),
+            Effect<ColorCycleEffect>(BottomUp, 6),
+            Effect<ColorCycleEffect>(BottomUp, 2),
+            Effect<RainbowFillEffect>(48, 0),
+            Effect<ColorCycleEffect>(BottomUp, 3),
+            Effect<ColorCycleEffect>(BottomUp, 1),
             Starry<LongLifeSparkleStar>("Green Sparkle Stars", GreenColors_p, 2.0, 1, LINEARBLEND, 2.0, 0.0, 0.0, CRGB(0, 128, 0)),
             Starry<LongLifeSparkleStar>("Red Sparkle Stars",   GreenColors_p, 2.0, 1, LINEARBLEND, 2.0, 0.0, 0.0, CRGB::Red),
             Starry<LongLifeSparkleStar>("Blue Sparkle Stars",  GreenColors_p, 2.0, 1, LINEARBLEND, 2.0, 0.0, 0.0, CRGB::Blue),
-            Effect<idStripPalette,             PaletteEffect>(rainbowPalette, 256 / 16, .2, 0)
+            Effect<PaletteEffect>(rainbowPalette, 256 / 16, .2, 0)
         );
     #endif
 
     #if defined(EFFECTS_INSULATORS)
         // Insulators effect set
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idStripRainbowFill,                 InsulatorSpectrumEffect>("Spectrum Effect", RainbowColors_p),
-            Effect<idStripNewMoltenGlassOnVioletBkgnd, NewMoltenGlassOnVioletBkgnd>("Molten Glass", RainbowColors_p),
+            Effect<InsulatorSpectrumEffect>("Spectrum Effect", RainbowColors_p),
+            Effect<NewMoltenGlassOnVioletBkgnd>("Molten Glass", RainbowColors_p),
             Starry<MusicStar>("RGB Music Blend Stars", RGBColors_p, 0.8, 1, NOBLEND, 15.0, 0.1, 10.0),
             Starry<MusicStar>("Rainbow Music Stars",   RainbowColors_p, 2.0, 2, LINEARBLEND, 5.0, 0.0, 10.0),
-            Effect<idStripPaletteReel,                  PaletteReelEffect>("PaletteReelEffect"),
-            Effect<idStripColorBeatOverRed,           ColorBeatOverRed>("ColorBeatOverRed"),
-            Effect<idStripTapeReel,                     TapeReelEffect>("TapeReelEffect")
+            Effect<PaletteReelEffect>("PaletteReelEffect"),
+            Effect<ColorBeatOverRed>("ColorBeatOverRed"),
+            Effect<TapeReelEffect>("TapeReelEffect")
         );
     #endif
 
     #if defined(EFFECTS_CUBE)
         // Cube display effect set
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idStripPalette,                 PaletteEffect>(rainbowPalette, 256 / 16, .2, 0),
-            Effect<idStripSparklySpinningMusic,  SparklySpinningMusicEffect>("SparklySpinningMusical", RainbowColors_p),
-            Effect<idStripColorBeatOverRed,     ColorBeatOverRed>("ColorBeatOnRedBkgnd"),
-            Effect<idStripSimpleInsulatorBeat2,  SimpleInsulatorBeatEffect2>("SimpleInsulatorColorBeat"),
+            Effect<PaletteEffect>(rainbowPalette, 256 / 16, .2, 0),
+            Effect<SparklySpinningMusicEffect>("SparklySpinningMusical", RainbowColors_p),
+            Effect<ColorBeatOverRed>("ColorBeatOnRedBkgnd"),
+            Effect<SimpleInsulatorBeatEffect2>("SimpleInsulatorColorBeat"),
             Starry<MusicStar>("Rainbow Music Stars", RainbowColors_p, 2.0, 2, LINEARBLEND, 5.0, 0.0, 10.0)
         );
     #endif
@@ -508,66 +508,66 @@ void LoadEffectFactories()
     #if defined(EFFECTS_BELT)
         // LED belt effect set
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idStripTwinkle, TwinkleEffect>(NUM_LEDS / 4, 10)
+            Effect<TwinkleEffect>(NUM_LEDS / 4, 10)
         );
     #endif
 
     #if defined(EFFECTS_MAGICMIRROR)
         // Magic mirror effect set
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idStripMoltenGlassOnVioletBkgnd, MoltenGlassOnVioletBkgnd>("MoltenGlass", RainbowColors_p)
+            Effect<MoltenGlassOnVioletBkgnd>("MoltenGlass", RainbowColors_p)
         );
     #endif
 
     #if defined(EFFECTS_ATOMLIGHT)
         // Atom light effect set
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idStripColorFill,     ColorFillEffect>(CRGB::White, 1),
-            Effect<idStripFireFan,       FireFanEffect>(HeatColors_p, NUM_LEDS, 2, 2, 200, 2, 5, Sequential, true, false),
-            Effect<idStripFireFan,       FireFanEffect>(HeatColors_p, NUM_LEDS, 1, 12, 400, 2, NUM_LEDS / 2, Sequential, true, false),
-            Effect<idStripFireFan,       FireFanEffect>(GreenHeatColors_p, NUM_LEDS, 1, 10, 400, 2, NUM_LEDS / 2, Sequential, true, false),
-            Effect<idStripFireFan,       FireFanEffect>(BlueHeatColors_p, NUM_LEDS, 1, 10, 400, 2, NUM_LEDS / 2, Sequential, true, false),
-            Effect<idStripFireFan,       FireFanEffect>(RainbowColors_p, NUM_LEDS, 1, 10, 400, 2, NUM_LEDS / 2, Sequential, true, false),
-            Effect<idStripFireFan,       FireFanEffect>(HeatColors_p, NUM_LEDS, 1, 10, 400, 2, NUM_LEDS / 2, Sequential, true, false, true),
-            Effect<idStripBouncingBall,  BouncingBallEffect>(3, true, true, 1),
-            Effect<idStripRainbowFill,   RainbowFillEffect>(60, 0),
-            Effect<idStripColorCycle,    ColorCycleEffect>(Sequential),
-            Effect<idStripPalette,        PaletteEffect>(RainbowColors_p, 4, 0.1, 0.0, 1.0, 0.0),
-            Effect<idStripMeteor,         MeteorEffect>(20, 1, 25, .15, .05),
-            Effect<idStripMeteor,         MeteorEffect>(12, 1, 25, .15, .08),
-            Effect<idStripMeteor,         MeteorEffect>(6, 1, 25, .15, .12),
-            Effect<idStripMeteor,         MeteorEffect>(1, 1, 5, .15, .25),
-            Effect<idStripMeteor,         MeteorEffect>()
+            Effect<ColorFillEffect>(CRGB::White, 1),
+            Effect<FireFanEffect>(HeatColors_p, NUM_LEDS, 2, 2, 200, 2, 5, Sequential, true, false),
+            Effect<FireFanEffect>(HeatColors_p, NUM_LEDS, 1, 12, 400, 2, NUM_LEDS / 2, Sequential, true, false),
+            Effect<FireFanEffect>(GreenHeatColors_p, NUM_LEDS, 1, 10, 400, 2, NUM_LEDS / 2, Sequential, true, false),
+            Effect<FireFanEffect>(BlueHeatColors_p, NUM_LEDS, 1, 10, 400, 2, NUM_LEDS / 2, Sequential, true, false),
+            Effect<FireFanEffect>(RainbowColors_p, NUM_LEDS, 1, 10, 400, 2, NUM_LEDS / 2, Sequential, true, false),
+            Effect<FireFanEffect>(HeatColors_p, NUM_LEDS, 1, 10, 400, 2, NUM_LEDS / 2, Sequential, true, false, true),
+            Effect<BouncingBallEffect>(3, true, true, 1),
+            Effect<RainbowFillEffect>(60, 0),
+            Effect<ColorCycleEffect>(Sequential),
+            Effect<PaletteEffect>(RainbowColors_p, 4, 0.1, 0.0, 1.0, 0.0),
+            Effect<MeteorEffect>(20, 1, 25, .15, .05),
+            Effect<MeteorEffect>(12, 1, 25, .15, .08),
+            Effect<MeteorEffect>(6, 1, 25, .15, .12),
+            Effect<MeteorEffect>(1, 1, 5, .15, .25),
+            Effect<MeteorEffect>()
         );
     #endif
 
     #if defined(EFFECTS_PLATECOVER)
         // Plate cover effect set
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idStripColorFill,     ColorFillEffect>("Solid White", CRGB::White, 1),
-            Effect<idStripColorFill,     ColorFillEffect>("Solid Red",   CRGB::Red,   1),
-            Effect<idStripColorFill,     ColorFillEffect>("Solid Amber", CRGB(255, 50, 0), 1),
-            Effect<idStripFireFan,       FireFanEffect>(HeatColors_p, NUM_LEDS, 4, 5.0, 200, 8, 8, Sequential, true, true, true, 90),
-            Effect<idStripRainbowFill,   RainbowFillEffect>(16, 3, true),
-            Effect<idStripMeteor,         MeteorEffect>(2, 1, 15, .75, .75),
-            Effect<idStripColorFill,     ColorFillEffect>("Off", CRGB::Black, 1)
+            Effect<ColorFillEffect>("Solid White", CRGB::White, 1),
+            Effect<ColorFillEffect>("Solid Red",   CRGB::Red,   1),
+            Effect<ColorFillEffect>("Solid Amber", CRGB(255, 50, 0), 1),
+            Effect<FireFanEffect>(HeatColors_p, NUM_LEDS, 4, 5.0, 200, 8, 8, Sequential, true, true, true, 90),
+            Effect<RainbowFillEffect>(16, 3, true),
+            Effect<MeteorEffect>(2, 1, 15, .75, .75),
+            Effect<ColorFillEffect>("Off", CRGB::Black, 1)
         );
     #endif
 
     #if defined(EFFECTS_SPIRALLAMP)
         // Spiral lamp effect set
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idStripVUMeterVertical, VUMeterVerticalEffect>(),
-            Effect<idStripMeteor,           MeteorEffect>(4, 4, 10, 1.0, 1.0),
-            Effect<idStripColorFill,       ColorFillEffect>("Solid White", CRGB::White, 1),
-            Effect<idStripFireFan,         FireFanEffect>(HeatColors_p,      NUM_LEDS, 1, 2.5, 200, 2, 15, Sequential, true, false),
-            Effect<idStripFireFan,         FireFanEffect>(GreenHeatColors_p, NUM_LEDS, 1, 2.5, 200, 2, 15, Sequential, true, false),
-            Effect<idStripFireFan,         FireFanEffect>(BlueHeatColors_p,  NUM_LEDS, 1, 2.5, 200, 2, 15, Sequential, true, false),
-            Effect<idStripFireFan,         FireFanEffect>(RainbowColors_p,   NUM_LEDS, 1, 2.5, 200, 2, 15, Sequential, true, false),
-            Effect<idStripFireFan,         FireFanEffect>(HeatColors_p,      NUM_LEDS, 1, 2.5, 200, 2, 15, Sequential, true, false, true),
-            Effect<idStripRainbowFill,     RainbowFillEffect>(120, 0),
-            Effect<idStripPalette,          PaletteEffect>(RainbowColors_p, 4, 0.1, 0.0, 1.0, 0.0),
-            Effect<idStripBouncingBall,    BouncingBallEffect>(3, true, true, 8),
+            Effect<VUMeterVerticalEffect>(),
+            Effect<MeteorEffect>(4, 4, 10, 1.0, 1.0),
+            Effect<ColorFillEffect>("Solid White", CRGB::White, 1),
+            Effect<FireFanEffect>(HeatColors_p,      NUM_LEDS, 1, 2.5, 200, 2, 15, Sequential, true, false),
+            Effect<FireFanEffect>(GreenHeatColors_p, NUM_LEDS, 1, 2.5, 200, 2, 15, Sequential, true, false),
+            Effect<FireFanEffect>(BlueHeatColors_p,  NUM_LEDS, 1, 2.5, 200, 2, 15, Sequential, true, false),
+            Effect<FireFanEffect>(RainbowColors_p,   NUM_LEDS, 1, 2.5, 200, 2, 15, Sequential, true, false),
+            Effect<FireFanEffect>(HeatColors_p,      NUM_LEDS, 1, 2.5, 200, 2, 15, Sequential, true, false, true),
+            Effect<RainbowFillEffect>(120, 0),
+            Effect<PaletteEffect>(RainbowColors_p, 4, 0.1, 0.0, 1.0, 0.0),
+            Effect<BouncingBallEffect>(3, true, true, 8),
             Starry<MusicStar>("Rainbow Twinkle Stars", RainbowColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 0.0, 0.0, STARRYNIGHT_MUSICFACTOR),
             Starry<Star>("Rainbow Twinkle Stars", RainbowColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
             Starry<Star>("Red Sparkle Stars",     RedColors_p,   STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
@@ -576,9 +576,9 @@ void LoadEffectFactories()
             Starry<MusicStar>("Blue Stars",       BlueColors_p,  STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
             Starry<Star>("Green Sparkle Stars",   GreenColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
             Starry<MusicStar>("Green Stars",      GreenColors_p, STARRYNIGHT_PROBABILITY, 1, LINEARBLEND, 2.0, 0.0, STARRYNIGHT_MUSICFACTOR),
-            Effect<idStripTwinkle,          TwinkleEffect>(NUM_LEDS / 2, 20, 50),
-            Effect<idStripPalette,          PaletteEffect>(RainbowColors_p, .25, 1, 0, 1.0, 0.0, LINEARBLEND, true, 1.0),
-            Effect<idStripPalette,          PaletteEffect>(RainbowColors_p)
+            Effect<TwinkleEffect>(NUM_LEDS / 2, 20, 50),
+            Effect<PaletteEffect>(RainbowColors_p, .25, 1, 0, 1.0, 0.0, LINEARBLEND, true, 1.0),
+            Effect<PaletteEffect>(RainbowColors_p)
         );
     #endif
 
@@ -586,7 +586,7 @@ void LoadEffectFactories()
 
         // Hexagon effect set
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idHexagonOuterRing, OuterHexRingEffect>()
+            Effect<OuterHexRingEffect>()
         );
 
     #endif
@@ -595,7 +595,7 @@ void LoadEffectFactories()
     if (g_ptrEffectFactories->IsEmpty())
     {
         RegisterAll(*g_ptrEffectFactories,
-            Effect<idStripRainbowFill, RainbowFillEffect>(6, 2)
+            Effect<RainbowFillEffect>(6, 2)
         );
     }
 

--- a/src/gfxbase.cpp
+++ b/src/gfxbase.cpp
@@ -78,7 +78,7 @@
     template<>
     void GFXBase::MoveFractionalNoiseX<NoiseApproach::One>(uint8_t amt, uint8_t shift)
     {
-        std::unique_ptr<CRGB[]> ledsTemp = make_unique_psram_array<CRGB>(NUM_LEDS);
+        std::unique_ptr<CRGB[]> ledsTemp = make_unique_psram<CRGB[]>(NUM_LEDS);
 
         // move delta pixelwise
         for (int y = 0; y < _height; y++)
@@ -161,7 +161,7 @@
     template<>
     void GFXBase::MoveFractionalNoiseY<NoiseApproach::One>(uint8_t amt, uint8_t shift)
     {
-        std::unique_ptr<CRGB[]> ledsTemp = make_unique_psram_array<CRGB>(NUM_LEDS);
+    std::unique_ptr<CRGB[]> ledsTemp = make_unique_psram<CRGB[]>(NUM_LEDS);
 
         // move delta pixelwise
         for (int x = 0; x < _width; x++)

--- a/src/gfxbase.cpp
+++ b/src/gfxbase.cpp
@@ -47,13 +47,11 @@
             for (uint16_t j = 0; j < _height; j++)
             {
                 uint32_t joffset = _ptrNoise->noise_scale_y * (j - ((_height + 1) / 2));
+                uint16_t data    = inoise16(_ptrNoise->noise_x + ioffset, _ptrNoise->noise_y + joffset, _ptrNoise->noise_z) >> 8;
+                uint8_t  olddata = _ptrNoise->noise[i][j];
+                uint8_t  newdata = scale8(olddata, _ptrNoise->noisesmoothing) + scale8(data, 256 - _ptrNoise->noisesmoothing);
 
-                uint16_t data = inoise16(_ptrNoise->noise_x + ioffset, _ptrNoise->noise_y + joffset, _ptrNoise->noise_z) >> 8;
-
-                uint8_t olddata = _ptrNoise->noise[i][j];
-                uint8_t newdata = scale8(olddata, _ptrNoise->noisesmoothing) + scale8(data, 256 - _ptrNoise->noisesmoothing);
                 data = newdata;
-
                 _ptrNoise->noise[i][j] = data;
             }
         }
@@ -68,9 +66,9 @@
             for (uint8_t j = 0; j < HEIGHT; j++)
             {
                 int32_t joffset = _ptrNoise->noise_scale_y * (j - CENTER_Y_MINOR);
-                int8_t data = inoise16(_ptrNoise->noise_x + ioffset, _ptrNoise->noise_y + joffset, _ptrNoise->noise_z) >> 8;
-                int8_t olddata = _ptrNoise->noise[i][j];
-                int8_t newdata = scale8(olddata, _ptrNoise->noisesmoothing) + scale8(data, 255 - _ptrNoise->noisesmoothing);
+                int8_t  data    = inoise16(_ptrNoise->noise_x + ioffset, _ptrNoise->noise_y + joffset, _ptrNoise->noise_z) >> 8;
+                int8_t  olddata = _ptrNoise->noise[i][j];
+                int8_t  newdata = scale8(olddata, _ptrNoise->noisesmoothing) + scale8(data, 255 - _ptrNoise->noisesmoothing);
                 data = newdata;
                 _ptrNoise->noise[i][j] = data;
             }
@@ -276,6 +274,7 @@ GFXBase::GFXBase(int w, int h) : Adafruit_GFX(w, h),
 // Dirty hack to support FastLED, which calls out of band to get the pixel index for "the" array, without
 // any indication of which array or who's asking, so we assume the first matrix. If you have trouble with
 // more than one matrix and some FastLED functions like blur2d, this would be why.
+
 uint16_t XY(uint8_t x, uint8_t y)
 {
     static auto& g = *(g_ptrSystem->EffectManager().g());


### PR DESCRIPTION
Migrate macros to templates, simplify effects table, add effectId() to all derived effects

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).