### PR TITLE
Refactor: Centralize polar coordinate calculations for radial effects

### DIFF
--- a/include/effects/matrix/PatternSMHypnosis.h
+++ b/include/effects/matrix/PatternSMHypnosis.h
@@ -7,17 +7,6 @@
 
 class PatternSMHypnosis : public EffectWithId<idMatrixSMHypnosis>
 {
-  private:
-
-    const uint8_t C_X = MATRIX_WIDTH / 2;
-    const uint8_t C_Y = MATRIX_HEIGHT / 2;
-    const uint8_t mapp = 255 / MATRIX_WIDTH;
-    struct
-    {
-        uint8_t angle;
-        uint8_t radius;
-    } rMap[MATRIX_WIDTH][MATRIX_HEIGHT];
-
   public:
 
     PatternSMHypnosis() : EffectWithId<idMatrixSMHypnosis>("Hypnosis") {}
@@ -31,15 +20,6 @@ class PatternSMHypnosis : public EffectWithId<idMatrixSMHypnosis>
     void Start() override
     {
         g()->Clear();
-        for (int8_t x = -C_X; x < C_X + (MATRIX_WIDTH % 2); x++)
-        {
-            for (int8_t y = -C_Y; y < C_Y + (MATRIX_HEIGHT % 2); y++)
-            {
-                rMap[x + C_X][y + C_Y].angle = 128 * (atan2(y, x) / PI);
-                rMap[x + C_X][y + C_Y].radius = hypot(x, y) * mapp; // thanks
-                                                                    // Sutaburosu
-            }
-        }
     }
 
     uint16_t t = 0;
@@ -47,10 +27,12 @@ class PatternSMHypnosis : public EffectWithId<idMatrixSMHypnosis>
     void Draw() override
     {
         t += 4;
+        const auto& rMap = LEDMatrixGFX::getPolarMap(); // Get the map on demand
+
         for (uint x = 0; x < MATRIX_WIDTH; x++)
             for (uint y = 0; y < MATRIX_HEIGHT; y++)
                 g()->leds[XY(x, y)] = ColorFromPalette(g()->IsPalettePaused()
                                       ? g()->GetCurrentPalette()
-                                      : RainbowStripeColors_p, t / 2 + rMap[x][y].radius + rMap[x][y].angle, sin8(rMap[x][y].angle + (rMap[x][y].radius * 2) - t));
+                                      : RainbowStripeColors_p, t / 2 + rMap[x][y].scaled_radius + rMap[x][y].angle, sin8(rMap[x][y].angle + (rMap[x][y].scaled_radius * 2) - t));
     }
 };

--- a/include/effects/matrix/PatternSMRadialFire.h
+++ b/include/effects/matrix/PatternSMRadialFire.h
@@ -11,28 +11,6 @@ class PatternSMRadialFire : public EffectWithId<idMatrixSMRadialFire>
     PatternSMRadialFire() : EffectWithId<idMatrixSMRadialFire>("RadialFire") {}
     PatternSMRadialFire(const JsonObjectConst &jsonObject) : EffectWithId<idMatrixSMRadialFire>(jsonObject) {}
 
