### PR TITLE
Fonts depend on USE_MATRIX, not on WIFI

### DIFF
--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -139,7 +139,7 @@ INIT_EFFECT_SETTING_SPECS(LEDStripEffect, _baseSettingSpecs);
 
 // Apple5x7 font definition - needed for WiFi-enabled matrix patterns using Adafruit-style fonts
 // Define this unconditionally (guarded by ENABLE_WIFI) so the symbol is always available regardless of M5/LGFX usage.
-#if ENABLE_WIFI && USE_MATRIX
+#if USE_MATRIX
 #include <FontGfx_apple5x7.h>           // Requires the SmartMatrix dependency to pick up this font
 #endif
 


### PR DESCRIPTION
## Description
Finally, tab5demo supports alleffects, which requires the font.
I do NOT have NETWORKING turnon yet (soon!)

When I downmerged the trunk, there was a new rule that Fonts isn't defined without WIFI.
That's not a good restriction. If USE_MATRIX is enough to gate it.

Fixes link errors in PatternPongClock, Weather, and, uhm, another one. 

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [ ] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [ ] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [ ] I selected `main` as the target branch.
* [ ] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
