### PR TITLE
Replace legacy LEDS alias for FastLED

### DIFF
--- a/include/effects/matrix/PatternSMTwister.h
+++ b/include/effects/matrix/PatternSMTwister.h
@@ -45,7 +45,7 @@ class PatternSMTwister : public EffectWithId<idMatrixSMTwister>
     void Draw() override
     {
         uint16_t a = millis() / 10;
-        LEDS.clear();
+        FastLED.clear();
 
         for (uint16_t i = 0; i < MATRIX_HEIGHT; i++)
         {


### PR DESCRIPTION
## Description

Removes the reference to `LEDS` from `PatternSMTwister`, that being a legacy alias for `FastLED` that seems to have disappeared between the CI build for #757, and the merge of that same PR.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).