### PR TITLE
Simplify effect ID implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,8 @@ Example in globals.h:
 
 To add new effects, you:
 
-1. Derive from `LEDStripEffect` (or an existing effect class) and the good stuff happens in the only important function, `Draw()`.
-Check out what the built in effects do, but in short you're basically drawing into an array of CRGB objects that each represent a 24-bit color triplet. Once you're done, the CRGB array is sent to the LEDs and you are asked for the next frame immediately. Your draw method should take somewhere around 30ms, ideally, and should `delay()` to sleep for the balance if it's quicker. You **can** draw repeatedly basically in a busy loop, but its not needed.
+1. Derive from `EffectWithId` (or an existing effect class) and the good stuff happens in the only important function, `Draw()`.
+Check out what the built-in effects do, but in short you're basically drawing into an array of CRGB objects that each represent a 24-bit color triplet. Once you're done, the CRGB array is sent to the LEDs and you are asked for the next frame immediately. Your draw method should take somewhere around 30ms, ideally, and should `delay()` to sleep for the balance if it's quicker. You **can** draw repeatedly basically in a busy loop, but its not needed.
 2. Add an effect number `#define` for your effect class to `effects.h`. Each effect class needs only one effect number, and please make sure the number you choose is not already used by another effect class! More information about the link between an effect class and its associated effect number can be found in `effects.h`.
 3. Add your class to the effect list created in the `LoadEffectFactories()` function in `effects.cpp` (under your build configuration section, like `DEMO`). The `ADD_EFFECT()` macro expects the effect number and type name of your new effect as parameters. Any additional parameters are passed to the effect's constructor when it's created.
 
