### PR TITLE
Refactor/improv header loop

### DIFF
--- a/include/improvserial.h
+++ b/include/improvserial.h
@@ -214,6 +214,14 @@ protected:
                 }
                 return false;
             }
+            else if (at == 6)
+            {
+                return byte == IMPROV_SERIAL_VERSION;
+            }
+            else if (at == 7)
+            {
+                return true;
+            }
 
             uint8_t type = raw[7];
 


### PR DESCRIPTION
## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->
Incorporate feedback from https://github.com/PlummersSoftwareLLC/NightDriverStrip/pull/795#issuecomment-3678525602 to unroll loop of testing against "IMPROV" header.

This is a stacked PR atop #795, so the default diff gets goofy. Let's assume that PR lands. The new changes you requested are specifically the commit at https://github.com/PlummersSoftwareLLC/NightDriverStrip/pull/797/commits/559ddf259eb33fb7a8c37a2786b77eb8e41fde6a


Gemini (antigravity) reviewed this and agrees the behaviour is the same. I only tested CLI on tiny-demo, but running this on the cereberal simulator, for whatever that's worth, it seems like it's right.

Of course, since you're Mr. Improv here, if you hate this and want to go your own way or want to tweak it before a commit or whatever, feel free. I have no emotional investment in this PR.

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).