### PR TITLE
Sync effect visualizer to effect output, improve FPS calc, use FrameEventListener

### DIFF
--- a/config/web_projects.json
+++ b/config/web_projects.json
@@ -118,10 +118,6 @@
                     "name":"Demo"
                 },
                 {
-                    "tag": "magicmirror",
-                    "name": "Magic Mirror"
-                },
-                {
                     "tag": "spectrumlite",
                     "name": "Spectrum"
                 }

--- a/include/effects/matrix/PatternMandala.h
+++ b/include/effects/matrix/PatternMandala.h
@@ -58,8 +58,6 @@
 
 #ifndef PatternMandala_H
 #define PatternMandala_H
-#if     USE_HUB75
-
 // Introduction:
 // -------------
 // This file contains the implementation of the `PatternMandala` class, a sophisticated
@@ -177,5 +175,4 @@ public:
     }
 };
 
-#endif
 #endif

--- a/include/effects/matrix/PatternSMHypnosis.h
+++ b/include/effects/matrix/PatternSMHypnosis.h
@@ -27,7 +27,7 @@ class PatternSMHypnosis : public EffectWithId<PatternSMHypnosis>
     void Draw() override
     {
         t += 4;
-        const auto& rMap = HUB75GFX::getPolarMap(); // Get the map on demand
+        const auto& rMap = GFXBase::getPolarMap();
 
         for (uint x = 0; x < MATRIX_WIDTH; x++)
             for (uint y = 0; y < MATRIX_HEIGHT; y++)

--- a/include/effects/matrix/PatternSMRadialFire.h
+++ b/include/effects/matrix/PatternSMRadialFire.h
@@ -24,7 +24,7 @@ class PatternSMRadialFire : public EffectWithId<PatternSMRadialFire>
         static uint32_t t;
         t += speed;
 
-        const auto& rMap = HUB75GFX::getPolarMap();
+        const auto& rMap = GFXBase::getPolarMap();
 
         for (uint8_t x = 0; x < MATRIX_WIDTH; x++)
         {

--- a/include/effects/matrix/PatternSMRainbowTunnel.h
+++ b/include/effects/matrix/PatternSMRainbowTunnel.h
@@ -26,7 +26,7 @@ class PatternSMRainbowTunnel : public EffectWithId<PatternSMRainbowTunnel>
         static uint16_t t;
 
         t += speed;
-        const auto& rMap = HUB75GFX::getPolarMap();
+        const auto& rMap = GFXBase::getPolarMap();
 
         for (uint8_t x = 0; x < MATRIX_WIDTH; x++)
         {

--- a/include/screen.h
+++ b/include/screen.h
@@ -154,7 +154,43 @@ class Screen : public GFXBase
     static void FlipToNextPage();
 
   private:
-    // Page registry and page count helpers
+    // Cached screen refresh FPS (updated each loop iteration)
+    float _screenFPS = 0.0f;
+    uint32_t _lastScreenMillis = 0;
+    bool _fpsTouchedThisFrame = false;
+
+  public:
+
+    inline float GetScreenFPS() const { return _screenFPS; }
+    
+    inline void SetScreenFPS(float fps)
+    {
+        _screenFPS = fps;
+        _fpsTouchedThisFrame = true;
+    }
+    
+    // TouchFPS
+    // Marks the FPS value as intentionally managed this frame without changing it.
+    // This prevents the fallback loop-based FPS from overwriting an effect-driven FPS
+    // when the active page prefers to keep the last effect cadence.
+    inline void TouchFPS()
+    {
+        _fpsTouchedThisFrame = true;
+    }
+
+    inline void UpdateScreenFPSFromDelta(uint32_t dtMs)
+    {
+        if (dtMs == 0) 
+            return;
+        const float inst = 1000.0f / (float)dtMs;
+        // Light smoothing to avoid flicker
+        _screenFPS = (_screenFPS * 0.8f) + (inst * 0.2f);
+        _fpsTouchedThisFrame = true;
+    }
+
+  private:
+  
+  // Page registry and page count helpers
     static std::vector<std::unique_ptr<class Page>>& Pages();
     static int ActivePageCount();
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -470,7 +470,7 @@ build_flags     = -DUSE_MATRIX=1
                   -DUSE_HUB75=0
                   -DUSE_WS281X=1
                   -DNUM_CHANNELS=1
-                  -DEFFECTS_STACKDEMO=1
+                  -DEFFECTS_FULLMATRIX=1
                   -DMATRIX_WIDTH=64
                   -DMATRIX_HEIGHT=32
                   -DSHOW_VU_METER=1

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -62,19 +62,10 @@
 
 #if USE_HUB75
     #include "hub75gfx.h"
-    #include "effects/matrix/PatternPongClock.h"
-    #include "effects/matrix/PatternMandala.h"
-    // These effects require HUB75GFX::getPolarMap()
-    #include "effects/matrix/PatternSMHypnosis.h"
-    #include "effects/matrix/PatternSMRainbowTunnel.h"
-    #include "effects/matrix/PatternSMRadialWave.h"
-    #include "effects/matrix/PatternSMRadialFire.h"
+#endif
 
-    #if USE_NOISE
-        #include "effects/matrix/PatternNoiseSmearing.h"
-        #include "effects/matrix/PatternSMSmoke.h"
-    #endif
-
+#ifdef USE_WS281X
+    #include "ws281xgfx.h"
 #endif
 
 #if USE_MATRIX
@@ -85,7 +76,17 @@
         #include "effects/matrix/PatternStocks.h"
     #endif
 
+    #if USE_NOISE
+        #include "effects/matrix/PatternNoiseSmearing.h"
+        #include "effects/matrix/PatternSMSmoke.h"
+    #endif
+
     #include "effects/matrix/PatternPongClock.h"
+    #include "effects/matrix/PatternMandala.h"
+    #include "effects/matrix/PatternSMHypnosis.h"
+    #include "effects/matrix/PatternSMRainbowTunnel.h"
+    #include "effects/matrix/PatternSMRadialWave.h"
+    #include "effects/matrix/PatternSMRadialFire.h"
     #include "effects/matrix/PatternAnimatedGIF.h"
     #include "effects/matrix/PatternSMStarDeep.h"
     #include "effects/matrix/PatternSMAmberRain.h"
@@ -120,11 +121,6 @@
     #include "effects/matrix/PatternBounce.h"
     #include "effects/matrix/PatternSpin.h"
     #include "effects/matrix/PatternMisc.h"
-#endif
-
-
-#ifdef USE_WS281X
-    #include "ws281xgfx.h"
 #endif
 
 // Global effect set version
@@ -276,64 +272,6 @@ void LoadEffectFactories()
         // Lantern effect set
         RegisterAll(*g_ptrEffectFactories,
             Effect<FireEffect>("Calm Fire", NUM_LEDS, 40, 5, 50, 3, 3, true, true)
-        );
-    #endif
-
-    #if defined(EFFECTS_STACKDEMO)
-        RegisterAll(*g_ptrEffectFactories,
-            Effect<PatternPongClock>(),
-            Effect<PatternStocks>(),
-            Effect<PatternSubscribers>(),
-            Effect<PatternWeather>(),
-            Effect<SpectrumBarEffect>("Audiograph", 16, 4, 0),
-            Effect<SpectrumAnalyzerEffect>("Spectrum", NUM_BANDS, spectrumAltColors, false, 0, 0, 1.6, 1.6),
-            Effect<SpectrumAnalyzerEffect>("AudioWave", MATRIX_WIDTH, CRGB(0,0,40), 0, 1.25, 1.25, true),
-            Effect<PatternAnimatedGIF>("Rings", GIFIdentifier::ThreeRings),
-            Effect<PatternAnimatedGIF>("Fire Log", GIFIdentifier::Firelog),
-            Effect<PatternAnimatedGIF>("Nyancat", GIFIdentifier::Nyancat),
-            Effect<PatternAnimatedGIF>("Pacman", GIFIdentifier::Pacman),
-            Effect<PatternAnimatedGIF>("Atomic", GIFIdentifier::Atomic),
-            Effect<PatternAnimatedGIF>("Banana", GIFIdentifier::Banana, true, CRGB::DarkBlue),
-            Effect<PatternSMFire2021>(),
-            Effect<GhostWave>("GhostWave", 0, 30, false, 10),
-            Effect<PatternSMGamma>(),
-            Effect<PatternSMMetaBalls>(),
-            Effect<PatternSMSupernova>(),
-            Effect<PatternCube>(),
-            Effect<PatternLife>(),
-            Effect<PatternCircuit>(),
-            Effect<SpectrumAnalyzerEffect>("USA", NUM_BANDS, USAColors_p, true, 0, 0, 0.75, 0.75),
-            Effect<SpectrumAnalyzerEffect>("Spectrum 2", 32, spectrumBasicColors, false, 100, 0, 0.75, 0.75),
-            Effect<SpectrumAnalyzerEffect>("Spectrum++", NUM_BANDS, spectrumBasicColors, false, 0, 40, -1.0, 2.0),
-            Effect<WaveformEffect>("WaveIn", 8),
-            Effect<GhostWave>("WaveOut", 0, 0, true, 0),
-            Effect<StarEffect<MusicStar>>("Stars", RainbowColors_p, 1.0, 1, LINEARBLEND, 2.0, 0.5, 10.0),
-            Effect<GhostWave>("PlasmaWave", 0, 255, false),
-            Effect<PatternSMNoise>("Shikon", PatternSMNoise::EffectType::Shikon_t),
-            Effect<PatternSMFlowFields>(),
-            Effect<PatternSMBlurringColors>(),
-            Effect<PatternSMWalkingMachine>(),
-            Effect<PatternSMStarDeep>(),
-            Effect<PatternSM2DDPR>(),
-            Effect<PatternSMPicasso3in1>("Lines", 38),
-            Effect<PatternSMPicasso3in1>("Circles", 73),
-            Effect<PatternSMAmberRain>(),
-            Effect<PatternSMStrobeDiffusion>(),
-            Effect<PatternSMSpiroPulse>(),
-            Effect<PatternSMTwister>(),
-            Effect<PatternSMHolidayLights>(),
-            Effect<PatternRose>(),
-            Effect<PatternPinwheel>(),
-            Effect<PatternSunburst>(),
-            Effect<PatternClock>(),
-            Effect<PatternAlienText>(),
-            Effect<PatternPulsar>(),
-            Effect<PatternBounce>(),
-            Effect<PatternWave>(),
-            Effect<PatternSwirl>(),
-            Effect<PatternSerendipity>(),
-            Effect<PatternMunch>(),
-            Effect<PatternMaze>()
         );
     #endif
 

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -270,19 +270,14 @@ class TitlePage : public Page
         static String sip = WiFi.localIP().toString();
         static String lastFooter;
         static uint32_t lastFullDraw = 0;
-        static uint32_t lastScreen = millis();
-
+    
         // Pick text size based on width (header size)
         display.setTextSize(display.width() > 160 ? 2 : 1);
         // Compute and cache content top using the header text size so it stays stable
         const int topMargin = display.fontHeight() * 3 + 4;
         _contentTop = topMargin;
 
-        // Screen FPS (for display updates)
-        float screenFPS = (millis() - lastScreen) / 1000.0f;
-        if (screenFPS != 0)
-            screenFPS = 1.0f / screenFPS;
-        lastScreen = millis();
+        const float screenFPS = display.GetScreenFPS();
 
         // Redraw header when needed
         if (bRedraw || lastFullDraw == 0 || millis() - lastFullDraw > 1000)
@@ -338,7 +333,9 @@ class TitlePage : public Page
                 int yh = display.height() - display.fontHeight();
                 auto w = display.textWidth(footer);
                 display.setCursor(display.width() / 2 - w / 2, yh);
-                display.print(footer);
+                
+                // Trailing spaces in case string got shorter...
+                display.print(footer + "   ");
             }
         }
     }
