### PR TITLE
Fix GCC 14 map allocator constness

### DIFF
--- a/include/effects/matrix/PatternAnimatedGIF.h
+++ b/include/effects/matrix/PatternAnimatedGIF.h
@@ -100,7 +100,8 @@ struct GIFInfo : public EmbeddedFile
     {}
 };
 
-    static const std::map<GIFIdentifier, const GIFInfo, std::less<GIFIdentifier>, psram_allocator<std::pair<const GIFIdentifier, const GIFInfo>>> AnimatedGIFs ={
+static const std::map<GIFIdentifier, const GIFInfo, std::less<GIFIdentifier>, psram_allocator<std::pair<const GIFIdentifier, const GIFInfo>>> AnimatedGIFs =
+{
     // Banana has 8 frames.  Most music is around 120BPM, so we need to play each frame for 1/15th of a second to somewhat align with a typical beat
     { GIFIdentifier::Banana,       GIFInfo(banana_start,      banana_end,      32, 32, 10 ) },      //  4 KB
     { GIFIdentifier::Nyancat,      GIFInfo(nyancat_start,     nyancat_end,     64, 32, 18 ) },      // 20 KB


### PR DESCRIPTION
  Fix static_assertion in `std::map`:

         The stricter GCC 14 compiler correctly flagged a type mismatch
         in the std::map allocator instantiation in
         include/effects/matrix/PatternAnimatedGIF.h. The value_type of the
         allocator must match the value_type of the map (which is
         std::pair<const Key, T>).

         Fix: I first added the missing const to the key type in the allocator
         template argument. Then, I encountered a secondary error (rebind_alloc
         mismatch) because std::map needs to rebind the allocator, which fails
         if the allocator itself is const-qualified. I removed the const
         qualifier from the allocator argument (leaving the map variable static
         const), which fully resolved the compilation error.


         Symptom: eleventy zillion template instantion errors.
## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