@@ -258,7 +258,7 @@ to pio or in a menu option inside the PlatformIO IDE/VS Code.
 
 The effects table is persisted to a JSON file on SPIFFS at regular intervals, to retain the state of effects (and in fact the whole effect list) across reboots. This is largely in preparation for future updates to NightDriverStrip, where the composition of the effect list configuration of individual effects can be changed using the device web application. The API endpoints to facilitate this are already available and ready for use (see [Device web UI and API](#device-web-ui-and-api), below.)
 
-This makes that an override of `SerializeToJSON()` and a corresponding deserializing constructor must be provided for effects that need (or want) to persist more than the properties that are (de)serialized from/to JSON by `LEDStripEffect` by default.
+This makes that an override of `SerializeToJSON()` and a corresponding deserializing constructor must be provided for effects that need (or want) to persist more than the properties that are (de)serialized from/to JSON by `EffectWithId` (which derives from `LEDStripEffect`) by default.
 
 Throughout the project, the library used for JSON handling and (de)serialization is [ArduinoJson](https://arduinojson.org/). Among others, this means that `SerializeToJSON()` functions _must_ return `true` _except_ when an ArduinoJson function (like `JsonObject::set()`) returns `false` to indicate it ran out of buffer memory.
 

--- a/include/effects/matrix/PatternAlienText.h
+++ b/include/effects/matrix/PatternAlienText.h
@@ -57,26 +57,24 @@
 #ifndef PatternAlienText_H
 #define PatternAlienText_H
 
-// Description: This file contains the implementation of the PatternAlienText class, 
-//              which is a subclass of LEDStripEffect. The class is designed to create 
-//              an effect that simulates alien text on an LED matrix. 
-// 
-//              The PatternAlienText class utilizes two main properties, charWidth and charHeight, 
-//              to define the dimensions of each 'character' in the alien text. It also uses leftMargin 
+// Description: This file contains the implementation of the PatternAlienText class,
+//              which is a subclass of LEDStripEffect. The class is designed to create
+//              an effect that simulates alien text on an LED matrix.
+//
+//              The PatternAlienText class utilizes two main properties, charWidth and charHeight,
+//              to define the dimensions of each 'character' in the alien text. It also uses leftMargin
 //              and topMargin to define the starting position of the text on the LED matrix.
-// 
-//              The Draw() method is the core function where the alien text is generated. It uses 
-//              randomization to light up LEDs in a way that mimics the appearance of a foreign script. 
-//              The color of the text is randomly chosen, and the arrangement of lit LEDs creates 
-//              the illusion of alien characters. This process repeats, moving across and then down 
+//
+//              The Draw() method is the core function where the alien text is generated. It uses
+//              randomization to light up LEDs in a way that mimics the appearance of a foreign script.
+//              The color of the text is randomly chosen, and the arrangement of lit LEDs creates
+//              the illusion of alien characters. This process repeats, moving across and then down
 //              the matrix, simulating scrolling text.
 
-class PatternAlienText : public LEDStripEffect
+class PatternAlienText : public EffectWithId<idMatrixAlienText>
 {
-public:
-  static constexpr EffectId kId = idMatrixAlienText;
-  EffectId effectId() const override { return kId; }
-  
+
+
 private:
   const int charWidth = 6;
   const int charHeight = 6;
@@ -87,11 +85,11 @@ private:
 
 public:
 
-  PatternAlienText() : LEDStripEffect(idMatrixAlienText, "AlienText")
+  PatternAlienText() : EffectWithId<idMatrixAlienText>("AlienText")
   {
   }
 
-  PatternAlienText(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
+  PatternAlienText(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixAlienText>(jsonObject)
   {
   }
 

--- a/include/effects/matrix/PatternAlienText.h
+++ b/include/effects/matrix/PatternAlienText.h
@@ -75,7 +75,7 @@ class PatternAlienText : public EffectWithId<idMatrixAlienText>
 {
 private:
 
-const int charWidth = 6;
+  const int charWidth = 6;
   const int charHeight = 6;
   const int leftMargin = 2;
   const int topMargin = 2;

--- a/include/effects/matrix/PatternAlienText.h
+++ b/include/effects/matrix/PatternAlienText.h
@@ -73,10 +73,9 @@
 
 class PatternAlienText : public EffectWithId<idMatrixAlienText>
 {
-
-
 private:
-  const int charWidth = 6;
+
+const int charWidth = 6;
   const int charHeight = 6;
   const int leftMargin = 2;
   const int topMargin = 2;
@@ -85,13 +84,8 @@ private:
 
 public:
 
-  PatternAlienText() : EffectWithId<idMatrixAlienText>("AlienText")
-  {
-  }
-
-  PatternAlienText(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixAlienText>(jsonObject)
-  {
-  }
+  PatternAlienText() : EffectWithId<idMatrixAlienText>("AlienText") {}
+  PatternAlienText(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixAlienText>(jsonObject) {}
 
   void Start() override
   {

--- a/include/effects/matrix/PatternAnimatedGIF.h
+++ b/include/effects/matrix/PatternAnimatedGIF.h
@@ -136,12 +136,8 @@ const std::unique_ptr<GifDecoder<MATRIX_WIDTH, MATRIX_HEIGHT, 16, true>> g_ptrGI
 //
 // Draws a cycling animated GIF on the LED matrix.  Use GifDecoder to do the heavy lifting behind the scenes.
 
-class PatternAnimatedGIF : public LEDStripEffect 
+class PatternAnimatedGIF : public EffectWithId<idMatrixAnimatedGIF>
 {
-  public:
-    static constexpr EffectId kId = idMatrixAnimatedGIF;
-    EffectId effectId() const override { return kId; }
-
   private:
 
     GIFIdentifier _gifIndex  = GIFIdentifier::INVALID;
@@ -211,7 +207,7 @@ class PatternAnimatedGIF : public LEDStripEffect
 public:
 
     PatternAnimatedGIF(const String & friendlyName, GIFIdentifier gifIndex, bool preClear = false, CRGB bkColor = CRGB::Black) :
-    LEDStripEffect(idMatrixAnimatedGIF, friendlyName),
+    EffectWithId<idMatrixAnimatedGIF>(friendlyName),
         _preClear(preClear),
         _gifIndex(gifIndex),
         _bkColor(bkColor)
@@ -219,7 +215,7 @@ public:
     }
 
     PatternAnimatedGIF(const JsonObjectConst& jsonObject)
-        : LEDStripEffect(jsonObject),
+        : EffectWithId<idMatrixAnimatedGIF>(jsonObject),
           _preClear(jsonObject[PTY_PRECLEAR]),
           _gifIndex((GIFIdentifier)jsonObject[PTY_GIFINDEX].as<std::underlying_type_t<GIFIdentifier>>()),
           _bkColor(jsonObject[PTY_BKCOLOR])

--- a/include/effects/matrix/PatternBounce.h
+++ b/include/effects/matrix/PatternBounce.h
@@ -78,12 +78,13 @@
 class PatternBounce : public EffectWithId<idMatrixBounce>
 {
 private:
+
     static const int count = MATRIX_WIDTH;
     PVector gravity = PVector(0, 0.0125);
 
 public:
-    PatternBounce() : EffectWithId<idMatrixBounce>("Bounce") {}
 
+    PatternBounce() : EffectWithId<idMatrixBounce>("Bounce") {}
     PatternBounce(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixBounce>(jsonObject) {}
 
     bool RequiresDoubleBuffering() const override

--- a/include/effects/matrix/PatternBounce.h
+++ b/include/effects/matrix/PatternBounce.h
@@ -56,6 +56,7 @@
 
 #include "Vector.h"
 #include "Boid.h"
+#include "ledstripeffect.h"
 
 // Description: This file defines the PatternBounce class, a subclass of LEDStripEffect.
 //              The class creates a bouncing effect on an LED matrix, where multiple points
@@ -81,13 +82,9 @@ private:
     PVector gravity = PVector(0, 0.0125);
 
 public:
-    PatternBounce() : EffectWithId<idMatrixBounce>("Bounce")
-    {
-    }
+    PatternBounce() : EffectWithId<idMatrixBounce>("Bounce") {}
 
-    PatternBounce(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixBounce>(jsonObject)
-    {
-    }
+    PatternBounce(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixBounce>(jsonObject) {}
 
     bool RequiresDoubleBuffering() const override
     {

--- a/include/effects/matrix/PatternBounce.h
+++ b/include/effects/matrix/PatternBounce.h
@@ -57,38 +57,35 @@
 #include "Vector.h"
 #include "Boid.h"
 
-// Description: This file defines the PatternBounce class, a subclass of LEDStripEffect. 
-//              The class creates a bouncing effect on an LED matrix, where multiple points 
+// Description: This file defines the PatternBounce class, a subclass of LEDStripEffect.
+//              The class creates a bouncing effect on an LED matrix, where multiple points
 //              (referred to as 'boids') bounce off the bottom edge of the matrix.
 //
-//              The PatternBounce class uses the PVector class for representing the gravity 
-//              affecting the boids. Each boid's velocity and position are calculated based 
+//              The PatternBounce class uses the PVector class for representing the gravity
+//              affecting the boids. Each boid's velocity and position are calculated based
 //              on this gravity, and their interaction with the bottom edge of the LED matrix.
 //
-//              The Start() method initializes the boids with a vertical velocity and positions 
-//              them along the top edge of the matrix. Each boid is assigned a unique color from 
+//              The Start() method initializes the boids with a vertical velocity and positions
+//              them along the top edge of the matrix. Each boid is assigned a unique color from
 //              the current color palette.
 //
-//              The Draw() method updates the position of each boid based on its velocity and 
-//              gravity. When a boid hits the bottom edge of the matrix, its velocity is inverted, 
-//              creating a bouncing effect. The method also handles dimming and blurring of the 
+//              The Draw() method updates the position of each boid based on its velocity and
+//              gravity. When a boid hits the bottom edge of the matrix, its velocity is inverted,
+//              creating a bouncing effect. The method also handles dimming and blurring of the
 //              LEDs to enhance the visual effect.
 
-class PatternBounce : public LEDStripEffect
+class PatternBounce : public EffectWithId<idMatrixBounce>
 {
 private:
     static const int count = MATRIX_WIDTH;
     PVector gravity = PVector(0, 0.0125);
 
 public:
-    static constexpr EffectId kId = idMatrixBounce;
-    EffectId effectId() const override { return kId; }
-
-    PatternBounce() : LEDStripEffect(kId, "Bounce")
+    PatternBounce() : EffectWithId<idMatrixBounce>("Bounce")
     {
     }
 
-    PatternBounce(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
+    PatternBounce(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixBounce>(jsonObject)
     {
     }
 
@@ -139,7 +136,7 @@ public:
 
             g()->_boids[i] = boid;
         }
-        
+
         // If the combined velocity of all the boids is less than 1.0, restart the animation.
         // The value of 1.0 is arbitrary, but it seems to work well.
 

--- a/include/effects/matrix/PatternCircuit.h
+++ b/include/effects/matrix/PatternCircuit.h
@@ -90,6 +90,7 @@
 class PatternCircuit : public EffectWithId<idMatrixCircuit>
 {
 private:
+
     static const uint8_t SNAKE_LENGTH = 64;
 
     CRGB colors[SNAKE_LENGTH];
@@ -190,6 +191,7 @@ private:
     }
 
 public:
+
     PatternCircuit() : EffectWithId<idMatrixCircuit>("Circuit") { construct(); }
     PatternCircuit(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixCircuit>(jsonObject) { construct(); }
     ~PatternCircuit() { free(snakes); }

--- a/include/effects/matrix/PatternCircuit.h
+++ b/include/effects/matrix/PatternCircuit.h
@@ -58,36 +58,36 @@
 #ifndef PatternCircuit_H
 #define PatternCircuit_H
 
-// Description: This file defines the PatternCircuit class, a subclass of LEDStripEffect, 
+// Description: This file defines the PatternCircuit class, a subclass of LEDStripEffect,
 //              designed to create a dynamic 'circuit-like' visual effect on an LED matrix.
-//              The effect simulates 'snakes' of light moving across the matrix, reminiscent 
+//              The effect simulates 'snakes' of light moving across the matrix, reminiscent
 //              of electrical currents flowing through a circuit.
 //
-//              The PatternCircuit class uses a 'Path' structure to define the trajectory and 
-//              appearance of each snake. Each Path contains a series of 'pixels', representing 
+//              The PatternCircuit class uses a 'Path' structure to define the trajectory and
+//              appearance of each snake. Each Path contains a series of 'pixels', representing
 //              the segments of the snake, and a 'direction' indicating the movement of the snake.
 //
 //              The main features of the PatternCircuit class include:
 //
-//              - Multiple snake paths: Multiple instances of Path are created to simulate 
+//              - Multiple snake paths: Multiple instances of Path are created to simulate
 //                several snakes moving independently on the matrix.
 //
-//              - Randomized movement: The snakes change direction randomly, enhancing the 
+//              - Randomized movement: The snakes change direction randomly, enhancing the
 //                dynamic feel of the effect.
 //
-//              - Color and brightness variation: Each segment of a snake has a different color 
+//              - Color and brightness variation: Each segment of a snake has a different color
 //                and brightness, fading towards the tail, creating a sense of depth and movement.
 //
-//              - Reset mechanism: The entire pattern resets at a regular interval, ensuring 
+//              - Reset mechanism: The entire pattern resets at a regular interval, ensuring
 //                the effect remains lively and unpredictable.
 //
-//              The Draw() method is the heart of the PatternCircuit effect. It periodically resets 
-//              the paths, fades random pixels to create a dynamic background, and updates the 
-//              position and direction of each snake. The draw method of each Path instance is 
-//              responsible for rendering the snake on the LED matrix, using a palette of colors 
+//              The Draw() method is the heart of the PatternCircuit effect. It periodically resets
+//              the paths, fades random pixels to create a dynamic background, and updates the
+//              position and direction of each snake. The draw method of each Path instance is
+//              responsible for rendering the snake on the LED matrix, using a palette of colors
 //              to create a gradient effect along the length of the snake.
 
-class PatternCircuit : public LEDStripEffect
+class PatternCircuit : public EffectWithId<idMatrixCircuit>
 {
 private:
     static const uint8_t SNAKE_LENGTH = 64;
@@ -190,11 +190,8 @@ private:
     }
 
 public:
-    static constexpr EffectId kId = idMatrixCircuit;
-    EffectId effectId() const override { return kId; }
-    
-    PatternCircuit() : LEDStripEffect(idMatrixCircuit, "Circuit") { construct(); }
-    PatternCircuit(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject) { construct(); }
+    PatternCircuit() : EffectWithId<idMatrixCircuit>("Circuit") { construct(); }
+    PatternCircuit(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixCircuit>(jsonObject) { construct(); }
     ~PatternCircuit() { free(snakes); }
 
     unsigned long msStart;

--- a/include/effects/matrix/PatternClock.h
+++ b/include/effects/matrix/PatternClock.h
@@ -34,28 +34,25 @@
 // Description:
 //
 // This file defines the PatternClock class, a subclass of LEDStripEffect.
-// The class is designed to render a clock effect on an LED matrix. It 
-// includes functionality to display time with hour, minute, and second 
-// hands, along with tick marks for each hour. The clock's appearance and 
+// The class is designed to render a clock effect on an LED matrix. It
+// includes functionality to display time with hour, minute, and second
+// hands, along with tick marks for each hour. The clock's appearance and
 // behavior are customizable through various methods.
 
-class PatternClock : public LEDStripEffect
+class PatternClock : public EffectWithId<idMatrixClock>
 {
     // Radius is the lesser of the height and width so that the round clock can fit
     // on rectangular display
 
     float    radius;
 
-  public:
+    public:
 
-    static constexpr EffectId kId = idMatrixClock;
-    EffectId effectId() const override { return kId; }
-    
-    PatternClock() : LEDStripEffect(kId, "Clock")
+        PatternClock() : EffectWithId<idMatrixClock>("Clock")
     {
     }
 
-    PatternClock(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
+        PatternClock(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixClock>(jsonObject)
     {
     }
 

--- a/include/effects/matrix/PatternClock.h
+++ b/include/effects/matrix/PatternClock.h
@@ -41,15 +41,15 @@
 
 class PatternClock : public EffectWithId<idMatrixClock>
 {
+  private:
+
     // Radius is the lesser of the height and width so that the round clock can fit
     // on rectangular display
-
     float    radius;
 
   public:
 
     PatternClock() : EffectWithId<idMatrixClock>("Clock") {}
-
     PatternClock(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixClock>(jsonObject) {}
 
     bool RequiresDoubleBuffering() const override

--- a/include/effects/matrix/PatternClock.h
+++ b/include/effects/matrix/PatternClock.h
@@ -46,15 +46,11 @@ class PatternClock : public EffectWithId<idMatrixClock>
 
     float    radius;
 
-    public:
+  public:
 
-        PatternClock() : EffectWithId<idMatrixClock>("Clock")
-    {
-    }
+    PatternClock() : EffectWithId<idMatrixClock>("Clock") {}
 
-        PatternClock(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixClock>(jsonObject)
-    {
-    }
+    PatternClock(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixClock>(jsonObject) {}
 
     bool RequiresDoubleBuffering() const override
     {

--- a/include/effects/matrix/PatternCube.h
+++ b/include/effects/matrix/PatternCube.h
@@ -64,9 +64,9 @@
 
 // Description:
 // This file defines the PatternCube class, a subclass of LEDStripEffect.
-// The class implements a 3D rotating cube effect on an LED matrix. It 
-// features customizable parameters for cube dimensions, rotation angles, 
-// focal length of the camera, and positioning. The cube is constructed, 
+// The class implements a 3D rotating cube effect on an LED matrix. It
+// features customizable parameters for cube dimensions, rotation angles,
+// focal length of the camera, and positioning. The cube is constructed,
 // rotated, and projected onto a 2D plane for display.
 //
 // Key Features:
@@ -77,7 +77,7 @@
 //
 // On displays that are 2X as wide as tall, two cubes will be drawn
 
-class PatternCube : public LEDStripEffect
+class PatternCube : public EffectWithId<idMatrixCube>
 {
   private:
     float focal = 30; // Focal of the camera
@@ -214,15 +214,12 @@ class PatternCube : public LEDStripEffect
     }
 
   public:
-    static constexpr EffectId kId = idMatrixCube;
-    EffectId effectId() const override { return kId; }
-    
-    PatternCube() : LEDStripEffect(kId, "Cubes")
+    PatternCube() : EffectWithId<idMatrixCube>("Cubes")
     {
       construct();
     }
 
-    PatternCube(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
+    PatternCube(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixCube>(jsonObject)
     {
       construct();
     }
@@ -255,7 +252,7 @@ class PatternCube : public LEDStripEffect
         for (i = 0; i < 12; i++)
         {
           e = edge + i;
-          if (!e->visible) 
+          if (!e->visible)
               g()->BresenhamLine(screen[e->x].x+xOffset, screen[e->x].y, screen[e->y].x+xOffset, screen[e->y].y, color);
         }
 

--- a/include/effects/matrix/PatternCube.h
+++ b/include/effects/matrix/PatternCube.h
@@ -80,6 +80,7 @@
 class PatternCube : public EffectWithId<idMatrixCube>
 {
   private:
+
     float focal = 30; // Focal of the camera
     int cubeWidth = 28; // Cube size
     float Angx = 20.0, AngxSpeed = 0.05; // rotation (angle+speed) around X-axis
@@ -214,6 +215,7 @@ class PatternCube : public EffectWithId<idMatrixCube>
     }
 
   public:
+  
     PatternCube() : EffectWithId<idMatrixCube>("Cubes")
     {
       construct();

--- a/include/effects/matrix/PatternLife.h
+++ b/include/effects/matrix/PatternLife.h
@@ -235,13 +235,9 @@ private:
 
 public:
 
-    PatternLife() : EffectWithId<idMatrixLife>("Life")
-    {
-    }
+    PatternLife() : EffectWithId<idMatrixLife>("Life") {}
 
-    PatternLife(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixLife>(jsonObject)
-    {
-    }
+    PatternLife(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixLife>(jsonObject) {}
 
     void Reset()
     {

--- a/include/effects/matrix/PatternLife.h
+++ b/include/effects/matrix/PatternLife.h
@@ -72,13 +72,13 @@ extern "C"
 // Introduction:
 // -------------
 // This file contains the implementation for a life simulation game, inspired by Conway's Game of Life,
-// designed to be rendered on an LED matrix. The game is a zero-player game, meaning its evolution is 
+// designed to be rendered on an LED matrix. The game is a zero-player game, meaning its evolution is
 // determined by its initial state, requiring no further input from human players.
 //
 // Game Mechanics:
 // ---------------
-// 1. The game universe is a two-dimensional orthogonal grid of square cells, each of which is in one of two 
-//    possible states: alive or dead. Every cell interacts with its eight neighbors, which are the cells 
+// 1. The game universe is a two-dimensional orthogonal grid of square cells, each of which is in one of two
+//    possible states: alive or dead. Every cell interacts with its eight neighbors, which are the cells
 //    directly horizontally, vertically, or diagonally adjacent.
 // 2. At each step in time, the following transitions occur:
 //    a. Any live cell with fewer than two live neighbors dies (underpopulation).
@@ -90,17 +90,17 @@ extern "C"
 //
 // Rendering on LED Matrix:
 // ------------------------
-// 1. Each cell of the grid is represented by an LED in the matrix. A live cell is displayed by turning the 
+// 1. Each cell of the grid is represented by an LED in the matrix. A live cell is displayed by turning the
 //    corresponding LED on, while a dead cell is represented by turning the LED off.
 // 2. The LED matrix is controlled via C++ code which sends signals to each LED to manage its state.
-// 3. The rendering loop operates at a set interval, updating the state of each cell based on the rules 
+// 3. The rendering loop operates at a set interval, updating the state of each cell based on the rules
 //    of the game.
 // 4. Optimization techniques such as buffering are used to prevent flickering and to ensure smooth transitions
 //    between generations.
 //
 // Code Structure:
 // ---------------
-// 1. Class `PatternLife`: This class encapsulates the logic for the life simulation game. It includes methods 
+// 1. Class `PatternLife`: This class encapsulates the logic for the life simulation game. It includes methods
 //    for initializing the game, computing the next generation, and rendering the current state to the LED matrix.
 // 2. Method `initialize()`: Sets up the initial state of the grid, potentially randomly or based on predefined patterns.
 // 3. Method `update()`: Applies the rules of the game to compute the next generation.
@@ -108,9 +108,9 @@ extern "C"
 //
 // Performance Considerations:
 // ---------------------------
-// 1. Memory Efficiency: The implementation uses efficient data structures to store the state of each cell, 
+// 1. Memory Efficiency: The implementation uses efficient data structures to store the state of each cell,
 //    minimizing memory usage.
-// 2. Speed Optimization: The update and render methods are optimized for speed to allow for a fluid 
+// 2. Speed Optimization: The update and render methods are optimized for speed to allow for a fluid
 //    visualization on the LED matrix.
 //
 
@@ -128,7 +128,7 @@ public:
 
 constexpr auto CRC_LENGTH = (std::max(MATRIX_HEIGHT, MATRIX_WIDTH) * 4 + 1);
 
-class PatternLife : public LEDStripEffect
+class PatternLife : public EffectWithId<idMatrixLife>
 {
 private:
     std::unique_ptr<Cell [][MATRIX_HEIGHT]> world;
@@ -162,7 +162,7 @@ private:
     //
     // Example:  Seed: 92465, Generations: 1626
 
-    static constexpr std::array<unsigned long, 19> bakedInSeeds = 
+    static constexpr std::array<unsigned long, 19> bakedInSeeds =
     {
         130908,         // 3253
         1576,           // 3125
@@ -235,14 +235,11 @@ private:
 
 public:
 
-    static constexpr EffectId kId = idMatrixLife;
-    EffectId effectId() const override { return kId; }
-    
-    PatternLife() : LEDStripEffect(kId, "Life")
+    PatternLife() : EffectWithId<idMatrixLife>("Life")
     {
     }
 
-    PatternLife(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
+    PatternLife(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixLife>(jsonObject)
     {
     }
 

--- a/include/effects/matrix/PatternLife.h
+++ b/include/effects/matrix/PatternLife.h
@@ -236,7 +236,6 @@ private:
 public:
 
     PatternLife() : EffectWithId<idMatrixLife>("Life") {}
-
     PatternLife(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixLife>(jsonObject) {}
 
     void Reset()

--- a/include/effects/matrix/PatternMandala.h
+++ b/include/effects/matrix/PatternMandala.h
@@ -93,11 +93,9 @@ private:
     int16_t dsy;
 
 public:
+
     PatternMandala() : EffectWithId<idMatrixMandala>("MRI") {}
-
     PatternMandala(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixMandala>(jsonObject) {}
-
-    /// Generate an 8-bit random number
 
     virtual size_t DesiredFramesPerSecond() const override
     {

--- a/include/effects/matrix/PatternMandala.h
+++ b/include/effects/matrix/PatternMandala.h
@@ -64,13 +64,13 @@
 // -------------
 // This file contains the implementation of the `PatternMandala` class, a sophisticated
 // effect for LED strip displays. It utilizes a noise-based algorithm to create
-// intricate, continuously evolving mandala patterns. This effect is part of a larger 
+// intricate, continuously evolving mandala patterns. This effect is part of a larger
 // system that drives LED strip animations.
 //
 // Class Overview:
 // ---------------
-// `PatternMandala` is derived from `LEDStripEffect`, indicating its purpose as a specific 
-// visual effect for LED strips. It is designed to generate mandala-like patterns using 
+// `PatternMandala` is derived from `LEDStripEffect`, indicating its purpose as a specific
+// visual effect for LED strips. It is designed to generate mandala-like patterns using
 // noise and random number generation to achieve a dynamic, ever-changing display.
 //
 // Key Variables:
@@ -79,7 +79,7 @@
 //   coordinates and scaling, controlling the movement and zoom level of the noise pattern.
 // - `NUM_LAYERS`: A macro defining the number of noise layers used in the pattern.
 
-class PatternMandala : public LEDStripEffect
+class PatternMandala : public EffectWithId<idMatrixMandala>
 {
 private:
     // The coordinates for 16-bit noise spaces.
@@ -93,14 +93,11 @@ private:
     int16_t dsy;
 
 public:
-    static constexpr EffectId kId = idMatrixMandala;
-    EffectId effectId() const override { return kId; }
-    
-    PatternMandala() : LEDStripEffect(kId, "MRI")
+    PatternMandala() : EffectWithId<idMatrixMandala>("MRI")
     {
     }
 
-    PatternMandala(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
+    PatternMandala(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixMandala>(jsonObject)
     {
     }
 

--- a/include/effects/matrix/PatternMandala.h
+++ b/include/effects/matrix/PatternMandala.h
@@ -93,13 +93,9 @@ private:
     int16_t dsy;
 
 public:
-    PatternMandala() : EffectWithId<idMatrixMandala>("MRI")
-    {
-    }
+    PatternMandala() : EffectWithId<idMatrixMandala>("MRI") {}
 
-    PatternMandala(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixMandala>(jsonObject)
-    {
-    }
+    PatternMandala(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixMandala>(jsonObject) {}
 
     /// Generate an 8-bit random number
 

--- a/include/effects/matrix/PatternMaze.h
+++ b/include/effects/matrix/PatternMaze.h
@@ -276,7 +276,6 @@ private:
 public:
 
     PatternMaze() : EffectWithId<idMatrixMaze>("Maze") {}
-
     PatternMaze(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixMaze>(jsonObject) {}
 
     void Draw() override

--- a/include/effects/matrix/PatternMaze.h
+++ b/include/effects/matrix/PatternMaze.h
@@ -58,38 +58,34 @@
 
 // The `PatternMaze` class, inheriting from `LEDStripEffect`, is designed to create
 // dynamic maze patterns on an LED matrix. It showcases an intricate combination of
-// object-oriented programming and LED display manipulation in C++. This class is 
-// particularly useful for LED projects that require visually engaging, algorithmically 
+// object-oriented programming and LED display manipulation in C++. This class is
+// particularly useful for LED projects that require visually engaging, algorithmically
 // generated patterns, such as interactive art installations or creative lighting designs.
 //
 // Key Components:
-// - `Directions` Enum: Enumerates possible movement directions within the maze (Up, Down, 
+// - `Directions` Enum: Enumerates possible movement directions within the maze (Up, Down,
 //   Left, Right), providing a clear, manageable way to handle direction-based logic.
-// - `Point` Structure: Central to maze generation, it represents coordinates on the LED 
-//   matrix and includes methods to create new points and move existing ones in specified 
-//   directions. It also features a method to find the opposite of a given direction, 
+// - `Point` Structure: Central to maze generation, it represents coordinates on the LED
+//   matrix and includes methods to create new points and move existing ones in specified
+//   directions. It also features a method to find the opposite of a given direction,
 //   crucial for maze path tracing.
 //
 // Class Variables:
-// - `width` and `height`: Define the dimensions of the maze, dynamically set based on 
+// - `width` and `height`: Define the dimensions of the maze, dynamically set based on
 //   the matrix size.
 // - `grid`: A two-dimensional array representing the maze structure on the LED matrix.
-// - Maze generation tools: Including `Point` objects, an array for cell tracking, and 
+// - Maze generation tools: Including `Point` objects, an array for cell tracking, and
 //   variables for algorithm management and color selection.
 //
 // Maze Generation Logic:
-// - Utilizes a combination of different maze generation algorithms, such as recursive 
-//   backtracking and Prim's algorithm. This flexibility allows for a variety of maze 
+// - Utilizes a combination of different maze generation algorithms, such as recursive
+//   backtracking and Prim's algorithm. This flexibility allows for a variety of maze
 //   patterns.
-// - `drawNextCell`: The core function for drawing each cell of the maze, updating the 
+// - `drawNextCell`: The core function for drawing each cell of the maze, updating the
 //   grid, and managing cell progression.
 
 
-class PatternMaze : public LEDStripEffect {
-public:
-    static constexpr EffectId kId = idMatrixMaze;
-    EffectId effectId() const override { return kId; }
-    
+class PatternMaze : public EffectWithId<idMatrixMaze> {
 private:
     enum Directions {
         None = 0,
@@ -279,11 +275,11 @@ private:
 
 public:
 
-    PatternMaze() : LEDStripEffect(idMatrixMaze, "Maze")
+    PatternMaze() : EffectWithId<idMatrixMaze>("Maze")
     {
     }
 
-    PatternMaze(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
+    PatternMaze(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixMaze>(jsonObject)
     {
     }
 

--- a/include/effects/matrix/PatternMaze.h
+++ b/include/effects/matrix/PatternMaze.h
@@ -275,13 +275,9 @@ private:
 
 public:
 
-    PatternMaze() : EffectWithId<idMatrixMaze>("Maze")
-    {
-    }
+    PatternMaze() : EffectWithId<idMatrixMaze>("Maze") {}
 
-    PatternMaze(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixMaze>(jsonObject)
-    {
-    }
+    PatternMaze(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixMaze>(jsonObject) {}
 
     void Draw() override
     {

--- a/include/effects/matrix/PatternMisc.h
+++ b/include/effects/matrix/PatternMisc.h
@@ -62,13 +62,9 @@ class PatternSunburst : public EffectWithId<idMatrixSunburst>
 {
   public:
 
-    PatternSunburst() : EffectWithId<idMatrixSunburst>("Sunburst")
-    {
-    }
+    PatternSunburst() : EffectWithId<idMatrixSunburst>("Sunburst") {}
 
-    PatternSunburst(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixSunburst>(jsonObject)
-    {
-    }
+    PatternSunburst(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixSunburst>(jsonObject) {}
 
     virtual size_t DesiredFramesPerSecond() const override
     {
@@ -103,13 +99,9 @@ class PatternRose : public EffectWithId<idMatrixRose>
 {
   public:
 
-    PatternRose() : EffectWithId<idMatrixRose>("Rose")
-    {
-    }
+    PatternRose() : EffectWithId<idMatrixRose>("Rose") {}
 
-    PatternRose(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixRose>(jsonObject)
-    {
-    }
+    PatternRose(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixRose>(jsonObject) {}
 
     virtual size_t DesiredFramesPerSecond() const override
     {
@@ -157,13 +149,9 @@ class PatternPinwheel : public EffectWithId<idMatrixPinwheel>
 {
   public:
 
-    PatternPinwheel() : EffectWithId<idMatrixPinwheel>("Pinwheel")
-    {
-    }
+    PatternPinwheel() : EffectWithId<idMatrixPinwheel>("Pinwheel") {}
 
-    PatternPinwheel(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixPinwheel>(jsonObject)
-    {
-    }
+    PatternPinwheel(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixPinwheel>(jsonObject) {}
 
     void Start() override
     {
@@ -201,13 +189,9 @@ class PatternInfinity : public EffectWithId<idMatrixInfinity>
 {
 public:
 
-    PatternInfinity() : EffectWithId<idMatrixInfinity>("Infinity")
-    {
-    }
+    PatternInfinity() : EffectWithId<idMatrixInfinity>("Infinity") {}
 
-    PatternInfinity(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixInfinity>(jsonObject)
-    {
-    }
+    PatternInfinity(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixInfinity>(jsonObject) {}
 
     virtual size_t DesiredFramesPerSecond() const override
     {
@@ -266,13 +250,9 @@ private:
     uint8_t generation = 0;
 
 public:
-    PatternMunch() : EffectWithId<idMatrixMunch>("Munch")
-    {
-    }
+    PatternMunch() : EffectWithId<idMatrixMunch>("Munch") {}
 
-    PatternMunch(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixMunch>(jsonObject)
-    {
-    }
+    PatternMunch(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixMunch>(jsonObject) {}
 
     virtual size_t DesiredFramesPerSecond() const override
     {

--- a/include/effects/matrix/PatternMisc.h
+++ b/include/effects/matrix/PatternMisc.h
@@ -63,7 +63,6 @@ class PatternSunburst : public EffectWithId<idMatrixSunburst>
   public:
 
     PatternSunburst() : EffectWithId<idMatrixSunburst>("Sunburst") {}
-
     PatternSunburst(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixSunburst>(jsonObject) {}
 
     virtual size_t DesiredFramesPerSecond() const override
@@ -100,7 +99,6 @@ class PatternRose : public EffectWithId<idMatrixRose>
   public:
 
     PatternRose() : EffectWithId<idMatrixRose>("Rose") {}
-
     PatternRose(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixRose>(jsonObject) {}
 
     virtual size_t DesiredFramesPerSecond() const override
@@ -190,7 +188,6 @@ class PatternInfinity : public EffectWithId<idMatrixInfinity>
 public:
 
     PatternInfinity() : EffectWithId<idMatrixInfinity>("Infinity") {}
-
     PatternInfinity(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixInfinity>(jsonObject) {}
 
     virtual size_t DesiredFramesPerSecond() const override
@@ -244,14 +241,15 @@ public:
 class PatternMunch : public EffectWithId<idMatrixMunch>
 {
 private:
+
     uint8_t count = 0;
     uint8_t dir = 1;
     uint8_t flip = 0;
     uint8_t generation = 0;
 
 public:
-    PatternMunch() : EffectWithId<idMatrixMunch>("Munch") {}
 
+    PatternMunch() : EffectWithId<idMatrixMunch>("Munch") {}
     PatternMunch(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixMunch>(jsonObject) {}
 
     virtual size_t DesiredFramesPerSecond() const override

--- a/include/effects/matrix/PatternMisc.h
+++ b/include/effects/matrix/PatternMisc.h
@@ -58,18 +58,15 @@
 
 #include "Geometry.h"
 
-class PatternSunburst : public LEDStripEffect
+class PatternSunburst : public EffectWithId<idMatrixSunburst>
 {
   public:
 
-    static constexpr EffectId kId = idMatrixSunburst;
-    EffectId effectId() const override { return kId; }
-
-    PatternSunburst() : LEDStripEffect(kId, "Sunburst")
+    PatternSunburst() : EffectWithId<idMatrixSunburst>("Sunburst")
     {
     }
 
-    PatternSunburst(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
+    PatternSunburst(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixSunburst>(jsonObject)
     {
     }
 
@@ -102,18 +99,15 @@ class PatternSunburst : public LEDStripEffect
     }
 };
 
-class PatternRose : public LEDStripEffect
+class PatternRose : public EffectWithId<idMatrixRose>
 {
   public:
 
-    static constexpr EffectId kId = idMatrixRose;
-    EffectId effectId() const override { return kId; }
-    
-    PatternRose() : LEDStripEffect(kId, "Rose")
+    PatternRose() : EffectWithId<idMatrixRose>("Rose")
     {
     }
 
-    PatternRose(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
+    PatternRose(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixRose>(jsonObject)
     {
     }
 
@@ -159,18 +153,15 @@ class PatternRose : public LEDStripEffect
     }
 };
 
-class PatternPinwheel : public LEDStripEffect
+class PatternPinwheel : public EffectWithId<idMatrixPinwheel>
 {
   public:
 
-    static constexpr EffectId kId = idMatrixPinwheel;
-    EffectId effectId() const override { return kId; }
-
-    PatternPinwheel() : LEDStripEffect(kId, "Pinwheel")
+    PatternPinwheel() : EffectWithId<idMatrixPinwheel>("Pinwheel")
     {
     }
 
-    PatternPinwheel(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
+    PatternPinwheel(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixPinwheel>(jsonObject)
     {
     }
 
@@ -206,18 +197,15 @@ class PatternPinwheel : public LEDStripEffect
     }
 };
 
-class PatternInfinity : public LEDStripEffect
+class PatternInfinity : public EffectWithId<idMatrixInfinity>
 {
 public:
 
-    static constexpr EffectId kId = idMatrixInfinity;
-    EffectId effectId() const override { return kId; }
-
-    PatternInfinity() : LEDStripEffect(kId, "Infinity")
+    PatternInfinity() : EffectWithId<idMatrixInfinity>("Infinity")
     {
     }
 
-    PatternInfinity(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
+    PatternInfinity(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixInfinity>(jsonObject)
     {
     }
 
@@ -269,7 +257,7 @@ public:
 };
 
 
-class PatternMunch : public LEDStripEffect
+class PatternMunch : public EffectWithId<idMatrixMunch>
 {
 private:
     uint8_t count = 0;
@@ -278,14 +266,11 @@ private:
     uint8_t generation = 0;
 
 public:
-    static constexpr EffectId kId = idMatrixMunch;
-    EffectId effectId() const override { return kId; }
-    
-    PatternMunch() : LEDStripEffect(kId, "Munch")
+    PatternMunch() : EffectWithId<idMatrixMunch>("Munch")
     {
     }
 
-    PatternMunch(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
+    PatternMunch(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixMunch>(jsonObject)
     {
     }
 

--- a/include/effects/matrix/PatternNoiseSmearing.h
+++ b/include/effects/matrix/PatternNoiseSmearing.h
@@ -61,8 +61,8 @@
 class PatternRainbowFlag : public EffectWithId<idMatrixRainbowFlag>
 {
 public:
-  PatternRainbowFlag() : EffectWithId<idMatrixRainbowFlag>("RainbowFlag") {}
 
+  PatternRainbowFlag() : EffectWithId<idMatrixRainbowFlag>("RainbowFlag") {}
   PatternRainbowFlag(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixRainbowFlag>(jsonObject) {}
 
   void Draw() override
@@ -102,8 +102,6 @@ public:
 
     g()->MoveY(3);
     g()->MoveFractionalNoiseX<NoiseApproach::One>(4);
-
-
   }
 };
 #endif

--- a/include/effects/matrix/PatternNoiseSmearing.h
+++ b/include/effects/matrix/PatternNoiseSmearing.h
@@ -61,13 +61,9 @@
 class PatternRainbowFlag : public EffectWithId<idMatrixRainbowFlag>
 {
 public:
-  PatternRainbowFlag() : EffectWithId<idMatrixRainbowFlag>("RainbowFlag")
-  {
-  }
+  PatternRainbowFlag() : EffectWithId<idMatrixRainbowFlag>("RainbowFlag") {}
 
-  PatternRainbowFlag(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixRainbowFlag>(jsonObject)
-  {
-  }
+  PatternRainbowFlag(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixRainbowFlag>(jsonObject) {}
 
   void Draw() override
   {

--- a/include/effects/matrix/PatternNoiseSmearing.h
+++ b/include/effects/matrix/PatternNoiseSmearing.h
@@ -58,14 +58,14 @@
 #ifndef PatternNoiseSmearing_H
 #define PatternNoiseSmearing_H
 
-class PatternRainbowFlag : public LEDStripEffect
+class PatternRainbowFlag : public EffectWithId<idMatrixRainbowFlag>
 {
 public:
-  PatternRainbowFlag() : LEDStripEffect(idMatrixRainbowFlag, "RainbowFlag")
+  PatternRainbowFlag() : EffectWithId<idMatrixRainbowFlag>("RainbowFlag")
   {
   }
 
-  PatternRainbowFlag(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
+  PatternRainbowFlag(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixRainbowFlag>(jsonObject)
   {
   }
 

--- a/include/effects/matrix/PatternPongClock.h
+++ b/include/effects/matrix/PatternPongClock.h
@@ -74,12 +74,8 @@
 #define SPEEDUP 1.15
 #define MAXSPEED 4.0f
 
-class PatternPongClock : public LEDStripEffect 
+class PatternPongClock : public EffectWithId<idMatrixPongClock>
 {
-  public:
-    static constexpr EffectId kId = idMatrixPongClock;
-    EffectId effectId() const override { return kId; }
-  
   private:
     float ballpos_x, ballpos_y;
     uint8_t erase_x = 10; // holds ball old pos so we can erase it, set to blank area of screen initially.
@@ -99,11 +95,11 @@ class PatternPongClock : public LEDStripEffect
 
   public:
 
-    PatternPongClock() : LEDStripEffect(idMatrixPongClock, "PongClock")
+    PatternPongClock() : EffectWithId<idMatrixPongClock>("PongClock")
     {
     }
 
-    PatternPongClock(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
+    PatternPongClock(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixPongClock>(jsonObject)
     {
     }
 

--- a/include/effects/matrix/PatternPongClock.h
+++ b/include/effects/matrix/PatternPongClock.h
@@ -96,7 +96,6 @@ class PatternPongClock : public EffectWithId<idMatrixPongClock>
   public:
 
     PatternPongClock() : EffectWithId<idMatrixPongClock>("PongClock") {}
-
     PatternPongClock(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixPongClock>(jsonObject) {}
 
     virtual size_t DesiredFramesPerSecond() const override

--- a/include/effects/matrix/PatternPongClock.h
+++ b/include/effects/matrix/PatternPongClock.h
@@ -95,13 +95,9 @@ class PatternPongClock : public EffectWithId<idMatrixPongClock>
 
   public:
 
-    PatternPongClock() : EffectWithId<idMatrixPongClock>("PongClock")
-    {
-    }
+    PatternPongClock() : EffectWithId<idMatrixPongClock>("PongClock") {}
 
-    PatternPongClock(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixPongClock>(jsonObject)
-    {
-    }
+    PatternPongClock(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixPongClock>(jsonObject) {}
 
     virtual size_t DesiredFramesPerSecond() const override
     {

--- a/include/effects/matrix/PatternPulse.h
+++ b/include/effects/matrix/PatternPulse.h
@@ -58,7 +58,7 @@
 #ifndef PatternPulse_H
 #define PatternPulse_H
 
-class PatternPulse : public LEDStripEffect
+class PatternPulse : public EffectWithId<idMatrixPulse>
 {
   private:
 
@@ -69,16 +69,11 @@ class PatternPulse : public LEDStripEffect
     int maxSteps = min(MATRIX_HEIGHT, MATRIX_WIDTH);
     float fadeRate = 0.90;
     int diff;
-
   public:
 
-    PatternPulse() : LEDStripEffect(idMatrixPulse, "Pulse")
-    {
-    }
+    PatternPulse() : EffectWithId<idMatrixPulse>("Pulse") {}
 
-    PatternPulse(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    PatternPulse(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixPulse>(jsonObject) {}
 
     void Draw() override
     {
@@ -121,11 +116,7 @@ class PatternPulse : public LEDStripEffect
         // effects.standardNoiseSmearing();
     }
 };
-class PatternPulsar : public BeatEffectBase, public LEDStripEffect {
-    public:
-        static constexpr EffectId kId = idMatrixPulsar;
-        EffectId effectId() const override { return kId; }
-        
+class PatternPulsar : public BeatEffectBase, public EffectWithId<idMatrixPulsar> {
     private:
 
     struct PulsePop
@@ -145,16 +136,15 @@ class PatternPulsar : public BeatEffectBase, public LEDStripEffect {
     int diff;
 
   public:
-
     PatternPulsar() :
         BeatEffectBase(1.5, 0.25 ),
-    LEDStripEffect(idMatrixPulsar, "Pulsars")
+        EffectWithId<idMatrixPulsar>("Pulsars")
     {
     }
 
     PatternPulsar(const JsonObjectConst& jsonObject) :
         BeatEffectBase(1.5, 0.25 ),
-        LEDStripEffect(jsonObject)
+        EffectWithId<idMatrixPulsar>(jsonObject)
     {
     }
 

--- a/include/effects/matrix/PatternPulse.h
+++ b/include/effects/matrix/PatternPulse.h
@@ -117,7 +117,7 @@ class PatternPulse : public EffectWithId<idMatrixPulse>
     }
 };
 class PatternPulsar : public BeatEffectBase, public EffectWithId<idMatrixPulsar> {
-    private:
+  private:
 
     struct PulsePop
     {

--- a/include/effects/matrix/PatternPulse.h
+++ b/include/effects/matrix/PatternPulse.h
@@ -69,10 +69,10 @@ class PatternPulse : public EffectWithId<idMatrixPulse>
     int maxSteps = min(MATRIX_HEIGHT, MATRIX_WIDTH);
     float fadeRate = 0.90;
     int diff;
+
   public:
 
     PatternPulse() : EffectWithId<idMatrixPulse>("Pulse") {}
-
     PatternPulse(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixPulse>(jsonObject) {}
 
     void Draw() override
@@ -118,7 +118,6 @@ class PatternPulse : public EffectWithId<idMatrixPulse>
 };
 class PatternPulsar : public BeatEffectBase, public EffectWithId<idMatrixPulsar> {
   private:
-
     struct PulsePop
     {
       public:

--- a/include/effects/matrix/PatternQR.h
+++ b/include/effects/matrix/PatternQR.h
@@ -34,7 +34,7 @@
 
 #include "qrcode.h"
 
-class PatternQR : public LEDStripEffect
+class PatternQR : public EffectWithId<idMatrixQR>
 {
     void construct()
     {
@@ -51,12 +51,12 @@ protected:
 
 public:
 
-    PatternQR() : LEDStripEffect(idMatrixQR, "QR")
+    PatternQR() : EffectWithId<idMatrixQR>("QR")
     {
         construct();
     }
 
-    PatternQR(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
+    PatternQR(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixQR>(jsonObject)
     {
         construct();
     }

--- a/include/effects/matrix/PatternRadar.h
+++ b/include/effects/matrix/PatternRadar.h
@@ -54,23 +54,18 @@
 #ifndef PatternRadar_H
 #define PatternRadar_H
 
-class PatternRadar : public LEDStripEffect
+class PatternRadar : public EffectWithId<idMatrixRadar>
 {
 private:
   uint8_t theta = 0;
   uint8_t hueoffset = 0;
 
 public:
-  static constexpr EffectId kId = idMatrixRadar;
-  EffectId effectId() const override { return kId; }
-  
-  PatternRadar() : LEDStripEffect(kId, "Radar")
-  {
-  }
+  // ID provided by EffectWithId
 
-  PatternRadar(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
-  {
-  }
+  PatternRadar() : EffectWithId<idMatrixRadar>("Radar") {}
+
+  PatternRadar(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixRadar>(jsonObject) {}
 
   void Draw() override
   {

--- a/include/effects/matrix/PatternRadar.h
+++ b/include/effects/matrix/PatternRadar.h
@@ -57,14 +57,13 @@
 class PatternRadar : public EffectWithId<idMatrixRadar>
 {
 private:
+
   uint8_t theta = 0;
   uint8_t hueoffset = 0;
 
 public:
-  // ID provided by EffectWithId
 
   PatternRadar() : EffectWithId<idMatrixRadar>("Radar") {}
-
   PatternRadar(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixRadar>(jsonObject) {}
 
   void Draw() override

--- a/include/effects/matrix/PatternSM2DDPR.h
+++ b/include/effects/matrix/PatternSM2DDPR.h
@@ -7,7 +7,8 @@
 // I'll admit this math may as well be magic, but it's pretty.
 
 class PatternSM2DDPR : public EffectWithId<idMatrixSM2DDPR> {
-    private:
+  private:
+
     uint8_t ZVoffset = 0;
 
     const int Scale = 127;
@@ -19,10 +20,10 @@ class PatternSM2DDPR : public EffectWithId<idMatrixSM2DDPR> {
     const float radius = HALF_WIDTH;
     //   byte effect = 1;
 
-    public:
-        PatternSM2DDPR() : EffectWithId<idMatrixSM2DDPR>("Crystallize") {}
+  public:
 
-        PatternSM2DDPR(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSM2DDPR>(jsonObject) {}
+    PatternSM2DDPR() : EffectWithId<idMatrixSM2DDPR>("Crystallize") {}
+    PatternSM2DDPR(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSM2DDPR>(jsonObject) {}
 
     void Start() override {}
 

--- a/include/effects/matrix/PatternSM2DDPR.h
+++ b/include/effects/matrix/PatternSM2DDPR.h
@@ -6,11 +6,7 @@
 // Looks best on a square display, but OK on rectangles.
 // I'll admit this math may as well be magic, but it's pretty.
 
-class PatternSM2DDPR : public LEDStripEffect {
-    public:
-        static constexpr EffectId kId = idMatrixSM2DDPR;
-        EffectId effectId() const override { return kId; }
-        
+class PatternSM2DDPR : public EffectWithId<idMatrixSM2DDPR> {
     private:
     uint8_t ZVoffset = 0;
 
@@ -23,18 +19,12 @@ class PatternSM2DDPR : public LEDStripEffect {
     const float radius = HALF_WIDTH;
     //   byte effect = 1;
 
-  public:
-    PatternSM2DDPR() : LEDStripEffect(idMatrixSM2DDPR, "Crystallize")
-    {
-    }
+    public:
+        PatternSM2DDPR() : EffectWithId<idMatrixSM2DDPR>("Crystallize") {}
 
-    PatternSM2DDPR(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+        PatternSM2DDPR(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSM2DDPR>(jsonObject) {}
 
-    void Start() override
-    {
-    }
+    void Start() override {}
 
     // Use integer-only Pythagorean to compute the radius from x^2 and y^2.
     int16_t ZVcalcRadius(int16_t x, int16_t y)

--- a/include/effects/matrix/PatternSMAmberRain.h
+++ b/include/effects/matrix/PatternSMAmberRain.h
@@ -4,9 +4,8 @@
 
 // Derived from https://editor.soulmatelights.com/gallery/2007-amber-rain
 
-class Circle
+struct Circle
 {
-  public:
     float thickness = 3.0;
     long startTime;
     uint16_t offset;
@@ -42,6 +41,7 @@ const int NUMBER_OF_CIRCLES = 20;
 class PatternSMAmberRain : public EffectWithId<idMatrixSMAmberRain>
 {
   private:
+
     Circle circles[NUMBER_OF_CIRCLES] = {};
 
     void drawCircle(Circle circle)
@@ -84,11 +84,8 @@ class PatternSMAmberRain : public EffectWithId<idMatrixSMAmberRain>
     }
 
   public:
-    static constexpr EffectId kId = idMatrixSMAmberRain;
-    EffectId effectId() const override { return kId; }
 
     PatternSMAmberRain() : EffectWithId<idMatrixSMAmberRain>("Color Rain") {}
-
     PatternSMAmberRain(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMAmberRain>(jsonObject) {}
 
     void Start() override

--- a/include/effects/matrix/PatternSMAmberRain.h
+++ b/include/effects/matrix/PatternSMAmberRain.h
@@ -39,7 +39,7 @@ class Circle
 
 const int NUMBER_OF_CIRCLES = 20;
 
-class PatternSMAmberRain : public LEDStripEffect
+class PatternSMAmberRain : public EffectWithId<idMatrixSMAmberRain>
 {
   private:
     Circle circles[NUMBER_OF_CIRCLES] = {};
@@ -86,14 +86,10 @@ class PatternSMAmberRain : public LEDStripEffect
   public:
     static constexpr EffectId kId = idMatrixSMAmberRain;
     EffectId effectId() const override { return kId; }
-    
-    PatternSMAmberRain() : LEDStripEffect(kId, "Color Rain")
-    {
-    }
 
-    PatternSMAmberRain(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    PatternSMAmberRain() : EffectWithId<idMatrixSMAmberRain>("Color Rain") {}
+
+    PatternSMAmberRain(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMAmberRain>(jsonObject) {}
 
     void Start() override
     {

--- a/include/effects/matrix/PatternSMBlurringColors.h
+++ b/include/effects/matrix/PatternSMBlurringColors.h
@@ -7,7 +7,7 @@
 
 // Derived from https://editor.soulmatelights.com/gallery/2128-bluringcolors
 
-class PatternSMBlurringColors : public LEDStripEffect
+class PatternSMBlurringColors : public EffectWithId<idMatrixSMBlurringColors>
 {
   private:
     // A more cache-friendly version of the 7 independent arrays that were
@@ -77,7 +77,7 @@ class PatternSMBlurringColors : public LEDStripEffect
     void drawPixelXY(uint8_t x, uint8_t y, CRGB color)
     {
         y = MATRIX_HEIGHT - 1 - y;
-        if (g()->isValidPixel(x, y)) 
+        if (g()->isValidPixel(x, y))
             g()->leds[XY(x, y)] = color;
     }
 
@@ -194,11 +194,8 @@ class PatternSMBlurringColors : public LEDStripEffect
 
   public:
 
-    static constexpr EffectId kId = idMatrixSMBlurringColors;
-    EffectId effectId() const override { return kId; }
-    
-    PatternSMBlurringColors() : LEDStripEffect(idMatrixSMBlurringColors, "Powder") {}
-    PatternSMBlurringColors(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject) {}
+        PatternSMBlurringColors() : EffectWithId<idMatrixSMBlurringColors>("Powder") {}
+        PatternSMBlurringColors(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMBlurringColors>(jsonObject) {}
 
     void Start() override
     {

--- a/include/effects/matrix/PatternSMBlurringColors.h
+++ b/include/effects/matrix/PatternSMBlurringColors.h
@@ -17,9 +17,8 @@ class PatternSMBlurringColors : public EffectWithId<idMatrixSMBlurringColors>
     class PowderItem
     {
       public:
-        PowderItem()
-        {
-        }
+
+        PowderItem() {}
 
         void Clear()
         {
@@ -194,8 +193,8 @@ class PatternSMBlurringColors : public EffectWithId<idMatrixSMBlurringColors>
 
   public:
 
-        PatternSMBlurringColors() : EffectWithId<idMatrixSMBlurringColors>("Powder") {}
-        PatternSMBlurringColors(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMBlurringColors>(jsonObject) {}
+    PatternSMBlurringColors() : EffectWithId<idMatrixSMBlurringColors>("Powder") {}
+    PatternSMBlurringColors(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMBlurringColors>(jsonObject) {}
 
     void Start() override
     {

--- a/include/effects/matrix/PatternSMFire2021.h
+++ b/include/effects/matrix/PatternSMFire2021.h
@@ -7,6 +7,7 @@
 class PatternSMFire2021 : public EffectWithId<idMatrixSMFire2021>
 {
   private:
+
     uint8_t Speed = 150; // 1-252 ...why is not 255?! // Setting
     uint8_t Scale = 9;   // 1-99 is palette and scale // Setting
 
@@ -18,8 +19,8 @@ class PatternSMFire2021 : public EffectWithId<idMatrixSMFire2021>
     const TProgmemRGBPalette16 *curPalette;
 
   public:
-    PatternSMFire2021() : EffectWithId<idMatrixSMFire2021>("Fireplace") {}
 
+    PatternSMFire2021() : EffectWithId<idMatrixSMFire2021>("Fireplace") {}
     PatternSMFire2021(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMFire2021>(jsonObject) {}
 
     void Start() override

--- a/include/effects/matrix/PatternSMFire2021.h
+++ b/include/effects/matrix/PatternSMFire2021.h
@@ -4,12 +4,8 @@
 
 // Derived from https://editor.soulmatelights.com/gallery/388-fire2021
 
-class PatternSMFire2021 : public LEDStripEffect
+class PatternSMFire2021 : public EffectWithId<idMatrixSMFire2021>
 {
-  public:
-    static constexpr EffectId kId = idMatrixSMFire2021;
-    EffectId effectId() const override { return kId; }
-
   private:
     uint8_t Speed = 150; // 1-252 ...why is not 255?! // Setting
     uint8_t Scale = 9;   // 1-99 is palette and scale // Setting
@@ -22,13 +18,9 @@ class PatternSMFire2021 : public LEDStripEffect
     const TProgmemRGBPalette16 *curPalette;
 
   public:
-    PatternSMFire2021() : LEDStripEffect(idMatrixSMFire2021, "Fireplace")
-    {
-    }
+    PatternSMFire2021() : EffectWithId<idMatrixSMFire2021>("Fireplace") {}
 
-    PatternSMFire2021(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    PatternSMFire2021(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMFire2021>(jsonObject) {}
 
     void Start() override
     {
@@ -38,12 +30,12 @@ class PatternSMFire2021 : public LEDStripEffect
         deltaValue = Scale * 0.0899; // /100.0F * ((sizeof(palette_arr)
                                      // /sizeof(TProgmemRGBPalette16 *))-0.01F));
         deltaValue = (((Scale - 1U) % 11U + 1U));
-        step = map(Speed * Speed, 1U, 65025U, (deltaValue - 1U) / 2U + 1U,
+        step = ::map(Speed * Speed, 1U, 65025U, (deltaValue - 1U) / 2U + 1U,
                    deltaValue * 18U + 44); // корректируем скорость эффекта в наш диапазон допустимых
         // deltaValue = (((Scale - 1U) % 11U + 2U) << 4U); // ширина языков пламени
         // (масштаб шума Перлина)
         deltaValue = 0.7 * deltaValue * deltaValue + 31.3; // ширина языков пламени (масштаб шума Перлина)
-        pcnt = map(step, 1U, 255U, 20U, 128U); // nblend 3th param
+        pcnt = ::map(step, 1U, 255U, 20U, 128U); // nblend 3th param
     }
 
     void Draw() override

--- a/include/effects/matrix/PatternSMFlowFields.h
+++ b/include/effects/matrix/PatternSMFlowFields.h
@@ -10,6 +10,7 @@
 class PatternSMFlowFields : public EffectWithId<idMatrixSMFlowFields>
 {
   private:
+
     const int WIDTH = MATRIX_WIDTH;
     const int HEIGHT = MATRIX_HEIGHT;
     const int COLS = MATRIX_WIDTH;
@@ -78,8 +79,8 @@ class PatternSMFlowFields : public EffectWithId<idMatrixSMFlowFields>
     uint16_t scale = 30;
 
   public:
-    PatternSMFlowFields() : EffectWithId<idMatrixSMFlowFields>("Liquidflow") {}
 
+    PatternSMFlowFields() : EffectWithId<idMatrixSMFlowFields>("Liquidflow") {}
     PatternSMFlowFields(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMFlowFields>(jsonObject) {}
 
     void Start() override

--- a/include/effects/matrix/PatternSMFlowFields.h
+++ b/include/effects/matrix/PatternSMFlowFields.h
@@ -7,7 +7,7 @@
 // Derived from https://editor.soulmatelights.com/gallery/2132-flowfields
 // This makes a very cool green vine that grows up the display.
 
-class PatternSMFlowFields : public LEDStripEffect
+class PatternSMFlowFields : public EffectWithId<idMatrixSMFlowFields>
 {
   private:
     const int WIDTH = MATRIX_WIDTH;
@@ -78,16 +78,9 @@ class PatternSMFlowFields : public LEDStripEffect
     uint16_t scale = 30;
 
   public:
-    static constexpr EffectId kId = idMatrixSMFlowFields;
-    EffectId effectId() const override { return kId; }
-    
-    PatternSMFlowFields() : LEDStripEffect(idMatrixSMFlowFields, "Liquidflow")
-    {
-    }
+    PatternSMFlowFields() : EffectWithId<idMatrixSMFlowFields>("Liquidflow") {}
 
-    PatternSMFlowFields(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    PatternSMFlowFields(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMFlowFields>(jsonObject) {}
 
     void Start() override
     {

--- a/include/effects/matrix/PatternSMGamma.h
+++ b/include/effects/matrix/PatternSMGamma.h
@@ -5,14 +5,11 @@
 // Derived from https://editor.soulmatelights.com/gallery/2091-q24
 // Simple, but interesting rolling depth with a blue lens flare.
 
-class PatternSMGamma : public LEDStripEffect
+class PatternSMGamma : public EffectWithId<idMatrixSMGamma>
 {
   public:
-    static constexpr EffectId kId = idMatrixSMGamma;
-    EffectId effectId() const override { return kId; }
-    
-    PatternSMGamma() : LEDStripEffect(idMatrixSMGamma, "Gamma") {}
-    PatternSMGamma(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject) {}
+    PatternSMGamma() : EffectWithId<idMatrixSMGamma>("Gamma") {}
+    PatternSMGamma(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMGamma>(jsonObject) {}
 
   private:
 

--- a/include/effects/matrix/PatternSMGamma.h
+++ b/include/effects/matrix/PatternSMGamma.h
@@ -8,6 +8,7 @@
 class PatternSMGamma : public EffectWithId<idMatrixSMGamma>
 {
   public:
+  
     PatternSMGamma() : EffectWithId<idMatrixSMGamma>("Gamma") {}
     PatternSMGamma(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMGamma>(jsonObject) {}
 

--- a/include/effects/matrix/PatternSMHolidayLights.h
+++ b/include/effects/matrix/PatternSMHolidayLights.h
@@ -130,8 +130,8 @@ void spruce()
 
 
   public:
-    PatternSMHolidayLights() : EffectWithId<idMatrixSMHolidayLights>("Tannenbaum") {}
 
+    PatternSMHolidayLights() : EffectWithId<idMatrixSMHolidayLights>("Tannenbaum") {}
     PatternSMHolidayLights(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMHolidayLights>(jsonObject) {}
 
     void Start() override

--- a/include/effects/matrix/PatternSMHolidayLights.h
+++ b/include/effects/matrix/PatternSMHolidayLights.h
@@ -8,12 +8,9 @@
 //@stepko
 // Merry Christmas and Happy New Year
 
-class PatternSMHolidayLights : public LEDStripEffect 
+class PatternSMHolidayLights : public EffectWithId<idMatrixSMHolidayLights>
 {
-  public:
-    static constexpr EffectId kId = idMatrixSMHolidayLights;
-    EffectId effectId() const override { return kId; }
-  
+
   private:
 
     static constexpr int speed = (200 / (MATRIX_HEIGHT - 4));
@@ -88,7 +85,7 @@ void spruce()
 
     // Fade all LED channels to black based on the 'speed' value.
     // The 'map' function scales the 'speed' value from one range to another.
-    fadeAllChannelsToBlackBy(map(speed, 1, 255, 1, 100));
+    fadeAllChannelsToBlackBy(::map(speed, 1, 255, 1, 100));
 
     uint8_t z;
     if (effId == 3)
@@ -99,14 +96,14 @@ void spruce()
     for (uint8_t i = 0; i < minDim; i++)
     {
         // Calculate 'x' based on various factors.
-        unsigned x = beatsin16(i * (map(speed, 1, 255, 3, 20)), i * 2, (minDim * 4 - 2) - (i * 2 + 2));
+        unsigned x = beatsin16(i * (::map(speed, 1, 255, 3, 20)), i * 2, (minDim * 4 - 2) - (i * 2 + 2));
 
         if (effId == 2)
         {
             // Draw a pixel with certain conditions if 'effId' is 2.
             drawPixelXYF_X(x / 4 + height_adj, i,
                            random8(10) == 0 ? CHSV(random8(), random8(32, 255), 255)
-                                            : CHSV(100, 255, map(speed, 1, 255, 128, 100)));
+                                            : CHSV(100, 255, ::map(speed, 1, 255, 128, 100)));
         }
         else
         {
@@ -133,13 +130,9 @@ void spruce()
 
 
   public:
-    PatternSMHolidayLights() : LEDStripEffect(idMatrixSMHolidayLights, "Tannenbaum")
-    {
-    }
+    PatternSMHolidayLights() : EffectWithId<idMatrixSMHolidayLights>("Tannenbaum") {}
 
-    PatternSMHolidayLights(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    PatternSMHolidayLights(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMHolidayLights>(jsonObject) {}
 
     void Start() override
     {

--- a/include/effects/matrix/PatternSMHypnosis.h
+++ b/include/effects/matrix/PatternSMHypnosis.h
@@ -5,7 +5,7 @@
 // Inspired by https://editor.soulmatelights.com/gallery/2272-hypnosis
 // Spiraling swirls of rotating colors.
 
-class PatternSMHypnosis : public LEDStripEffect
+class PatternSMHypnosis : public EffectWithId<idMatrixSMHypnosis>
 {
   private:
     const uint8_t C_X = MATRIX_WIDTH / 2;
@@ -18,16 +18,9 @@ class PatternSMHypnosis : public LEDStripEffect
     } rMap[MATRIX_WIDTH][MATRIX_HEIGHT];
 
   public:
-    static constexpr EffectId kId = idMatrixSMHypnosis;
-    EffectId effectId() const override { return kId; }
-    
-    PatternSMHypnosis() : LEDStripEffect(kId, "Hypnosis")
-    {
-    }
+    PatternSMHypnosis() : EffectWithId<idMatrixSMHypnosis>("Hypnosis") {}
 
-    PatternSMHypnosis(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    PatternSMHypnosis(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMHypnosis>(jsonObject) {}
 
     size_t DesiredFramesPerSecond() const override
     {

--- a/include/effects/matrix/PatternSMHypnosis.h
+++ b/include/effects/matrix/PatternSMHypnosis.h
@@ -8,6 +8,7 @@
 class PatternSMHypnosis : public EffectWithId<idMatrixSMHypnosis>
 {
   private:
+
     const uint8_t C_X = MATRIX_WIDTH / 2;
     const uint8_t C_Y = MATRIX_HEIGHT / 2;
     const uint8_t mapp = 255 / MATRIX_WIDTH;
@@ -18,8 +19,8 @@ class PatternSMHypnosis : public EffectWithId<idMatrixSMHypnosis>
     } rMap[MATRIX_WIDTH][MATRIX_HEIGHT];
 
   public:
-    PatternSMHypnosis() : EffectWithId<idMatrixSMHypnosis>("Hypnosis") {}
 
+    PatternSMHypnosis() : EffectWithId<idMatrixSMHypnosis>("Hypnosis") {}
     PatternSMHypnosis(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMHypnosis>(jsonObject) {}
 
     size_t DesiredFramesPerSecond() const override

--- a/include/effects/matrix/PatternSMMetaBalls.h
+++ b/include/effects/matrix/PatternSMMetaBalls.h
@@ -9,6 +9,7 @@
 class PatternSMMetaBalls : public EffectWithId<idMatrixSMMetaBalls>
 {
   private:
+
     uint8_t bx[5];
     uint8_t by[5];
 
@@ -25,8 +26,8 @@ class PatternSMMetaBalls : public EffectWithId<idMatrixSMMetaBalls>
     }
 
   public:
-    PatternSMMetaBalls() : EffectWithId<idMatrixSMMetaBalls>("MetaBalls") {}
 
+    PatternSMMetaBalls() : EffectWithId<idMatrixSMMetaBalls>("MetaBalls") {}
     PatternSMMetaBalls(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMMetaBalls>(jsonObject) {}
 
     void Start() override

--- a/include/effects/matrix/PatternSMMetaBalls.h
+++ b/include/effects/matrix/PatternSMMetaBalls.h
@@ -6,7 +6,7 @@
 // N Glowing balls in orbit around each other around a rotating plane.
 // BUGBUG: Harvest possible speed fx from https://pastebin.com/VTAg4QAZ
 
-class PatternSMMetaBalls : public LEDStripEffect
+class PatternSMMetaBalls : public EffectWithId<idMatrixSMMetaBalls>
 {
   private:
     uint8_t bx[5];
@@ -25,16 +25,9 @@ class PatternSMMetaBalls : public LEDStripEffect
     }
 
   public:
-    static constexpr EffectId kId = idMatrixSMMetaBalls;
-    EffectId effectId() const override { return kId; }
-    
-    PatternSMMetaBalls() : LEDStripEffect(kId, "MetaBalls")
-    {
-    }
+    PatternSMMetaBalls() : EffectWithId<idMatrixSMMetaBalls>("MetaBalls") {}
 
-    PatternSMMetaBalls(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    PatternSMMetaBalls(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMMetaBalls>(jsonObject) {}
 
     void Start() override
     {

--- a/include/effects/matrix/PatternSMNoise.h
+++ b/include/effects/matrix/PatternSMNoise.h
@@ -352,7 +352,7 @@ DEFINE_GRADIENT_PALETTE(shikon_23_gp){
     2,   32,  205, 2,   2,   2,   216, 2,   2,   2,   217, 217, 47,  0,   228, 217, 47,  0,   228, 2,   2,
     2,   242, 2,   2,   2,   243, 26,  0,   219, 250, 26,  0,   219, 255, 2,   2,   2};
 
-class PatternSMNoise : public LEDStripEffect
+class PatternSMNoise : public EffectWithId<idMatrixSMNoise>
 {
   public:
     enum /* class */EffectType {
@@ -363,23 +363,20 @@ class PatternSMNoise : public LEDStripEffect
         ColorCube_t
     };
 
-    static constexpr EffectId kId = idMatrixSMNoise;
-    EffectId effectId() const override { return kId; }
-
     PatternSMNoise(const String& name, EffectType effect)
-      : LEDStripEffect(kId, name),
+      : EffectWithId<idMatrixSMNoise>(name),
         _effect(effect)
     {
     }
 
     PatternSMNoise()
-      : LEDStripEffect(kId, "Lava Lamp"),
+      : EffectWithId<idMatrixSMNoise>("Lava Lamp"),
         _effect(EffectType::Unknown)
     {
     }
 
     PatternSMNoise(const JsonObjectConst &jsonObject)
-      : LEDStripEffect(jsonObject),
+      : EffectWithId<idMatrixSMNoise>(jsonObject),
         _effect(static_cast<EffectType>(jsonObject[PTY_EFFECT]))
     {
     }

--- a/include/effects/matrix/PatternSMNoise.h
+++ b/include/effects/matrix/PatternSMNoise.h
@@ -355,7 +355,8 @@ DEFINE_GRADIENT_PALETTE(shikon_23_gp){
 class PatternSMNoise : public EffectWithId<idMatrixSMNoise>
 {
   public:
-    enum /* class */EffectType {
+
+    enum EffectType {
         Unknown,
         LavaLampRainbow_t,
         LavaLampRainbowStripe_t,
@@ -438,6 +439,7 @@ class PatternSMNoise : public EffectWithId<idMatrixSMNoise>
     }
 
   private:
+  
     int mode{EffectType::Unknown}; // Which of the 17 effects(!) are we showing?
     EffectType _effect;
 

--- a/include/effects/matrix/PatternSMPicasso3in1.h
+++ b/include/effects/matrix/PatternSMPicasso3in1.h
@@ -4,13 +4,8 @@
 
 // Inspired by https://editor.soulmatelights.com/gallery/1177-picasso-3in1
 
-class PatternSMPicasso3in1 : public LEDStripEffect 
+class PatternSMPicasso3in1 : public EffectWithId<idMatrixSMPicasso3in1>
 {
-  public:
-  
-    static constexpr EffectId kId = idMatrixSMPicasso3in1;
-    EffectId effectId() const override { return kId; }
-    
   private:
 
     // Suggested values for Mesmerizer w/ 1/2 HUB75 panel: 10, 36, 70
@@ -158,20 +153,20 @@ class PatternSMPicasso3in1 : public LEDStripEffect
 
   public:
     PatternSMPicasso3in1()
-      : LEDStripEffect(idMatrixSMPicasso3in1, "Picasso"),
+      : EffectWithId<idMatrixSMPicasso3in1>("Picasso"),
         _scale(-1)
     {
     }
 
     PatternSMPicasso3in1(const String& name, int scale)
-      : LEDStripEffect(idMatrixSMPicasso3in1, name),
+      : EffectWithId<idMatrixSMPicasso3in1>(name),
         _scale(scale)
     {
     }
 
 
     PatternSMPicasso3in1(const JsonObjectConst &jsonObject)
-      : LEDStripEffect(jsonObject),
+      : EffectWithId<idMatrixSMPicasso3in1>(jsonObject),
       _scale(jsonObject[PTY_SCALE])
     {
     }
@@ -226,11 +221,11 @@ class PatternSMPicasso3in1 : public LEDStripEffect
 
 	    Scale = _scale;
 
-        if (Scale < 34U) 
+        if (Scale < 34U)
             PicassoRoutine1();  // Scale is less than 34
-        else if (Scale > 67U) 
+        else if (Scale > 67U)
             PicassoRoutine3();  // Scale is greater than 67
-        else 
+        else
             PicassoRoutine2();  // Scale is between 34 and 67
     }
 };

--- a/include/effects/matrix/PatternSMPicasso3in1.h
+++ b/include/effects/matrix/PatternSMPicasso3in1.h
@@ -152,6 +152,7 @@ class PatternSMPicasso3in1 : public EffectWithId<idMatrixSMPicasso3in1>
     }
 
   public:
+  
     PatternSMPicasso3in1()
       : EffectWithId<idMatrixSMPicasso3in1>("Picasso"),
         _scale(-1)

--- a/include/effects/matrix/PatternSMRadialFire.h
+++ b/include/effects/matrix/PatternSMRadialFire.h
@@ -4,19 +4,16 @@
 
 // Derived from https://editor.soulmatelights.com/gallery/1570-radialfire
 
-class PatternSMRadialFire : public LEDStripEffect
+class PatternSMRadialFire : public EffectWithId<idMatrixSMRadialFire>
 {
 public:
-    static constexpr EffectId kId = idMatrixSMRadialFire;
-    EffectId effectId() const override { return kId; }
-
-    PatternSMRadialFire() : LEDStripEffect(idMatrixSMRadialFire, "RadialFire") {}
-    PatternSMRadialFire(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject) {}
+    PatternSMRadialFire() : EffectWithId<idMatrixSMRadialFire>("RadialFire") {}
+    PatternSMRadialFire(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMRadialFire>(jsonObject) {}
 
   private:
     static auto constexpr C_X = (MATRIX_WIDTH / 2);
     static auto constexpr C_Y = (MATRIX_HEIGHT / 2);
-    
+
     std::unique_ptr<uint8_t[]> XY_angle_buf;
     std::unique_ptr<uint8_t[]> XY_radius_buf;
 
@@ -54,7 +51,7 @@ public:
                 uint8_t radius = XY_radius_buf[idx];
                 int16_t Bri = inoise8(angle * scaleX, (radius * scaleY) - t) - radius * (255 / MATRIX_HEIGHT);
                 uint8_t Col = Bri;
-                
+
                 if (Bri < 0)
                     Bri = 0;
                 if (Bri != 0)
@@ -67,9 +64,9 @@ public:
 
                 // Step 2: Choose base color depending on palette state
                 CRGB baseColor;
-                if (g()->IsPalettePaused()) 
+                if (g()->IsPalettePaused())
                     baseColor = g()->ColorFromCurrentPalette(Col);
-                else 
+                else
                     baseColor = CRGB::Red;
 
                 // Step 3: Get black body heat color

--- a/include/effects/matrix/PatternSMRadialFire.h
+++ b/include/effects/matrix/PatternSMRadialFire.h
@@ -6,11 +6,13 @@
 
 class PatternSMRadialFire : public EffectWithId<idMatrixSMRadialFire>
 {
-public:
+  public:
+
     PatternSMRadialFire() : EffectWithId<idMatrixSMRadialFire>("RadialFire") {}
     PatternSMRadialFire(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMRadialFire>(jsonObject) {}
 
   private:
+
     static auto constexpr C_X = (MATRIX_WIDTH / 2);
     static auto constexpr C_Y = (MATRIX_HEIGHT / 2);
 

--- a/include/effects/matrix/PatternSMRadialWave.h
+++ b/include/effects/matrix/PatternSMRadialWave.h
@@ -5,12 +5,8 @@
 // Derived from https://editor.soulmatelights.com/gallery/1090-radialwave
 // A three-veined swirl rotates and changes direction, looking like an exhaust.
 
-class PatternSMRadialWave : public LEDStripEffect
+class PatternSMRadialWave : public EffectWithId<idMatrixSMRadialWave>
 {
-  public:
-    static constexpr EffectId kId = idMatrixSMRadialWave;
-    EffectId effectId() const override { return kId; }
-  
   private:
     // RadialWave
     // Stepko and Sutaburosu
@@ -28,13 +24,8 @@ class PatternSMRadialWave : public LEDStripEffect
     } rMap[MATRIX_WIDTH][MATRIX_HEIGHT];
 
   public:
-    PatternSMRadialWave() : LEDStripEffect(idMatrixSMRadialWave, "RadialWave")
-    {
-    }
-
-    PatternSMRadialWave(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    PatternSMRadialWave() : EffectWithId<idMatrixSMRadialWave>("RadialWave") {}
+    PatternSMRadialWave(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMRadialWave>(jsonObject) {}
 
     virtual size_t DesiredFramesPerSecond() const           // Desired framerate of the LED drawing
     {

--- a/include/effects/matrix/PatternSMRadialWave.h
+++ b/include/effects/matrix/PatternSMRadialWave.h
@@ -24,6 +24,7 @@ class PatternSMRadialWave : public EffectWithId<idMatrixSMRadialWave>
     } rMap[MATRIX_WIDTH][MATRIX_HEIGHT];
 
   public:
+  
     PatternSMRadialWave() : EffectWithId<idMatrixSMRadialWave>("RadialWave") {}
     PatternSMRadialWave(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMRadialWave>(jsonObject) {}
 

--- a/include/effects/matrix/PatternSMRainbowTunnel.h
+++ b/include/effects/matrix/PatternSMRainbowTunnel.h
@@ -5,7 +5,7 @@
 // Inspired by https://editor.soulmatelights.com/gallery/1620-rainbow-tunel
 // Like Hypnosis, a swirling radial rainbow, but entering a black hole.
 
-class PatternSMRainbowTunnel : public LEDStripEffect
+class PatternSMRainbowTunnel : public EffectWithId<idMatrixSMRainbowTunnel>
 {
   private:
     // RadialRainbow
@@ -23,16 +23,8 @@ class PatternSMRainbowTunnel : public LEDStripEffect
     } rMap[MATRIX_WIDTH][MATRIX_HEIGHT];
 
   public:
-    static constexpr EffectId kId = idMatrixSMRainbowTunnel;
-    EffectId effectId() const override { return kId; }
-
-    PatternSMRainbowTunnel() : LEDStripEffect(idMatrixSMRainbowTunnel, "Colorspin")
-    {
-    }
-
-    PatternSMRainbowTunnel(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    PatternSMRainbowTunnel() : EffectWithId<idMatrixSMRainbowTunnel>("Colorspin") {}
+    PatternSMRainbowTunnel(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMRainbowTunnel>(jsonObject) {}
 
     void Start() override
     {
@@ -53,7 +45,7 @@ class PatternSMRainbowTunnel : public LEDStripEffect
         static constexpr uint8_t scaleX = 4;
         static constexpr uint8_t scaleY = 4;
         static constexpr uint8_t speed = 2;
-        
+
         static uint16_t t;
 
         t += speed;

--- a/include/effects/matrix/PatternSMRainbowTunnel.h
+++ b/include/effects/matrix/PatternSMRainbowTunnel.h
@@ -23,6 +23,7 @@ class PatternSMRainbowTunnel : public EffectWithId<idMatrixSMRainbowTunnel>
     } rMap[MATRIX_WIDTH][MATRIX_HEIGHT];
 
   public:
+  
     PatternSMRainbowTunnel() : EffectWithId<idMatrixSMRainbowTunnel>("Colorspin") {}
     PatternSMRainbowTunnel(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMRainbowTunnel>(jsonObject) {}
 

--- a/include/effects/matrix/PatternSMSmoke.h
+++ b/include/effects/matrix/PatternSMSmoke.h
@@ -4,12 +4,8 @@
 
 // Derived from https://editor.soulmatelights.com/gallery/1116-smoke
 
-class PatternSMSmoke : public LEDStripEffect
+class PatternSMSmoke : public EffectWithId<idMatrixSMSmoke>
 {
-public:
-  static constexpr EffectId kId = idMatrixSMSmoke;
-  EffectId effectId() const override { return kId; }
-
 private:
   static constexpr uint8_t Scale = 50; // 1-100. Setting
 
@@ -22,14 +18,10 @@ private:
 
 public:
   PatternSMSmoke()
-    : LEDStripEffect(idMatrixSMSmoke, "Smoke")
-  {
-  }
+    : EffectWithId<idMatrixSMSmoke>("Smoke") {}
 
   PatternSMSmoke(const JsonObjectConst &jsonObject)
-    : LEDStripEffect(jsonObject)
-  {
-  }
+    : EffectWithId<idMatrixSMSmoke>(jsonObject) {}
 
   virtual size_t DesiredFramesPerSecond() const           // Desired framerate of the LED drawing
   {

--- a/include/effects/matrix/PatternSMSmoke.h
+++ b/include/effects/matrix/PatternSMSmoke.h
@@ -7,6 +7,7 @@
 class PatternSMSmoke : public EffectWithId<idMatrixSMSmoke>
 {
 private:
+
   static constexpr uint8_t Scale = 50; // 1-100. Setting
 
   static constexpr int WIDTH = MATRIX_WIDTH;
@@ -17,6 +18,7 @@ private:
   uint8_t deltaHue {0}, deltaHue2 {0};
 
 public:
+
   PatternSMSmoke()
     : EffectWithId<idMatrixSMSmoke>("Smoke") {}
 

--- a/include/effects/matrix/PatternSMSpiroPulse.h
+++ b/include/effects/matrix/PatternSMSpiroPulse.h
@@ -7,7 +7,7 @@
 //
 // This is one of relatively few that would look better at a higher refresh.
 
-class PatternSMSpiroPulse : public LEDStripEffect
+class PatternSMSpiroPulse : public EffectWithId<idMatrixSMSpiroPulse>
 {
   private:
     static constexpr int CenterX = ((MATRIX_WIDTH / 2) - 0.5);
@@ -60,16 +60,9 @@ class PatternSMSpiroPulse : public LEDStripEffect
     }
 
   public:
-    static constexpr EffectId kId = idMatrixSMSpiroPulse;
-    EffectId effectId() const override { return kId; }
-    
-    PatternSMSpiroPulse() : LEDStripEffect(idMatrixSMSpiroPulse, "Spiro")
-    {
-    }
+    PatternSMSpiroPulse() : EffectWithId<idMatrixSMSpiroPulse>("Spiro") {}
 
-    PatternSMSpiroPulse(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    PatternSMSpiroPulse(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMSpiroPulse>(jsonObject) {}
 
     void Start() override
     {

--- a/include/effects/matrix/PatternSMSpiroPulse.h
+++ b/include/effects/matrix/PatternSMSpiroPulse.h
@@ -10,6 +10,7 @@
 class PatternSMSpiroPulse : public EffectWithId<idMatrixSMSpiroPulse>
 {
   private:
+
     static constexpr int CenterX = ((MATRIX_WIDTH / 2) - 0.5);
     static constexpr int CenterY = ((MATRIX_HEIGHT / 2) - 0.5);
     bool incenter {false};
@@ -60,8 +61,8 @@ class PatternSMSpiroPulse : public EffectWithId<idMatrixSMSpiroPulse>
     }
 
   public:
-    PatternSMSpiroPulse() : EffectWithId<idMatrixSMSpiroPulse>("Spiro") {}
 
+    PatternSMSpiroPulse() : EffectWithId<idMatrixSMSpiroPulse>("Spiro") {}
     PatternSMSpiroPulse(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMSpiroPulse>(jsonObject) {}
 
     void Start() override

--- a/include/effects/matrix/PatternSMStarDeep.h
+++ b/include/effects/matrix/PatternSMStarDeep.h
@@ -6,7 +6,7 @@
 // The original has a bunch of Palette management stuff we just didn't
 // implement.
 
-class PatternSMStarDeep : public LEDStripEffect
+class PatternSMStarDeep : public EffectWithId<idMatrixSMStarDeep>
 {
   private:
 // Why are these named "bballs"? Probably reused effect innards.
@@ -43,16 +43,9 @@ class PatternSMStarDeep : public LEDStripEffect
     const int spirocenterY = CENTER_Y_MINOR;
 
   public:
-    static constexpr EffectId kId = idMatrixSMStarDeep;
-    EffectId effectId() const override { return kId; }
-    
-    PatternSMStarDeep() : LEDStripEffect(kId, "Star Deep")
-    {
-    }
+    PatternSMStarDeep() : EffectWithId<idMatrixSMStarDeep>("Star Deep") {}
 
-    PatternSMStarDeep(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    PatternSMStarDeep(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMStarDeep>(jsonObject) {}
 
     void Start() override
     {

--- a/include/effects/matrix/PatternSMStarDeep.h
+++ b/include/effects/matrix/PatternSMStarDeep.h
@@ -9,7 +9,8 @@
 class PatternSMStarDeep : public EffectWithId<idMatrixSMStarDeep>
 {
   private:
-// Why are these named "bballs"? Probably reused effect innards.
+
+   // Why are these named "bballs"? Probably reused effect innards.
    static constexpr int bballsMaxNUM = 100U; // the maximum number of tracked
                                   // objects (very affects memory consumption)
     uint8_t bballsCOLOR[bballsMaxNUM]; // star color (reusing the Balls effect array)
@@ -43,8 +44,8 @@ class PatternSMStarDeep : public EffectWithId<idMatrixSMStarDeep>
     const int spirocenterY = CENTER_Y_MINOR;
 
   public:
-    PatternSMStarDeep() : EffectWithId<idMatrixSMStarDeep>("Star Deep") {}
 
+    PatternSMStarDeep() : EffectWithId<idMatrixSMStarDeep>("Star Deep") {}
     PatternSMStarDeep(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMStarDeep>(jsonObject) {}
 
     void Start() override

--- a/include/effects/matrix/PatternSMStrobeDiffusion.h
+++ b/include/effects/matrix/PatternSMStrobeDiffusion.h
@@ -13,9 +13,9 @@
 // magic for blur2d().
 
 #if ENABLE_AUDIO
-class PatternSMStrobeDiffusion : public BeatEffectBase, public LEDStripEffect
+class PatternSMStrobeDiffusion : public BeatEffectBase, public EffectWithId<idMatrixSMStrobeDiffusion>
 #else
-class PatternSMStrobeDiffusion : public LEDStripEffect
+class PatternSMStrobeDiffusion : public EffectWithId<idMatrixSMStrobeDiffusion>
 #endif
 {
   private:
@@ -32,17 +32,13 @@ class PatternSMStrobeDiffusion : public LEDStripEffect
 #else
     const int top_line_offset = 0;
 #endif
-
   public:
-    static constexpr EffectId kId = idMatrixSMStrobeDiffusion;
-    EffectId effectId() const override { return kId; }
-    
     PatternSMStrobeDiffusion()
         :
 #if ENABLE_AUDIO
           BeatEffectBase(1.50, 0.05),
 #endif
-          LEDStripEffect(kId, "Diffusion")
+          EffectWithId<idMatrixSMStrobeDiffusion>("Diffusion")
     {
     }
 
@@ -51,7 +47,7 @@ class PatternSMStrobeDiffusion : public LEDStripEffect
 #if ENABLE_AUDIO
           BeatEffectBase(1.50, 0.05),
 #endif
-          LEDStripEffect(jsonObject)
+          EffectWithId<idMatrixSMStrobeDiffusion>(jsonObject)
     {
     }
 

--- a/include/effects/matrix/PatternSMStrobeDiffusion.h
+++ b/include/effects/matrix/PatternSMStrobeDiffusion.h
@@ -19,6 +19,7 @@ class PatternSMStrobeDiffusion : public EffectWithId<idMatrixSMStrobeDiffusion>
 #endif
 {
   private:
+
     uint8_t hue, hue2; // gradual hue shift or some other cyclic counter
     uint8_t step { 0 }; // some counter of frames or sequences of operations
     std::bitset<MATRIX_WIDTH * MATRIX_HEIGHT> noise3d[MATRIX_WIDTH * MATRIX_HEIGHT]; // Locations of snowflakes.
@@ -32,7 +33,9 @@ class PatternSMStrobeDiffusion : public EffectWithId<idMatrixSMStrobeDiffusion>
 #else
     const int top_line_offset = 0;
 #endif
+
   public:
+  
     PatternSMStrobeDiffusion()
       :
 #if ENABLE_AUDIO

--- a/include/effects/matrix/PatternSMStrobeDiffusion.h
+++ b/include/effects/matrix/PatternSMStrobeDiffusion.h
@@ -34,20 +34,20 @@ class PatternSMStrobeDiffusion : public EffectWithId<idMatrixSMStrobeDiffusion>
 #endif
   public:
     PatternSMStrobeDiffusion()
-        :
+      :
 #if ENABLE_AUDIO
-          BeatEffectBase(1.50, 0.05),
+        BeatEffectBase(1.50, 0.05),
 #endif
-          EffectWithId<idMatrixSMStrobeDiffusion>("Diffusion")
+        EffectWithId<idMatrixSMStrobeDiffusion>("Diffusion")
     {
     }
 
     PatternSMStrobeDiffusion(const JsonObjectConst &jsonObject)
-        :
+      :
 #if ENABLE_AUDIO
-          BeatEffectBase(1.50, 0.05),
+        BeatEffectBase(1.50, 0.05),
 #endif
-          EffectWithId<idMatrixSMStrobeDiffusion>(jsonObject)
+        EffectWithId<idMatrixSMStrobeDiffusion>(jsonObject)
     {
     }
 

--- a/include/effects/matrix/PatternSMSupernova.h
+++ b/include/effects/matrix/PatternSMSupernova.h
@@ -8,6 +8,7 @@
 class PatternSMSupernova : public EffectWithId<idMatrixSMSupernova>
 {
 public:
+
     PatternSMSupernova() : EffectWithId<idMatrixSMSupernova>("Supernova"), hue(0), hue2(0), step(0) {}
     PatternSMSupernova(const JsonObjectConst &jsonDebrisItem) : EffectWithId<idMatrixSMSupernova>(jsonDebrisItem) {}
 

--- a/include/effects/matrix/PatternSMSupernova.h
+++ b/include/effects/matrix/PatternSMSupernova.h
@@ -5,14 +5,11 @@
 // Inspired by https://editor.soulmatelights.com/gallery/1923-supernova
 
 
-class PatternSMSupernova : public LEDStripEffect
+class PatternSMSupernova : public EffectWithId<idMatrixSMSupernova>
 {
 public:
-    static constexpr EffectId kId = idMatrixSMSupernova;
-    EffectId effectId() const override { return kId; }
-    
-    PatternSMSupernova() : LEDStripEffect(idMatrixSMSupernova, "Supernova"), hue(0), hue2(0), step(0) {}
-    PatternSMSupernova(const JsonObjectConst &jsonDebrisItem) : LEDStripEffect(jsonDebrisItem) {}
+    PatternSMSupernova() : EffectWithId<idMatrixSMSupernova>("Supernova"), hue(0), hue2(0), step(0) {}
+    PatternSMSupernova(const JsonObjectConst &jsonDebrisItem) : EffectWithId<idMatrixSMSupernova>(jsonDebrisItem) {}
 
     virtual size_t DesiredFramesPerSecond() const override
     {
@@ -25,7 +22,7 @@ public:
         g()->Clear();
     }
 
-    void Draw() override 
+    void Draw() override
     {
         step = -1;
         g()->DimAll(200);
@@ -138,7 +135,7 @@ private:
     {
         const uint8_t xx = (x - (int)x) * 255, yy = (y - (int)y) * 255, ix = 255 - xx, iy = 255 - yy;
         const uint8_t wu[4] = {WU_WEIGHT(ix, iy), WU_WEIGHT(xx, iy), WU_WEIGHT(ix, yy), WU_WEIGHT(xx, yy)};
-        for (uint8_t i = 0; i < 4; i++) 
+        for (uint8_t i = 0; i < 4; i++)
         {
             const int xn = x + (i & 1);
             const int yn = y + ((i >> 1) & 1);

--- a/include/effects/matrix/PatternSMTwister.h
+++ b/include/effects/matrix/PatternSMTwister.h
@@ -6,7 +6,7 @@
 // High color barber-pole with varying Y-height stripes.
 // Quite hypnotic.
 
-class PatternSMTwister : public LEDStripEffect
+class PatternSMTwister : public EffectWithId<idMatrixSMTwister>
 {
   private:
     void mydrawLine(uint8_t x, uint8_t x1, uint8_t y, CHSV color, bool dot, bool grad, uint8_t numline, uint8_t side, uint8_t sinOff,
@@ -32,16 +32,9 @@ class PatternSMTwister : public LEDStripEffect
     }
 
   public:
-    static constexpr EffectId kId = idMatrixSMTwister;
-    EffectId effectId() const override { return kId; }
-    
-    PatternSMTwister() : LEDStripEffect(kId, "Twister")
-    {
-    }
+    PatternSMTwister() : EffectWithId<idMatrixSMTwister>("Twister") {}
 
-    PatternSMTwister(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    PatternSMTwister(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMTwister>(jsonObject) {}
 
     void Start() override
     {

--- a/include/effects/matrix/PatternSMTwister.h
+++ b/include/effects/matrix/PatternSMTwister.h
@@ -9,6 +9,7 @@
 class PatternSMTwister : public EffectWithId<idMatrixSMTwister>
 {
   private:
+
     void mydrawLine(uint8_t x, uint8_t x1, uint8_t y, CHSV color, bool dot, bool grad, uint8_t numline, uint8_t side, uint8_t sinOff,
                     uint16_t a)
     { // my ugly hori line draw function )))
@@ -32,8 +33,8 @@ class PatternSMTwister : public EffectWithId<idMatrixSMTwister>
     }
 
   public:
-    PatternSMTwister() : EffectWithId<idMatrixSMTwister>("Twister") {}
 
+    PatternSMTwister() : EffectWithId<idMatrixSMTwister>("Twister") {}
     PatternSMTwister(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMTwister>(jsonObject) {}
 
     void Start() override

--- a/include/effects/matrix/PatternSMWalkingMachine.h
+++ b/include/effects/matrix/PatternSMWalkingMachine.h
@@ -90,8 +90,8 @@ class PatternSMWalkingMachine : public EffectWithId<idMatrixSMWalkingMachine>
     } dot[7];
 
   public:
-    PatternSMWalkingMachine() : EffectWithId<idMatrixSMWalkingMachine>("Machine") {}
 
+    PatternSMWalkingMachine() : EffectWithId<idMatrixSMWalkingMachine>("Machine") {}
     PatternSMWalkingMachine(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMWalkingMachine>(jsonObject) {}
 
     virtual bool RequiresDoubleBuffering() const

--- a/include/effects/matrix/PatternSMWalkingMachine.h
+++ b/include/effects/matrix/PatternSMWalkingMachine.h
@@ -4,12 +4,8 @@
 
 // Derived from https://editor.soulmatelights.com/gallery/1990-walking-machine
 
-class PatternSMWalkingMachine : public LEDStripEffect
+class PatternSMWalkingMachine : public EffectWithId<idMatrixSMWalkingMachine>
 {
-public:
-    static constexpr EffectId kId = idMatrixSMWalkingMachine;
-    EffectId effectId() const override { return kId; }
-    
   private:
     // Walking machine
     // St3p40 aka Stepko
@@ -94,13 +90,9 @@ public:
     } dot[7];
 
   public:
-    PatternSMWalkingMachine() : LEDStripEffect(idMatrixSMWalkingMachine, "Machine")
-    {
-    }
+    PatternSMWalkingMachine() : EffectWithId<idMatrixSMWalkingMachine>("Machine") {}
 
-    PatternSMWalkingMachine(const JsonObjectConst &jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    PatternSMWalkingMachine(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMWalkingMachine>(jsonObject) {}
 
     virtual bool RequiresDoubleBuffering() const
     {

--- a/include/effects/matrix/PatternSerendipity.h
+++ b/include/effects/matrix/PatternSerendipity.h
@@ -58,7 +58,7 @@
 #ifndef PatternSpiral_H
 #define PatternSpiral_H
 
-class PatternSerendipity : public LEDStripEffect
+class PatternSerendipity : public EffectWithId<idMatrixSerendipity>
 {
 private:
     // Timer stuff (Oszillators)
@@ -94,16 +94,9 @@ private:
     }
 
 public:
-    static constexpr EffectId kId = idMatrixSerendipity;
-    EffectId effectId() const override { return kId; }
-    
-    PatternSerendipity() : LEDStripEffect(kId, "Serendipiti")
-    {
-    }
+    PatternSerendipity() : EffectWithId<idMatrixSerendipity>("Serendipity") {}
 
-    PatternSerendipity(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    PatternSerendipity(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixSerendipity>(jsonObject) {}
 
     bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
     {

--- a/include/effects/matrix/PatternSerendipity.h
+++ b/include/effects/matrix/PatternSerendipity.h
@@ -60,7 +60,8 @@
 
 class PatternSerendipity : public EffectWithId<idMatrixSerendipity>
 {
-private:
+  private:
+
     // Timer stuff (Oszillators)
     struct timer
     {
@@ -93,9 +94,9 @@ private:
         }
     }
 
-public:
-    PatternSerendipity() : EffectWithId<idMatrixSerendipity>("Serendipity") {}
+  public:
 
+    PatternSerendipity() : EffectWithId<idMatrixSerendipity>("Serendipity") {}
     PatternSerendipity(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixSerendipity>(jsonObject) {}
 
     bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override

--- a/include/effects/matrix/PatternSpin.h
+++ b/include/effects/matrix/PatternSpin.h
@@ -56,14 +56,7 @@
 
 class PatternSpin : public EffectWithId<idMatrixSpin>
 {
-public:
-    // ID provided by EffectWithId
-
-    PatternSpin() : EffectWithId<idMatrixSpin>("Spin") {}
-
-    PatternSpin(String friendlyName) : EffectWithId<idMatrixSpin>(friendlyName) {}
-
-    PatternSpin(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixSpin>(jsonObject) {}
+  private:
 
     float degrees = 0;
     float radius = 16;
@@ -75,6 +68,13 @@ public:
 
     float speed = speedStart;
     float velocity = velocityStart;
+
+
+  public:
+
+    PatternSpin() : EffectWithId<idMatrixSpin>("Spin") {}
+    PatternSpin(String friendlyName) : EffectWithId<idMatrixSpin>(friendlyName) {}
+    PatternSpin(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixSpin>(jsonObject) {}
 
     void Start() override
     {

--- a/include/effects/matrix/PatternSpin.h
+++ b/include/effects/matrix/PatternSpin.h
@@ -54,23 +54,16 @@
 #ifndef PatternSpin_H
 #define PatternSpin_H
 
-class PatternSpin : public LEDStripEffect
+class PatternSpin : public EffectWithId<idMatrixSpin>
 {
 public:
-    static constexpr EffectId kId = idMatrixSpin;
-    EffectId effectId() const override { return kId; }
-    
-    PatternSpin() : LEDStripEffect(kId, "Spin")
-    {
-    }
+    // ID provided by EffectWithId
 
-    PatternSpin(const char   * pszFriendlyName) : LEDStripEffect(idMatrixSpin, pszFriendlyName)
-    {
-    }
+    PatternSpin() : EffectWithId<idMatrixSpin>("Spin") {}
 
-    PatternSpin(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    PatternSpin(String friendlyName) : EffectWithId<idMatrixSpin>(friendlyName) {}
+
+    PatternSpin(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixSpin>(jsonObject) {}
 
     float degrees = 0;
     float radius = 16;

--- a/include/effects/matrix/PatternSpiro.h
+++ b/include/effects/matrix/PatternSpiro.h
@@ -63,6 +63,7 @@
 class PatternSpiro : public EffectWithId<idMatrixSpiro>
 {
 private:
+
   uint8_t theta1 = 0;
   uint8_t theta2 = 0;
   uint8_t hueoffset = 0;
@@ -81,8 +82,8 @@ private:
   boolean handledChange = false;
 
 public:
-  PatternSpiro() : EffectWithId<idMatrixSpiro>("Spiro") {}
 
+  PatternSpiro() : EffectWithId<idMatrixSpiro>("Spiro") {}
   PatternSpiro(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixSpiro>(jsonObject) {}
 
   virtual size_t DesiredFramesPerSecond() const override

--- a/include/effects/matrix/PatternSpiro.h
+++ b/include/effects/matrix/PatternSpiro.h
@@ -60,7 +60,7 @@
 #ifndef PatternSpiro_H
 #define PatternSpiro_H
 
-class PatternSpiro : public LEDStripEffect
+class PatternSpiro : public EffectWithId<idMatrixSpiro>
 {
 private:
   uint8_t theta1 = 0;
@@ -81,13 +81,9 @@ private:
   boolean handledChange = false;
 
 public:
-  PatternSpiro() : LEDStripEffect(idMatrixSpiro, "Spiro")
-  {
-  }
+  PatternSpiro() : EffectWithId<idMatrixSpiro>("Spiro") {}
 
-  PatternSpiro(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
-  {
-  }
+  PatternSpiro(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixSpiro>(jsonObject) {}
 
   virtual size_t DesiredFramesPerSecond() const override
   {

--- a/include/effects/matrix/PatternStocks.h
+++ b/include/effects/matrix/PatternStocks.h
@@ -179,7 +179,7 @@ public:
 //
 // Retrieves stock quotes from private server and displays them
 
-class PatternStocks : public LEDStripEffect
+class PatternStocks : public EffectWithId<idMatrixStocks>
 {
     AnimatedText textSymbol = AnimatedText("STOCK",  CRGB::White, &Apple5x7,  1.0f, MATRIX_WIDTH, 0,  0, 0);
     AnimatedText textPrice  = AnimatedText("PRICE",  CRGB::Grey,  &Apple5x7,  1.0f, MATRIX_WIDTH, 8,  0, 8);
@@ -351,14 +351,9 @@ private:
 
 public:
 
-    static constexpr EffectId kId = idMatrixStocks;
-    EffectId effectId() const override { return kId; }
-    
-    PatternStocks() : LEDStripEffect(kId, "Stocks")
-    {
-    }
+    PatternStocks() : EffectWithId<idMatrixStocks>("Stocks") {}
 
-    PatternStocks(const JsonObjectConst&  jsonObject) : LEDStripEffect(jsonObject)
+    PatternStocks(const JsonObjectConst&  jsonObject) : EffectWithId<idMatrixStocks>(jsonObject)
     {
         if (jsonObject["sds"].is<String>())
             stockServer = jsonObject["sds"].as<String>();

--- a/include/effects/matrix/PatternStocks.h
+++ b/include/effects/matrix/PatternStocks.h
@@ -71,6 +71,7 @@ using namespace std::chrono_literals;
 class AnimatedText
 {
   private:
+
     int startX;
     int startY;
     int endX;
@@ -85,6 +86,7 @@ class AnimatedText
 
 
   public:
+  
     AnimatedText(String text, CRGB color, const GFXfont * pfont, float animationTime, int startX, int startY, int endX, int endY)
     {
         startTime = system_clock::now();

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -43,7 +43,7 @@
 #define DEFAULT_CHANNEL_GUID "9558daa1-eae8-482f-8066-17fa787bc0e4"
 #define DEFAULT_CHANNEL_NAME "Daves Garage"
 
-class PatternSubscribers : public LEDStripEffect
+class PatternSubscribers : public EffectWithId<idMatrixSubscribers>
 {
   private:
     // This requires a matching INIT_EFFECT_SETTING_SPECS() in effects.cpp or linker errors will ensue
@@ -161,14 +161,9 @@ class PatternSubscribers : public LEDStripEffect
 
   public:
 
-    static constexpr EffectId kId = idMatrixSubscribers;
-    EffectId effectId() const override { return kId; }
-    
-    PatternSubscribers() : LEDStripEffect(kId, "Subs")
-    {
-    }
+    PatternSubscribers() : EffectWithId<idMatrixSubscribers>("Subs") {}
 
-    PatternSubscribers(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
+    PatternSubscribers(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixSubscribers>(jsonObject)
     {
         if (jsonObject["ycg"].is<String>())
             youtubeChannelGuid = jsonObject["ycg"].as<String>();

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -46,6 +46,7 @@
 class PatternSubscribers : public EffectWithId<idMatrixSubscribers>
 {
   private:
+
     // This requires a matching INIT_EFFECT_SETTING_SPECS() in effects.cpp or linker errors will ensue
     DECLARE_EFFECT_SETTING_SPECS(mySettingSpecs);
 
@@ -162,7 +163,6 @@ class PatternSubscribers : public EffectWithId<idMatrixSubscribers>
   public:
 
     PatternSubscribers() : EffectWithId<idMatrixSubscribers>("Subs") {}
-
     PatternSubscribers(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixSubscribers>(jsonObject)
     {
         if (jsonObject["ycg"].is<String>())

--- a/include/effects/matrix/PatternSwirl.h
+++ b/include/effects/matrix/PatternSwirl.h
@@ -57,23 +57,15 @@
 
 #ifndef PatternSwirl_H
 
-class PatternSwirl : public LEDStripEffect
+class PatternSwirl : public EffectWithId<idMatrixSwirl>
 {
-  public:
-    static constexpr EffectId kId = idMatrixSwirl;
-    EffectId effectId() const override { return kId; }
-
   private:
     const uint8_t borderWidth = 2;
 
 public:
-    PatternSwirl() : LEDStripEffect(idMatrixSwirl, "Swirl")
-    {
-    }
+    PatternSwirl() : EffectWithId<idMatrixSwirl>("Swirl") {}
 
-    PatternSwirl(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    PatternSwirl(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixSwirl>(jsonObject) {}
 
     void drawAt(int i, int j, CRGB color)
     {

--- a/include/effects/matrix/PatternSwirl.h
+++ b/include/effects/matrix/PatternSwirl.h
@@ -60,11 +60,12 @@
 class PatternSwirl : public EffectWithId<idMatrixSwirl>
 {
   private:
+
     const uint8_t borderWidth = 2;
 
-public:
-    PatternSwirl() : EffectWithId<idMatrixSwirl>("Swirl") {}
+  public:
 
+    PatternSwirl() : EffectWithId<idMatrixSwirl>("Swirl") {}
     PatternSwirl(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixSwirl>(jsonObject) {}
 
     void drawAt(int i, int j, CRGB color)

--- a/include/effects/matrix/PatternWave.h
+++ b/include/effects/matrix/PatternWave.h
@@ -61,6 +61,7 @@
 class PatternWave : public EffectWithId<idMatrixWave>
 {
   private:
+
     uint8_t thetaUpdate = 4;
     uint8_t thetaUpdateFrequency = 0;
     uint8_t theta = 0;
@@ -84,8 +85,8 @@ class PatternWave : public EffectWithId<idMatrixWave>
         waveCount = random(1, 3);
     }
 
-
 public:
+
     PatternWave() : EffectWithId<idMatrixWave>("Wave")
     {
         construct();

--- a/include/effects/matrix/PatternWave.h
+++ b/include/effects/matrix/PatternWave.h
@@ -58,12 +58,8 @@
 #ifndef PatternWave_H
 #define PatternWave_H
 
-class PatternWave : public LEDStripEffect
+class PatternWave : public EffectWithId<idMatrixWave>
 {
-  public:
-    static constexpr EffectId kId = idMatrixWave;
-    EffectId effectId() const override { return kId; }
-
   private:
     uint8_t thetaUpdate = 4;
     uint8_t thetaUpdateFrequency = 0;
@@ -90,12 +86,12 @@ class PatternWave : public LEDStripEffect
 
 
 public:
-    PatternWave() : LEDStripEffect(idMatrixWave, "Wave")
+    PatternWave() : EffectWithId<idMatrixWave>("Wave")
     {
         construct();
     }
 
-    PatternWave(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
+    PatternWave(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixWave>(jsonObject)
     {
         construct();
     }

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -121,12 +121,8 @@ static std::map<const String, EmbeddedFile, std::less<const String>, psram_alloc
  * @brief This class implements the Weather Data effect
  *
  */
-class PatternWeather : public LEDStripEffect
+class PatternWeather : public EffectWithId<idMatrixWeather>
 {
-  public:
-    static constexpr EffectId kId = idMatrixWeather;
-    EffectId effectId() const override { return kId; }
-
   private:
 
     String strLocationName    = "";
@@ -442,18 +438,14 @@ public:
      * @brief Construct a new Pattern Weather object
      *
      */
-    PatternWeather() : LEDStripEffect(idMatrixWeather, "Weather")
-    {
-    }
+    PatternWeather() : EffectWithId<idMatrixWeather>("Weather") {}
 
     /**
      * @brief Construct a new Pattern Weather object
      *
      * @param jsonObject Configuration JSON Object
      */
-    PatternWeather(const JsonObjectConst&  jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    PatternWeather(const JsonObjectConst&  jsonObject) : EffectWithId<idMatrixWeather>(jsonObject) {}
 
     /**
      * @brief Destroy the Pattern Weather object

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -41,11 +41,14 @@
 
 class InsulatorSpectrumEffect : public EffectWithId<idMatrixInsulatorSpectrum>, public BeatEffectBase, public ParticleSystem<SpinningPaletteRingParticle>
 {
+  private:
+
     int                    _iLastInsulator = 0;
     const CRGBPalette16 & _Palette;
     CRGB _baseColor = CRGB::Black;
 
   public:
+
     InsulatorSpectrumEffect(const String & strName, const CRGBPalette16 & Palette) :
         EffectWithId<idMatrixInsulatorSpectrum>(strName),
         BeatEffectBase(1.50, 0.25),
@@ -182,7 +185,8 @@ class VUMeter
 
 class VUMeterVertical : public VUMeter
 {
-private:
+  private:
+
     virtual inline void EraseVUMeter(std::vector<std::shared_ptr<GFXBase>> & GFX, int start, int yVU) const
     {
         for (int i = start; i <= GFX[0]->width(); i++)
@@ -200,7 +204,8 @@ private:
             device->setPixel(i, yVU, ColorFromPalette(pPalette ? *pPalette : vu_gpGreen,  i*256/GFX[0]->width()).fadeToBlackBy(fadeBy));
     }
 
-public:
+  public:
+
     void DrawVUMeter(std::vector<std::shared_ptr<GFXBase>> & GFX, int yVU = 0, const CRGBPalette16 * pPalette = nullptr)
     {
         const int MAX_FADE = 256;
@@ -236,6 +241,7 @@ public:
 class VUMeterEffect : virtual public VUMeter, public EffectWithId<idStripVUMeter>
 {
 public:
+
     virtual void Draw() override
     {
         DrawVUMeter(g_ptrSystem->EffectManager().GetBaseGraphics(), 0);
@@ -254,6 +260,7 @@ public:
 class VUMeterVerticalEffect : virtual public VUMeterVertical, public EffectWithId<idStripVUMeterVertical>
 {
 public:
+
     virtual void Draw() override
     {
         DrawVUMeter(g_ptrSystem->EffectManager().GetBaseGraphics(), 0);
@@ -275,9 +282,6 @@ public:
 
 class SpectrumAnalyzerEffect : public EffectWithId<idMatrixSpectrumAnalyzer>, virtual public VUMeter
 {
-  public:
-
-
   protected:
 
     uint8_t   _numBars;
@@ -535,7 +539,6 @@ class SpectrumAnalyzerEffect : public EffectWithId<idMatrixSpectrumAnalyzer>, vi
     }
 };
 
-
 // WaveformEffect [MATRIX EFFECT]
 //
 // Draws a colorful scrolling waveform driven by instantaneous VU as it scrolls
@@ -543,12 +546,14 @@ class SpectrumAnalyzerEffect : public EffectWithId<idMatrixSpectrumAnalyzer>, vi
 class WaveformEffect : public EffectWithId<idMatrixWaveform>
 {
     protected:
+
         uint8_t                      _iColorOffset = 0;
         uint8_t                      _increment = 0;
         float                        _iPeakVUy = 0;
         unsigned long                _msPeakVU = 0;
 
     public:
+
         WaveformEffect(const String & pszFriendlyName, uint8_t increment = 0)
             : EffectWithId<idMatrixWaveform>(pszFriendlyName),
               _increment(increment)
@@ -831,8 +836,8 @@ class SpectrumBarEffect : public EffectWithId<idMatrixSpectrumBar>, public BeatE
 class AudioSpikeEffect : public EffectWithId<idMatrixAudioSpike>
 {
   public:
-    AudioSpikeEffect(const String & pszFriendlyName) : EffectWithId<idMatrixAudioSpike>(pszFriendlyName) {}
 
+    AudioSpikeEffect(const String & pszFriendlyName) : EffectWithId<idMatrixAudioSpike>(pszFriendlyName) {}
     AudioSpikeEffect(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixAudioSpike>(jsonObject) {}
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -39,18 +39,15 @@
 
 #if ENABLE_AUDIO
 
-class InsulatorSpectrumEffect : public LEDStripEffect, public BeatEffectBase, public ParticleSystem<SpinningPaletteRingParticle>
+class InsulatorSpectrumEffect : public EffectWithId<idMatrixInsulatorSpectrum>, public BeatEffectBase, public ParticleSystem<SpinningPaletteRingParticle>
 {
     int                    _iLastInsulator = 0;
     const CRGBPalette16 & _Palette;
     CRGB _baseColor = CRGB::Black;
 
   public:
-    static constexpr EffectId kId = idMatrixInsulatorSpectrum;
-    EffectId effectId() const override { return kId; }
-
     InsulatorSpectrumEffect(const String & strName, const CRGBPalette16 & Palette) :
-        LEDStripEffect(strName),
+        EffectWithId<idMatrixInsulatorSpectrum>(strName),
         BeatEffectBase(1.50, 0.25),
         ParticleSystem<SpinningPaletteRingParticle>(),
         _Palette(Palette)
@@ -58,7 +55,7 @@ class InsulatorSpectrumEffect : public LEDStripEffect, public BeatEffectBase, pu
     }
 
     InsulatorSpectrumEffect(const JsonObjectConst& jsonObject) :
-        LEDStripEffect(jsonObject),
+        EffectWithId<idMatrixInsulatorSpectrum>(jsonObject),
         BeatEffectBase(1.50, 0.25),
         ParticleSystem<SpinningPaletteRingParticle>(),
         _Palette(jsonObject[PTY_PALETTE].as<CRGBPalette16>())
@@ -236,22 +233,20 @@ public:
     }
 };
 
-class VUMeterEffect : virtual public VUMeter, public LEDStripEffect
+class VUMeterEffect : virtual public VUMeter, public EffectWithId<idStripVUMeter>
 {
 public:
-    static constexpr EffectId kId = idStripVUMeter;
-    EffectId effectId() const override { return kId; }
     virtual void Draw() override
     {
         DrawVUMeter(g_ptrSystem->EffectManager().GetBaseGraphics(), 0);
     }
 
-    VUMeterEffect() : LEDStripEffect("VUMeter")
+    VUMeterEffect() : EffectWithId<idStripVUMeter>("VUMeter")
     {
     }
 
-    VUMeterEffect(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject)
+        VUMeterEffect(const JsonObjectConst& jsonObject)
+             : EffectWithId<idStripVUMeter>(jsonObject)
     {
     }
 
@@ -261,22 +256,20 @@ public:
     }
 };
 
-class VUMeterVerticalEffect : virtual public VUMeterVertical, public LEDStripEffect
+class VUMeterVerticalEffect : virtual public VUMeterVertical, public EffectWithId<idStripVUMeterVertical>
 {
 public:
-    static constexpr EffectId kId = idStripVUMeterVertical;
-    EffectId effectId() const override { return kId; }
     virtual void Draw() override
     {
         DrawVUMeter(g_ptrSystem->EffectManager().GetBaseGraphics(), 0);
     }
 
-    VUMeterVerticalEffect() : LEDStripEffect("Vertical VUMeter")
+    VUMeterVerticalEffect() : EffectWithId<idStripVUMeterVertical>("Vertical VUMeter")
     {
     }
 
-    VUMeterVerticalEffect(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject)
+        VUMeterVerticalEffect(const JsonObjectConst& jsonObject)
+                : EffectWithId<idStripVUMeterVertical>(jsonObject)
     {
     }
 
@@ -290,12 +283,10 @@ public:
 // An effect that draws an audio spectrum analyzer on a matrix.  It is assumed that the
 // matrix is 48x16 using LED Channel 0 only.   Has a VU meter up top and 16 bands.
 
-class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter 
+class SpectrumAnalyzerEffect : public EffectWithId<idMatrixSpectrumAnalyzer>, virtual public VUMeter
 {
   public:
-  
-    static constexpr EffectId kId = idMatrixSpectrumAnalyzer;
-    EffectId effectId() const override { return kId; }
+
 
   protected:
 
@@ -427,8 +418,8 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter
                            float           peak1DecayRate = 1.0,
                            float           peak2DecayRate = 1.0,
                            bool              bScrollBars  = false)
-    : LEDStripEffect(pszFriendlyName),
-          _numBars(cNumBars),
+    : EffectWithId<idMatrixSpectrumAnalyzer>(pszFriendlyName),
+              _numBars(cNumBars),
           _colorOffset(0),
           _colorScrollSpeed(scrollSpeed),
           _fadeRate(fadeRate),
@@ -447,7 +438,7 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter
                            float            peak1DecayRate = 1.0,
                            float            peak2DecayRate = 1.0,
                            bool                bScrollBars = false)
-    : LEDStripEffect(pszFriendlyName),
+    : EffectWithId<idMatrixSpectrumAnalyzer>(pszFriendlyName),
           _numBars(cNumBars),
           _colorOffset(0),
           _colorScrollSpeed(0),
@@ -462,7 +453,7 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter
     }
 
     SpectrumAnalyzerEffect(const JsonObjectConst& jsonObject)
-        : LEDStripEffect(jsonObject),
+        : EffectWithId<idMatrixSpectrumAnalyzer>(jsonObject),
           _numBars(jsonObject["nmb"]),
           _colorOffset(0),
           _colorScrollSpeed(jsonObject[PTY_SPEED]),
@@ -559,12 +550,9 @@ class SpectrumAnalyzerEffect : public LEDStripEffect, virtual public VUMeter
 //
 // Draws a colorful scrolling waveform driven by instantaneous VU as it scrolls
 
-class WaveformEffect : public LEDStripEffect 
+class WaveformEffect : public EffectWithId<idMatrixWaveform>
 {
     public:
- 
-        static constexpr EffectId kId = idMatrixWaveform;
-        EffectId effectId() const override { return kId; }
 
     protected:
         uint8_t                      _iColorOffset = 0;
@@ -574,13 +562,13 @@ class WaveformEffect : public LEDStripEffect
 
     public:
         WaveformEffect(const String & pszFriendlyName, uint8_t increment = 0)
-            : LEDStripEffect(pszFriendlyName),
+            : EffectWithId<idMatrixWaveform>(pszFriendlyName),
                     _increment(increment)
         {
         }
 
         WaveformEffect(const JsonObjectConst& jsonObject)
-            : LEDStripEffect(jsonObject),
+            : EffectWithId<idMatrixWaveform>(jsonObject),
                     _increment(jsonObject["inc"])
         {
         }
@@ -649,9 +637,9 @@ class GhostWave : public WaveformEffect
 {
   public:
     static constexpr EffectId kId = idMatrixGhostWave;
-    
+
     EffectId effectId() const override { return kId; }
-    
+
     uint8_t                   _blur     = 0;
     bool                      _erase    = true;
     int                       _fade     = 0;
@@ -730,18 +718,17 @@ class GhostWave : public WaveformEffect
 //
 // Draws an approximation of the waveform by mirroring the spectrum analyzer bars in four quadrants
 
-class SpectrumBarEffect : public LEDStripEffect, public BeatEffectBase
+class SpectrumBarEffect : public EffectWithId<idMatrixSpectrumBar>, public BeatEffectBase
 {
   public:
-    static constexpr EffectId kId = idMatrixSpectrumBar;
-    EffectId effectId() const override { return kId; }
+
 
     uint8_t _hueIncrement = 0;
     uint8_t _scrollIncrement = 0;
     uint8_t _hueStep = 0;
 
     SpectrumBarEffect(const char   * pszFriendlyName, uint8_t hueStep = 16, uint8_t hueIncrement = 4, uint8_t scrollIncrement = 0)
-    : LEDStripEffect(pszFriendlyName),
+    : EffectWithId<idMatrixSpectrumBar>(pszFriendlyName),
         _hueIncrement(hueIncrement),
         _scrollIncrement(scrollIncrement),
         _hueStep(hueStep)
@@ -749,7 +736,7 @@ class SpectrumBarEffect : public LEDStripEffect, public BeatEffectBase
     }
 
     SpectrumBarEffect(const JsonObjectConst& jsonObject)
-        : LEDStripEffect(jsonObject),
+        : EffectWithId<idMatrixSpectrumBar>(jsonObject),
           _hueIncrement(jsonObject[PTY_DELTAHUE]),
           _scrollIncrement(jsonObject[PTY_SPEED]),
           _hueStep(jsonObject[PTY_HUESTEP])
@@ -853,19 +840,16 @@ class SpectrumBarEffect : public LEDStripEffect, public BeatEffectBase
 //
 // Simply displays the raw audio sample buffer as a waveform
 
-class AudioSpikeEffect : public LEDStripEffect
+class AudioSpikeEffect : public EffectWithId<idMatrixAudioSpike>
 {
   public:
-    static constexpr EffectId kId = idMatrixAudioSpike;
-    EffectId effectId() const override { return kId; }
-
     AudioSpikeEffect(const String & pszFriendlyName)
-    : LEDStripEffect(pszFriendlyName)
+    : EffectWithId<idMatrixAudioSpike>(pszFriendlyName)
     {
     }
 
     AudioSpikeEffect(const JsonObjectConst& jsonObject)
-        : LEDStripEffect(jsonObject)
+        : EffectWithId<idMatrixAudioSpike>(jsonObject)
     {
     }
 

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -241,14 +241,9 @@ public:
         DrawVUMeter(g_ptrSystem->EffectManager().GetBaseGraphics(), 0);
     }
 
-    VUMeterEffect() : EffectWithId<idStripVUMeter>("VUMeter")
-    {
-    }
+    VUMeterEffect() : EffectWithId<idStripVUMeter>("VUMeter") {}
 
-        VUMeterEffect(const JsonObjectConst& jsonObject)
-             : EffectWithId<idStripVUMeter>(jsonObject)
-    {
-    }
+    VUMeterEffect(const JsonObjectConst& jsonObject) : EffectWithId<idStripVUMeter>(jsonObject) {}
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
@@ -264,14 +259,9 @@ public:
         DrawVUMeter(g_ptrSystem->EffectManager().GetBaseGraphics(), 0);
     }
 
-    VUMeterVerticalEffect() : EffectWithId<idStripVUMeterVertical>("Vertical VUMeter")
-    {
-    }
+    VUMeterVerticalEffect() : EffectWithId<idStripVUMeterVertical>("Vertical VUMeter") {}
 
-        VUMeterVerticalEffect(const JsonObjectConst& jsonObject)
-                : EffectWithId<idStripVUMeterVertical>(jsonObject)
-    {
-    }
+    VUMeterVerticalEffect(const JsonObjectConst& jsonObject) : EffectWithId<idStripVUMeterVertical>(jsonObject) {}
 
     bool SerializeToJSON(JsonObject& jsonObject) override
     {
@@ -418,8 +408,8 @@ class SpectrumAnalyzerEffect : public EffectWithId<idMatrixSpectrumAnalyzer>, vi
                            float           peak1DecayRate = 1.0,
                            float           peak2DecayRate = 1.0,
                            bool              bScrollBars  = false)
-    : EffectWithId<idMatrixSpectrumAnalyzer>(pszFriendlyName),
-              _numBars(cNumBars),
+        : EffectWithId<idMatrixSpectrumAnalyzer>(pszFriendlyName),
+          _numBars(cNumBars),
           _colorOffset(0),
           _colorScrollSpeed(scrollSpeed),
           _fadeRate(fadeRate),
@@ -438,7 +428,7 @@ class SpectrumAnalyzerEffect : public EffectWithId<idMatrixSpectrumAnalyzer>, vi
                            float            peak1DecayRate = 1.0,
                            float            peak2DecayRate = 1.0,
                            bool                bScrollBars = false)
-    : EffectWithId<idMatrixSpectrumAnalyzer>(pszFriendlyName),
+        : EffectWithId<idMatrixSpectrumAnalyzer>(pszFriendlyName),
           _numBars(cNumBars),
           _colorOffset(0),
           _colorScrollSpeed(0),
@@ -552,8 +542,6 @@ class SpectrumAnalyzerEffect : public EffectWithId<idMatrixSpectrumAnalyzer>, vi
 
 class WaveformEffect : public EffectWithId<idMatrixWaveform>
 {
-    public:
-
     protected:
         uint8_t                      _iColorOffset = 0;
         uint8_t                      _increment = 0;
@@ -563,13 +551,13 @@ class WaveformEffect : public EffectWithId<idMatrixWaveform>
     public:
         WaveformEffect(const String & pszFriendlyName, uint8_t increment = 0)
             : EffectWithId<idMatrixWaveform>(pszFriendlyName),
-                    _increment(increment)
+              _increment(increment)
         {
         }
 
         WaveformEffect(const JsonObjectConst& jsonObject)
             : EffectWithId<idMatrixWaveform>(jsonObject),
-                    _increment(jsonObject["inc"])
+              _increment(jsonObject["inc"])
         {
         }
 
@@ -635,14 +623,13 @@ class WaveformEffect : public EffectWithId<idMatrixWaveform>
 
 class GhostWave : public WaveformEffect
 {
-  public:
-    static constexpr EffectId kId = idMatrixGhostWave;
-
-    EffectId effectId() const override { return kId; }
+  private:
 
     uint8_t                   _blur     = 0;
     bool                      _erase    = true;
     int                       _fade     = 0;
+
+  public:
 
     GhostWave(const String & pszFriendlyName, uint8_t increment = 0, uint8_t blur = 0, bool erase = true, int fade = 0)
         : WaveformEffect(pszFriendlyName, increment),
@@ -720,15 +707,16 @@ class GhostWave : public WaveformEffect
 
 class SpectrumBarEffect : public EffectWithId<idMatrixSpectrumBar>, public BeatEffectBase
 {
-  public:
-
+  private:
 
     uint8_t _hueIncrement = 0;
     uint8_t _scrollIncrement = 0;
     uint8_t _hueStep = 0;
 
+  public:
+
     SpectrumBarEffect(const char   * pszFriendlyName, uint8_t hueStep = 16, uint8_t hueIncrement = 4, uint8_t scrollIncrement = 0)
-    : EffectWithId<idMatrixSpectrumBar>(pszFriendlyName),
+      : EffectWithId<idMatrixSpectrumBar>(pszFriendlyName),
         _hueIncrement(hueIncrement),
         _scrollIncrement(scrollIncrement),
         _hueStep(hueStep)
@@ -843,15 +831,9 @@ class SpectrumBarEffect : public EffectWithId<idMatrixSpectrumBar>, public BeatE
 class AudioSpikeEffect : public EffectWithId<idMatrixAudioSpike>
 {
   public:
-    AudioSpikeEffect(const String & pszFriendlyName)
-    : EffectWithId<idMatrixAudioSpike>(pszFriendlyName)
-    {
-    }
+    AudioSpikeEffect(const String & pszFriendlyName) : EffectWithId<idMatrixAudioSpike>(pszFriendlyName) {}
 
-    AudioSpikeEffect(const JsonObjectConst& jsonObject)
-        : EffectWithId<idMatrixAudioSpike>(jsonObject)
-    {
-    }
+    AudioSpikeEffect(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixAudioSpike>(jsonObject) {}
 
     virtual bool SerializeToJSON(JsonObject& jsonObject) override
     {

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -635,6 +635,9 @@ class GhostWave : public WaveformEffect
     int                       _fade     = 0;
 
   public:
+    // Provide distinct ID separate from WaveformEffect
+    static constexpr EffectId ID = idMatrixGhostWave;
+    EffectId effectId() const override { return ID; }
 
     GhostWave(const String & pszFriendlyName, uint8_t increment = 0, uint8_t blur = 0, bool erase = true, int fade = 0)
         : WaveformEffect(pszFriendlyName, increment),

--- a/include/effects/strip/bouncingballeffect.h
+++ b/include/effects/strip/bouncingballeffect.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "ledstripeffect.h"
 #include "effects.h"
 
 // BouncingBallEffect
@@ -47,7 +48,7 @@ static constexpr auto ballColors = to_array(
     CRGB::Indigo,
 });
 
-class BouncingBallEffect : public LEDStripEffect
+class BouncingBallEffect : public EffectWithId<idStripBouncingBall>
 {
   private:
 
@@ -73,11 +74,8 @@ class BouncingBallEffect : public LEDStripEffect
 
   public:
 
-    static constexpr EffectId kId = idStripBouncingBall;
-    EffectId effectId() const override { return kId; }
-
     BouncingBallEffect(size_t ballCount = 3, bool bMirrored = true, bool bErase = false, int ballSize = 5)
-        : LEDStripEffect(idStripBouncingBall, "Bouncing Balls"),
+        : EffectWithId<idStripBouncingBall>("Bouncing Balls"),
           _cBalls(ballCount),
           _cBallSize(ballSize),
           _bMirrored(bMirrored),
@@ -86,7 +84,7 @@ class BouncingBallEffect : public LEDStripEffect
     }
 
     BouncingBallEffect(const JsonObjectConst&  jsonObject)
-        : LEDStripEffect(jsonObject),
+        : EffectWithId<idStripBouncingBall>(jsonObject),
           _cBalls(jsonObject["blc"]),
           _cBallSize(jsonObject["bls"]),
           _bMirrored(jsonObject[PTY_MIRORRED]),

--- a/include/effects/strip/doublepaletteeffect.h
+++ b/include/effects/strip/doublepaletteeffect.h
@@ -42,7 +42,7 @@ class DoublePaletteEffect : public EffectWithId<idStripDoublePalette>
   public:
 
     DoublePaletteEffect()
-  :  EffectWithId<idStripDoublePalette>("Double Palette"),
+     :  EffectWithId<idStripDoublePalette>("Double Palette"),
         _PaletteEffect1(RainbowColors_p, 1.0,  0.03,  4.0, 3, 3, LINEARBLEND, false, 0.5),
         _PaletteEffect2(RainbowColors_p, 1.0, -0.03, -4.0, 3, 3, LINEARBLEND, false, 0.5)
     {

--- a/include/effects/strip/doublepaletteeffect.h
+++ b/include/effects/strip/doublepaletteeffect.h
@@ -32,12 +32,8 @@
 
 #include "effects.h"
 
-class DoublePaletteEffect : public LEDStripEffect
+class DoublePaletteEffect : public EffectWithId<idStripDoublePalette>
 {
-  public:
-    static constexpr EffectId kId = idStripDoublePalette;
-    EffectId effectId() const override { return kId; }
-
   private:
 
     PaletteEffect   _PaletteEffect1;
@@ -46,14 +42,14 @@ class DoublePaletteEffect : public LEDStripEffect
   public:
 
     DoublePaletteEffect()
-  :  LEDStripEffect("Double Palette"),
+  :  EffectWithId<idStripDoublePalette>("Double Palette"),
         _PaletteEffect1(RainbowColors_p, 1.0,  0.03,  4.0, 3, 3, LINEARBLEND, false, 0.5),
         _PaletteEffect2(RainbowColors_p, 1.0, -0.03, -4.0, 3, 3, LINEARBLEND, false, 0.5)
     {
     }
 
     DoublePaletteEffect(const JsonObjectConst&  jsonObject)
-      : LEDStripEffect(jsonObject),
+      : EffectWithId<idStripDoublePalette>(jsonObject),
         _PaletteEffect1(jsonObject["pt1"].as<JsonObjectConst>()),
         _PaletteEffect2(jsonObject["pt2"].as<JsonObjectConst>())
     {

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -791,6 +791,7 @@ public:
 class ColorCycleEffectBottomUp : public EffectWithId<idStripColorCycleBottomUp>
 {
 public:
+  using EffectWithId<idStripColorCycleBottomUp>::EffectWithId;
 
   void Draw() override
   {
@@ -814,6 +815,7 @@ public:
 class ColorCycleEffectTopDown : public EffectWithId<idStripColorCycleTopDown>
 {
 public:
+  using EffectWithId<idStripColorCycleTopDown>::EffectWithId;
 
   void Draw() override
   {
@@ -837,6 +839,7 @@ public:
 class ColorCycleEffectSequential : public EffectWithId<idStripColorCycleSequential>
 {
 public:
+  using EffectWithId<idStripColorCycleSequential>::EffectWithId;
 
   void Draw() override
   {
@@ -859,9 +862,15 @@ public:
 
 class SpinningPaletteEffect : public PaletteEffect
 {
+private:
+
   int iRotate = 0;
 
 public:
+
+  static constexpr EffectId ID = idStripPaletteSpin;
+  EffectId effectId() const override { return ID; }
+
   using PaletteEffect::PaletteEffect;
 
   void Draw() override
@@ -884,6 +893,8 @@ class ColorCycleEffectRightLeft : public EffectWithId<idStripColorCycleRightLeft
 {
 public:
 
+  using EffectWithId<idStripColorCycleRightLeft>::EffectWithId;
+
   void Draw() override
   {
     FastLED.clear(false);
@@ -904,6 +915,8 @@ public:
 class ColorCycleEffectLeftRight : public EffectWithId<idStripColorCycleLeftRight>
 {
 public:
+
+  using EffectWithId<idStripColorCycleLeftRight>::EffectWithId;
 
   void Draw() override
   {
@@ -954,6 +967,7 @@ protected:
   int CellCount() const { return LEDCount * CellsPerLED; }
 
 public:
+
   FireFanEffect(CRGBPalette16 palette,
                 int ledCount,
                 int cellsPerLED = 1,

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -1121,6 +1121,9 @@ public:
 class BlueFireFanEffect : public FireFanEffect
 {
 public:
+  using FireFanEffect::FireFanEffect;
+  static constexpr EffectId ID = idStripFireFanBlue;
+  EffectId effectId() const override { return ID; }
 
   virtual CRGB MapHeatToColor(uint8_t temperature, int iChannel = 0)
   {
@@ -1138,6 +1141,9 @@ public:
 class GreenFireFanEffect : public FireFanEffect
 {
 public:
+  using FireFanEffect::FireFanEffect;
+  static constexpr EffectId ID = idStripFireFanGreen;
+  EffectId effectId() const override { return ID; }
   virtual CRGB MapHeatToColor(uint8_t temperature, int iChannel = 0)
   {
     uint8_t t192 = round((temperature / 255.0) * 191);
@@ -1157,6 +1163,7 @@ private:
     int iRotate = 0;
 
 public:
+  using EffectWithId<idStripRGBRollAround>::EffectWithId;
 
   virtual void DrawColor(CRGB color, int phase)
   {
@@ -1181,7 +1188,7 @@ private:
     int iRotate = 0;
 
 public:
-  using EffectWithId::EffectWithId;
+  using EffectWithId<idStripHueTest>::EffectWithId;
 
   void Draw() override
   {

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -481,12 +481,13 @@ public:
 class TapeReelEffect : public EffectWithId<idStripTapeReel>
 {
 private:
+
   float ReelPos[NUM_FANS] = {0};
   float ReelDir[NUM_FANS] = {0};
 
 public:
-  TapeReelEffect(const String & strName) : EffectWithId<idStripTapeReel>(strName) {}
 
+  TapeReelEffect(const String & strName) : EffectWithId<idStripTapeReel>(strName) {}
   TapeReelEffect(const JsonObjectConst& jsonObject) : EffectWithId<idStripTapeReel>(jsonObject) {}
 
   void Draw() override

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -376,21 +376,13 @@ class EmptyEffect : public LEDStripEffect
   }
 };
 
-class FanBeatEffect : public LEDStripEffect
+class FanBeatEffect : public EffectWithId<idStripFanBeat>
 {
   public:
-    static constexpr EffectId kId = idStripFanBeat;
-    EffectId effectId() const override { return kId; }
 
-public:
+  FanBeatEffect(const String & strName) : EffectWithId<idStripFanBeat>(strName) {}
 
-  FanBeatEffect(const String & strName) : LEDStripEffect(idStripFanBeat, strName)
-  {
-  }
-
-  FanBeatEffect(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
-  {
-  }
+  FanBeatEffect(const JsonObjectConst& jsonObject) : EffectWithId<idStripFanBeat>(jsonObject) {}
 
   void Draw() override
   {
@@ -450,16 +442,15 @@ public:
   }
 };
 
-class CountEffect : public LEDStripEffect
+class CountEffect : public EffectWithId<idStripCount>
 {
-  public:
-    static constexpr EffectId kId = idStripCount;
-    EffectId effectId() const override { return kId; }
 
-  using LEDStripEffect::LEDStripEffect;
+private:
 
   const int DRAW_LEN = 16;
   const int OPEN_LEN = NUM_FANS * FAN_SIZE - DRAW_LEN;
+
+public:
 
   void Draw() override
   {
@@ -487,24 +478,16 @@ class CountEffect : public LEDStripEffect
   }
 };
 
-class TapeReelEffect : public LEDStripEffect
+class TapeReelEffect : public EffectWithId<idStripTapeReel>
 {
-  public:
-    static constexpr EffectId kId = idStripTapeReel;
-    EffectId effectId() const override { return kId; }
-
 private:
   float ReelPos[NUM_FANS] = {0};
   float ReelDir[NUM_FANS] = {0};
 
 public:
-  TapeReelEffect(const String & strName) : LEDStripEffect(idStripTapeReel, strName)
-  {
-  }
+  TapeReelEffect(const String & strName) : EffectWithId<idStripTapeReel>(strName) {}
 
-  TapeReelEffect(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
-  {
-  }
+  TapeReelEffect(const JsonObjectConst& jsonObject) : EffectWithId<idStripTapeReel>(jsonObject) {}
 
   void Draw() override
   {
@@ -577,25 +560,17 @@ public:
   }
 };
 
-class PaletteReelEffect : public LEDStripEffect
+class PaletteReelEffect : public EffectWithId<idStripPaletteReel>
 {
-  public:
-    static constexpr EffectId kId = idStripPaletteReel;
-    EffectId effectId() const override { return kId; }
-
 private:
   float ReelPos[NUM_FANS] = {0};
   float ReelDir[NUM_FANS] = {0};
   int ColorOffset[NUM_FANS] = {0};
 
 public:
-  PaletteReelEffect(const String & strName) : LEDStripEffect(idStripPaletteReel, strName)
-  {
-  }
+  PaletteReelEffect(const String & strName) : EffectWithId<idStripPaletteReel>(strName) {}
 
-  PaletteReelEffect(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
-  {
-  }
+  PaletteReelEffect(const JsonObjectConst& jsonObject) : EffectWithId<idStripPaletteReel>(jsonObject) {}
 
   void Draw() override
   {
@@ -680,23 +655,18 @@ public:
   }
 };
 
-class PaletteSpinEffect : public LEDStripEffect
+class PaletteSpinEffect : public EffectWithId<idStripPaletteSpin>
 {
-  public:
-    static constexpr EffectId kId = idStripPaletteSpin;
-    EffectId effectId() const override { return kId; }
-
+private:
     const CRGBPalette16 _Palette;
     bool _bReplaceMagenta;
     float _sparkleChance;
-
-private:
     float ReelPos[NUM_FANS] = {0};
     int ColorOffset[NUM_FANS] = {0};
 
 public:
   PaletteSpinEffect(const String &strName, const CRGBPalette16 &palette, bool bReplace, float sparkleChance = 0.0)
-  : LEDStripEffect(idStripPaletteSpin, strName),
+  : EffectWithId<idStripPaletteSpin>(strName),
         _Palette(palette),
         _bReplaceMagenta(bReplace),
         _sparkleChance(sparkleChance)
@@ -704,7 +674,7 @@ public:
   }
 
   PaletteSpinEffect(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject),
+      : EffectWithId<idStripPaletteSpin>(jsonObject),
         _Palette(jsonObject[PTY_PALETTE].as<CRGBPalette16>()),
         _bReplaceMagenta(jsonObject["rpm"]),
         _sparkleChance(jsonObject["sch"])
@@ -764,27 +734,22 @@ public:
     }
   }
 };
-class ColorCycleEffect : public LEDStripEffect
+class ColorCycleEffect : public EffectWithId<idStripColorCycle>
 {
-  public:
-    static constexpr EffectId kId = idStripColorCycle;
-    EffectId effectId() const override { return kId; }
-
+private:
   PixelOrder _order;
   int _step;
 
 public:
-  using LEDStripEffect::LEDStripEffect;
-
   ColorCycleEffect(PixelOrder order = Sequential, int step = 8)
-  : LEDStripEffect(idStripColorCycle, "ColorCylceEffect"),
+  : EffectWithId<idStripColorCycle>("ColorCylceEffect"),
       _order(order),
       _step(step)
   {
   }
 
   ColorCycleEffect(const JsonObjectConst& jsonObject)
-    : LEDStripEffect(jsonObject),
+    : EffectWithId<idStripColorCycle>(jsonObject),
       _order((PixelOrder)jsonObject[PTY_ORDER]),
       _step(jsonObject["stp"])
   {
@@ -822,14 +787,9 @@ public:
   }
 };
 
-class ColorCycleEffectBottomUp : public LEDStripEffect
+class ColorCycleEffectBottomUp : public EffectWithId<idStripColorCycleBottomUp>
 {
-  public:
-    static constexpr EffectId kId = idStripColorCycleBottomUp;
-    EffectId effectId() const override { return kId; }
-
 public:
-  using LEDStripEffect::LEDStripEffect;
 
   void Draw() override
   {
@@ -850,14 +810,9 @@ public:
   }
 };
 
-class ColorCycleEffectTopDown : public LEDStripEffect
+class ColorCycleEffectTopDown : public EffectWithId<idStripColorCycleTopDown>
 {
-  public:
-    static constexpr EffectId kId = idStripColorCycleTopDown;
-    EffectId effectId() const override { return kId; }
-
 public:
-  using LEDStripEffect::LEDStripEffect;
 
   void Draw() override
   {
@@ -878,14 +833,9 @@ public:
   }
 };
 
-class ColorCycleEffectSequential : public LEDStripEffect
+class ColorCycleEffectSequential : public EffectWithId<idStripColorCycleSequential>
 {
-  public:
-    static constexpr EffectId kId = idStripColorCycleSequential;
-    EffectId effectId() const override { return kId; }
-
 public:
-  using LEDStripEffect::LEDStripEffect;
 
   void Draw() override
   {
@@ -929,14 +879,9 @@ public:
   }
 };
 
-class ColorCycleEffectRightLeft : public LEDStripEffect
+class ColorCycleEffectRightLeft : public EffectWithId<idStripColorCycleRightLeft>
 {
-  public:
-    static constexpr EffectId kId = idStripColorCycleRightLeft;
-    EffectId effectId() const override { return kId; }
-
 public:
-  using LEDStripEffect::LEDStripEffect;
 
   void Draw() override
   {
@@ -955,14 +900,9 @@ public:
   }
 };
 
-class ColorCycleEffectLeftRight : public LEDStripEffect
+class ColorCycleEffectLeftRight : public EffectWithId<idStripColorCycleLeftRight>
 {
-  public:
-    static constexpr EffectId kId = idStripColorCycleLeftRight;
-    EffectId effectId() const override { return kId; }
-
 public:
-  using LEDStripEffect::LEDStripEffect;
 
   void Draw() override
   {
@@ -981,12 +921,8 @@ public:
   }
 };
 
-class FireFanEffect : public LEDStripEffect
+class FireFanEffect : public EffectWithId<idStripFireFan>
 {
-  public:
-    static constexpr EffectId kId = idStripFireFan;
-    EffectId effectId() const override { return kId; }
-
 protected:
   CRGBPalette16 Palette;
   int LEDCount; // Number of LEDs total
@@ -1029,7 +965,7 @@ public:
                 bool bmirrored = false,
                 bool bmulticolor = false,
                 uint8_t maxSparkTemp = 255)
-  : LEDStripEffect(idStripFireFan, "FireFanEffect"),
+  : EffectWithId<idStripFireFan>("FireFanEffect"),
         Palette(palette),
         LEDCount(ledCount),
         CellsPerLED(cellsPerLED),
@@ -1049,7 +985,7 @@ public:
   }
 
   FireFanEffect(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject),
+      : EffectWithId<idStripFireFan>(jsonObject),
         Palette(jsonObject[PTY_PALETTE].as<CRGBPalette16>()),
         LEDCount(jsonObject[PTY_LEDCOUNT]),
         CellsPerLED(jsonObject[PTY_CELLSPERLED]),
@@ -1183,11 +1119,7 @@ public:
 
 class BlueFireFanEffect : public FireFanEffect
 {
-  public:
-    static constexpr EffectId kId = idStripFireFanBlue;
-    EffectId effectId() const override { return kId; }
-
-  using FireFanEffect::FireFanEffect;
+public:
 
   virtual CRGB MapHeatToColor(uint8_t temperature, int iChannel = 0)
   {
@@ -1204,12 +1136,7 @@ class BlueFireFanEffect : public FireFanEffect
 
 class GreenFireFanEffect : public FireFanEffect
 {
-  public:
-    static constexpr EffectId kId = idStripFireFanGreen;
-    EffectId effectId() const override { return kId; }
-
-  using FireFanEffect::FireFanEffect;
-
+public:
   virtual CRGB MapHeatToColor(uint8_t temperature, int iChannel = 0)
   {
     uint8_t t192 = round((temperature / 255.0) * 191);
@@ -1223,16 +1150,12 @@ class GreenFireFanEffect : public FireFanEffect
   }
 };
 
-class RGBRollAround : public LEDStripEffect
+class RGBRollAround : public EffectWithId<idStripRGBRollAround>
 {
-  public:
-    static constexpr EffectId kId = idStripRGBRollAround;
-    EffectId effectId() const override { return kId; }
-  
+private:
     int iRotate = 0;
 
 public:
-  using LEDStripEffect::LEDStripEffect;
 
   virtual void DrawColor(CRGB color, int phase)
   {
@@ -1250,16 +1173,14 @@ public:
   }
 };
 
-class HueTest : public LEDStripEffect
+class HueTest : public EffectWithId<idStripHueTest>
 {
-  public:
-    static constexpr EffectId kId = idStripHueTest;
-    EffectId effectId() const override { return kId; }
+private:
 
     int iRotate = 0;
 
 public:
-  using LEDStripEffect::LEDStripEffect;
+  using EffectWithId::EffectWithId;
 
   void Draw() override
   {
@@ -1272,19 +1193,14 @@ public:
   }
 };
 
-class RingTestEffect : public LEDStripEffect
+class RingTestEffect : public EffectWithId<idStripRingTest>
 {
   public:
-    static constexpr EffectId kId = idStripRingTest;
-    EffectId effectId() const override { return kId; }
+  // ID provided by EffectWithId
 
-    RingTestEffect() : LEDStripEffect(idStripRingTest, "Ring Test")
-    {
-    }
+    RingTestEffect() : EffectWithId<idStripRingTest>("Ring Test") {}
 
-    RingTestEffect(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    RingTestEffect(const JsonObjectConst& jsonObject) : EffectWithId<idStripRingTest>(jsonObject) {}
 
     void Draw() override
     {
@@ -1460,25 +1376,16 @@ public:
   }
 };
 
-class LanternEffect : public LEDStripEffect
+class LanternEffect : public EffectWithId<idStripLantern>
 {
-  public:
-    static constexpr EffectId kId = idStripLantern;
-    EffectId effectId() const override { return kId; }
-    
-    static const int _maxParticles = 1;
-
 private:
+  static const int _maxParticles = 1;
   LanternParticle _particles[_maxParticles];
 
 public:
-  LanternEffect() : LEDStripEffect(idStripLantern, "LanternEffect")
-  {
-  }
+  LanternEffect() : EffectWithId<idStripLantern>("LanternEffect") {}
 
-  LanternEffect(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
-  {
-  }
+  LanternEffect(const JsonObjectConst& jsonObject) : EffectWithId<idStripLantern>(jsonObject) {}
 
   size_t DesiredFramesPerSecond() const override
   {

--- a/include/effects/strip/fireeffect.h
+++ b/include/effects/strip/fireeffect.h
@@ -207,14 +207,11 @@ class FireEffect : public EffectWithId<idStripFire>
 
 class PaletteFlameEffect : public FireEffect
 {
-    public:
-        static constexpr EffectId kId = idStripPaletteFlame;
-        EffectId effectId() const override { return kId; }
+  private:
+    CRGBPalette16 _palette;
+    bool _ignoreGlobalColor;
 
-        CRGBPalette16 _palette;
-        bool _ignoreGlobalColor;
-
-public:
+  public:
     PaletteFlameEffect(const String & strName,
                        const CRGBPalette16 &palette,
                        bool ignoreGlobalColor = false,
@@ -273,10 +270,6 @@ public:
 #if ENABLE_AUDIO
 class MusicalPaletteFire : public PaletteFlameEffect, protected BeatEffectBase
 {
-    public:
-        static constexpr EffectId kId = idStripMusicalPaletteFire;
-    EffectId effectId() const override { return kId; }
-
   public:
 
     MusicalPaletteFire(const String & strName,
@@ -292,15 +285,12 @@ class MusicalPaletteFire : public PaletteFlameEffect, protected BeatEffectBase
                        bool mirrored = false)
         : PaletteFlameEffect(strName, palette, ignoreGlobalColor, ledCount, cellsPerLED, cooling, sparking, sparks, sparkHeight, reversed, mirrored),
           BeatEffectBase(1.00, 0.01)
-
-
     {
     }
 
     MusicalPaletteFire(const JsonObjectConst& jsonObject)
         : PaletteFlameEffect(jsonObject),
           BeatEffectBase(1.00, 0.01)
-
     {
     }
 
@@ -336,7 +326,7 @@ private:
 public:
 
     ClassicFireEffect(bool mirrored = false, bool reversed = false, int cooling = 5)
-    : EffectWithId<idStripClassicFire>("Classic Fire"),
+        : EffectWithId<idStripClassicFire>("Classic Fire"),
           _Mirrored(mirrored),
           _Reversed(reversed),
           _Cooling(cooling)
@@ -488,7 +478,7 @@ public:
                      bool turbo = false,
                      bool mirrored = false)
 
-    : EffectWithId<idStripSmoothFire>("Fire Sound Effect v2"),
+        : EffectWithId<idStripSmoothFire>("Fire Sound Effect v2"),
           _Reversed(reversed),
           _Cooling(cooling),
           _Sparks(sparks),

--- a/include/effects/strip/fireeffect.h
+++ b/include/effects/strip/fireeffect.h
@@ -37,11 +37,9 @@
 #include "systemcontainer.h"
 #include <numeric>
 
-class FireEffect : public LEDStripEffect
+class FireEffect : public EffectWithId<idStripFire>
 {
-  public:
-    static constexpr EffectId kId = idStripFire;
-    EffectId effectId() const override { return kId; }
+  private:
 
     void construct()
     {
@@ -75,7 +73,7 @@ class FireEffect : public LEDStripEffect
   public:
 
     FireEffect(const String & strName, int ledCount = NUM_LEDS, int cellsPerLED = 1, int cooling = 20, int sparking = 100, int sparks = 3, int sparkHeight = 4,  bool breversed = false, bool bmirrored = false)
-    : LEDStripEffect(strName),
+    : EffectWithId<idStripFire>(strName),
           LEDCount(ledCount),
           CellsPerLED(cellsPerLED),
           Cooling(cooling),
@@ -92,7 +90,7 @@ class FireEffect : public LEDStripEffect
     }
 
     FireEffect(const JsonObjectConst& jsonObject)
-        : LEDStripEffect(jsonObject),
+        : EffectWithId<idStripFire>(jsonObject),
           LEDCount(jsonObject[PTY_LEDCOUNT]),
           CellsPerLED(jsonObject[PTY_CELLSPERLED]),
           Cooling(jsonObject[PTY_COOLING]),
@@ -212,7 +210,7 @@ class PaletteFlameEffect : public FireEffect
     public:
         static constexpr EffectId kId = idStripPaletteFlame;
         EffectId effectId() const override { return kId; }
-    
+
         CRGBPalette16 _palette;
         bool _ignoreGlobalColor;
 
@@ -328,11 +326,9 @@ class MusicalPaletteFire : public PaletteFlameEffect, protected BeatEffectBase
 };
 #endif
 
-class ClassicFireEffect : public LEDStripEffect
+class ClassicFireEffect : public EffectWithId<idStripClassicFire>
 {
-  public:
-    static constexpr EffectId kId = idStripClassicFire;
-    EffectId effectId() const override { return kId; }
+private:
     bool _Mirrored;
     bool _Reversed;
     int  _Cooling;
@@ -340,7 +336,7 @@ class ClassicFireEffect : public LEDStripEffect
 public:
 
     ClassicFireEffect(bool mirrored = false, bool reversed = false, int cooling = 5)
-    : LEDStripEffect("Classic Fire"),
+    : EffectWithId<idStripClassicFire>("Classic Fire"),
           _Mirrored(mirrored),
           _Reversed(reversed),
           _Cooling(cooling)
@@ -348,7 +344,7 @@ public:
     }
 
     ClassicFireEffect(const JsonObjectConst& jsonObject)
-        : LEDStripEffect(jsonObject),
+        : EffectWithId<idStripClassicFire>(jsonObject),
           _Mirrored(jsonObject[PTY_MIRORRED]),
           _Reversed(jsonObject[PTY_REVERSED]),
           _Cooling(jsonObject[PTY_COOLING])
@@ -463,12 +459,8 @@ public:
 
 };
 
-class SmoothFireEffect : public LEDStripEffect
+class SmoothFireEffect : public EffectWithId<idStripSmoothFire>
 {
-  public:
-    static constexpr EffectId kId = idStripSmoothFire;
-    EffectId effectId() const override { return kId; }
-
 private:
     bool _Reversed;
     float _Cooling;
@@ -496,7 +488,7 @@ public:
                      bool turbo = false,
                      bool mirrored = false)
 
-    : LEDStripEffect(idStripSmoothFire, "Fire Sound Effect v2"),
+    : EffectWithId<idStripSmoothFire>("Fire Sound Effect v2"),
           _Reversed(reversed),
           _Cooling(cooling),
           _Sparks(sparks),
@@ -509,7 +501,7 @@ public:
     }
 
     SmoothFireEffect(const JsonObjectConst& jsonObject)
-        : LEDStripEffect(jsonObject),
+        : EffectWithId<idStripSmoothFire>(jsonObject),
           _Reversed(jsonObject[PTY_REVERSED]),
           _Cooling(jsonObject[PTY_COOLING]),
           _Sparks(jsonObject[PTY_SPARKS]),
@@ -625,11 +617,9 @@ public:
 
 };
 
-class BaseFireEffect : public LEDStripEffect
+class BaseFireEffect : public EffectWithId<idStripBaseFire>
 {
-  public:
-    static constexpr EffectId kId = idStripBaseFire;
-    EffectId effectId() const override { return kId; }
+  private:
 
     void construct()
     {
@@ -662,7 +652,7 @@ class BaseFireEffect : public LEDStripEffect
   public:
 
     BaseFireEffect(int ledCount, int cellsPerLED = 1, int cooling = 20, int sparking = 100, int sparks = 3, int sparkHeight = 4, bool breversed = false, bool bmirrored = false)
-        : LEDStripEffect(idStripBaseFire, "BaseFireEffect"),
+        : EffectWithId<idStripBaseFire>("BaseFireEffect"),
           Cooling(cooling),
           Sparks(sparks),
           SparkHeight(sparkHeight),
@@ -677,7 +667,7 @@ class BaseFireEffect : public LEDStripEffect
     }
 
     BaseFireEffect(const JsonObjectConst& jsonObject)
-        : LEDStripEffect(jsonObject),
+        : EffectWithId<idStripBaseFire>(jsonObject),
           Cooling(jsonObject[PTY_COOLING]),
           Sparks(jsonObject[PTY_SPARKS]),
           SparkHeight(jsonObject[PTY_SPARKHEIGHT]),

--- a/include/effects/strip/fireeffect.h
+++ b/include/effects/strip/fireeffect.h
@@ -299,13 +299,9 @@ class MusicalPaletteFire : public PaletteFlameEffect, protected BeatEffectBase
     virtual void HandleBeat(bool bMajor, float elapsed, float span) override
     {
         if (elapsed > 1)
-        {
             GenerateSparks(100);
-        }
         else
-        {
             GenerateSparks(g_Analyzer.VURatio() * 50);
-        }
     }
 
     virtual void Draw() override
@@ -318,12 +314,13 @@ class MusicalPaletteFire : public PaletteFlameEffect, protected BeatEffectBase
 
 class ClassicFireEffect : public EffectWithId<idStripClassicFire>
 {
-private:
+  private:
+
     bool _Mirrored;
     bool _Reversed;
     int  _Cooling;
 
-public:
+  public:
 
     ClassicFireEffect(bool mirrored = false, bool reversed = false, int cooling = 5)
         : EffectWithId<idStripClassicFire>("Classic Fire"),
@@ -451,7 +448,8 @@ public:
 
 class SmoothFireEffect : public EffectWithId<idStripSmoothFire>
 {
-private:
+  private:
+
     bool _Reversed;
     float _Cooling;
     int _Sparks;
@@ -463,7 +461,7 @@ private:
 
     float * _Temperatures = nullptr;
 
-public:
+  public:
     // Parameter:   Cooling   Sparks    driftPasses  drift sparkHeight   Turbo
     // Calm Fire:     0.75f        2         1         64       8          F
     // Full Red:      0.75f        8         1        128      16          F
@@ -617,6 +615,7 @@ class BaseFireEffect : public EffectWithId<idStripBaseFire>
     }
 
   protected:
+  
     int     Cooling;            // Rate at which the pixels cool off
     int     Sparks;             // How many sparks will be attempted each frame
     int     SparkHeight;        // If created, max height for a spark

--- a/include/effects/strip/laserline.h
+++ b/include/effects/strip/laserline.h
@@ -65,13 +65,10 @@ public:
     }
 };
 
-class LaserLineEffect : public BeatEffectBase, public LEDStripEffect
+class LaserLineEffect : public BeatEffectBase, public EffectWithId<idStripLaserLine>
 {
-  public:
-    static constexpr EffectId kId = idStripLaserLine;
-    EffectId effectId() const override { return kId; }
-
-    private:
+  private:
+  
     std::vector<LaserShot>      _shots;
     std::shared_ptr<GFXBase>    _gfx;
     float                      _defaultSize;
@@ -81,7 +78,7 @@ class LaserLineEffect : public BeatEffectBase, public LEDStripEffect
 
     LaserLineEffect(float speed, float size)
         : BeatEffectBase(1.50, 0.00),
-          LEDStripEffect(idStripLaserLine, "LaserLine"),
+          EffectWithId<idStripLaserLine>("LaserLine"),
           _defaultSize(size),
           _defaultSpeed(speed)
     {
@@ -89,7 +86,7 @@ class LaserLineEffect : public BeatEffectBase, public LEDStripEffect
 
     LaserLineEffect(const JsonObjectConst& jsonObject)
         : BeatEffectBase(1.50, 0.00),
-          LEDStripEffect(jsonObject),
+          EffectWithId<idStripLaserLine>(jsonObject),
           _defaultSize(jsonObject[PTY_SIZE]),
           _defaultSpeed(jsonObject[PTY_SPEED])
     {

--- a/include/effects/strip/laserline.h
+++ b/include/effects/strip/laserline.h
@@ -34,12 +34,14 @@
 
 class LaserShot
 {
+  private:
+
     float         _position = 0.0;
     float         _speed    = 10.0;
     float         _size     = 10.0;
     uint8_t       _hue      = 0;
 
-public:
+  public:
 
     LaserShot(float position, float speed, float size, uint8_t hue)
     {
@@ -68,7 +70,7 @@ public:
 class LaserLineEffect : public BeatEffectBase, public EffectWithId<idStripLaserLine>
 {
   private:
-  
+
     std::vector<LaserShot>      _shots;
     std::shared_ptr<GFXBase>    _gfx;
     float                      _defaultSize;

--- a/include/effects/strip/meteoreffect.h
+++ b/include/effects/strip/meteoreffect.h
@@ -35,13 +35,15 @@
 
 class MeteorChannel
 {
+  private:
+
     std::vector<float> hue;
     std::vector<float> iPos;
     std::vector<bool>  bLeft;
     std::vector<float> speed;
     std::vector<float> lastBeat;
 
-public:
+  public:
 
     size_t        meteorCount;
     uint8_t       meteorSize;
@@ -51,10 +53,7 @@ public:
     bool          meteorRandomDecay = true;
     const float  minTimeBetweenBeats = 0.6;
 
-    MeteorChannel()
-    {
-
-    }
+    MeteorChannel() {}
 
     virtual void Init(std::shared_ptr<GFXBase> pGFX, size_t meteors = 4, int size = 4, int decay = 3, float minSpeed = 0.5, float maxSpeed = 0.5)
     {
@@ -163,6 +162,7 @@ public:
 class MeteorEffect : public EffectWithId<idStripMeteor>
 {
   private:
+
     std::vector<MeteorChannel> _Meteors;
 
     int                        _cMeteors;

--- a/include/effects/strip/meteoreffect.h
+++ b/include/effects/strip/meteoreffect.h
@@ -174,7 +174,7 @@ class MeteorEffect : public EffectWithId<idStripMeteor>
   public:
 
     MeteorEffect(int cMeteors = 4, uint size = 4, uint decay = 3, float minSpeed = 0.2, float maxSpeed = 0.2)
-    : EffectWithId<idStripMeteor>("Color Meteors"),
+        : EffectWithId<idStripMeteor>("Color Meteors"),
           _Meteors(),
           _cMeteors(cMeteors),
           _meteorSize(size),

--- a/include/effects/strip/meteoreffect.h
+++ b/include/effects/strip/meteoreffect.h
@@ -160,12 +160,8 @@ public:
     }
 };
 
-class MeteorEffect : public LEDStripEffect
+class MeteorEffect : public EffectWithId<idStripMeteor>
 {
-  public:
-    static constexpr EffectId kId = idStripMeteor;
-    EffectId effectId() const override { return kId; }
-  
   private:
     std::vector<MeteorChannel> _Meteors;
 
@@ -178,7 +174,7 @@ class MeteorEffect : public LEDStripEffect
   public:
 
     MeteorEffect(int cMeteors = 4, uint size = 4, uint decay = 3, float minSpeed = 0.2, float maxSpeed = 0.2)
-    : LEDStripEffect(idStripMeteor, "Color Meteors"),
+    : EffectWithId<idStripMeteor>("Color Meteors"),
           _Meteors(),
           _cMeteors(cMeteors),
           _meteorSize(size),
@@ -189,7 +185,7 @@ class MeteorEffect : public LEDStripEffect
     }
 
     MeteorEffect(const JsonObjectConst& jsonObject)
-        : LEDStripEffect(jsonObject),
+        : EffectWithId<idStripMeteor>(jsonObject),
           _Meteors(),
           _cMeteors(jsonObject["mto"]),
           _meteorSize(jsonObject[PTY_SIZE]),

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -43,7 +43,7 @@
 //
 // Fills the spokes with a rainbow palette, skipping dots as specified
 
-class SimpleRainbowTestEffect : public LEDStripEffect
+class SimpleRainbowTestEffect : public EffectWithId<idStripSimpleRainbowTest>
 {
   private:
     uint8_t     _EveryNth;
@@ -52,17 +52,15 @@ class SimpleRainbowTestEffect : public LEDStripEffect
   public:
 
     SimpleRainbowTestEffect(uint8_t speedDivisor = 8, uint8_t everyNthPixel = 12)
-  : LEDStripEffect(idStripSimpleRainbowTest, "Simple Rainbow"),
+  : EffectWithId<idStripSimpleRainbowTest>("Simple Rainbow"),
           _EveryNth(everyNthPixel),
           _SpeedDivisor(speedDivisor)
     {
         debugV("SimpleRainbowTestEffect constructor");
     }
-    static constexpr EffectId kId = idStripSimpleRainbowTest;
-    EffectId effectId() const override { return kId; }
 
     SimpleRainbowTestEffect(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject),
+      : EffectWithId<idStripSimpleRainbowTest>(jsonObject),
           _EveryNth(jsonObject[PTY_EVERYNTH]),
           _SpeedDivisor(jsonObject[PTY_SPEEDDIVISOR])
     {
@@ -93,7 +91,7 @@ class SimpleRainbowTestEffect : public LEDStripEffect
 //
 // Fills the spokes with a rainbow palette, skipping dots as specified
 
-class RainbowTwinkleEffect : public LEDStripEffect
+class RainbowTwinkleEffect : public EffectWithId<idStripRainbowTwinkle>
 {
   private:
     float _speedDivisor;
@@ -102,17 +100,15 @@ class RainbowTwinkleEffect : public LEDStripEffect
   public:
 
     RainbowTwinkleEffect(float speedDivisor = 12.0f, int deltaHue = 14)
-  : LEDStripEffect(idStripRainbowTwinkle, "Rainbow Twinkle"),
+  : EffectWithId<idStripRainbowTwinkle>("Rainbow Twinkle"),
         _speedDivisor(speedDivisor),
         _deltaHue(deltaHue)
     {
         debugV("RainbowFill constructor");
     }
-    static constexpr EffectId kId = idStripRainbowTwinkle;
-    EffectId effectId() const override { return kId; }
 
     RainbowTwinkleEffect(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject),
+      : EffectWithId<idStripRainbowTwinkle>(jsonObject),
         _speedDivisor(jsonObject[PTY_SPEEDDIVISOR]),
         _deltaHue(jsonObject[PTY_DELTAHUE])
     {
@@ -155,12 +151,11 @@ class RainbowTwinkleEffect : public LEDStripEffect
 // Fills the spokes with a rainbow palette
 
 
-class RainbowFillEffect : public LEDStripEffect
+class RainbowFillEffect : public EffectWithId<idStripRainbowFill>
 {
   public:
-    static constexpr EffectId kId = idStripRainbowFill;
-    EffectId effectId() const override { return kId; }
-  
+
+
     protected:
 
     float _speedDivisor;
@@ -170,7 +165,7 @@ class RainbowFillEffect : public LEDStripEffect
   public:
 
     RainbowFillEffect(float speedDivisor = 12.0f, int deltaHue = 14, bool mirrored = false)
-  : LEDStripEffect(idStripRainbowFill, "RainbowFill Rainbow"),
+  : EffectWithId<idStripRainbowFill>("RainbowFill Rainbow"),
         _speedDivisor(speedDivisor),
         _deltaHue(deltaHue),
         _mirrored(mirrored)
@@ -179,7 +174,7 @@ class RainbowFillEffect : public LEDStripEffect
     }
 
     RainbowFillEffect(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject),
+      : EffectWithId<idStripRainbowFill>(jsonObject),
         _speedDivisor(jsonObject[PTY_SPEEDDIVISOR]),
         _deltaHue(jsonObject[PTY_DELTAHUE]),
         _mirrored(jsonObject[PTY_MIRRORED])
@@ -223,7 +218,7 @@ class RainbowFillEffect : public LEDStripEffect
 // Unless a user chooses to ignore the global color, the global color will be used instead when
 // DeviceConfig().ApplyGlobalColors() returns true.
 
-class ColorFillEffect : public LEDStripEffect
+class ColorFillEffect : public EffectWithId<idStripColorFill>
 {
   private:
 
@@ -236,18 +231,16 @@ protected:
   public:
 
     ColorFillEffect(const String &name, CRGB color = CRGB(246,200,160), int everyNth = 10, bool ignoreGlobalColor = false)
-  : LEDStripEffect(idStripColorFill, name),
+  : EffectWithId<idStripColorFill>(name),
         _everyNth(everyNth),
         _color(color),
         _ignoreGlobalColor(ignoreGlobalColor)
     {
         debugV("Color Fill constructor");
     }
-    static constexpr EffectId kId = idStripColorFill;
-    EffectId effectId() const override { return kId; }
 
     ColorFillEffect(CRGB color = CRGB(246,200,160), int everyNth = 10, bool ignoreGlobalColor = false)
-  : LEDStripEffect(idStripColorFill, "Color Fill"),
+  : EffectWithId<idStripColorFill>("Color Fill"),
         _everyNth(everyNth),
         _color(color),
         _ignoreGlobalColor(ignoreGlobalColor)
@@ -256,7 +249,7 @@ protected:
     }
 
     ColorFillEffect(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject),
+      : EffectWithId<idStripColorFill>(jsonObject),
         _everyNth(jsonObject[PTY_EVERYNTH]),
         _color(jsonObject[PTY_COLOR].as<CRGB>()),
         _ignoreGlobalColor(jsonObject[PTY_IGNOREGLOBALCOLOR])
@@ -298,7 +291,7 @@ protected:
 extern const uint8_t logo_start[] asm("_binary_assets_bmp_lowreslogo_jpg_start");
 extern const uint8_t logo_end[]   asm("_binary_assets_bmp_lowreslogo_jpg_end");
 
-class SplashLogoEffect : public LEDStripEffect
+class SplashLogoEffect : public EffectWithId<idStripSplashLogo>
 {
   private:
     EmbeddedFile logo;
@@ -306,16 +299,14 @@ class SplashLogoEffect : public LEDStripEffect
   public:
 
     SplashLogoEffect()
-  : LEDStripEffect(idStripSplashLogo, "Mesmerizer"),
+  : EffectWithId<idStripSplashLogo>("Mesmerizer"),
         logo(logo_start, logo_end)
     {
         debugV("Splash logo constructor");
     }
-    static constexpr EffectId kId = idStripSplashLogo;
-    EffectId effectId() const override { return kId; }
 
     SplashLogoEffect(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject),
+      : EffectWithId<idStripSplashLogo>(jsonObject),
         logo(logo_start, logo_end)
     {
         debugV("Splash logo JSON constructor");
@@ -352,7 +343,7 @@ class SplashLogoEffect : public LEDStripEffect
 // Green     WiFi working but no clock yet
 // White     Ready!
 
-class StatusEffect : public LEDStripEffect
+class StatusEffect : public EffectWithId<idStripStatus>
 {
   protected:
 
@@ -362,17 +353,15 @@ class StatusEffect : public LEDStripEffect
   public:
 
     StatusEffect(CRGB color = CRGB(255,255,255), int everyNth = 10)     // Warmer: CRGB(246,200,160)
-  : LEDStripEffect(idStripStatus, "Status Fill"),
+  : EffectWithId<idStripStatus>("Status Fill"),
         _everyNth(everyNth),
         _color(color)
     {
         debugV("Status Fill constructor");
     }
-    static constexpr EffectId kId = idStripStatus;
-    EffectId effectId() const override { return kId; }
 
     StatusEffect(const JsonObjectConst& jsonObject)     // Warmer: CRGB(246,200,160)
-      : LEDStripEffect(jsonObject),
+      : EffectWithId<idStripStatus>(jsonObject),
         _everyNth(jsonObject[PTY_EVERYNTH]),
         _color(jsonObject[PTY_COLOR].as<CRGB>())
     {
@@ -429,7 +418,7 @@ static constexpr auto TwinkleColors =  to_array(
 });
 #endif
 
-class TwinkleEffect : public LEDStripEffect
+class TwinkleEffect : public EffectWithId<idStripTwinkle>
 {
   protected:
 
@@ -440,17 +429,15 @@ class TwinkleEffect : public LEDStripEffect
   public:
 
     TwinkleEffect(int countToDraw = NUM_LEDS / 2, uint8_t fadeFactor = 10, int updateSpeed = 10)
-  : LEDStripEffect(idStripTwinkle, "Twinkle"),
+      : EffectWithId<idStripTwinkle>("Twinkle"),
         _countToDraw(countToDraw),
         _fadeFactor(fadeFactor),
         _updateSpeed(updateSpeed)
     {
     }
-    static constexpr EffectId kId = idStripTwinkle;
-    EffectId effectId() const override { return kId; }
 
     TwinkleEffect(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject),
+      : EffectWithId<idStripTwinkle>(jsonObject),
         _countToDraw(jsonObject["ctd"]),
         _fadeFactor(jsonObject[PTY_FADE]),
         _updateSpeed(jsonObject[PTY_SPEED])
@@ -524,18 +511,17 @@ class TwinkleEffect : public LEDStripEffect
 //
 // A Battlestar Galactica inspired effect that moves red and green bars back and forth
 
-class SilonEffect : public LEDStripEffect
+class SilonEffect : public EffectWithId<idMatrixSilon>
 {
   public:
 
-  SilonEffect() : LEDStripEffect(idMatrixSilon, "SilonEffect")
+  SilonEffect() : EffectWithId<idMatrixSilon>("SilonEffect")
     {
     }
-    static constexpr EffectId kId = idMatrixSilon;
-    EffectId effectId() const override { return kId; }
+
 
     SilonEffect(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject)
+      : EffectWithId<idMatrixSilon>(jsonObject)
     {
     }
 
@@ -574,18 +560,17 @@ class SilonEffect : public LEDStripEffect
 //
 // A Display for the front of the PDP-11/34
 
-class PDPGridEffect : public LEDStripEffect
+class PDPGridEffect : public EffectWithId<idMatrixPDPGrid>
 {
   public:
 
-  PDPGridEffect() : LEDStripEffect(idMatrixPDPGrid, "PDPGridEffect")
+  PDPGridEffect() : EffectWithId<idMatrixPDPGrid>("PDPGridEffect")
     {
     }
-    static constexpr EffectId kId = idMatrixPDPGrid;
-    EffectId effectId() const override { return kId; }
+
 
     PDPGridEffect(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject)
+      : EffectWithId<idMatrixPDPGrid>(jsonObject)
     {
     }
 
@@ -605,7 +590,7 @@ class PDPGridEffect : public LEDStripEffect
     virtual void Start() override
     {
         g()->Clear();
-    }    
+    }
 
     virtual void Draw() override
     {
@@ -624,12 +609,12 @@ class PDPGridEffect : public LEDStripEffect
 //
 // Connection Machine 5 LED simulation for the PDP-11/34 CMX display
 
-class PDPCMXEffect : public LEDStripEffect
+class PDPCMXEffect : public EffectWithId<idMatrixPDPCMX>
 {
   private:
     static constexpr int GROUP_HEIGHT = 5; // Height of each logical group
     static constexpr float LED_PROBABILITY = 0.30f; // 30% chance of LED being on
-    
+
     void scrollGroup(int groupStartY, bool scrollLeft)
     {
         // Scroll existing LEDs in the group
@@ -658,7 +643,7 @@ class PDPCMXEffect : public LEDStripEffect
                 setPixelOnAllChannels(0, y, CRGB::Black);
             }
         }
-        
+
         // Add new random LEDs on the appropriate edge
         for (int y = groupStartY; y < groupStartY + GROUP_HEIGHT && y < MATRIX_HEIGHT; y++)
         {
@@ -675,14 +660,13 @@ class PDPCMXEffect : public LEDStripEffect
 
   public:
 
-  PDPCMXEffect() : LEDStripEffect(idMatrixPDPCMX, "PDPCMXEffect")
+  PDPCMXEffect() : EffectWithId<idMatrixPDPCMX>("PDPCMXEffect")
     {
     }
-    static constexpr EffectId kId = idMatrixPDPCMX;
-    EffectId effectId() const override { return kId; }
+
 
     PDPCMXEffect(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject)
+      : EffectWithId<idMatrixPDPCMX>(jsonObject)
     {
     }
 
@@ -705,7 +689,7 @@ class PDPCMXEffect : public LEDStripEffect
     {
         // Process each logical group
         int numGroups = (MATRIX_HEIGHT + GROUP_HEIGHT - 1) / GROUP_HEIGHT; // Ceiling division
-        
+
         fadeAllChannelsToBlackBy(5);
         EVERY_N_MILLISECONDS(200)
         {
@@ -713,7 +697,7 @@ class PDPCMXEffect : public LEDStripEffect
           {
               int groupStartY = group * GROUP_HEIGHT;
               bool scrollLeft = (group % 2 == 0); // Alternate direction: even groups scroll left, odd scroll right
-              
+
               scrollGroup(groupStartY, scrollLeft);
           }
         }
@@ -725,18 +709,17 @@ class PDPCMXEffect : public LEDStripEffect
 // Hexagon Effects
 ////////////////////////////////////////////////
 
-class OuterHexRingEffect : public LEDStripEffect
+class OuterHexRingEffect : public EffectWithId<idHexagonOuterRing>
 {
   public:
 
-  OuterHexRingEffect() : LEDStripEffect(idHexagonOuterRing, "OuterRingHexEffect")
+  OuterHexRingEffect() : EffectWithId<idHexagonOuterRing>("OuterRingHexEffect")
     {
     }
-    static constexpr EffectId kId = idHexagonOuterRing;
-    EffectId effectId() const override { return kId; }
+
 
     OuterHexRingEffect(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject)
+      : EffectWithId<idHexagonOuterRing>(jsonObject)
     {
     }
 

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -52,7 +52,7 @@ class SimpleRainbowTestEffect : public EffectWithId<idStripSimpleRainbowTest>
   public:
 
     SimpleRainbowTestEffect(uint8_t speedDivisor = 8, uint8_t everyNthPixel = 12)
-  : EffectWithId<idStripSimpleRainbowTest>("Simple Rainbow"),
+        : EffectWithId<idStripSimpleRainbowTest>("Simple Rainbow"),
           _EveryNth(everyNthPixel),
           _SpeedDivisor(speedDivisor)
     {
@@ -60,7 +60,7 @@ class SimpleRainbowTestEffect : public EffectWithId<idStripSimpleRainbowTest>
     }
 
     SimpleRainbowTestEffect(const JsonObjectConst& jsonObject)
-      : EffectWithId<idStripSimpleRainbowTest>(jsonObject),
+        : EffectWithId<idStripSimpleRainbowTest>(jsonObject),
           _EveryNth(jsonObject[PTY_EVERYNTH]),
           _SpeedDivisor(jsonObject[PTY_SPEEDDIVISOR])
     {
@@ -100,7 +100,7 @@ class RainbowTwinkleEffect : public EffectWithId<idStripRainbowTwinkle>
   public:
 
     RainbowTwinkleEffect(float speedDivisor = 12.0f, int deltaHue = 14)
-  : EffectWithId<idStripRainbowTwinkle>("Rainbow Twinkle"),
+      : EffectWithId<idStripRainbowTwinkle>("Rainbow Twinkle"),
         _speedDivisor(speedDivisor),
         _deltaHue(deltaHue)
     {
@@ -220,9 +220,7 @@ class RainbowFillEffect : public EffectWithId<idStripRainbowFill>
 
 class ColorFillEffect : public EffectWithId<idStripColorFill>
 {
-  private:
-
-protected:
+  protected:
 
     int _everyNth;
     CRGB _color;
@@ -299,7 +297,7 @@ class SplashLogoEffect : public EffectWithId<idStripSplashLogo>
   public:
 
     SplashLogoEffect()
-  : EffectWithId<idStripSplashLogo>("Mesmerizer"),
+      : EffectWithId<idStripSplashLogo>("Mesmerizer"),
         logo(logo_start, logo_end)
     {
         debugV("Splash logo constructor");
@@ -353,7 +351,7 @@ class StatusEffect : public EffectWithId<idStripStatus>
   public:
 
     StatusEffect(CRGB color = CRGB(255,255,255), int everyNth = 10)     // Warmer: CRGB(246,200,160)
-  : EffectWithId<idStripStatus>("Status Fill"),
+      : EffectWithId<idStripStatus>("Status Fill"),
         _everyNth(everyNth),
         _color(color)
     {
@@ -513,20 +511,15 @@ class TwinkleEffect : public EffectWithId<idStripTwinkle>
 
 class SilonEffect : public EffectWithId<idMatrixSilon>
 {
-  public:
-
-  SilonEffect() : EffectWithId<idMatrixSilon>("SilonEffect")
-    {
-    }
-
-
-    SilonEffect(const JsonObjectConst& jsonObject)
-      : EffectWithId<idMatrixSilon>(jsonObject)
-    {
-    }
-
+  private:
     int _offset = 0;
     int _direction = 1;
+
+  public:
+
+    SilonEffect() : EffectWithId<idMatrixSilon>("SilonEffect") {}
+
+    SilonEffect(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixSilon>(jsonObject) {}
 
     virtual size_t DesiredFramesPerSecond() const
     {
@@ -562,20 +555,16 @@ class SilonEffect : public EffectWithId<idMatrixSilon>
 
 class PDPGridEffect : public EffectWithId<idMatrixPDPGrid>
 {
-  public:
-
-  PDPGridEffect() : EffectWithId<idMatrixPDPGrid>("PDPGridEffect")
-    {
-    }
-
-
-    PDPGridEffect(const JsonObjectConst& jsonObject)
-      : EffectWithId<idMatrixPDPGrid>(jsonObject)
-    {
-    }
+  private:
 
     int _offset = 0;
     int _direction = 1;
+
+  public:
+
+    PDPGridEffect() : EffectWithId<idMatrixPDPGrid>("PDPGridEffect") {}
+
+    PDPGridEffect(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixPDPGrid>(jsonObject) {}
 
     virtual size_t DesiredFramesPerSecond() const
     {
@@ -660,15 +649,9 @@ class PDPCMXEffect : public EffectWithId<idMatrixPDPCMX>
 
   public:
 
-  PDPCMXEffect() : EffectWithId<idMatrixPDPCMX>("PDPCMXEffect")
-    {
-    }
+    PDPCMXEffect() : EffectWithId<idMatrixPDPCMX>("PDPCMXEffect") {}
 
-
-    PDPCMXEffect(const JsonObjectConst& jsonObject)
-      : EffectWithId<idMatrixPDPCMX>(jsonObject)
-    {
-    }
+    PDPCMXEffect(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixPDPCMX>(jsonObject) {}
 
     virtual size_t DesiredFramesPerSecond() const
     {
@@ -713,15 +696,9 @@ class OuterHexRingEffect : public EffectWithId<idHexagonOuterRing>
 {
   public:
 
-  OuterHexRingEffect() : EffectWithId<idHexagonOuterRing>("OuterRingHexEffect")
-    {
-    }
+    OuterHexRingEffect() : EffectWithId<idHexagonOuterRing>("OuterRingHexEffect") {}
 
-
-    OuterHexRingEffect(const JsonObjectConst& jsonObject)
-      : EffectWithId<idHexagonOuterRing>(jsonObject)
-    {
-    }
+    OuterHexRingEffect(const JsonObjectConst& jsonObject) : EffectWithId<idHexagonOuterRing>(jsonObject) {}
 
     virtual void Draw() override
     {

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -46,6 +46,7 @@
 class SimpleRainbowTestEffect : public EffectWithId<idStripSimpleRainbowTest>
 {
   private:
+
     uint8_t     _EveryNth;
     uint8_t     _SpeedDivisor;
 
@@ -94,6 +95,7 @@ class SimpleRainbowTestEffect : public EffectWithId<idStripSimpleRainbowTest>
 class RainbowTwinkleEffect : public EffectWithId<idStripRainbowTwinkle>
 {
   private:
+
     float _speedDivisor;
     int   _deltaHue;
 
@@ -153,10 +155,7 @@ class RainbowTwinkleEffect : public EffectWithId<idStripRainbowTwinkle>
 
 class RainbowFillEffect : public EffectWithId<idStripRainbowFill>
 {
-  public:
-
-
-    protected:
+  protected:
 
     float _speedDivisor;
     int   _deltaHue;
@@ -292,6 +291,7 @@ extern const uint8_t logo_end[]   asm("_binary_assets_bmp_lowreslogo_jpg_end");
 class SplashLogoEffect : public EffectWithId<idStripSplashLogo>
 {
   private:
+
     EmbeddedFile logo;
 
   public:
@@ -512,13 +512,13 @@ class TwinkleEffect : public EffectWithId<idStripTwinkle>
 class SilonEffect : public EffectWithId<idMatrixSilon>
 {
   private:
+
     int _offset = 0;
     int _direction = 1;
 
   public:
 
     SilonEffect() : EffectWithId<idMatrixSilon>("SilonEffect") {}
-
     SilonEffect(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixSilon>(jsonObject) {}
 
     virtual size_t DesiredFramesPerSecond() const
@@ -563,7 +563,6 @@ class PDPGridEffect : public EffectWithId<idMatrixPDPGrid>
   public:
 
     PDPGridEffect() : EffectWithId<idMatrixPDPGrid>("PDPGridEffect") {}
-
     PDPGridEffect(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixPDPGrid>(jsonObject) {}
 
     virtual size_t DesiredFramesPerSecond() const
@@ -601,6 +600,7 @@ class PDPGridEffect : public EffectWithId<idMatrixPDPGrid>
 class PDPCMXEffect : public EffectWithId<idMatrixPDPCMX>
 {
   private:
+
     static constexpr int GROUP_HEIGHT = 5; // Height of each logical group
     static constexpr float LED_PROBABILITY = 0.30f; // 30% chance of LED being on
 
@@ -650,7 +650,6 @@ class PDPCMXEffect : public EffectWithId<idMatrixPDPCMX>
   public:
 
     PDPCMXEffect() : EffectWithId<idMatrixPDPCMX>("PDPCMXEffect") {}
-
     PDPCMXEffect(const JsonObjectConst& jsonObject) : EffectWithId<idMatrixPDPCMX>(jsonObject) {}
 
     virtual size_t DesiredFramesPerSecond() const
@@ -697,7 +696,6 @@ class OuterHexRingEffect : public EffectWithId<idHexagonOuterRing>
   public:
 
     OuterHexRingEffect() : EffectWithId<idHexagonOuterRing>("OuterRingHexEffect") {}
-
     OuterHexRingEffect(const JsonObjectConst& jsonObject) : EffectWithId<idHexagonOuterRing>(jsonObject) {}
 
     virtual void Draw() override

--- a/include/effects/strip/musiceffect.h
+++ b/include/effects/strip/musiceffect.h
@@ -51,6 +51,7 @@
 class BeatEffectBase
 {
   protected:
+
     const int _maxSamples = 60;
     std::deque<float> _samples;
     double _lastBeat = 0;

--- a/include/effects/strip/musiceffect.h
+++ b/include/effects/strip/musiceffect.h
@@ -111,11 +111,11 @@ class BeatEffectBase
             }
             else
             {
-              debugV("Beat: elapsed: %0.2lf, range: %0.2lf\n", elapsed, maximum - minimum);
+                debugV("Beat: elapsed: %0.2lf, range: %0.2lf\n", elapsed, maximum - minimum);
 
-              HandleBeat(false, elapsed, maximum - minimum);
-              _lastBeat = g_Values.AppTime.CurrentTime();
-              _samples.clear();
+                HandleBeat(false, elapsed, maximum - minimum);
+                _lastBeat = g_Values.AppTime.CurrentTime();
+                _samples.clear();
             }
         }
     }
@@ -189,7 +189,7 @@ class SimpleColorBeat : public BeatEffectBase, public EffectWithId<idStripSimple
   public:
 
     SimpleColorBeat(const String & strName)
-  : BeatEffectBase(0.5, 0.25), EffectWithId<idStripSimpleColorBeat>(strName) {}
+      : BeatEffectBase(0.5, 0.25), EffectWithId<idStripSimpleColorBeat>(strName) {}
 
     SimpleColorBeat(const JsonObjectConst& jsonObject)
       : BeatEffectBase(0.5, 0.25), EffectWithId<idStripSimpleColorBeat>(jsonObject) {}

--- a/include/effects/strip/musiceffect.h
+++ b/include/effects/strip/musiceffect.h
@@ -126,12 +126,8 @@ class BeatEffectBase
 // Uses a very sensitive beat detection.  Fills all pixels blue based on VU, and on beats, fills a random insulator
 // with a random color.  Longer beats get more insulators.  Very long beats get everything filled with purple.
 
-class SimpleColorBeat : public BeatEffectBase, public LEDStripEffect
+class SimpleColorBeat : public BeatEffectBase, public EffectWithId<idStripSimpleColorBeat>
 {
-  public:
-    static constexpr EffectId kId = idStripSimpleColorBeat;
-    EffectId effectId() const override { return kId; }
-
   protected:
 
     int _iLastInsulator = -1;
@@ -193,14 +189,10 @@ class SimpleColorBeat : public BeatEffectBase, public LEDStripEffect
   public:
 
     SimpleColorBeat(const String & strName)
-  : BeatEffectBase(0.5, 0.25), LEDStripEffect(strName)
-    {
-    }
+  : BeatEffectBase(0.5, 0.25), EffectWithId<idStripSimpleColorBeat>(strName) {}
 
     SimpleColorBeat(const JsonObjectConst& jsonObject)
-      : BeatEffectBase(0.5, 0.25), LEDStripEffect(jsonObject)
-    {
-    }
+      : BeatEffectBase(0.5, 0.25), EffectWithId<idStripSimpleColorBeat>(jsonObject) {}
 };
 
 #endif // ENABLE_AUDIO

--- a/include/effects/strip/paletteeffect.h
+++ b/include/effects/strip/paletteeffect.h
@@ -32,12 +32,8 @@
 
 #include "effects.h"
 
-class PaletteEffect : public LEDStripEffect
+class PaletteEffect : public EffectWithId<idStripPalette>
 {
-  public:
-    static constexpr EffectId kId = idStripPalette;
-    EffectId effectId() const override { return kId; }
-    
   private:
 
     float _startIndex;
@@ -63,7 +59,7 @@ class PaletteEffect : public LEDStripEffect
                   TBlendType blend = LINEARBLEND,
                   bool  bErase = true,
                   float brightness = 1.0)
-  : LEDStripEffect("Palette Effect"),
+  : EffectWithId<idStripPalette>("Palette Effect"),
         _startIndex(0.0f),
         _paletteIndex(0.0f),
         _palette(palette),
@@ -78,7 +74,7 @@ class PaletteEffect : public LEDStripEffect
     {
     }
 
-    PaletteEffect(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject),
+    PaletteEffect(const JsonObjectConst& jsonObject) : EffectWithId<idStripPalette>(jsonObject),
       _startIndex(0.0f),
       _paletteIndex(0.0f),
       _palette(jsonObject[PTY_PALETTE].as<CRGBPalette16>()),

--- a/include/effects/strip/paletteeffect.h
+++ b/include/effects/strip/paletteeffect.h
@@ -110,10 +110,6 @@ class PaletteEffect : public EffectWithId<idStripPalette>
         return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
 
-    ~PaletteEffect()
-    {
-    }
-
     void Draw() override
     {
         if (_bErase)

--- a/include/effects/strip/paletteeffect.h
+++ b/include/effects/strip/paletteeffect.h
@@ -59,7 +59,7 @@ class PaletteEffect : public EffectWithId<idStripPalette>
                   TBlendType blend = LINEARBLEND,
                   bool  bErase = true,
                   float brightness = 1.0)
-  : EffectWithId<idStripPalette>("Palette Effect"),
+      : EffectWithId<idStripPalette>("Palette Effect"),
         _startIndex(0.0f),
         _paletteIndex(0.0f),
         _palette(palette),
@@ -74,18 +74,19 @@ class PaletteEffect : public EffectWithId<idStripPalette>
     {
     }
 
-    PaletteEffect(const JsonObjectConst& jsonObject) : EffectWithId<idStripPalette>(jsonObject),
-      _startIndex(0.0f),
-      _paletteIndex(0.0f),
-      _palette(jsonObject[PTY_PALETTE].as<CRGBPalette16>()),
-      _density(jsonObject["dns"]),
-      _paletteSpeed(jsonObject[PTY_SPEED]),
-      _lightSize(jsonObject["lsz"]),
-      _gapSize(jsonObject["gsz"]),
-      _LEDSPerSecond(jsonObject["lps"]),
-      _blend(static_cast<TBlendType>(jsonObject[PTY_BLEND])),
-      _bErase(jsonObject[PTY_ERASE]),
-      _brightness(jsonObject["bns"])
+    PaletteEffect(const JsonObjectConst& jsonObject)
+      : EffectWithId<idStripPalette>(jsonObject),
+        _startIndex(0.0f),
+        _paletteIndex(0.0f),
+        _palette(jsonObject[PTY_PALETTE].as<CRGBPalette16>()),
+        _density(jsonObject["dns"]),
+        _paletteSpeed(jsonObject[PTY_SPEED]),
+        _lightSize(jsonObject["lsz"]),
+        _gapSize(jsonObject["gsz"]),
+        _LEDSPerSecond(jsonObject["lps"]),
+        _blend(static_cast<TBlendType>(jsonObject[PTY_BLEND])),
+        _bErase(jsonObject[PTY_ERASE]),
+        _brightness(jsonObject["bns"])
     {
     }
 

--- a/include/effects/strip/particles.h
+++ b/include/effects/strip/particles.h
@@ -384,18 +384,18 @@ class RingParticle : public FadingColoredObject
 
 
 #if ENABLE_AUDIO
-class ColorBeatWithFlash : public BeatEffectBase, public ParticleSystem<RingParticle>, LEDStripEffect
+class ColorBeatWithFlash : public BeatEffectBase, public ParticleSystem<RingParticle>, EffectWithId<idStripColorBeatWithFlash>
 {
     int _iLastInsulator = 0;
     CRGB _baseColor = CRGB::Black;
 
   public:
 
-    ColorBeatWithFlash(const String & strName) : BeatEffectBase(), ParticleSystem<RingParticle>(), LEDStripEffect(idStripColorBeatWithFlash, strName)
+    ColorBeatWithFlash(const String & strName) : BeatEffectBase(), ParticleSystem<RingParticle>(), EffectWithId<idStripColorBeatWithFlash>(strName)
     {
     }
 
-    ColorBeatWithFlash(const JsonObjectConst& jsonObject) : BeatEffectBase(), ParticleSystem<RingParticle>(), LEDStripEffect(jsonObject)
+    ColorBeatWithFlash(const JsonObjectConst& jsonObject) : BeatEffectBase(), ParticleSystem<RingParticle>(), EffectWithId<idStripColorBeatWithFlash>(jsonObject)
     {
     }
 
@@ -439,7 +439,7 @@ class ColorBeatWithFlash : public BeatEffectBase, public ParticleSystem<RingPart
     }
 };
 
-class ColorBeatOverRed : public LEDStripEffect, public BeatEffectBase, public ParticleSystem<RingParticle>
+class ColorBeatOverRed : public EffectWithId<idStripColorBeatOverRed>, public BeatEffectBase, public ParticleSystem<RingParticle>
 {
     int  _iLastInsulator = 0;
     CRGB _baseColor = CRGB::Black;
@@ -447,14 +447,14 @@ class ColorBeatOverRed : public LEDStripEffect, public BeatEffectBase, public Pa
   public:
 
     ColorBeatOverRed(const String & strName)
-  : LEDStripEffect(idStripColorBeatOverRed, strName),
+  : EffectWithId<idStripColorBeatOverRed>(strName),
         BeatEffectBase(1.75, 0.2),
         ParticleSystem<RingParticle>()
     {
     }
 
     ColorBeatOverRed(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject),
+  : EffectWithId<idStripColorBeatOverRed>(jsonObject),
         BeatEffectBase(1.75, 0.2),
         ParticleSystem<RingParticle>()
     {
@@ -699,7 +699,7 @@ class HotWhiteRingParticle : public FadingObject
 #if ENABLE_AUDIO
 
 
-class MoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase, public ParticleSystem<SpinningPaletteRingParticle>
+class MoltenGlassOnVioletBkgnd : public EffectWithId<idStripMoltenGlassOnVioletBkgnd>, public BeatEffectBase, public ParticleSystem<SpinningPaletteRingParticle>
 {
     int                    _iLastInsulator = 0;
     const CRGBPalette16 & _Palette;
@@ -708,7 +708,7 @@ class MoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase, p
   public:
 
     MoltenGlassOnVioletBkgnd(const String & strName, const CRGBPalette16 & Palette)
-  : LEDStripEffect(idStripMoltenGlassOnVioletBkgnd, strName),
+      : EffectWithId<idStripMoltenGlassOnVioletBkgnd>(strName),
         BeatEffectBase(1.50, 0.05),
         ParticleSystem<SpinningPaletteRingParticle>(),
         _Palette(Palette)
@@ -716,7 +716,7 @@ class MoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase, p
     }
 
     MoltenGlassOnVioletBkgnd(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject),
+      : EffectWithId<idStripMoltenGlassOnVioletBkgnd>(jsonObject),
         BeatEffectBase(1.50, 0.05),
         ParticleSystem<SpinningPaletteRingParticle>(),
         _Palette(jsonObject[PTY_PALETTE].as<CRGBPalette16>())
@@ -789,7 +789,7 @@ class MoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase, p
     }
 };
 
-class NewMoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase, public ParticleSystem<SpinningPaletteRingParticle>
+class NewMoltenGlassOnVioletBkgnd : public EffectWithId<idStripNewMoltenGlassOnVioletBkgnd>, public BeatEffectBase, public ParticleSystem<SpinningPaletteRingParticle>
 {
     int  _iLastInsulator = 0;
     const CRGBPalette16 & _Palette;
@@ -798,7 +798,7 @@ class NewMoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase
   public:
 
     NewMoltenGlassOnVioletBkgnd(const String & strName, const CRGBPalette16 & Palette)
-  : LEDStripEffect(idStripNewMoltenGlassOnVioletBkgnd, strName),
+      : EffectWithId<idStripNewMoltenGlassOnVioletBkgnd>(strName),
         BeatEffectBase(1.0, 0.25 ),
         ParticleSystem<SpinningPaletteRingParticle>(),
         _Palette(Palette)
@@ -806,7 +806,7 @@ class NewMoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase
     }
 
     NewMoltenGlassOnVioletBkgnd(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject),
+      : EffectWithId<idStripNewMoltenGlassOnVioletBkgnd>(jsonObject),
         BeatEffectBase(1.0, 0.25 ),
         ParticleSystem<SpinningPaletteRingParticle>(),
         _Palette(jsonObject[PTY_PALETTE].as<CRGBPalette16>())
@@ -878,7 +878,7 @@ class NewMoltenGlassOnVioletBkgnd : public LEDStripEffect, public BeatEffectBase
     }
 };
 
-class SparklySpinningMusicEffect : public LEDStripEffect, public BeatEffectBase, public ParticleSystem<SpinningPaletteRingParticle>
+class SparklySpinningMusicEffect : public EffectWithId<idStripSparklySpinningMusic>, public BeatEffectBase, public ParticleSystem<SpinningPaletteRingParticle>
 {
     int  _iLastInsulator = 0;
     const CRGBPalette16 & _Palette;
@@ -887,12 +887,12 @@ class SparklySpinningMusicEffect : public LEDStripEffect, public BeatEffectBase,
   public:
 
     SparklySpinningMusicEffect(const String & strName, const CRGBPalette16 & Palette)
-  : LEDStripEffect(idStripSparklySpinningMusic, strName), BeatEffectBase(), ParticleSystem<SpinningPaletteRingParticle>(), _Palette(Palette)
+      : EffectWithId<idStripSparklySpinningMusic>(strName), BeatEffectBase(), ParticleSystem<SpinningPaletteRingParticle>(), _Palette(Palette)
     {
     }
 
     SparklySpinningMusicEffect(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject),
+      : EffectWithId<idStripSparklySpinningMusic>(jsonObject),
         BeatEffectBase(),
         ParticleSystem<SpinningPaletteRingParticle>(),
         _Palette(jsonObject[PTY_PALETTE].as<CRGBPalette16>())
@@ -941,20 +941,18 @@ class SparklySpinningMusicEffect : public LEDStripEffect, public BeatEffectBase,
     }
 };
 
-class MusicalHotWhiteInsulatorEffect : public LEDStripEffect, public BeatEffectBase, public ParticleSystem<HotWhiteRingParticle>
+class MusicalHotWhiteInsulatorEffect : public EffectWithId<idStripMusicalHotWhiteInsulator>, public BeatEffectBase, public ParticleSystem<HotWhiteRingParticle>
 {
+  private:
+
     int  _iLastInsulator = 0;
     CRGB _baseColor      = CRGB::Black;
 
   public:
 
-  MusicalHotWhiteInsulatorEffect(const String & strName) : LEDStripEffect(idStripMusicalHotWhiteInsulator, strName), BeatEffectBase(), ParticleSystem<HotWhiteRingParticle>()
-    {
-    }
+    MusicalHotWhiteInsulatorEffect(const String & strName) : EffectWithId<idStripMusicalHotWhiteInsulator>(strName), BeatEffectBase(), ParticleSystem<HotWhiteRingParticle>() {}
 
-    MusicalHotWhiteInsulatorEffect(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject), BeatEffectBase(), ParticleSystem<HotWhiteRingParticle>()
-    {
-    }
+    MusicalHotWhiteInsulatorEffect(const JsonObjectConst& jsonObject) : EffectWithId<idStripMusicalHotWhiteInsulator>(jsonObject), BeatEffectBase(), ParticleSystem<HotWhiteRingParticle>() {}
 
     virtual void HandleBeat(bool bMajor, float elapsed, float span) override
     {

--- a/include/effects/strip/particles.h
+++ b/include/effects/strip/particles.h
@@ -378,6 +378,8 @@ class RingParticle : public FadingColoredObject
 #if ENABLE_AUDIO
 class ColorBeatWithFlash : public BeatEffectBase, public ParticleSystem<RingParticle>, public EffectWithId<idStripColorBeatWithFlash>
 {
+  private:
+
     int _iLastInsulator = 0;
     CRGB _baseColor = CRGB::Black;
 
@@ -439,20 +441,22 @@ class ColorBeatWithFlash : public BeatEffectBase, public ParticleSystem<RingPart
 
 class ColorBeatOverRed : public EffectWithId<idStripColorBeatOverRed>, public BeatEffectBase, public ParticleSystem<RingParticle>
 {
+  private:
+
     int  _iLastInsulator = 0;
     CRGB _baseColor = CRGB::Black;
 
   public:
 
     ColorBeatOverRed(const String & strName)
-  : EffectWithId<idStripColorBeatOverRed>(strName),
+      : EffectWithId<idStripColorBeatOverRed>(strName),
         BeatEffectBase(1.75, 0.2),
         ParticleSystem<RingParticle>()
     {
     }
 
     ColorBeatOverRed(const JsonObjectConst& jsonObject)
-  : EffectWithId<idStripColorBeatOverRed>(jsonObject),
+      : EffectWithId<idStripColorBeatOverRed>(jsonObject),
         BeatEffectBase(1.75, 0.2),
         ParticleSystem<RingParticle>()
     {
@@ -699,6 +703,8 @@ class HotWhiteRingParticle : public FadingObject
 
 class MoltenGlassOnVioletBkgnd : public EffectWithId<idStripMoltenGlassOnVioletBkgnd>, public BeatEffectBase, public ParticleSystem<SpinningPaletteRingParticle>
 {
+  private:
+
     int                    _iLastInsulator = 0;
     const CRGBPalette16 & _Palette;
     CRGB _baseColor = CRGB::Black;
@@ -789,6 +795,8 @@ class MoltenGlassOnVioletBkgnd : public EffectWithId<idStripMoltenGlassOnVioletB
 
 class NewMoltenGlassOnVioletBkgnd : public EffectWithId<idStripNewMoltenGlassOnVioletBkgnd>, public BeatEffectBase, public ParticleSystem<SpinningPaletteRingParticle>
 {
+  private:
+
     int  _iLastInsulator = 0;
     const CRGBPalette16 & _Palette;
     CRGB _baseColor = CRGB::Black;
@@ -878,6 +886,8 @@ class NewMoltenGlassOnVioletBkgnd : public EffectWithId<idStripNewMoltenGlassOnV
 
 class SparklySpinningMusicEffect : public EffectWithId<idStripSparklySpinningMusic>, public BeatEffectBase, public ParticleSystem<SpinningPaletteRingParticle>
 {
+  private:
+  
     int  _iLastInsulator = 0;
     const CRGBPalette16 & _Palette;
     CRGB _baseColor = CRGB::Black;

--- a/include/effects/strip/particles.h
+++ b/include/effects/strip/particles.h
@@ -154,10 +154,7 @@ class FadingCountDownObject : public FadingObject
 
   public:
 
-    FadingCountDownObject(unsigned long maxvalue)
-      : _maxValue(maxvalue)
-    {
-    }
+    FadingCountDownObject(unsigned long maxvalue) : _maxValue(maxvalue) {}
 
     virtual unsigned long CurrentCountdown()
     {
@@ -177,10 +174,7 @@ class FadingColoredObject : public FadingObject
 
   public:
 
-    FadingColoredObject(CRGB baseColor)
-      : _baseColor(baseColor)
-    {
-    }
+    FadingColoredObject(CRGB baseColor) : _baseColor(baseColor) {}
 
     virtual CRGB ObjectColor() const
     {
@@ -312,9 +306,7 @@ template <typename Type = DrawableParticle> class ParticleSystem
 
   public:
 
-    ParticleSystem<Type>()
-    {
-    }
+    ParticleSystem<Type>() {}
 
     virtual void Render(const std::vector<std::shared_ptr<GFXBase>>& _gfx)
     {
@@ -384,18 +376,24 @@ class RingParticle : public FadingColoredObject
 
 
 #if ENABLE_AUDIO
-class ColorBeatWithFlash : public BeatEffectBase, public ParticleSystem<RingParticle>, EffectWithId<idStripColorBeatWithFlash>
+class ColorBeatWithFlash : public BeatEffectBase, public ParticleSystem<RingParticle>, public EffectWithId<idStripColorBeatWithFlash>
 {
     int _iLastInsulator = 0;
     CRGB _baseColor = CRGB::Black;
 
   public:
 
-    ColorBeatWithFlash(const String & strName) : BeatEffectBase(), ParticleSystem<RingParticle>(), EffectWithId<idStripColorBeatWithFlash>(strName)
+    ColorBeatWithFlash(const String & strName)
+      : BeatEffectBase(),
+        ParticleSystem<RingParticle>(),
+        EffectWithId<idStripColorBeatWithFlash>(strName)
     {
     }
 
-    ColorBeatWithFlash(const JsonObjectConst& jsonObject) : BeatEffectBase(), ParticleSystem<RingParticle>(), EffectWithId<idStripColorBeatWithFlash>(jsonObject)
+    ColorBeatWithFlash(const JsonObjectConst& jsonObject)
+      : BeatEffectBase(),
+        ParticleSystem<RingParticle>(),
+        EffectWithId<idStripColorBeatWithFlash>(jsonObject)
     {
     }
 

--- a/include/effects/strip/snakeeffect.h
+++ b/include/effects/strip/snakeeffect.h
@@ -45,6 +45,7 @@ class SnakeEffect : public EffectWithId<idStripSnake>
     }
 
   protected:
+  
     int     LEDCount;             // Number of LEDs total
     int     SnakeSpeed;           // Max duration between iterations.
 

--- a/include/effects/strip/snakeeffect.h
+++ b/include/effects/strip/snakeeffect.h
@@ -34,13 +34,10 @@
 #include "effects.h"
 #include "globals.h"
 
-class SnakeEffect : public LEDStripEffect
+class SnakeEffect : public EffectWithId<idStripSnake>
 {
-  public:
-  
-    static constexpr EffectId kId = idStripSnake;
-    EffectId effectId() const override { return kId; }
-    
+  private:
+
     void construct()
     {
         lastLEDIndex = LEDCount - 1;
@@ -70,7 +67,7 @@ class SnakeEffect : public LEDStripEffect
   public:
 
     SnakeEffect(const char * strName, int ledCount = NUM_LEDS, int snakeSpeed = dSnakeSpeed)
-    : LEDStripEffect(idStripSnake, strName),
+        : EffectWithId<idStripSnake>(strName),
           LEDCount(ledCount),
           SnakeSpeed(snakeSpeed)
     {
@@ -78,7 +75,7 @@ class SnakeEffect : public LEDStripEffect
     }
 
     SnakeEffect(const JsonObjectConst& jsonObject)
-        : LEDStripEffect(jsonObject),
+        : EffectWithId<idStripSnake>(jsonObject),
           LEDCount(jsonObject[PTY_LEDCOUNT]),
           SnakeSpeed(jsonObject[PTY_SPEED])
     {

--- a/include/effects/strip/stareffect.h
+++ b/include/effects/strip/stareffect.h
@@ -84,16 +84,11 @@ class RandomPaletteColorStar : public MovingFadingPaletteObject, public ObjectSi
 
 class LongLifeSparkleStar : public MovingFadingPaletteObject, public ObjectSize
 {
-    float PreignitionTime() const override         { return .25f;  }
-    float IgnitionTime()    const override         { return 5.0f;  }
-    float HoldTime()        const override         { return 0.00f; }
-    float FadeTime()        const override         { return 0.0f;  }
-
   public:
 
     static int GetStarTypeNumber()
     {
-    return idStarLongLifeSparkle;
+        return idStarLongLifeSparkle;
     }
 
     virtual float GetStarSize()
@@ -106,6 +101,11 @@ class LongLifeSparkleStar : public MovingFadingPaletteObject, public ObjectSize
           ObjectSize(starSize)
     {
     }
+
+    float PreignitionTime() const override         { return .25f;  }
+    float IgnitionTime()    const override         { return 5.0f;  }
+    float HoldTime()        const override         { return 0.00f; }
+    float FadeTime()        const override         { return 0.0f;  }
 };
 
 class ColorStar : public MovingFadingColoredObject, public ObjectSize
@@ -173,7 +173,7 @@ class MusicStar : public Star
 
 class MusicPulseStar : public Star
 {
-    public:
+  public:
 
     MusicPulseStar(const CRGBPalette16 & palette, TBlendType blendType = LINEARBLEND, float maxSpeed = 0.0, float size = 0.0)
       : Star(palette, blendType, maxSpeed, size)
@@ -181,9 +181,7 @@ class MusicPulseStar : public Star
 
     }
 
-    virtual ~MusicPulseStar()
-    {
-    }
+    virtual ~MusicPulseStar() {}
 
     static int GetStarTypeNumber()
     {
@@ -201,10 +199,11 @@ class MusicPulseStar : public Star
 
 class BubblyStar : public Star
 {
-    protected:
+  protected:
+
     int         _hue;
 
-    public:
+  public:
 
     BubblyStar(const CRGBPalette16 & palette, TBlendType blendType = LINEARBLEND, float maxSpeed = 2.0, float starSize = 12)
       : Star(palette, blendType, maxSpeed, starSize)
@@ -239,7 +238,7 @@ class BubblyStar : public Star
 
 class FlashStar : public Star
 {
-    using Star::Star;
+  public:
 
     static int GetStarTypeNumber()
     {
@@ -254,10 +253,11 @@ class FlashStar : public Star
 
 class ColorCycleStar : public Star
 {
-    protected:
+  protected:
+
     int         _brightness;
 
-    public:
+  public:
 
     ColorCycleStar(const CRGBPalette16 & palette, TBlendType blendType = LINEARBLEND, float maxSpeed = 2.0, int speedDivisor = 1)
       : Star(palette, blendType, maxSpeed)
@@ -289,11 +289,13 @@ class ColorCycleStar : public Star
 
 class MultiColorStar : public Star
 {
-    protected:
+  protected:
+
     uint8_t         _brightness;
     uint8_t         _hue;
 
-    public:
+  public:
+
     MultiColorStar(const CRGBPalette16 & palette, TBlendType blendType = LINEARBLEND, float maxSpeed = 2.0, int speedDivisor = 1)
       : Star(palette, blendType, maxSpeed)
     {
@@ -420,6 +422,7 @@ template <typename ObjectType> class BeatStarterEffect : public BeatEffectBase
 template <typename StarType> class StarryNightEffect : public EffectWithId<idStripStarryNight>
 {
   protected:
+
     std::deque<StarType>         _allParticles;
     const CRGBPalette16         _palette;
     float                        _newStarProbability;
@@ -586,13 +589,13 @@ template <typename StarType> class BlurStarEffect : public StarryNightEffect<Sta
 class TwinkleStarEffect : public EffectWithId<idStripTwinkleStar>
 {
   private:
+
     #define NUM_TWINKLES 100
     int buffer[NUM_TWINKLES];
 
   public:
 
     TwinkleStarEffect() : EffectWithId<idStripTwinkleStar>("Twinkle Star") {}
-
     TwinkleStarEffect(const JsonObjectConst& jsonObject) : EffectWithId<idStripTwinkleStar>(jsonObject) {}
 
     bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override

--- a/include/effects/strip/stareffect.h
+++ b/include/effects/strip/stareffect.h
@@ -417,7 +417,7 @@ template <typename ObjectType> class BeatStarterEffect : public BeatEffectBase
 //
 // Generates up to
 
-template <typename StarType> class StarryNightEffect : public LEDStripEffect
+template <typename StarType> class StarryNightEffect : public EffectWithId<idStripStarryNight>
 {
   protected:
     std::deque<StarType>         _allParticles;
@@ -432,11 +432,6 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
 
   public:
 
-        // All StarryNight variants share the same EffectId; star type is encoded separately
-        static constexpr EffectId kId = idStripStarryNight;
-        EffectId effectId() const override { return kId; }
-
-
     StarryNightEffect<StarType>(const String & strName,
                                 const CRGBPalette16& palette,
                                 float probability = 1.0,
@@ -446,7 +441,7 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
                                 float blurFactor = 0.0,
                                 float musicFactor = 1.0,
                                 CRGB skyColor = CRGB::Black)
-    : LEDStripEffect(strName),
+      : EffectWithId<idStripStarryNight>(strName),
         _palette(palette),
         _newStarProbability(probability),
         _starSize(starSize),
@@ -459,7 +454,7 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
     }
 
     StarryNightEffect<StarType>(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject),
+      : EffectWithId<idStripStarryNight>(jsonObject),
         _palette(jsonObject[PTY_PALETTE].as<CRGBPalette16>()),
         _newStarProbability(jsonObject["spb"]),
         _starSize(jsonObject[PTY_SIZE]),
@@ -566,8 +561,6 @@ template <typename StarType> class StarryNightEffect : public LEDStripEffect
 
 template <typename StarType> class BlurStarEffect : public StarryNightEffect<StarType>
 {
-  private:
-
   public:
 
     BlurStarEffect<StarType>(const CRGBPalette16 & palette, float probability = 0.2, size_t starSize = 1, TBlendType blendType = LINEARBLEND, float maxSpeed = 20.0)
@@ -590,25 +583,17 @@ template <typename StarType> class BlurStarEffect : public StarryNightEffect<Sta
 //
 // Twinkles random colored dots on and off
 
-class TwinkleStarEffect : public LEDStripEffect
+class TwinkleStarEffect : public EffectWithId<idStripTwinkleStar>
 {
-  public:
-
-    static constexpr EffectId kId = idStripTwinkleStar;
-    EffectId effectId() const override { return kId; }
-  
+  private:
     #define NUM_TWINKLES 100
     int buffer[NUM_TWINKLES];
 
-public:
+  public:
 
-    TwinkleStarEffect() : LEDStripEffect("Twinkle Star")
-    {
-    }
+    TwinkleStarEffect() : EffectWithId<idStripTwinkleStar>("Twinkle Star") {}
 
-    TwinkleStarEffect(const JsonObjectConst& jsonObject) : LEDStripEffect(jsonObject)
-    {
-    }
+    TwinkleStarEffect(const JsonObjectConst& jsonObject) : EffectWithId<idStripTwinkleStar>(jsonObject) {}
 
     bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
     {

--- a/include/effects/strip/tempeffect.h
+++ b/include/effects/strip/tempeffect.h
@@ -112,10 +112,12 @@ class SimpleInsulatorBeatEffect2 : public EffectWithId<idStripSimpleInsulatorBea
 class VUInsulatorsEffect : public EffectWithId<idStripVUInsulators>
 {
   private:
-  
+
     int _last = 1;
 
   public:
+    
+    using EffectWithId<idStripVUInsulators>::EffectWithId;
 
     void DrawVUPixels(int i, int fadeBy, const CRGBPalette16 & palette)
     {

--- a/include/effects/strip/tempeffect.h
+++ b/include/effects/strip/tempeffect.h
@@ -116,7 +116,7 @@ class VUInsulatorsEffect : public EffectWithId<idStripVUInsulators>
     int _last = 1;
 
   public:
-    
+
     using EffectWithId<idStripVUInsulators>::EffectWithId;
 
     void DrawVUPixels(int i, int fadeBy, const CRGBPalette16 & palette)

--- a/include/effects/strip/tempeffect.h
+++ b/include/effects/strip/tempeffect.h
@@ -35,12 +35,8 @@
 
 #include <deque>
 
-class SimpleInsulatorBeatEffect : public LEDStripEffect, public BeatEffectBase
+class SimpleInsulatorBeatEffect : public EffectWithId<idStripSimpleInsulatorBeat>, public BeatEffectBase
 {
-  public:
-    static constexpr EffectId kId = idStripSimpleInsulatorBeat;
-    EffectId effectId() const override { return kId; }
-
   protected:
 
     std::deque<int> _lit;
@@ -71,23 +67,14 @@ class SimpleInsulatorBeatEffect : public LEDStripEffect, public BeatEffectBase
     using BeatEffectBase::BeatEffectBase;
 
     SimpleInsulatorBeatEffect(const String & strName)
-  : LEDStripEffect(idStripSimpleInsulatorBeat, strName), BeatEffectBase(0.5, 0.01)
-    {
-    }
+      : EffectWithId<idStripSimpleInsulatorBeat>(strName), BeatEffectBase(0.5, 0.01) {}
 
     SimpleInsulatorBeatEffect(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject), BeatEffectBase(0.5, 0.01)
-    {
-    }
-
+      : EffectWithId<idStripSimpleInsulatorBeat>(jsonObject), BeatEffectBase(0.5, 0.01) {}
 };
 
-class SimpleInsulatorBeatEffect2 : public LEDStripEffect, public BeatEffectBase
+class SimpleInsulatorBeatEffect2 : public EffectWithId<idStripSimpleInsulatorBeat2>, public BeatEffectBase
 {
-  public:
-    static constexpr EffectId kId = idStripSimpleInsulatorBeat2;
-    EffectId effectId() const override { return kId; }
-
   protected:
 
     std::deque<int> _lit;
@@ -116,25 +103,19 @@ class SimpleInsulatorBeatEffect2 : public LEDStripEffect, public BeatEffectBase
   public:
 
     SimpleInsulatorBeatEffect2(const String & strName)
-  : LEDStripEffect(idStripSimpleInsulatorBeat2, strName), BeatEffectBase()
-    {
-    }
+      : EffectWithId<idStripSimpleInsulatorBeat2>(strName), BeatEffectBase() {}
 
     SimpleInsulatorBeatEffect2(const JsonObjectConst& jsonObject)
-      : LEDStripEffect(jsonObject), BeatEffectBase()
-    {
-    }
+      : EffectWithId<idStripSimpleInsulatorBeat2>(jsonObject), BeatEffectBase() {}
 };
 
-class VUInsulatorsEffect : public LEDStripEffect
+class VUInsulatorsEffect : public EffectWithId<idStripVUInsulators>
 {
-  public:
-    static constexpr EffectId kId = idStripVUInsulators;
-    EffectId effectId() const override { return kId; }
-    
+  private:
+  
     int _last = 1;
 
-    using LEDStripEffect::LEDStripEffect;
+  public:
 
     void DrawVUPixels(int i, int fadeBy, const CRGBPalette16 & palette)
     {

--- a/include/effectsupport.h
+++ b/include/effectsupport.h
@@ -35,6 +35,7 @@
 #include "globals.h"
 // Needed for StarryNightEffect used by helpers below
 #include "effects/strip/stareffect.h"
+#include <type_traits>
 
 // Palettes used by a number of effects
 
@@ -188,6 +189,16 @@ const CRGBPalette16 rainbowPalette(RainbowColors_p);
 
 extern DRAM_ATTR std::unique_ptr<EffectFactories> g_ptrEffectFactories;
 
+template<class T>
+using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
+
+template <class T>
+constexpr EffectId effect_id_of_type() {
+    static_assert(std::is_base_of_v<LEDStripEffect, remove_cvref_t<T>>,
+                  "Type must derive from EffectWithId<Id>");
+    return remove_cvref_t<T>::ID;   // compile-time constant
+}
+
 // --- Macro-free helpers for concise, type-safe effect registration ---
 
 // Adds a default and JSON effect factory for a specific effect number and type.
@@ -197,19 +208,10 @@ inline EffectFactories::NumberedFactory& AddEffect(EffectFactories& factories, A
 {
     static_assert(std::is_enum_v<decltype(TEffect::kId)>, "TEffect must have static constexpr kId");
     return factories.AddEffect(
-        TEffect::kId,
+        effect_id_of_type<TEffect>(),
         [=]() -> std::shared_ptr<LEDStripEffect> { return make_shared_psram<TEffect>(args...); },
         [](const JsonObjectConst& jsonObject) -> std::shared_ptr<LEDStripEffect> { return make_shared_psram<TEffect>(jsonObject); }
     );
-}
-
-// Adds a default and JSON effect factory, but the default effect will be disabled upon creation.
-template<typename TEffect, typename... Args>
-inline EffectFactories::NumberedFactory& AddEffectDisabled(EffectFactories& factories, Args&&... args)
-{
-    auto& nf = AddEffect<TEffect>(factories, std::forward<Args>(args)...);
-    nf.LoadDisabled = true;
-    return nf;
 }
 
 // Used by Starry Night helper
@@ -220,19 +222,10 @@ template<typename TStar, typename... Args>
 inline EffectFactories::NumberedFactory& AddStarryNightEffect(EffectFactories& factories, Args&&... args)
 {
     return factories.AddEffect(
-    idStripStarryNight,
+        idStripStarryNight,
         [=]() -> std::shared_ptr<LEDStripEffect> { return make_shared_psram<StarryNightEffect<TStar>>(args...); },
         [](const JsonObjectConst& jsonObject) -> std::shared_ptr<LEDStripEffect> { return CreateStarryNightEffectFromJSON(jsonObject); }
     );
-}
-
-// Disabled-on-load variant for Starry Night
-template<typename TStar, typename... Args>
-inline EffectFactories::NumberedFactory& AddStarryNightEffectDisabled(EffectFactories& factories, Args&&... args)
-{
-    auto& nf = AddStarryNightEffect<TStar>(factories, std::forward<Args>(args)...);
-    nf.LoadDisabled = true;
-    return nf;
 }
 
 // Fold-expression helper to register many at once with brief syntax:

--- a/include/effectsupport.h
+++ b/include/effectsupport.h
@@ -206,7 +206,6 @@ constexpr EffectId effect_id_of_type() {
 template<typename TEffect, typename... Args>
 inline EffectFactories::NumberedFactory& AddEffect(EffectFactories& factories, Args&&... args)
 {
-    static_assert(std::is_enum_v<decltype(TEffect::kId)>, "TEffect must have static constexpr kId");
     return factories.AddEffect(
         effect_id_of_type<TEffect>(),
         [=]() -> std::shared_ptr<LEDStripEffect> { return make_shared_psram<TEffect>(args...); },

--- a/include/ledstripeffect.h
+++ b/include/ledstripeffect.h
@@ -222,17 +222,6 @@ class LEDStripEffect : public IJSONSerializable
             _friendlyName = strName;
     }
 
-    // Transitional ctor: accept an id but ignore it. This allows existing call sites
-    // to compile while we migrate them to the name-only constructor.
-    explicit LEDStripEffect(EffectId /*ignoredId*/, const String & strName)
-        : LEDStripEffect(strName)
-    {}
-
-    // Some call sites may pass a raw int; accept and ignore it as well.
-    explicit LEDStripEffect(int /*ignoredId*/, const String & strName)
-        : LEDStripEffect(strName)
-    {}
-
     explicit LEDStripEffect(const JsonObjectConst&  jsonObject)
         : _friendlyName(jsonObject["fn"].as<String>())
     {
@@ -302,7 +291,7 @@ class LEDStripEffect : public IJSONSerializable
 
     // Runtime effect id. Subclasses must override to return their EffectId
 
-       
+
     virtual EffectId effectId() const = 0;
 
     virtual size_t DesiredFramesPerSecond() const           // Desired framerate of the LED drawing
@@ -492,7 +481,7 @@ class LEDStripEffect : public IJSONSerializable
         if (pixel >= 0 && pixel < _cLEDs)
             for (auto& device : _GFX)
                 device->fadePixelToBlackBy(pixel, fadeValue);
-        
+
     }
 
     void fadeAllChannelsToBlackBy(uint8_t fadeValue) const
@@ -642,3 +631,24 @@ class LEDStripEffect : public IJSONSerializable
     }
 };
 
+template<EffectId EId>
+class EffectWithId : public LEDStripEffect
+{
+  public:
+
+    static constexpr EffectId ID = EId;
+
+    explicit EffectWithId(const String & strName)
+        : LEDStripEffect(strName)
+    {}
+
+    explicit EffectWithId(const JsonObjectConst&  jsonObject)
+        : LEDStripEffect(jsonObject)
+    {}
+
+    // Override to return the effect id for this effect
+    EffectId effectId() const override
+    {
+        return EId;
+    }
+};

--- a/platformio.ini
+++ b/platformio.ini
@@ -119,7 +119,7 @@ build_flags     = ${dev_esp32_s3.build_flags}
                   -DTFT_HEIGHT=240
                   -DTFT_BL=45
                   -DTFT_BACKLIGHT_ON=HIGH
-                  -DTFT_RGB_ORDER=TFT_RGB                  
+                  -DTFT_RGB_ORDER=TFT_RGB
                   -DTFT_CS=7
                   -DTFT_DC=39
                   -DTFT_RST=40
@@ -436,8 +436,8 @@ build_flags     = -DDEMO=1
                   -DENABLE_NTP=0
                   -DENABLE_OTA=0
                   -DENABLE_WEBSERVER=0
-                  -DLED_PIN0=5                  
-                  ${dev_esp32.build_flags}                  
+                  -DLED_PIN0=5
+                  ${dev_esp32.build_flags}
 
 ; This is the basic DEMO project again, but expanded to work on the M5, which means it can draw to
 ; the built in LCD.  It's made so that you can connect to the small 4-pin connector on the M5,
@@ -523,7 +523,7 @@ build_flags     = -DM5DEMO=1
                   -DLED_PIN0=32
                   -DTOGGLE_BUTTON_1=37
                   -DTOGGLE_BUTTON_2=39
-                  -DDEFAULT_INFO_PAGE=1                  
+                  -DDEFAULT_INFO_PAGE=1
                   -DNUM_BANDS=80
                   ${dev_m5stack.build_flags}
 
@@ -590,7 +590,7 @@ build_flags     = -DDEMO=1
                   -DENABLE_AUDIO=1
                   -DCOLORDATA_SERVER_ENABLED=0
                   -DDEFAULT_EFFECT_INTERVAL=60*60*24*5
-                  -DNUM_BANDS=64                 
+                  -DNUM_BANDS=64
                   -DINPUT_PIN=41
                   -DUSE_I2S_AUDIO=1
                   -DI2S_BCLK_PIN=39
@@ -632,7 +632,7 @@ extends         = dev_adafruit_feather
 build_flags     = -DLEDSTRIP=1
                   -DEFFECTS_MINIMAL=1
                   ${dev_adafruit_feather.build_flags}
-                  ${psram_flags.build_flags}                  
+                  ${psram_flags.build_flags}
 
 [env:ledstrip_feather_hexagon]
 extends         = dev_adafruit_feather
@@ -1036,7 +1036,7 @@ board_build.flash_freq = 40m
 build_flags     = -DTTGO=1
                   -DEFFECTS_TTGO=1
                   -DUSE_SCREEN=1
-                  -DDEFAULT_INFO_PAGE=1                  
+                  -DDEFAULT_INFO_PAGE=1
                   -DUSE_TFTSPI=1
                   -DUSER_SETUP_LOADED
                   -DST7789_DRIVER
@@ -1362,4 +1362,3 @@ build_flags     = -DCUBE=1
                   -DCOLOR_ORDER=EOrder::RGB
                   -DEFFECTS_MINIMAL=1
                   ${dev_m5stick_c_plus.build_flags}
- 


### PR DESCRIPTION
## Description

This builds on #748 by implementing the effect ID (renamed from `kId`) and `effectId()` static members in a class template between `LEDStripEffect` and the effects called `EffectWithId`, based on an `EffectId` that is passed as a template parameter when defining the effect class.

This:

- Removes the need for an effect-specific definition of `ID` and `effectId()` in most effect classes; the requirement remains only for effect classes that derive from `EffectWithId` indirectly, i.e. via another effect.
- Makes the setting of an `EffectId` for an effect class derived from `EffectWithId` a "pre-compile time check" in most development environments.
- Fixes a number of accessor specifiers, which made private members public.
- Removes a lot of trailing spaces, and makes the line white spacing in effect classes far more consistent.
- Removes unnecessary `Add...Disabled()` functions from effectsupport.h.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).