### PR TITLE
Refactor: Apply Class Template Argument Deduction (CTAD)

### DIFF
--- a/include/effects/strip/particles.h
+++ b/include/effects/strip/particles.h
@@ -305,7 +305,7 @@ template <typename Type = DrawableParticle> class ParticleSystem
 
   public:
 
-    ParticleSystem<Type>()
+    ParticleSystem()
     {
     }
 

--- a/include/effects/strip/particles.h
+++ b/include/effects/strip/particles.h
@@ -306,7 +306,7 @@ template <typename Type = DrawableParticle> class ParticleSystem
 
   public:
 
-    ParticleSystem<Type>() {}
+    ParticleSystem() {}
 
     virtual void Render(const std::vector<std::shared_ptr<GFXBase>>& _gfx)
     {

--- a/include/effects/strip/stareffect.h
+++ b/include/effects/strip/stareffect.h
@@ -433,15 +433,15 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
   public:
 
 
-    StarryNightEffect<StarType>(const String & strName,
-                                const CRGBPalette16& palette,
-                                float probability = 1.0,
-                                float starSize = 1.0,
-                                TBlendType blendType = LINEARBLEND,
-                                float maxSpeed = 100.0,
-                                float blurFactor = 0.0,
-                                float musicFactor = 1.0,
-                                CRGB skyColor = CRGB::Black)
+    StarryNightEffect(const String & strName,
+                      const CRGBPalette16& palette,
+                      float probability = 1.0,
+                      float starSize = 1.0,
+                      TBlendType blendType = LINEARBLEND,
+                      float maxSpeed = 100.0,
+                      float blurFactor = 0.0,
+                      float musicFactor = 1.0,
+                      CRGB skyColor = CRGB::Black)
       : LEDStripEffect(EFFECT_STRIP_STARRY_NIGHT, strName),
         _palette(palette),
         _newStarProbability(probability),
@@ -454,7 +454,7 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
     {
     }
 
-    StarryNightEffect<StarType>(const JsonObjectConst& jsonObject)
+    StarryNightEffect(const JsonObjectConst& jsonObject)
       : LEDStripEffect(jsonObject),
         _palette(jsonObject[PTY_PALETTE].as<CRGBPalette16>()),
         _newStarProbability(jsonObject["spb"]),
@@ -566,12 +566,12 @@ template <typename StarType> class BlurStarEffect : public StarryNightEffect<Sta
 
   public:
 
-    BlurStarEffect<StarType>(const CRGBPalette16 & palette, float probability = 0.2, size_t starSize = 1, TBlendType blendType = LINEARBLEND, float maxSpeed = 20.0)
+    BlurStarEffect(const CRGBPalette16 & palette, float probability = 0.2, size_t starSize = 1, TBlendType blendType = LINEARBLEND, float maxSpeed = 20.0)
         : StarryNightEffect<StarType>(palette, probability, starSize, blendType, maxSpeed)
     {
     }
 
-    BlurStarEffect<StarType>(const JsonObjectConst& jsonObject)
+    BlurStarEffect(const JsonObjectConst& jsonObject)
         : StarryNightEffect<StarType>(jsonObject)
     {
     }


### PR DESCRIPTION
## Description

This commit refactors several class template instantiations to leverage C++17's Class Template Argument Deduction (CTAD) feature. By removing redundant template arguments from constructor calls, the code becomes more concise and readable without altering its functionality.

Affected files:
- `include/effects/strip/particles.h`
- `include/effects/strip/stareffect.h`

Tested:
  Imported from my branch. Survives a build-all and run.

<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
