### PR TITLE
Move polar coordinate calculations to GFXBase, rename LED____Gfx classes

### DIFF
--- a/CODEBASE_INTRO.md
+++ b/CODEBASE_INTRO.md
@@ -43,10 +43,10 @@ The text in this document regularly mentions "LED display" as the visualization 
 
 ### `LEDMatrixGfx`
 
-- Located in: [ledmatrixgfx.h](./include/ledmatrixgfx.h) and [ledmatrixgfx.cpp](./src/ledmatrixgfx.cpp)
-- Role: Extends `GFXBase` for matrix-style LED arrangements.
+- Located in: [smartmatrixgfx.h](./include/smartmatrixgfx.h) and [smartmatrixgfx.cpp](./src/smartmatrixgfx.cpp)
+- Role: Extends `GFXBase` for HUB75 matrix-style LED arrangements, driven through the [SmartMatrix](https://github.com/pixelmatix/SmartMatrix) library.
 - Key functionalities: Matrix-specific drawing, dimension management.
-- Explanation: This class extends the functionalities of [`GFXBase`](#the-core-gfxbase) to cater to matrix-style LED arrangements. It provides methods to draw on a matrix, manage its dimensions, and handle matrix-specific effects.
+- Explanation: This class extends the functionalities of [`GFXBase`](#the-core-gfxbase) to cater to matrix-style LED arrangements, as supported by SmartMatrix. It provides methods to draw on a matrix, manage its dimensions, and handle matrix-specific effects.
 
 ### `EffectManager`
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Check out what the built-in effects do, but in short you're basically drawing in
 
 There is a global `EffectManager` instance that first creates the effect table from a JSON file on SPIFFS, if present. Then it adds any other effects that are registered in `LoadEffectFactories()` but not included in the JSON file. It then rotates amongst those effects at a rate controlled by `DEFAULT_EFFECT_INTERVAL`. Effects are not notified when they go active or not, they're just asked to draw when needed.
 
-Each channel of LEDs has an `LEDStripGfx` instance associated with it. `_GFX[0]` is the `LEDStripGfx` associated with `LED_PIN0`, and so on. You can get the LED buffer of Pin0 by calling `_GFX[0]->leds()`, and it will contain `_GFX[0]->GetLEDCount` pixels. You can draw into the buffer without ever touching the raw bytes by calling `fill_solid`, `fill_rainbow`, `setPixel`, and other drawing functions.
+Each channel of LEDs has a `FastLEDGfx` instance associated with it. `_GFX[0]` is the `FastLEDGfx` associated with `LED_PIN0`, and so on. You can get the LED buffer of Pin0 by calling `_GFX[0]->leds()`, and it will contain `_GFX[0]->GetLEDCount` pixels. You can draw into the buffer without ever touching the raw bytes by calling `fill_solid`, `fill_rainbow`, `setPixel`, and other drawing functions.
 
 The simplest configuration, `DEMO`, assumes you have a single meter strip of 144 LEDs and a power supply connected to your ESP32. It boots up, finds a single `RainbowFillEffect` in the `LoadEffectFactories()` function, and repeatedly calls its `Draw()` method to update the CRGB array before sending it out to the LEDs. If working correctly it should draw a scrolling rainbow palette on your LED strip.
 

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -373,7 +373,7 @@ public:
         std::shared_ptr<LEDStripEffect> & effect = _tempEffect ? _tempEffect : _vEffects[_iCurrentEffect];
 
         #if USE_HUB75
-            auto pMatrix = std::static_pointer_cast<LEDMatrixGFX>(_gfx[0]);
+            auto pMatrix = std::static_pointer_cast<SmartMatrixGFX>(_gfx[0]);
             pMatrix->SetCaption(effect->FriendlyName(), CAPTION_TIME);
         #endif
 

--- a/include/effects/matrix/PatternAnimatedGIF.h
+++ b/include/effects/matrix/PatternAnimatedGIF.h
@@ -42,7 +42,7 @@
 #include "globals.h"
 #include <string.h>
 #include <ledstripeffect.h>
-#include <ledmatrixgfx.h>
+#include <smartmatrixgfx.h>
 #include <ArduinoJson.h>
 #include "systemcontainer.h"
 #include <map>
@@ -178,17 +178,17 @@ class PatternAnimatedGIF : public EffectWithId<PatternAnimatedGIF>
     static void drawPixelCallback(int16_t x, int16_t y, uint8_t red, uint8_t green, uint8_t blue)
     {
         auto& g = *(g_ptrSystem->EffectManager().g(0));
-        
+
         // Apply scaling transformation
         int16_t scaledX = (int16_t)(x * g_gifDecoderState._scaleX) + g_gifDecoderState._offsetX;
         int16_t scaledY = (int16_t)(y * g_gifDecoderState._scaleY) + g_gifDecoderState._offsetY;
-        
+
         if (false == g.isValidPixel(scaledX, scaledY))
         {
             debugV("drawPixelCallback: scaled pixel out of bounds: %d, %d (from source %d, %d)", scaledX, scaledY, x, y);
             return;
         }
-        
+
         // If we're scaling down (scale < 1.0), we might want to sample multiple source pixels
         // For now, we use simple nearest-neighbor scaling
         g.leds[XY(scaledX, scaledY)] = CRGB(red, green, blue);
@@ -267,31 +267,31 @@ public:
         // Calculate best-fit scaling if the GIF is larger than the matrix
         uint16_t gifWidth = gif->second._width;
         uint16_t gifHeight = gif->second._height;
-        
+
         float scaleX = 1.0f;
         float scaleY = 1.0f;
-        
+
         // If GIF is larger than matrix, calculate scaling to fit
         if (gifWidth > MATRIX_WIDTH || gifHeight > MATRIX_HEIGHT)
         {
             scaleX = (float)MATRIX_WIDTH / (float)gifWidth;
             scaleY = (float)MATRIX_HEIGHT / (float)gifHeight;
-            
+
             // Use the smaller scale factor to maintain aspect ratio (best fit)
             float scale = min(scaleX, scaleY);
             scaleX = scale;
             scaleY = scale;
         }
-        
+
         // Calculate the destination dimensions after scaling
         uint16_t dstWidth = (uint16_t)(gifWidth * scaleX);
         uint16_t dstHeight = (uint16_t)(gifHeight * scaleY);
-        
+
         // Center the scaled GIF on the matrix
         int offsetX = (MATRIX_WIDTH - dstWidth) / 2;
         int offsetY = (MATRIX_HEIGHT - dstHeight) / 2;
 
-        debugI("GIF scaling: %dx%d -> %dx%d (scale %.2f,%.2f) offset (%d,%d)", 
+        debugI("GIF scaling: %dx%d -> %dx%d (scale %.2f,%.2f) offset (%d,%d)",
                gifWidth, gifHeight, dstWidth, dstHeight, scaleX, scaleY, offsetX, offsetY);
 
         g_gifDecoderState._offsetX   = offsetX;

--- a/include/effects/matrix/PatternPongClock.h
+++ b/include/effects/matrix/PatternPongClock.h
@@ -146,7 +146,7 @@ class PatternPongClock : public EffectWithId<PatternPongClock>
             g()->setPixel(MATRIX_WIDTH / 2, 6, RED16);
         }
 
-        LEDMatrixGFX::backgroundLayer.setFont(gohufont11b);
+        SmartMatrixGFX::backgroundLayer.setFont(gohufont11b);
 
         // The compiler warns that with a nul terminator, 4 bytes could be needed, which is true
         // but we're only writing 3 bytes, but I'll waste the byte to avoid the warning.
@@ -155,10 +155,10 @@ class PatternPongClock : public EffectWithId<PatternPongClock>
 
         auto clockColor = rgb24(255,255,255);
         sprintf(buffer, "%2d", hours);
-        LEDMatrixGFX::backgroundLayer.drawString(MATRIX_WIDTH / 2 - 12, 0, clockColor, buffer);
+        SmartMatrixGFX::backgroundLayer.drawString(MATRIX_WIDTH / 2 - 12, 0, clockColor, buffer);
 
         sprintf(buffer, "%02d", mins);
-        LEDMatrixGFX::backgroundLayer.drawString(MATRIX_WIDTH / 2 + 2, 0, clockColor, buffer);
+        SmartMatrixGFX::backgroundLayer.drawString(MATRIX_WIDTH / 2 + 2, 0, clockColor, buffer);
 
         // if restart flag is 1, set up a new game
         if (restart)
@@ -306,7 +306,7 @@ class PatternPongClock : public EffectWithId<PatternPongClock>
 
         // draw bat 1
         //       if (bat1_update) {
-        LEDMatrixGFX::backgroundLayer.fillRectangle(BAT1_X - 1, bat1_y, BAT1_X, bat1_y + BAT_HEIGHT, rgb24(255,255,255));
+        SmartMatrixGFX::backgroundLayer.fillRectangle(BAT1_X - 1, bat1_y, BAT1_X, bat1_y + BAT_HEIGHT, rgb24(255,255,255));
         //      }
 
         // move bat 2 towards target (don't go any further or bat will move off screen)
@@ -324,7 +324,7 @@ class PatternPongClock : public EffectWithId<PatternPongClock>
             bat2_update = 1;
         }
 
-        LEDMatrixGFX::backgroundLayer.fillRectangle(BAT2_X + 1, bat2_y, BAT2_X + 2, bat2_y +BAT_HEIGHT, rgb24(255,255,255));
+        SmartMatrixGFX::backgroundLayer.fillRectangle(BAT2_X + 1, bat2_y, BAT2_X + 2, bat2_y +BAT_HEIGHT, rgb24(255,255,255));
 
         // update the ball position using the velocity
         ballpos_x = ballpos_x + ballvel_x;

--- a/include/effects/matrix/PatternSMHypnosis.h
+++ b/include/effects/matrix/PatternSMHypnosis.h
@@ -27,7 +27,7 @@ class PatternSMHypnosis : public EffectWithId<PatternSMHypnosis>
     void Draw() override
     {
         t += 4;
-        const auto& rMap = LEDMatrixGFX::getPolarMap(); // Get the map on demand
+        const auto& rMap = SmartMatrixGFX::getPolarMap(); // Get the map on demand
 
         for (uint x = 0; x < MATRIX_WIDTH; x++)
             for (uint y = 0; y < MATRIX_HEIGHT; y++)

--- a/include/effects/matrix/PatternSMRadialFire.h
+++ b/include/effects/matrix/PatternSMRadialFire.h
@@ -24,7 +24,7 @@ class PatternSMRadialFire : public EffectWithId<PatternSMRadialFire>
         static uint32_t t;
         t += speed;
 
-        const auto& rMap = LEDMatrixGFX::getPolarMap();
+        const auto& rMap = SmartMatrixGFX::getPolarMap();
 
         for (uint8_t x = 0; x < MATRIX_WIDTH; x++)
         {

--- a/include/effects/matrix/PatternSMRadialWave.h
+++ b/include/effects/matrix/PatternSMRadialWave.h
@@ -26,7 +26,7 @@ class PatternSMRadialWave : public EffectWithId<PatternSMRadialWave>
     {
         static uint32_t t = 0;
         t++;
-        const auto& rMap = LEDMatrixGFX::getPolarMap();
+        const auto& rMap = GFXBase::getPolarMap();
 
         for (uint8_t x = 0; x < MATRIX_WIDTH; x++)
         {

--- a/include/effects/matrix/PatternSMRainbowTunnel.h
+++ b/include/effects/matrix/PatternSMRainbowTunnel.h
@@ -26,7 +26,7 @@ class PatternSMRainbowTunnel : public EffectWithId<PatternSMRainbowTunnel>
         static uint16_t t;
 
         t += speed;
-        const auto& rMap = LEDMatrixGFX::getPolarMap();
+        const auto& rMap = SmartMatrixGFX::getPolarMap();
 
         for (uint8_t x = 0; x < MATRIX_WIDTH; x++)
         {

--- a/include/effects/matrix/PatternStocks.h
+++ b/include/effects/matrix/PatternStocks.h
@@ -43,7 +43,7 @@
 #include <HTTPClient.h>
 #include <UrlEncode.h>
 #include <ledstripeffect.h>
-#include <ledmatrixgfx.h>
+#include <smartmatrixgfx.h>
 #include <ArduinoJson.h>
 #include "systemcontainer.h"
 #include <chrono>

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -216,15 +216,15 @@ class PatternSubscribers : public EffectWithId<PatternSubscribers>
 
     void Draw() override
     {
-        LEDMatrixGFX::backgroundLayer.fillScreen(rgb24(backgroundColor.r, backgroundColor.g, backgroundColor.b));
-        LEDMatrixGFX::backgroundLayer.setFont(font5x7);
+        SmartMatrixGFX::backgroundLayer.fillScreen(rgb24(backgroundColor.r, backgroundColor.g, backgroundColor.b));
+        SmartMatrixGFX::backgroundLayer.setFont(font5x7);
 
         // Draw a border around the edge of the panel
-        LEDMatrixGFX::backgroundLayer.drawRectangle(0, 1, MATRIX_WIDTH - 1, MATRIX_HEIGHT - 2,
+        SmartMatrixGFX::backgroundLayer.drawRectangle(0, 1, MATRIX_WIDTH - 1, MATRIX_HEIGHT - 2,
                                                     rgb24(borderColor.r, borderColor.g, borderColor.b));
 
         // Draw the channel name
-        LEDMatrixGFX::backgroundLayer.drawString(2, 3, rgb24(255,255,255), youtubeChannelName.c_str());
+        SmartMatrixGFX::backgroundLayer.drawString(2, 3, rgb24(255,255,255), youtubeChannelName.c_str());
 
         // Start in the middle of the panel and then back up a half a row to center vertically,
         // then back up left one half a char for every 10s digit in the subscriber count.  This
@@ -242,12 +242,12 @@ class PatternSubscribers : public EffectWithId<PatternSubscribers>
         String result = str_sprintf("%ld", subscribers);
         const char * pszText = result.c_str();
 
-        LEDMatrixGFX::backgroundLayer.setFont(gohufont11b);
-        LEDMatrixGFX::backgroundLayer.drawString(x-1, y,   rgb24(0,0,0),          pszText);
-        LEDMatrixGFX::backgroundLayer.drawString(x+1, y,   rgb24(0,0,0),          pszText);
-        LEDMatrixGFX::backgroundLayer.drawString(x,   y-1, rgb24(0,0,0),          pszText);
-        LEDMatrixGFX::backgroundLayer.drawString(x,   y+1, rgb24(0,0,0),          pszText);
-        LEDMatrixGFX::backgroundLayer.drawString(x,   y,   rgb24(255,255,255),    pszText);
+        SmartMatrixGFX::backgroundLayer.setFont(gohufont11b);
+        SmartMatrixGFX::backgroundLayer.drawString(x-1, y,   rgb24(0,0,0),          pszText);
+        SmartMatrixGFX::backgroundLayer.drawString(x+1, y,   rgb24(0,0,0),          pszText);
+        SmartMatrixGFX::backgroundLayer.drawString(x,   y-1, rgb24(0,0,0),          pszText);
+        SmartMatrixGFX::backgroundLayer.drawString(x,   y+1, rgb24(0,0,0),          pszText);
+        SmartMatrixGFX::backgroundLayer.drawString(x,   y,   rgb24(255,255,255),    pszText);
     }
 
     // Extension override to serialize our settings on top of those from LEDStripEffect

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -39,7 +39,7 @@
 #include <HTTPClient.h>
 #include <UrlEncode.h>
 #include <ledstripeffect.h>
-#include <ledmatrixgfx.h>
+#include <smartmatrixgfx.h>
 #include <ArduinoJson.h>
 #include "systemcontainer.h"
 #include <array>

--- a/include/fastledgfx.h
+++ b/include/fastledgfx.h
@@ -1,6 +1,6 @@
 //+--------------------------------------------------------------------------
 //
-// File:        LEDStripGFX.h
+// File:        FastLEDGFX.h
 //
 // NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
@@ -33,11 +33,11 @@
 #pragma once
 #include "gfxbase.h"
 
-// LEDStripGFX
+// FastLEDGFX
 //
 // A derivation of GFXBase that adds LED-strip-specific functionality
 
-class LEDStripGFX : public GFXBase
+class FastLEDGFX : public GFXBase
 {
 protected:
     static void AddLEDsToFastLED(std::vector<std::shared_ptr<GFXBase>>& devices)
@@ -100,15 +100,15 @@ protected:
 
 public:
 
-    LEDStripGFX(size_t w, size_t h) : GFXBase(w, h)
+    FastLEDGFX(size_t w, size_t h) : GFXBase(w, h)
     {
         debugV("Creating Device of size %zu x %zu", w, h);
         leds = static_cast<CRGB *>(calloc(w * h, sizeof(CRGB)));
         if(!leds)
-            throw std::runtime_error("Unable to allocate LEDs in LEDStripGFX");
+            throw std::runtime_error("Unable to allocate LEDs in FastLEDGFX");
     }
 
-    ~LEDStripGFX() override
+    ~FastLEDGFX() override
     {
         free(leds);
         leds = nullptr;
@@ -123,8 +123,8 @@ public:
 
         for (int i = 0; i < NUM_CHANNELS; i++)
         {
-            debugW("Allocating LEDStripGFX for channel %d", i);
-            devices.push_back(make_shared_psram<LEDStripGFX>(MATRIX_WIDTH, MATRIX_HEIGHT));
+            debugW("Allocating FastLEDGFX for channel %d", i);
+            devices.push_back(make_shared_psram<FastLEDGFX>(MATRIX_WIDTH, MATRIX_HEIGHT));
         }
 
         AddLEDsToFastLED(devices);
@@ -142,14 +142,14 @@ public:
 
 // HexagonGFX
 //
-// A version of the LEDStripGFX class that accounts for the layout of the hexagon LEDs
+// A version of the FastLEDGFX class that accounts for the layout of the hexagon LEDs
 //
 
-class HexagonGFX : public LEDStripGFX
+class HexagonGFX : public FastLEDGFX
 {
   public:
 
-    HexagonGFX(size_t numLeds) : LEDStripGFX(numLeds, 1)
+    HexagonGFX(size_t numLeds) : FastLEDGFX(numLeds, 1)
     {
     }
 

--- a/include/globals.h
+++ b/include/globals.h
@@ -64,7 +64,7 @@
 //              Mar-16-2022  v023       Davepl      Response packet on socket with stats
 //              Mar-17-2022  v024       Davepl      Catchup clock to server when in future
 //              May-17-2022  v025       Davepl      After merge of RepsonsePacket into main
-//              May-24-2022  v026       Davepl      Adding BaseGFX/LEDMatrixGFX/LEDStripGFX
+//              May-24-2022  v026       Davepl      Adding BaseGFX/SmartMatrixGFX/FastLEDGFX
 //              Oct-01-2022  v027       Davepl      Mesmerizer integration and screen fixes
 //              Oct-01-2022  v028       Davepl      Adjust buffer sizes due to lower mem free
 //              Oct-02-2022  v029       Davepl      Change WiFiUDP to use free/malloc
@@ -925,7 +925,7 @@ inline auto accumulate(const Range& r)
 
 #include "gfxbase.h"                            // GFXBase drawing interface
 #include "socketserver.h"                       // Incoming WiFi data connections
-#include "ledstripgfx.h"                        // Essential drawing code for strips
+#include "fastledgfx.h"                        // Essential drawing code for strips
 #include "ledstripeffect.h"                     // Defines base led effect classes
 #include "ntptimeclient.h"                      // setting the system clock from ntp
 #include "effectmanager.h"                      // For g_EffectManager

--- a/include/ledstripeffect.h
+++ b/include/ledstripeffect.h
@@ -33,7 +33,7 @@
 #include "effects.h"
 #include "gfxbase.h"
 #include "jsonserializer.h"
-#include "ledmatrixgfx.h"
+#include "smartmatrixgfx.h"
 #include "types.h"
 #include "hashing.h"
 
@@ -264,12 +264,12 @@ class LEDStripEffect : public IJSONSerializable
         return _GFX[channel];
     }
 
-    // mg is a shortcut for MATRIX projects to retrieve a pointer to the specialized LEDMatrixGFX type
+    // mg is a shortcut for MATRIX projects to retrieve a pointer to the specialized SmartMatrixGFX type
 
     #if USE_HUB75
-      std::shared_ptr<LEDMatrixGFX> mg(size_t channel = 0)
+      std::shared_ptr<SmartMatrixGFX> mg(size_t channel = 0)
       {
-        return std::static_pointer_cast<LEDMatrixGFX>(_GFX[channel]);
+        return std::static_pointer_cast<SmartMatrixGFX>(_GFX[channel]);
       }
     #endif
 

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -57,10 +57,10 @@
 //
 
 #if USE_HUB75
-    #include "ledmatrixgfx.h"
+    #include "smartmatrixgfx.h"
     #include "effects/matrix/PatternPongClock.h"
     #include "effects/matrix/PatternMandala.h"
-    // These effects require LEDMatrixGFX::getPolarMap()
+    // These effects require SmartMatrixGFX::getPolarMap()
     #include "effects/matrix/PatternSMHypnosis.h"
     #include "effects/matrix/PatternSMRainbowTunnel.h"
     #include "effects/matrix/PatternSMRadialWave.h"
@@ -120,7 +120,7 @@
 
 
 #ifdef USE_WS281X
-    #include "ledstripgfx.h"
+    #include "fastledgfx.h"
 #endif
 
 // Global effect set version

--- a/src/fastledgfx.cpp
+++ b/src/fastledgfx.cpp
@@ -1,6 +1,6 @@
 //+--------------------------------------------------------------------------
 //
-// File:        ledstripgfx.cpp
+// File:        fastledgfx.cpp
 //
 // NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
@@ -22,17 +22,17 @@
 //
 // Description:
 //
-//    Code for handling LED strips
+//    Code for handling LED strips with the FastLED library
 //
 // History:     Jul-22-2023         Rbergen      Created
 //
 //---------------------------------------------------------------------------
 
 #include "globals.h"
-#include "ledstripgfx.h"
+#include "fastledgfx.h"
 #include "systemcontainer.h"
 
-void LEDStripGFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDrawn)
+void FastLEDGFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDrawn)
 {
     auto pixelsDrawn = wifiPixelsDrawn > 0 ? wifiPixelsDrawn : localPixelsDrawn;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -435,7 +435,7 @@ void setup()
         #endif
     }
     #endif
-    
+
     // TOGGLE_BUTTON_0/1 are configured inside Screen's update loop
 
     #if AMOLED_S3
@@ -490,13 +490,13 @@ void setup()
 
     #if USE_HUB75
         // LEDMatrixGFX is used for HUB75 projects like the Mesmerizer
-        LEDMatrixGFX::InitializeHardware(devices);
+        SmartMatrixGFX::InitializeHardware(devices);
     #elif HEXAGON
         // Hexagon is for a PCB wtih 271 LEDss arranged in the face of a hexagon
         HexagonGFX::InitializeHardware(devices);
     #elif USE_WS281X
-        // LEDStripGFX is used for simple strips or for matrices woven from strips
-        LEDStripGFX::InitializeHardware(devices);
+        // FastLEDGFX is used for simple strips or for matrices woven from strips
+        FastLEDGFX::InitializeHardware(devices);
     #endif
 
     // Initialize all the built-in effects
@@ -599,7 +599,7 @@ void loop()
             #endif
 
             #if USE_HUB75
-                strOutput += str_sprintf("Refresh: %d Hz, Power: %d mW, Brite: %3.0lf%%, ", LEDMatrixGFX::matrix.getRefreshRate(), g_Values.MatrixPowerMilliwatts, g_Values.MatrixScaledBrightness / 2.55);
+                strOutput += str_sprintf("Refresh: %d Hz, Power: %d mW, Brite: %3.0lf%%, ", SmartMatrixGFX::matrix.getRefreshRate(), g_Values.MatrixPowerMilliwatts, g_Values.MatrixScaledBrightness / 2.55);
             #endif
 
             #if ENABLE_AUDIO

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -234,7 +234,7 @@ void SetupOTA(const String & strHostname)
                 debugI("OTA Progress: %u%%\r", p);
 
                 #if USE_HUB75
-                    auto pMatrix = std::static_pointer_cast<LEDMatrixGFX>(g_ptrSystem->EffectManager().GetBaseGraphics()[0]);
+                    auto pMatrix = std::static_pointer_cast<SmartMatrixGFX>(g_ptrSystem->EffectManager().GetBaseGraphics()[0]);
                     pMatrix->SetCaption(str_sprintf("Update:%d%%", p), CAPTION_TIME);
                 #endif
             }

--- a/src/smartmatrixgfx.cpp
+++ b/src/smartmatrixgfx.cpp
@@ -22,7 +22,7 @@
 //
 // Description:
 //
-//    Code for handling HUB75 matrix panels
+//    Code for handling HUB75 matrix panels with the SmartMatrix library
 //
 // History:     May-24-2021         Davepl      Commented
 //
@@ -33,17 +33,17 @@
 #if USE_HUB75
 
 #include <SmartMatrix.h>
-#include "ledmatrixgfx.h"
+#include "smartmatrixgfx.h"
 #include "systemcontainer.h"
 #include "soundanalyzer.h"
 
 // The declarations create the "layers" that make up the matrix display
 
-SMLayerBackground<LEDMatrixGFX::SM_RGB, LEDMatrixGFX::kBackgroundLayerOptions> LEDMatrixGFX::backgroundLayer(kMatrixWidth, kMatrixHeight);
-SMLayerBackground<LEDMatrixGFX::SM_RGB, LEDMatrixGFX::kBackgroundLayerOptions> LEDMatrixGFX::titleLayer(kMatrixWidth, kMatrixHeight);
-SmartMatrixHub75Calc<COLOR_DEPTH, LEDMatrixGFX::kMatrixWidth, LEDMatrixGFX::kMatrixHeight, LEDMatrixGFX::kPanelType, LEDMatrixGFX::kMatrixOptions> LEDMatrixGFX::matrix;
+SMLayerBackground<SmartMatrixGFX::SM_RGB, SmartMatrixGFX::kBackgroundLayerOptions> SmartMatrixGFX::backgroundLayer(kMatrixWidth, kMatrixHeight);
+SMLayerBackground<SmartMatrixGFX::SM_RGB, SmartMatrixGFX::kBackgroundLayerOptions> SmartMatrixGFX::titleLayer(kMatrixWidth, kMatrixHeight);
+SmartMatrixHub75Calc<COLOR_DEPTH, SmartMatrixGFX::kMatrixWidth, SmartMatrixGFX::kMatrixHeight, SmartMatrixGFX::kPanelType, SmartMatrixGFX::kMatrixOptions> SmartMatrixGFX::matrix;
 
-void LEDMatrixGFX::StartMatrix()
+void SmartMatrixGFX::StartMatrix()
 {
     matrix.addLayer(&backgroundLayer);
     matrix.addLayer(&titleLayer);
@@ -68,7 +68,7 @@ void LEDMatrixGFX::StartMatrix()
     matrix.setBrightness(255);
 }
 
-void LEDMatrixGFX::PrepareFrame()
+void SmartMatrixGFX::PrepareFrame()
 {
     // We treat the internal matrix buffer as our own little playground to draw in, but that assumes they're
     // both 24-bits RGB triplets.  Or at least the same size!
@@ -82,7 +82,7 @@ void LEDMatrixGFX::PrepareFrame()
         matrix.setCalcRefreshRateDivider(MATRIX_CALC_DIVIDER);
         matrix.setRefreshRate(MATRIX_REFRESH_RATE);
 
-        auto pMatrix = std::static_pointer_cast<LEDMatrixGFX>(g_ptrSystem->EffectManager().GetBaseGraphics()[0]);
+        auto pMatrix = std::static_pointer_cast<SmartMatrixGFX>(g_ptrSystem->EffectManager().GetBaseGraphics()[0]);
         pMatrix->setLeds(GetMatrixBackBuffer());
 
         // We set ourselves to the lower of the fader value or the brightness value,
@@ -143,13 +143,13 @@ void LEDMatrixGFX::PrepareFrame()
 //
 // Things we do with the matrix after rendering a frame, such as setting the brightness and swapping the backbuffer forward
 
-void LEDMatrixGFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDrawn)
+void SmartMatrixGFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDrawn)
 {
     // If we drew no pixels, there's nothing to post process
     if ((localPixelsDrawn + wifiPixelsDrawn) == 0)
         return;
 
-    auto pMatrix = std::static_pointer_cast<LEDMatrixGFX>(g_ptrSystem->EffectManager().g());
+    auto pMatrix = std::static_pointer_cast<SmartMatrixGFX>(g_ptrSystem->EffectManager().g());
 
     constexpr auto kCaptionPower = 500;                                                 // A guess as the power the caption will consume
     g_Values.MatrixPowerMilliwatts = pMatrix->EstimatePowerDraw();                             // What our drawn pixels will consume
@@ -194,7 +194,7 @@ void LEDMatrixGFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixe
     FastLED.countFPS();
 }
 
-CRGB *LEDMatrixGFX::GetMatrixBackBuffer()
+CRGB *SmartMatrixGFX::GetMatrixBackBuffer()
 {
     for (auto& device : g_ptrSystem->Devices())
         device->UpdatePaletteCycle();
@@ -202,7 +202,7 @@ CRGB *LEDMatrixGFX::GetMatrixBackBuffer()
     return (CRGB *)backgroundLayer.backBuffer();
 }
 
-void LEDMatrixGFX::MatrixSwapBuffers(bool bSwapBackground)
+void SmartMatrixGFX::MatrixSwapBuffers(bool bSwapBackground)
 {
     // If an effect redraws itself entirely ever frame, it can skip saving the most recent buffer, so
     // can swap without waiting for a copy.


### PR DESCRIPTION
## Description

This is a code implementation of the state of the conversation in #768 when [this comment](https://github.com/PlummersSoftwareLLC/NightDriverStrip/issues/768#issuecomment-3239060695) was posted, including the idea suggested in that comment.

This is a draft PR, because:

- It is based on the `tempchanges` branch, which is not yet merged (#766 aims to achieve that). Fur purposes of review focus, this PR is also using `tempchanges` as the base branch.
- This PR is mainly here to visualize the idea and let it simmer, including in my own head.

Fixes #768, if ever merged. 

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).