-  private:
-
-    static auto constexpr C_X = (MATRIX_WIDTH / 2);
-    static auto constexpr C_Y = (MATRIX_HEIGHT / 2);
-
-    std::unique_ptr<uint8_t[]> XY_angle_buf;
-    std::unique_ptr<uint8_t[]> XY_radius_buf;
-
-    bool Init(std::vector<std::shared_ptr<GFXBase>>& gfx) override
-    {
-        XY_angle_buf = make_unique_psram<uint8_t[]>(MATRIX_WIDTH * MATRIX_HEIGHT);
-        XY_radius_buf = make_unique_psram<uint8_t[]>(MATRIX_WIDTH * MATRIX_HEIGHT);
-        for (int8_t x = -C_X; x < C_X + (MATRIX_WIDTH % 2); x++) {
-            for (int8_t y = -C_Y; y < C_Y + (MATRIX_HEIGHT % 2); y++) {
-                int idx = (x + C_X) + MATRIX_WIDTH * (y + C_Y);
-                XY_angle_buf[idx] = 128 * (atan2(y, x) / PI);
-                XY_radius_buf[idx] = hypot(x, y); // thanks Sutaburosu
-            }
-        }
-        return LEDStripEffect::Init(gfx);
-    }
-
     void Start() override
     {
         g()->Clear();
@@ -42,15 +20,18 @@ class PatternSMRadialFire : public EffectWithId<idMatrixSMRadialFire>
     {
         static uint8_t scaleX = 16;
         static uint8_t scaleY = 1;
-
         static uint8_t speed = 24;
         static uint32_t t;
         t += speed;
-        for (uint8_t x = 0; x < MATRIX_WIDTH; x++) {
-            for (uint8_t y = 0; y < MATRIX_HEIGHT; y++) {
-                int idx = x + MATRIX_WIDTH * y;
-                uint8_t angle = XY_angle_buf[idx];
-                uint8_t radius = XY_radius_buf[idx];
+
+        const auto& rMap = LEDMatrixGFX::getPolarMap();
+
+        for (uint8_t x = 0; x < MATRIX_WIDTH; x++)
+        {
+            for (uint8_t y = 0; y < MATRIX_HEIGHT; y++)
+            {
+                uint8_t angle = rMap[x][y].angle;
+                uint8_t radius = rMap[x][y].unscaled_radius; // Use the unscaled radius
                 int16_t Bri = inoise8(angle * scaleX, (radius * scaleY) - t) - radius * (255 / MATRIX_HEIGHT);
                 uint8_t Col = Bri;
 

--- a/include/effects/matrix/PatternSMRadialWave.h
+++ b/include/effects/matrix/PatternSMRadialWave.h
@@ -7,22 +7,6 @@
 
 class PatternSMRadialWave : public EffectWithId<idMatrixSMRadialWave>
 {
-  private:
-    // RadialWave
-    // Stepko and Sutaburosu
-    // 22/05/22
-
-    bool setupm = 1;
-    static constexpr int8_t C_X = MATRIX_WIDTH / 2;
-    static constexpr int8_t C_Y = MATRIX_HEIGHT / 2;
-    static constexpr uint8_t mapp = 255 / MATRIX_WIDTH;
-    // BUGBUG: should probably be allocated into slow RAM.
-    struct
-    {
-        uint8_t angle;
-        uint8_t radius;
-    } rMap[MATRIX_WIDTH][MATRIX_HEIGHT];
-
   public:
   
     PatternSMRadialWave() : EffectWithId<idMatrixSMRadialWave>("RadialWave") {}
@@ -36,27 +20,20 @@ class PatternSMRadialWave : public EffectWithId<idMatrixSMRadialWave>
     void Start() override
     {
         g()->Clear();
-        for (int8_t x = -C_X; x < C_X + (MATRIX_WIDTH % 2); x++)
-        {
-            for (int8_t y = -C_Y; y < C_Y + (MATRIX_HEIGHT % 2); y++)
-            {
-                rMap[x + C_X][y + C_Y].angle = 128 * (atan2(y, x) / PI);
-                rMap[x + C_X][y + C_Y].radius = hypot(x, y) * mapp; // thanks
-                                                                    // Sutaburosu
-            }
-        }
     }
 
     void Draw() override
     {
         static uint32_t t = 0;
         t++;
+        const auto& rMap = LEDMatrixGFX::getPolarMap();
+
         for (uint8_t x = 0; x < MATRIX_WIDTH; x++)
         {
             for (uint8_t y = 0; y < MATRIX_HEIGHT; y++)
             {
                 uint8_t angle = rMap[x][y].angle;
-                uint8_t radius = rMap[x][y].radius;
+                uint8_t radius = rMap[x][y].scaled_radius;
                 g()->leds[XY(x, y)] = CHSV(t + radius, 255, sin8(t * 4 + sin8(t * 4 - radius) + angle * 3));
             }
         }

--- a/include/effects/matrix/PatternSMRainbowTunnel.h
+++ b/include/effects/matrix/PatternSMRainbowTunnel.h
@@ -7,21 +7,6 @@
 
 class PatternSMRainbowTunnel : public EffectWithId<idMatrixSMRainbowTunnel>
 {
-  private:
-    // RadialRainbow
-    // Stepko and Sutaburosu
-    // 23/12/21
-
-    static constexpr uint8_t C_X = MATRIX_WIDTH / 2;
-    static constexpr uint8_t C_Y = MATRIX_HEIGHT / 2;
-    static constexpr uint8_t mapp = 255 / MATRIX_WIDTH;
-
-    struct
-    {
-        uint8_t angle;
-        uint8_t radius;
-    } rMap[MATRIX_WIDTH][MATRIX_HEIGHT];
-
   public:
   
     PatternSMRainbowTunnel() : EffectWithId<idMatrixSMRainbowTunnel>("Colorspin") {}
@@ -30,15 +15,6 @@ class PatternSMRainbowTunnel : public EffectWithId<idMatrixSMRainbowTunnel>
     void Start() override
     {
         g()->Clear();
-        for (int8_t x = -C_X; x < C_X + (MATRIX_WIDTH % 2); x++)
-        {
-            for (int8_t y = -C_Y; y < C_Y + (MATRIX_HEIGHT % 2); y++)
-            {
-                rMap[x + C_X][y + C_Y].angle = 128 * (atan2(y, x) / PI);
-                rMap[x + C_X][y + C_Y].radius = hypot(x, y) * mapp; // thanks
-                                                                    // Sutaburosu
-            }
-        }
     }
 
     void Draw() override
@@ -50,12 +26,14 @@ class PatternSMRainbowTunnel : public EffectWithId<idMatrixSMRainbowTunnel>
         static uint16_t t;
 
         t += speed;
+        const auto& rMap = LEDMatrixGFX::getPolarMap();
+
         for (uint8_t x = 0; x < MATRIX_WIDTH; x++)
         {
             for (uint8_t y = 0; y < MATRIX_HEIGHT; y++)
             {
                 uint8_t angle = rMap[x][y].angle;
-                uint8_t radius = rMap[x][y].radius;
+                uint8_t radius = rMap[x][y].scaled_radius;
                 g()->leds[XY(x, y)] =
                     CHSV((angle * scaleX) - t + (radius * scaleY), 255, constrain(radius * 3, 0, 255));
             }

--- a/include/ledmatrixgfx.h
+++ b/include/ledmatrixgfx.h
@@ -35,6 +35,10 @@
 #if USE_HUB75
 
 #include "globals.h"
+#include <cmath>
+#include <memory>
+#include <mutex>
+#include "types.h"
 
 //
 // Matrix Panel
@@ -70,6 +74,64 @@ public:
 
     ~LEDMatrixGFX() override
     = default;
+
+    // A 3-byte struct will have one byte of padding so each element
+    // begins on a NA boundary. Making this
+    // struct __attribute__((packed)) PolarMap
+    // might conserve 25% of this buffer, but it might also force
+    // single elements to be split across a (locked) cache line.
+    // We'll thus leave this naturally aligned unless we have a
+    // really great reason not to.
+    struct PolarMap {
+        uint8_t angle;
+        uint8_t scaled_radius;
+        uint8_t unscaled_radius;
+    };
+
+    using PolarMapArray = PolarMap[kMatrixWidth][kMatrixHeight];
+
+    static const PolarMapArray& getPolarMap() {
+        static std::unique_ptr<PolarMapArray> rMap_ptr;
+        static std::mutex rMap_mutex;
+
+        // Double-checked locking for thread-safe, on-demand initialization
+        if (!rMap_ptr) {
+            std::lock_guard<std::mutex> lock(rMap_mutex);
+            if (!rMap_ptr) {
+                // Allocate from PSRAM using the project's helper
+                rMap_ptr = make_unique_psram<PolarMapArray>();
+
+                auto& rMap = *rMap_ptr;
+                const uint8_t C_X = kMatrixWidth / 2;
+                const uint8_t C_Y = kMatrixHeight / 2;
+                const float mapp = 255.0f / kMatrixWidth;
+
+                for (int8_t x = -C_X; x < C_X + (kMatrixWidth % 2); x++) {
+                    for (int8_t y = -C_Y; y < C_Y + (MATRIX_HEIGHT % 2); y++) {
+                        float angle_rad = atan2f(static_cast<float>(y), static_cast<float>(x));
+                        float radius_float = hypotf(static_cast<float>(x), static_cast<float>(y));
+
+                        rMap[x + C_X][y + C_Y].angle = 128.0f * (angle_rad / (float)M_PI);
+                        rMap[x + C_X][y + C_Y].scaled_radius = radius_float * mapp;
+                        rMap[x + C_X][y + C_Y].unscaled_radius = radius_float;
+                    }
+                }
+
+                // A note on the radius calculations:
+                //
+                // `unscaled_radius` is the true geometric distance from the center of the
+                // matrix to the pixel. This is useful for effects that need the real
+                // physical distance.
+                //
+                // `scaled_radius` maps the geometric radius to a range that is more
+                // suitable for use with 8-bit FastLED functions (like inoise8).
+                // The scaling is normalized by the matrix width, which is a common
+                // technique to make radial effects work consistently across different
+                // matrix sizes.
+            }
+        }
+        return *rMap_ptr;
+    }
 
     static void InitializeHardware(std::vector<std::shared_ptr<GFXBase>>& devices)
     {

--- a/include/types.h
+++ b/include/types.h
@@ -361,6 +361,18 @@ make_unique_psram(size_t size)
     return std::unique_ptr<T>(ptr);
 }
 
+// Overload for 2D arrays
+template<typename T>
+std::enable_if_t<std::rank<T>::value == 2, std::unique_ptr<T>>
+make_unique_psram()
+{
+    using U = typename std::remove_all_extents<T>::type;
+    size_t size = std::extent<T, 0>::value * std::extent<T, 1>::value;
+    psram_allocator<U> allocator;
+    U* ptr = allocator.allocate(size);
+    return std::unique_ptr<T>(reinterpret_cast<T*>(ptr));
+}
+
 // make_shared_psram
 //
 // Same as std::make_shared except allocates preferentially from the PSRAM pool


### PR DESCRIPTION
Refactor: Centralize polar coordinate calculations for radial effects
  Refactor several radial matrix effects to use a single, shared
  polar coordinate map, improving performance, memory usage, and
  code maintainability.

  Previously, PatternSMHypnosis, PatternSMRadialFire, PatternSMRadialWave,
  and PatternSMRainbowTunnel each performed their own redundant
  calculations for angle and radius on startup.

  This change introduces a centralized getPolarMap() function that
  provides a pre-computed map with the following improvements:

   * On-Demand & Thread-Safe: The map is allocated and computed only once
     on the first request, in a thread-safe manner. (Don't benchmark
     that first frame draw...)
   * Memory Efficient: A single shared map is allocated in PSRAM,
     significantly reducing the memory footprint compared to multiple,
     stack-allocated maps.
   * Performant: All floating-point calculations now use
     hardware-accelerated single-precision floats.
   * Unified: The shared map now includes both scaled and unscaled radius
     values to accommodate the needs of all refactored effects, including
     the special case of PatternSMRadialFire.

  This refactoring makes the code cleaner, more efficient, and easier to
  maintain, while also providing a reusable utility for future radial
  effects.

Fixes #751.
Slugwork (like pretentious commit messages) assisted by Gemini, but
design by me.

This is a respin of #752, performed via a cherry-pick, which was wrecked
via a collisioni of my own carelessness in letting  commit
https://github.com/PlummersSoftwareLLC/NightDriverStrip/pull/752/commits/76b51bed3de21c0693f81b44034e29a1f0e5ce3b
bleed over and the push of #748  which necessitated me using all my
mad templating skills (no, really, ALL of them!) to add back
multidimensional psram allocation. This code is just painful
when rewritten to try to fit the single dimension nature newly
enforced.



## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