@@ -408,13 +405,42 @@ class CurrentEffectSummaryPage final : public TitlePage
 
 class EffectSimulatorPage final : public TitlePage
 {
+    BaseFrameEventListener frameEventListener;
+    bool bClearCompleted = false;
+    uint32_t _lastEffectDrawMs = 0;
+
   public:
+    EffectSimulatorPage()
+    {
+        g_ptrSystem->EffectManager().AddFrameEventListener(frameEventListener);
+    }
+
     std::string Name() const override { return "CurrentEffect"; }
 
     void Draw(Screen &display, bool bRedraw) override
     {
-        // Draw shared header/footer first (will be compact on small displays)
+        if (!bClearCompleted)
+        {
+            display.fillScreen(BLACK16);
+            bClearCompleted = true;
+        }
+
+        if (bRedraw)
+        {
+            display.fillScreen(BLACK16);
+        }
+
+        // Always update shared header/footer so stats (LED/Aud/Ser/Scr) stay fresh
         TitlePage::Draw(display, bRedraw);
+
+        // If no new effect frame, skip the matrix blit but keep the refreshed footer.
+        // Also mark FPS as touched so the loop-based fallback doesn't overwrite the
+        // effect-driven FPS with the UI refresh cadence.
+        if (!frameEventListener.CheckAndClearNewFrameAvailable())
+        {
+            display.TouchFPS();
+            return;
+        }
 
         // Determine content area between header and footer
         const int headerTop = ContentTop(display);
@@ -423,9 +449,6 @@ class EffectSimulatorPage final : public TitlePage
         const int contentHeight = display.height() - bottomMargin - contentTop;
         const int contentWidth = display.width();
 
-        // Clear content area first
-        if (bRedraw)
-            display.fillRect(0, contentTop, contentWidth, contentHeight, BLACK16);
 
         // Matrix dimensions - handle single-row LED strips by wrapping into a matrix
         int mw = MATRIX_WIDTH;
@@ -466,6 +489,17 @@ class EffectSimulatorPage final : public TitlePage
             return;
 
         // Blit: draw each LED as a scale x scale rectangle (direct buffer reads, no per-dest-pixel loop)
+        // Track effect draw cadence and update the screen FPS to reflect actual effect rendering rate
+        uint32_t nowMs = millis();
+        if (_lastEffectDrawMs != 0)
+        {
+            uint32_t dt = nowMs - _lastEffectDrawMs;
+            if (dt > 0)
+            {
+                display.UpdateScreenFPSFromDelta(dt);
+            }
+        }
+        _lastEffectDrawMs = nowMs;
         int ledIndex = 0;
         for (int y = 0; y < mh; ++y)
         {
@@ -561,10 +595,30 @@ void IRAM_ATTR Screen::Update(bool bRedraw)
     if (g_iCurrentPage >= activeCount)
         g_iCurrentPage = std::max(0, activeCount - 1);
 
+    // Reset per-frame override flag
+    _fpsTouchedThisFrame = false;
+
     StartFrame();
     auto &pages = Pages();
     pages[g_iCurrentPage]->Draw(*this, bRedraw);
     EndFrame();
+
+    // If the active page did not set FPS explicitly, fall back to generic frame cadence
+    static uint32_t s_lastFrameMs = 0;
+    const uint32_t now = millis();
+    if (!_fpsTouchedThisFrame)
+    {
+        if (s_lastFrameMs != 0)
+        {
+            const uint32_t dt = now - s_lastFrameMs;
+            if (dt > 0)
+            {
+                const float inst = 1000.0f / (float)dt;
+                _screenFPS = (_screenFPS * 0.8f) + (inst * 0.2f);
+            }
+        }
+    }
+    s_lastFrameMs = now;
 }
 
 // Screen::RunUpdateLoop
@@ -594,11 +648,6 @@ void IRAM_ATTR Screen::RunUpdateLoop()
         s_buttonsInited = true;
     }
 
-    // Frame rate timing variables
-    constexpr uint32_t kTargetFPS = 60;
-    constexpr uint32_t kTargetFrameTimeMs = 1000 / kTargetFPS; // 33.33ms for 30fps
-    constexpr uint32_t kMinDelayMs = 1;
-    uint32_t lastFrameTime = millis();
 
     for (;;)
     {
@@ -657,24 +706,7 @@ void IRAM_ATTR Screen::RunUpdateLoop()
             delay(1);
         }
         bRedraw = false;
-
-        // Calculate frame rate-based delay for 30fps
-        uint32_t frameProcessingTime = millis() - frameStartTime;
-        uint32_t delayTime = kMinDelayMs; // Start with minimum delay
-
-        if (frameProcessingTime < kTargetFrameTimeMs)
-        {
-            delayTime = kTargetFrameTimeMs - frameProcessingTime;
-        }
-
-        // Ensure minimum delay of 1ms
-        if (delayTime < kMinDelayMs)
-        {
-            delayTime = kMinDelayMs;
-        }
-
-        delay(delayTime);
-        lastFrameTime = millis();
+        delay(1);
     }
 }
 

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -419,16 +419,11 @@ class EffectSimulatorPage final : public TitlePage
 
     void Draw(Screen &display, bool bRedraw) override
     {
-        if (!bClearCompleted)
+        if (!bClearCompleted || bRedraw)
         {
             display.fillScreen(BLACK16);
             bClearCompleted = true;
-        }
-
-        if (bRedraw)
-        {
-            display.fillScreen(BLACK16);
-        }
+        } 
 
         // Always update shared header/footer so stats (LED/Aud/Ser/Scr) stay fresh
         TitlePage::Draw(display, bRedraw);


### PR DESCRIPTION
## Description
Uses FrameEventListener to sync the visualizer to the LED effects, improves FPS calcs.

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).