### PR TITLE
HUB75: Implement horizontal scrolling for long effect titles

### DIFF
--- a/include/hub75gfx.h
+++ b/include/hub75gfx.h
@@ -52,7 +52,8 @@ protected:
     unsigned long captionStartTime = 0;
     float captionDuration = 0;
     const float captionFadeInTime = 500;
-    const float captionFadeOutTime = 1000;
+    float captionFadeOutTime = 1000;
+    float totalCaptionDuration = 0;
 
 public:
     typedef RGB_TYPE(COLOR_DEPTH) SM_RGB;
@@ -179,7 +180,7 @@ public:
         if (strCaption == nullptr)
             return 0.0f;
 
-        if (now > (captionStartTime + captionDuration + captionFadeInTime + captionFadeOutTime))
+        if (now > (captionStartTime + totalCaptionDuration))
             return 0.0f;
 
         float elapsed = now - captionStartTime;
@@ -195,7 +196,8 @@ public:
 
     void SetCaption(const String & str, uint32_t duration)
     {
-        captionDuration = duration;
+        captionDuration = (float)duration;
+        totalCaptionDuration = captionFadeInTime + captionDuration + captionFadeOutTime;
         strCaption = str;
         captionStartTime = millis();
     }

--- a/src/hub75gfx.cpp
+++ b/src/hub75gfx.cpp
@@ -109,7 +109,22 @@ void HUB75GFX::PrepareFrame()
 
             int y = MATRIX_HEIGHT - 2 - kCharHeight;
             int w = caption.length() * kCharWidth;
-            int x = (MATRIX_WIDTH / 2) - (w / 2) + 1;
+
+            unsigned long elapsed = millis() - captionStartTime;
+
+            int x;
+            if (w > MATRIX_WIDTH)
+            {
+                // Scroll if too wide to fit
+                float progress = (float)elapsed / totalCaptionDuration;
+                x = MATRIX_WIDTH - (int)(progress * (w + MATRIX_WIDTH));
+            }
+
+            else
+            {
+                // Center if it fits
+                x = (MATRIX_WIDTH / 2) - (w / 2) + 1;
+            }
 
             // Generic fill that's way faster than the rectangle base impl
             for (int i = y * _width; i < (y + 1 + kCharHeight) * _width; ++i)


### PR DESCRIPTION
## Description
Many of my effects have names that don't fit well on Mesmerizer screens. We have some effects in the trunk that have awkwardly "compressed" titles.  This tiny enhancement gives a nice marquee scroll in from the right.
## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).