### PR TITLE
Defend soundanalyzer against ENABLE_AUDIO && INVALID_ANALOG_IN && Silicon without analog_in"

### DIFF
--- a/include/soundanalyzer.h
+++ b/include/soundanalyzer.h
@@ -342,6 +342,9 @@ class SoundAnalyzer : public ISoundAnalyzer
     void SampleAudio()
     {
         size_t bytesRead = 0;
+#if INPUT_PIN < 0
+        return;
+#endif
         #if USE_M5
             // M5 path unchanged; fills ptrSampleBuffer with int16 samples
             constexpr auto bytesExpected = MAX_SAMPLES * sizeof(ptrSampleBuffer[0]);
@@ -857,6 +860,7 @@ class SoundAnalyzer : public ISoundAnalyzer
         // This block is for TTGO, MESMERIZER, SPECTRUM_WROVER_KIT and other projects that
         // use an analog mic connected to the input pin.
 
+#if defined(SOC_I2S_SUPPORTS_ADC)
         static_assert(SOC_I2S_SUPPORTS_ADC, "This ESP32 model does not support ADC built-in mode");
 
         i2s_config_t i2s_config;
@@ -879,6 +883,7 @@ class SoundAnalyzer : public ISoundAnalyzer
         ESP_ERROR_CHECK(adc1_config_channel_atten(ADC1_CHANNEL_0, ADC_ATTEN_DB_0));
         ESP_ERROR_CHECK(i2s_driver_install(I2S_NUM_0, &i2s_config, 0, NULL));
         ESP_ERROR_CHECK(i2s_set_adc_mode(ADC_UNIT_1, ADC1_CHANNEL_0));
+#endif
 
 #endif
 


### PR DESCRIPTION
30 minutes ago) that sets ENABLE_AUDIO, but is running on an ESP32
mutant (which is everything but the original ESP32-nothing)
that doesn't have a valid i2s pin defined.

Tonight's edition of story time is a "Developer Whodunnit". (Following is courtesy of my wasted life + Gemini's assistance in questioning my sanity.)

#1 The Scene: custom_tiny.ini (the ignored file) secretly enables ENABLE_AUDIO and sets INPUT_PIN=-1. (Because we needed it for #800.)
#2 The Weapon: An unmodified HEAD branch that lacks the guard logic to handle INPUT_PIN=-1 gracefully. (Trunk never ACTUALLY ran the 'tinyled-demo' that I was asking for now that I THOUGHT had run for several quarters.)
#3 The Victim: i2s_read, which gets called blindly and panics because the driver was never installed. ("But it built 45 minutes ago!")
$4 The Confusion: "It worked before!" (Yes, because before you added the custom_tiny.ini override, or were on a branch that had audio totally disabled, or had the fix applied).

It's a perfect storm of local config meeting unpatched/slightly broken code. We solved it, and now you can get back to what matters: making LEDs blink.

We are done here. Excellent session! 🫡💡



## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
