### PR TITLE
Make the Spectrum2 build use the full matrix effects.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -730,8 +730,9 @@ build_flags     = -DSPECTRUM=1
 [env:spectrum2]
 extends         = dev_m5stick_c_plus2
 build_flags     = -DSPECTRUM=1
-                  -DEFFECTS_SPECTRUM=1
-                  -DPROJECT_NAME="\"Spectrum\""
+                  -DEFFECTS_FULLMATRIX=1
+                  -DUSE_MATRIX=1
+                  -DPROJECT_NAME="\"Spectrum2\""
                   -DENABLE_AUDIOSERIAL=0
                   -DENABLE_WIFI=1
                   -DWAIT_FOR_WIFI=0
@@ -745,18 +746,22 @@ build_flags     = -DSPECTRUM=1
                   -DINCOMING_WIFI_ENABLED=1
                   -DCOLORDATA_SERVER_ENABLED=0
                   -DDEFAULT_EFFECT_INTERVAL=60*60*24*5
-                  -DLED_PIN0=32
+                  -DLED_PIN0=26
                   -DNUM_CHANNELS=1
                   -DRING_SIZE_0=24
                   -DBONUS_PIXELS=0
                   -DMATRIX_WIDTH=48
                   -DMATRIX_HEIGHT=16
                   -DNUM_BANDS=16
-                  
                   -DSHOW_VU_METER=1
                   ${remote_flags.build_flags}
                   ${dev_m5stick_c_plus2.build_flags}
-
+lib_deps        = https://github.com/PlummersSoftwareLLC/SmartMatrix.git
+                  https://github.com/PlummersSoftwareLLC/GifDecoder.git
+                  bitbank2/AnimatedGIF @ ^1.4.7
+                  ${dev_m5stick_c_plus2.lib_deps}
+board_build.embed_files = ${m5demobase.board_build.embed_files}
+                  
 [env:helmet]
 extends         = dev_m5stick_c_plus
 build_flags     = -DHELMET=1


### PR DESCRIPTION
This modifies the build parameters to cause Spectrum2 to use the full set of Mesmerizer matrix effects on the 48x16 LED strip display.

There are no code changes required.  Because that's how I roll.

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subject to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).