### PR TITLE
Standardize format specifiers for GCC 14/Arduino3 compatibility

### DIFF
--- a/include/effects/matrix/PatternAnimatedGIF.h
+++ b/include/effects/matrix/PatternAnimatedGIF.h
@@ -292,7 +292,7 @@ public:
         int offsetY = (MATRIX_HEIGHT - dstHeight) / 2;
 
         debugI("GIF scaling: %dx%d -> %dx%d (scale %.2f,%.2f) offset (%d,%d)",
-               gifWidth, gifHeight, dstWidth, dstHeight, scaleX, scaleY, offsetX, offsetY);
+               (int)gifWidth, (int)gifHeight, (int)dstWidth, (int)dstHeight, scaleX, scaleY, (int)offsetX, (int)offsetY);
 
         g_gifDecoderState._offsetX   = offsetX;
         g_gifDecoderState._offsetY   = offsetY;

--- a/include/effects/strip/particles.h
+++ b/include/effects/strip/particles.h
@@ -310,7 +310,7 @@ template <typename Type = DrawableParticle> class ParticleSystem
 
     virtual void Render(const std::vector<std::shared_ptr<GFXBase>>& _gfx)
     {
-        debugV("ParticleSystemEffect::Draw for %d particles", _allParticles.size());
+        debugV("ParticleSystemEffect::Draw for %zu particles", (size_t)_allParticles.size());
 
         while (_allParticles.size() > 0 && _allParticles.front().Age() >= _allParticles.front().TotalLifetime())
             _allParticles.pop_front();

--- a/include/improvserial.h
+++ b/include/improvserial.h
@@ -339,7 +339,7 @@ protected:
                         log_write(".Sending details for SSID %s", WiFi.SSID(i).c_str());
                         // Send each ssid separately to avoid overflowing the buffer
                         std::vector<uint8_t> data = improv::build_rpc_response(
-                            improv::GET_WIFI_NETWORKS, {WiFi.SSID(i), str_sprintf("%d", WiFi.RSSI(i)), WiFi.encryptionType(i) != WIFI_AUTH_OPEN ? "YES" : "NO"}, false);
+                            improv::GET_WIFI_NETWORKS, {WiFi.SSID(i), str_sprintf("%ld", (long)WiFi.RSSI(i)), WiFi.encryptionType(i) != WIFI_AUTH_OPEN ? "YES" : "NO"}, false);
                         this->send_response_(data);
                     }
                 }

--- a/include/ledbuffer.h
+++ b/include/ledbuffer.h
@@ -122,7 +122,7 @@ class LEDBuffer
 
         if (payloadLength < length32 * sizeof(CRGB) + cbHeader)
         {
-            debugW("command16: %d   length32: %d,  payloadLength: %d\n", command16, length32, payloadLength);
+            debugW("command16: %hu   length32: %lu,  payloadLength: %zu\n", command16, (unsigned long)length32, payloadLength);
             debugW("Data size mismatch");
             return false;
         }
@@ -131,13 +131,13 @@ class LEDBuffer
             debugW("More data than we have LEDs\n");
             return false;
         }
-        debugV("PayloadLength: %d, command16: %d, Length32: %d", payloadLength, command16, length32);
+        debugV("PayloadLength: %zu, command16: %hu, Length32: %lu", payloadLength, command16, (unsigned long)length32);
 
         CRGB * pRGB = reinterpret_cast<CRGB *>(&payloadData[cbHeader]);
 
         memcpy(_leds.get(), pRGB, length32 * sizeof(CRGB));
         debugV("seconds, micros: %llu.%llu", seconds, micros);
-        debugV("Color0: %08x", (uint32_t) _leds[0]);
+        debugV("Color0: %08lx", (unsigned long)(uint32_t) _leds[0]);
         return true;
     }
 

--- a/include/systemcontainer.h
+++ b/include/systemcontainer.h
@@ -169,16 +169,16 @@ class SystemContainer
 
         if (cBuffers < MIN_BUFFERS)
         {
-            debugI("Not enough memory, could only allocate %d buffers and need %d\n", cBuffers, MIN_BUFFERS);
+            debugI("Not enough memory, could only allocate %lu buffers and need %lu\n", (unsigned long)cBuffers, (unsigned long)MIN_BUFFERS);
             throw std::runtime_error("Could not allocate all buffers");
         }
         if (cBuffers > MAX_BUFFERS)
         {
-            debugI("Could allocate %d buffers but limiting it to %d\n", cBuffers, MAX_BUFFERS);
+            debugI("Could allocate %lu buffers but limiting it to %lu\n", (unsigned long)cBuffers, (unsigned long)MAX_BUFFERS);
             cBuffers = MAX_BUFFERS;
         }
 
-        debugW("Reserving %d LED buffers for a total of %d bytes...", cBuffers, memtoalloc * cBuffers);
+        debugW("Reserving %lu LED buffers for a total of %lu bytes...", (unsigned long)cBuffers, (unsigned long)(memtoalloc * cBuffers));
 
         SC_MEMBER(BufferManagers) = make_unique_psram<std::vector<LEDBufferManager, psram_allocator<LEDBufferManager>>>();
 

--- a/include/taskmgr.h
+++ b/include/taskmgr.h
@@ -279,7 +279,7 @@ public:
     void StartScreenThread()
     {
         #if USE_SCREEN
-            Serial.print( str_sprintf(">> Launching Screen Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
+            Serial.print( str_sprintf(">> Launching Screen Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
             xTaskCreatePinnedToCore(ScreenUpdateLoopEntry, "Screen Loop", SCREEN_STACK_SIZE, nullptr, SCREEN_PRIORITY, &_taskScreen, SCREEN_CORE);
             CheckHeap();
         #endif
@@ -288,7 +288,7 @@ public:
     void StartSerialThread()
     {
         #if ENABLE_AUDIOSERIAL
-            Serial.print( str_sprintf(">> Launching Serial Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
+            Serial.print( str_sprintf(">> Launching Serial Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
             xTaskCreatePinnedToCore(AudioSerialTaskEntry, "Audio Serial Loop", DEFAULT_STACK_SIZE, nullptr, AUDIOSERIAL_PRIORITY, &_taskSerial, AUDIOSERIAL_CORE);
             CheckHeap();
         #endif
@@ -297,7 +297,7 @@ public:
     void StartColorDataThread()
     {
         #if COLORDATA_SERVER_ENABLED
-            Serial.print( str_sprintf(">> Launching ColorData Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
+            Serial.print( str_sprintf(">> Launching ColorData Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
             xTaskCreatePinnedToCore(ColorDataTaskEntry, "ColorData Loop", DEFAULT_STACK_SIZE, nullptr, COLORDATA_PRIORITY, &_taskColorData, COLORDATA_CORE);
             CheckHeap();
         #endif
@@ -305,7 +305,7 @@ public:
 
     void StartDrawThread()
     {
-        Serial.print( str_sprintf(">> Launching Drawing Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
+        Serial.print( str_sprintf(">> Launching Drawing Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
         xTaskCreatePinnedToCore(DrawLoopTaskEntry, "Draw Loop", DRAWING_STACK_SIZE, nullptr, DRAWING_PRIORITY, &_taskDraw, DRAWING_CORE);
         CheckHeap();
     }
@@ -313,7 +313,7 @@ public:
     void StartAudioThread()
     {
         #if ENABLE_AUDIO
-            Serial.print( str_sprintf(">> Launching Audio Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
+            Serial.print( str_sprintf(">> Launching Audio Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
             xTaskCreatePinnedToCore(AudioSamplerTaskEntry, "Audio Sampler Loop", AUDIO_STACK_SIZE, nullptr, AUDIO_PRIORITY, &_taskAudio, AUDIO_CORE);
             CheckHeap();
         #endif
@@ -322,7 +322,7 @@ public:
     void StartNetworkThread()
     {
         #if ENABLE_WIFI
-            Serial.print( str_sprintf(">> Launching Network Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
+            Serial.print( str_sprintf(">> Launching Network Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
             xTaskCreatePinnedToCore(NetworkHandlingLoopEntry, "NetworkHandlingLoop", NET_STACK_SIZE, nullptr, NET_PRIORITY, &_taskNetwork, NET_CORE);
             CheckHeap();
         #endif
@@ -331,7 +331,7 @@ public:
     void StartDebugThread()
     {
         #if ENABLE_WIFI
-            Serial.print( str_sprintf(">> Launching Debug Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
+            Serial.print( str_sprintf(">> Launching Debug Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
             xTaskCreatePinnedToCore(DebugLoopTaskEntry, "Debug Loop", DEBUG_STACK_SIZE, nullptr, DEBUG_PRIORITY, &_taskDebug, DEBUG_CORE);
             CheckHeap();
         #endif
@@ -340,7 +340,7 @@ public:
     void StartSocketThread()
     {
         #if INCOMING_WIFI_ENABLED
-            Serial.print( str_sprintf(">> Launching Socket Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
+            Serial.print( str_sprintf(">> Launching Socket Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
             xTaskCreatePinnedToCore(SocketServerTaskEntry, "Socket Server Loop", SOCKET_STACK_SIZE, nullptr, SOCKET_PRIORITY, &_taskSocket, SOCKET_CORE);
             CheckHeap();
         #endif
@@ -349,7 +349,7 @@ public:
     void StartRemoteThread()
     {
         #if ENABLE_REMOTE
-            Serial.print( str_sprintf(">> Launching Remote Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
+            Serial.print( str_sprintf(">> Launching Remote Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
             xTaskCreatePinnedToCore(RemoteLoopEntry, "IR Remote Loop", REMOTE_STACK_SIZE, nullptr, REMOTE_PRIORITY, &_taskRemote, REMOTE_CORE);
             CheckHeap();
         #endif
@@ -357,7 +357,7 @@ public:
 
     void StartJSONWriterThread()
     {
-        Serial.print( str_sprintf(">> Launching JSON Writer Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
+        Serial.print( str_sprintf(">> Launching JSON Writer Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
         xTaskCreatePinnedToCore(JSONWriterTaskEntry, "JSON Writer Loop", JSON_STACK_SIZE, nullptr, JSONWRITER_PRIORITY, &_taskJSONWriter, JSONWRITER_CORE);
         CheckHeap();
     }
@@ -392,7 +392,7 @@ public:
         EffectTaskParams* pTaskParams = new EffectTaskParams(std::move(function), pEffect);
         TaskHandle_t effectTask = nullptr;
 
-        Serial.print( str_sprintf(">> Launching %s Effect Thread.  Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", name, ESP.getFreeHeap(),ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize()) );
+        Serial.print( str_sprintf(">> Launching %s Effect Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", name, (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
 
         if (xTaskCreatePinnedToCore(EffectTaskEntry, name, DEFAULT_STACK_SIZE, pTaskParams, priority, &effectTask, core) == pdPASS)
             _vEffectTasks.push_back(effectTask);

--- a/include/types.h
+++ b/include/types.h
@@ -246,11 +246,11 @@ inline void * PreferPSRAMAlloc(size_t s)
 
     if (s_psramAvailable)
     {
-        debugV("PSRAM Array Request for %u bytes\n", s);
+        debugV("PSRAM Array Request for %zu bytes\n", s);
         auto p = ps_malloc(s);
         if (!p)
         {
-            debugE("PSRAM Allocation failed for %u bytes\n", s);
+            debugE("PSRAM Allocation failed for %zu bytes\n", s);
             throw std::bad_alloc();
         }
         return p;
@@ -260,7 +260,7 @@ inline void * PreferPSRAMAlloc(size_t s)
         auto p = malloc(s);
         if (!p)
         {
-            debugE("RAM Allocation failed for %u bytes\n", s);
+            debugE("RAM Allocation failed for %zu bytes\n", s);
             throw std::bad_alloc();
         }
         return p;

--- a/src/amoled/LV_Helper.cpp
+++ b/src/amoled/LV_Helper.cpp
@@ -74,7 +74,7 @@ void beginLvglHelper(LilyGo_Display &board, bool debug)
     buf = (lv_color_t *)ps_malloc(lv_buffer_size);
     assert(buf);
 
-    Serial.printf("AMOLED: Allocated %d bytes for lvgl buffer: %p\n", lv_buffer_size, buf);
+    Serial.printf("AMOLED: Allocated %zu bytes for lvgl buffer: %p\n", (size_t)lv_buffer_size, buf);
 
     lv_disp_draw_buf_init( &draw_buf, buf, NULL, board.width() * board.height());
 

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -245,11 +245,11 @@ void IRAM_ATTR AudioSerialTaskEntry(void *)
     VICESocketServer socketServer(NetworkPort::VICESocketServer);
     if (!socketServer.begin())
     {
-        debugE("Unable to start socket server on port %u for VICE!", NetworkPort::VICESocketServer);
+        debugE("Unable to start socket server on port %u for VICE!", (unsigned int)NetworkPort::VICESocketServer);
     }
     else
     {
-        debugW("Started socket server for VICE on port %u!", NetworkPort::VICESocketServer);
+        debugW("Started socket server for VICE on port %u!", (unsigned int)NetworkPort::VICESocketServer);
     }
 #endif
 

--- a/src/debug_cli.cpp
+++ b/src/debug_cli.cpp
@@ -289,13 +289,13 @@ static void DoDirectoryListing(const cli_argv &argv)
 
         if (file.isDirectory())
         {
-            cli_printf("%-32s DIR      %d-%02d-%02d %02d:%02d:%02d\n", file.name(), tm.tm_year + 1900, tm.tm_mon + 1,
-                       tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
+            cli_printf("%-32s DIR      %d-%02d-%02d %02d:%02d:%02d\n", file.name(), (int)(tm.tm_year + 1900), (int)(tm.tm_mon + 1),
+                       (int)tm.tm_mday, (int)tm.tm_hour, (int)tm.tm_min, (int)tm.tm_sec);
         }
         else
         {
-            cli_printf("%-32s %8d %d-%02d-%02d %02d:%02d:%02d\n", file.name(), file.size(), tm.tm_year + 1900,
-                       tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
+            cli_printf("%-32s %8zu %d-%02d-%02d %02d:%02d:%02d\n", file.name(), (size_t)file.size(), (int)(tm.tm_year + 1900),
+                       (int)(tm.tm_mon + 1), (int)tm.tm_mday, (int)tm.tm_hour, (int)tm.tm_min, (int)tm.tm_sec);
         }
         file = root.openNextFile();
     }
@@ -399,7 +399,7 @@ static const command core_commands[] = {
              int val = atoi(std::string(argv[1]).c_str());
              g_ptrSystem->DeviceConfig().SetBrightness(val);
          }
-         cli_printf("Brightness: %d\n", g_ptrSystem->DeviceConfig().GetBrightness());
+         cli_printf("Brightness: %lu\n", (unsigned long)g_ptrSystem->DeviceConfig().GetBrightness());
      }},
     {"ls", "Show filesytem directory", "NAME", DoDirectoryListing},                    // Function pointer
     {"effect", "[next|prev] Show/change current effect", "Effects.", DoEffectCommand}, // Function pointer

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -288,7 +288,7 @@ void WriteCurrentEffectIndexFile()
     }
 
     auto bytesWritten = file.print(g_ptrSystem->EffectManager().GetCurrentEffectIndex());
-    debugI("Number of bytes written to file %s: %zu", CURRENT_EFFECT_CONFIG_FILE, bytesWritten);
+    debugI("Number of bytes written to file %s: %zu", CURRENT_EFFECT_CONFIG_FILE, (size_t)bytesWritten);
 
     file.flush();
     file.close();
@@ -380,7 +380,7 @@ void EffectManager::ClearRemoteColor(bool retainRemoteEffect)
 
 void EffectManager::ApplyGlobalColor(CRGB color) const
 {
-    debugI("Setting Global Color: %08X\n", (uint32_t) color);
+    debugI("Setting Global Color: %08lX\n", (unsigned long)(uint32_t)color);
 
     auto& deviceConfig = g_ptrSystem->DeviceConfig();
     deviceConfig.SetColorSettings(color, deviceConfig.GlobalColor());

--- a/src/hub75gfx.cpp
+++ b/src/hub75gfx.cpp
@@ -57,7 +57,7 @@ void HUB75GFX::StartMatrix()
     matrix.setMaxCalculationCpuPercentage(95);
     matrix.begin();
 
-    Serial.printf("Matrix Refresh Rate: %d\n", matrix.getRefreshRate());
+    Serial.printf("Matrix Refresh Rate: %lu\n", (unsigned long)matrix.getRefreshRate());
 
     //backgroundLayer.setRefreshRate(100);
     backgroundLayer.fillScreen(rgb24(0, 64, 0));
@@ -176,7 +176,7 @@ void HUB75GFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDr
 
     auto targetBrightness = min({ g_ptrSystem->DeviceConfig().GetBrightness(), g_Values.Fader, g_Values.MatrixScaledBrightness });
 
-    debugV("MW: %d, Setting Scaled Brightness to: %d", g_Values.MatrixPowerMilliwatts, targetBrightness);
+    debugV("MW: %lu, Setting Scaled Brightness to: %lu", (unsigned long)g_Values.MatrixPowerMilliwatts, (unsigned long)targetBrightness);
     pMatrix->SetBrightness(targetBrightness);
 
     #if SHOW_FPS_ON_MATRIX

--- a/src/jsonserializer.cpp
+++ b/src/jsonserializer.cpp
@@ -95,7 +95,7 @@ bool SaveToJSONFile(const String & fileName, IJSONSerializable& object)
     }
 
     size_t bytesWritten = serializeJson(jsonDoc, file);
-    debugI("Number of bytes written to JSON file %s: %zu", fileName.c_str(), bytesWritten);
+    debugI("Number of bytes written to JSON file %s: %zu", fileName.c_str(), (size_t)bytesWritten);
 
     file.flush();
     file.close();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -224,9 +224,9 @@ void PrintOutputHeader()
         debugI("ESP32 PSRAM Init: %s", psramInit() ? "OK" : "FAIL");
     #endif
 
-    debugI("Version %u: Wifi SSID: \"%s\" - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u",
-            FLASH_VERSION, cszSSID, ESP.getFreeHeap(), ESP.getPsramSize(), ESP.getFreePsram());
-    debugI("ESP32 Clock Freq : %d MHz", ESP.getCpuFreqMHz());
+    debugI("Version %u: Wifi SSID: \"%s\" - ESP32 Free Memory: %zu, PSRAM:%zu, PSRAM Free: %zu",
+            FLASH_VERSION, cszSSID, (size_t)ESP.getFreeHeap(), (size_t)ESP.getPsramSize(), (size_t)ESP.getFreePsram());
+    debugI("ESP32 Clock Freq : %lu MHz", (unsigned long)ESP.getCpuFreqMHz());
 
     // Initial CLI prompt
     RunCommand("");
@@ -652,8 +652,8 @@ void loop()
                 strOutput += str_sprintf("WiFi: %s, MAC: %s, IP: %s ", WLtoString(WiFi.status()), WiFi.macAddress().c_str(), WiFi.localIP().toString().c_str());
             #endif
 
-            strOutput += str_sprintf("Mem: %u, LargestBlk: %u, PSRAM Free: %u/%u, ", ESP.getFreeHeap(), ESP.getMaxAllocHeap(), ESP.getFreePsram(), ESP.getPsramSize());
-            strOutput += str_sprintf("LED FPS: %d ", g_Values.FPS);
+            strOutput += str_sprintf("Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize());
+            strOutput += str_sprintf("LED FPS: %lu ", (unsigned long)g_Values.FPS);
 
             #if USE_WS281X
                 strOutput += str_sprintf("LED Bright: %3.0lf%%, LED Watts: %u, ", g_Values.Brite, g_Values.Watts);
@@ -673,7 +673,7 @@ void loop()
 
             #if INCOMING_WIFI_ENABLED
                 auto& bufferManager = g_ptrSystem->BufferManagers()[0];
-                strOutput += str_sprintf("Buffer: %d/%d, ", bufferManager.Depth(), bufferManager.BufferCount());
+                strOutput += str_sprintf("Buffer: %zu/%zu, ", (size_t)bufferManager.Depth(), (size_t)bufferManager.BufferCount());
             #endif
 
             const auto& taskManager = g_ptrSystem->TaskManager();

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -57,9 +57,9 @@ void DoStatsCommand()
 {
     auto& bufferManager = g_ptrSystem->BufferManagers()[0];
 
-    cli_printf("%s:%zux%d %uK", FLASH_VERSION_NAME, g_ptrSystem->Devices().size(), NUM_LEDS, ESP.getFreeHeap() / 1024);
+    cli_printf("%s:%zux%d %zuK", FLASH_VERSION_NAME, g_ptrSystem->Devices().size(), NUM_LEDS, (size_t)(ESP.getFreeHeap() / 1024));
     cli_printf("%sdB:%s",String(WiFi.RSSI()).substring(1).c_str(), WiFi.isConnected() ? WiFi.localIP().toString().c_str() : "None");
-    cli_printf("BUFR:%02zu/%02zu [%dfps]", bufferManager.Depth(), bufferManager.BufferCount(), g_Values.FPS);
+    cli_printf("BUFR:%02zu/%02zu [%lufps]", (size_t)bufferManager.Depth(), (size_t)bufferManager.BufferCount(), (unsigned long)g_Values.FPS);
     cli_printf("DATA:%+04.2lf-%+04.2lf", bufferManager.AgeOfOldestBuffer(), bufferManager.AgeOfNewestBuffer());
 
     #if ENABLE_AUDIO
@@ -142,7 +142,7 @@ void onReceiveESPNOW(const uint8_t *macAddr, const uint8_t *data, int dataLen)
 
     if (message.cbSize != sizeof(message))
     {
-        debugE("ESPNOW Message received with wrong structure size: %d but should be %d", message.cbSize, sizeof(message));
+        debugE("ESPNOW Message received with wrong structure size: %u but should be %zu", message.cbSize, sizeof(message));
         return;
     }
 
@@ -159,7 +159,7 @@ void onReceiveESPNOW(const uint8_t *macAddr, const uint8_t *data, int dataLen)
             break;
 
         case ESPNowCommand::ESPNOW_SETEFFECT:
-            debugI("ESPNOW Setting effect index to %d", message.arg1);
+            debugI("ESPNOW Setting effect index to %u", message.arg1);
             g_ptrSystem->EffectManager().SetCurrentEffectIndex(message.arg1);
             break;
 
@@ -371,8 +371,8 @@ void IRAM_ATTR RemoteLoopEntry(void *)
                 WiFi.disconnect();
                 debugV("Wifi.mode");
                 WiFi.mode(WIFI_STA);
-                debugW("Connecting to Wifi SSID: \"%s\" - ESP32 Free Memory: %u, PSRAM:%u, PSRAM Free: %u\n",
-                       WiFi_ssid.c_str(), ESP.getFreeHeap(), ESP.getPsramSize(), ESP.getFreePsram());
+                debugW("Connecting to Wifi SSID: \"%s\" - ESP32 Free Memory: %zu, PSRAM:%zu, PSRAM Free: %zu\n",
+                       WiFi_ssid.c_str(), (size_t)ESP.getFreeHeap(), (size_t)ESP.getPsramSize(), (size_t)ESP.getFreePsram());
 
                 WiFi.begin(WiFi_ssid.c_str(), WiFi_password.c_str());
 
@@ -474,9 +474,9 @@ void IRAM_ATTR RemoteLoopEntry(void *)
                     uint64_t seconds   = ULONGFromMemory(&payloadData[8]);
                     uint64_t micros    = ULONGFromMemory(&payloadData[16]);
 
-                debugV("ProcessIncomingData -- Bands: %u, Length: %u, Seconds: %llu, Micros: %llu ... ",
-                       numbands,
-                       length32,
+                debugV("ProcessIncomingData -- Bands: %u, Length: %lu, Seconds: %llu, Micros: %llu ... ",
+                       (unsigned int)numbands,
+                       (unsigned long)length32,
                        seconds,
                        micros);
 
@@ -507,9 +507,9 @@ void IRAM_ATTR RemoteLoopEntry(void *)
                 uint64_t seconds   = ULONGFromMemory(&payloadData[8]);
                 uint64_t micros    = ULONGFromMemory(&payloadData[16]);
 
-                debugV("ProcessIncomingData -- Channel: %u, Length: %u, Seconds: %llu, Micros: %llu ... ",
-                    channel16,
-                    length32,
+                debugV("ProcessIncomingData -- Channel: %u, Length: %lu, Seconds: %llu, Micros: %llu ... ",
+                    (unsigned int)channel16,
+                    (unsigned long)length32,
                     seconds,
                     micros);
 

--- a/src/ntptimeclient.cpp
+++ b/src/ntptimeclient.cpp
@@ -103,7 +103,7 @@ bool NTPTimeClient::UpdateClockFromWeb(WiFiUDP * pUDP)
         return false;
     }
 
-    debugW("NTP clock: Raw values sec=%u, usec=%llu", frac, microsecs);
+    debugW("NTP clock: Raw values sec=%lu, usec=%llu", (unsigned long)frac, microsecs);
 
     tvNew.tv_sec = ((unsigned long)chNtpPacket[40] << 24) +       // bits 24 through 31 of ntp time
         ((unsigned long)chNtpPacket[41] << 16) +                        // bits 16 through 23 of ntp time
@@ -141,9 +141,9 @@ bool NTPTimeClient::UpdateClockFromWeb(WiFiUDP * pUDP)
     char chBuffer[128];
     struct tm * tmPointer = localtime(&tvNew.tv_sec);
     strftime(chBuffer, sizeof(chBuffer), "%d %b %Y %H:%M:%S", tmPointer);
-    debugI("NTP clock: response received, updated time to: %ld.%ld, DELTA: %lf\n",
-            tvNew.tv_sec,
-            tvNew.tv_usec,
+    debugI("NTP clock: response received, updated time to: %lld.%lld, DELTA: %lf\n",
+            (long long)tvNew.tv_sec,
+            (long long)tvNew.tv_usec,
             dNew - dOld );
 
     _bClockSet = true;  // Clock has been set at least once

--- a/src/remotecontrol.cpp
+++ b/src/remotecontrol.cpp
@@ -49,7 +49,7 @@ void RemoteControl::handle()
     uint result = results.value;
     _IR_Receive.resume();
 
-    debugI("Received IR Remote Code: 0x%08X, Decode: %08X\n", result, results.decode_type);
+    debugI("Received IR Remote Code: 0x%08lX, Decode: %08lX\n", (unsigned long)result, (unsigned long)results.decode_type);
 
     if (0xFFFFFFFF == result || result == lastResult)
     {
@@ -68,7 +68,7 @@ void RemoteControl::handle()
 
         if (millis() - lastRepeatTime > kMinRepeatms)
         {
-            debugV("Remote Repeat; lastResult == %08x, elapsed = %lu\n", lastResult, millis()-lastRepeatTime);
+            debugV("Remote Repeat; lastResult == %08lx, elapsed = %lu\n", (unsigned long)lastResult, (unsigned long)(millis()-lastRepeatTime));
             result = lastResult;
             lastRepeatTime = millis();
         }
@@ -141,7 +141,7 @@ void RemoteControl::handle()
         effectManager.ShowVU( !effectManager.IsVUVisible() );
     }
 
-    debugI("Looking for match for remote color code: %08X\n", result);
+    debugI("Looking for match for remote color code: %08lX\n", (unsigned long)result);
 
     for (const auto & RemoteColorCode : RemoteColorCodes)
     {
@@ -151,7 +151,7 @@ void RemoteControl::handle()
             // crate a ColorFillEffect, and apply it as a temporary effect.  This will override the current
             // effect until the next effect change or remote command.
 
-            debugI("Changing Color via remote: %08X\n", (uint32_t) RemoteColorCode.color);
+            debugI("Changing Color via remote: %08lX\n", (unsigned long)(uint32_t) RemoteColorCode.color);
             effectManager.ApplyGlobalColor(RemoteColorCode.color);
             #if FULL_COLOR_REMOTE_FILL
                 auto effect = make_shared_psram<ColorFillEffect>("Remote Color", RemoteColorCode.color, 1, true);

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -112,8 +112,8 @@ class BasicInfoSummaryPage final : public Page
         // Second param is background for clean overwrite
         display.setTextColor(display.GetTextColor(), display.GetBkgndColor());
         display.setCursor(xMargin, yMargin);
-        display.println(str_sprintf("%s:%dx%d %c %dK", FLASH_VERSION_NAME, g_ptrSystem->Devices().size(), NUM_LEDS,
-                                    chStatus, ESP.getFreeHeap() / 1024));
+        display.println(str_sprintf("%s:%zu %c %zuk", FLASH_VERSION_NAME, (size_t)g_ptrSystem->Devices().size(),
+                                    chStatus, (size_t)(ESP.getFreeHeap() / 1024)));
 
         // WiFi info line 2
         auto lineHeight = display.fontHeight();
@@ -123,13 +123,13 @@ class BasicInfoSummaryPage final : public Page
         else
         {
             const IPAddress address = WiFi.localIP();
-            display.println(str_sprintf("%ddB:%d.%d.%d.%d", (int)labs(WiFi.RSSI()), address[0], address[1], address[2], address[3]));
+            display.println(str_sprintf("%ddB:%d.%d.%d.%d", (int)labs(WiFi.RSSI()), (int)address[0], (int)address[1], (int)address[2], (int)address[3]));
         }
 
         // Buffer Status Line 3
         auto &bufferManager = g_ptrSystem->BufferManagers()[0];
         display.setCursor(xMargin + 0, yMargin + lineHeight * 4);
-        display.println(str_sprintf("BUFR:%02d/%02d %dfps ", bufferManager.Depth(), bufferManager.BufferCount(), g_Values.FPS));
+        display.println(str_sprintf("BUFR:%02lu/%02lu %lufps ", (unsigned long)bufferManager.Depth(), (unsigned long)bufferManager.BufferCount(), (unsigned long)g_Values.FPS));
 
         // Data Status Line 4
         display.setCursor(xMargin + 0, yMargin + lineHeight * 2);
@@ -150,7 +150,7 @@ class BasicInfoSummaryPage final : public Page
         if (display.height() >= lineHeight * 5 + lineHeight)
         {
             display.setCursor(xMargin + 0, yMargin + lineHeight * 5);
-            display.println(str_sprintf("POWR:%3.0lf%% %4uW\n", g_Values.Brite, g_Values.Watts));
+            display.println(str_sprintf("POWR:%3.0lf%% %4luW\n", g_Values.Brite, (unsigned long)g_Values.Watts));
         }
 
         // PSRAM/CPU Info Line 7 - only if display tall enough
@@ -319,9 +319,9 @@ class TitlePage : public Page
             }
 
             // Footer line
-            String footer = str_sprintf(" LED: %2d  Scr: %02d", g_Values.FPS, (int)screenFPS);
+            String footer = str_sprintf(" LED: %2lu  Scr: %02d", (unsigned long)g_Values.FPS, (int)screenFPS);
             #if ENABLE_AUDIO
-                footer = str_sprintf(" LED: %2d  Aud: %2d Ser:%2d Scr: %02d", g_Values.FPS, g_Analyzer.AudioFPS(), g_Analyzer.SerialFPS(), (int)screenFPS);
+                footer = str_sprintf(" LED: %2lu  Aud: %2lu Ser:%2lu Scr: %02d", (unsigned long)g_Values.FPS, (unsigned long)g_Analyzer.AudioFPS(), (unsigned long)g_Analyzer.SerialFPS(), (int)screenFPS);
             #endif
 
             if (footer != lastFooter)

--- a/src/socketserver.cpp
+++ b/src/socketserver.cpp
@@ -83,11 +83,11 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
             uint32_t compressedSize = _pBuffer[7] << 24  | _pBuffer[6] << 16  | _pBuffer[5] << 8  | _pBuffer[4];
             uint32_t expandedSize   = _pBuffer[11] << 24 | _pBuffer[10] << 16 | _pBuffer[9] << 8  | _pBuffer[8];
             uint32_t reserved       = _pBuffer[15] << 24 | _pBuffer[14] << 16 | _pBuffer[13] << 8 | _pBuffer[12];
-            debugV("Compressed Header: compressedSize: %u, expandedSize: %u, reserved: %u", compressedSize, expandedSize, reserved);
+            debugV("Compressed Header: compressedSize: %lu, expandedSize: %lu, reserved: %lu", (unsigned long)compressedSize, (unsigned long)expandedSize, (unsigned long)reserved);
 
             if (expandedSize > MAXIMUM_PACKET_SIZE)
             {
-                debugE("Expanded packet would be %u but buffer is only %u !!!!\n", expandedSize, MAXIMUM_PACKET_SIZE);
+                debugE("Expanded packet would be %lu but buffer is only %lu !!!!\n", (unsigned long)expandedSize, (unsigned long)MAXIMUM_PACKET_SIZE);
                 break;
             }
 
@@ -96,7 +96,7 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
                 debugW("Could not read compressed data from stream\n");
                 break;
             }
-            debugV("Successfully read %u bytes", COMPRESSED_HEADER_SIZE + compressedSize);
+            debugV("Successfully read %zu bytes", (size_t)(COMPRESSED_HEADER_SIZE + compressedSize));
 
             // If our buffer is in PSRAM it would be expensive to decompress in place, as the SPIRAM doesn't like
             // non-linear access from what I can tell.  I bet it must send addr+len to request each unique read, so
@@ -141,7 +141,7 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
 
                     size_t totalExpected = STANDARD_DATA_HEADER_SIZE + length32;
 
-                    debugV("PeakData Header: numbands=%u, length=%u, seconds=%llu, micro=%llu", numbands, length32, seconds, micros);
+                    debugV("PeakData Header: numbands=%u, length=%lu, seconds=%llu, micro=%llu", numbands, (unsigned long)length32, seconds, micros);
 
                     if (numbands != NUM_BANDS)
                     {
@@ -151,13 +151,13 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
 
                     if (length32 != numbands * sizeof(float))
                     {
-                        debugE("Expecting %zu bytes for %d audio bands, but received %zu.  Ensure float size and endianness matches between sender and receiver systems.", totalExpected, NUM_BANDS, _cbReceived);
+                        debugE("Expecting %zu bytes for %d audio bands, but received %zu.  Ensure float size and endianness matches between sender and receiver systems.", (size_t)totalExpected, (int)NUM_BANDS, (size_t)_cbReceived);
                         break;
                     }
 
                     if (false == ReadUntilNBytesReceived(new_socket, totalExpected))
                     {
-                        debugE("Error in getting peak data from wifi, could not read the %zu bytes", totalExpected);
+                        debugE("Error in getting peak data from wifi, could not read the %zu bytes", (size_t)totalExpected);
                         break;
                     }
 
@@ -165,7 +165,7 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
                         break;
 
                     // Consume the data by resetting the buffer
-                    debugV("Consuming the data as WIFI_COMMAND_PEAKDATA by setting _cbReceived to from %zu down 0.", _cbReceived);
+                    debugV("Consuming the data as WIFI_COMMAND_PEAKDATA by setting _cbReceived to from %zu down 0.", (size_t)_cbReceived);
                 }
                 #else
                     // Audio disabled: consume any declared payload to keep stream in sync, then ignore it
@@ -173,10 +173,10 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
                     size_t totalExpected = STANDARD_DATA_HEADER_SIZE + length32;
                     if (!ReadUntilNBytesReceived(new_socket, totalExpected))
                     {
-                        debugW("Audio disabled, failed to skip PEAKDATA payload of %zu bytes", totalExpected);
+                        debugW("Audio disabled, failed to skip PEAKDATA payload of %zu bytes", (size_t)totalExpected);
                         break;
                     }
-                    debugV("Audio disabled; skipped PEAKDATA payload (%zu bytes)", totalExpected);
+                    debugV("Audio disabled; skipped PEAKDATA payload (%zu bytes)", (size_t)totalExpected);
                 #endif
                 ResetReadBuffer();
 
@@ -190,16 +190,16 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
                 uint64_t seconds   = ULONGFromMemory(&_pBuffer.get()[8]);
                 uint64_t micros    = ULONGFromMemory(&_pBuffer.get()[16]);
 
-                debugV("Uncompressed Header: channel16=%u, length=%u, seconds=%llu, micro=%llu", channel16, length32, seconds, micros);
+                debugV("Uncompressed Header: channel16=%u, length=%lu, seconds=%llu, micro=%llu", channel16, (unsigned long)length32, seconds, micros);
 
                 size_t totalExpected = STANDARD_DATA_HEADER_SIZE + length32 * LED_DATA_SIZE;
                 if (totalExpected > MAXIMUM_PACKET_SIZE)
                 {
-                    debugW("Too many bytes promised (%zu) - more than we can use for our LEDs at max packet (%u)\n", totalExpected, MAXIMUM_PACKET_SIZE);
+                    debugW("Too many bytes promised (%zu) - more than we can use for our LEDs at max packet (%lu)\n", (size_t)totalExpected, (unsigned long)MAXIMUM_PACKET_SIZE);
                     break;
                 }
 
-                debugV("Expecting %zu total bytes", totalExpected);
+                debugV("Expecting %zu total bytes", (size_t)totalExpected);
                 if (false == ReadUntilNBytesReceived(new_socket, totalExpected))
                 {
                     debugW("Error in getting pixel data from wifi\n");
@@ -215,14 +215,14 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
                 }
 
                 // Consume the data by resetting the buffer
-                debugV("Consuming the data as WIFI_COMMAND_PIXELDATA64 by setting _cbReceived to from %zu down 0.", _cbReceived);
+                debugV("Consuming the data as WIFI_COMMAND_PIXELDATA64 by setting _cbReceived to from %zu down 0.", (size_t)_cbReceived);
                 ResetReadBuffer();
 
                 bSendResponsePacket = true;
             }
             else
             {
-                debugW("Unknown command in packet received: %d\n", command16);
+                debugW("Unknown command in packet received: %u\n", command16);
                 break;
             }
         }

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -118,10 +118,10 @@ void CWebServer::begin()
     EmbeddedWebFile ico_file(ico_start, ico_end, "image/vnd.microsoft.icon", "gzip");
     EmbeddedWebFile timezones_file(timezones_start, timezones_end - 1, "text/json"); // end - 1 because of zero-termination
 
-    debugI("Embedded html file size: %d", html_file.length);
-    debugI("Embedded jsx file size: %d", js_file.length);
-    debugI("Embedded ico file size: %d", ico_file.length);
-    debugI("Embedded timezones file size: %d", timezones_file.length);
+    debugI("Embedded html file size: %zu", (size_t)html_file.length);
+    debugI("Embedded jsx file size: %zu", (size_t)js_file.length);
+    debugI("Embedded ico file size: %zu", (size_t)ico_file.length);
+    debugI("Embedded timezones file size: %zu", (size_t)timezones_file.length);
 
     _staticStats.HeapSize = ESP.getHeapSize();
     _staticStats.DmaHeapSize = heap_caps_get_total_size(MALLOC_CAP_DMA);


### PR DESCRIPTION
# PR Description: GCC 14 Format Specifier Standardization

_This is a hybrid of human and machine (Gemini, CLion, Clang-tidy, GCC) work. I've had some variation of this in my local trees now for about a year and a half and this PR started from that base. This version works on both G++14 and GCC8. I wrote a special wrapper that makes a compile_commands.json, grabs the flags out of it, uses G++14 instead of G++8, and then adds "-fsyntax-only" and, to be sure, "-Wformat=2," so I could at least trivially parse the source on the two different compilers at the same time. After that worked, I had Gemini build a "Rules of the Road" based on those numerous changes to record how passing should be done and then apply those rules to everything *outside* the ifdef brackets we can exercise. I let Gemini write this description because I was so disgusted with the final result._  

This PR establishes and applies a standardized set of "Rules of the Road" for `printf`-style format specifiers across the core codebase. This is a critical preparation step for the upcoming migration to GCC 14 and the enforcement of the `-Wformat=2` warning flag.

## Technical Rationale: Why so many casts?

In earlier GCC versions, the compiler was often lenient if you passed a type that was bit-compatible with the specifier (e.g., passing a 32-bit `unsigned int` to a `%lu` which expects a 32-bit `unsigned long`). GCC 14 treats these as distinct type identities.

### 1. Type Identity Consistency
On the ESP32 toolchains, `uint32_t` is typically an alias for `unsigned long`. However, another toolchain might define it as `unsigned int`. By explicitly casting to `(unsigned long)` and using `%lu`, we:
- **Guarantee a match** across all ESP32 variants (S2, S3, C3, Classic).
- **Prevent environment-specific warnings** that occur when toolchains disagree on type aliases.

### 2. Standardizing `size_t`
The most frequent mismatch was `size_t` being logged with `%d`. This often works solely due to luck (stack layout) and fails on 64-bit or stricter 32-bit audits. We have standardized on `%zu` with an explicit `(size_t)` cast.

### 3. "Rules of the Road" Applied
- **`uint32_t`** -> `%lu` with `(unsigned long)` cast.
- **`int32_t`** -> `%ld` with `(long)` cast.
- **`size_t`** -> `%zu` with `(size_t)` cast.
- **`CRGB` (Hex Colors)** -> `%08lX` with `(unsigned long)` cast.
- **Small Integers** (`uint8_t`, `int16_t`, etc.) -> `%d` with `(int)` cast.

## Impact
While this adds verbosity ("casts") to the logging calls, it provides the "Type Safety contract" necessary to keep the project build warning-clean. A warning-clean build is essential for catching real logic bugs in a project with this many build environments.

## Files Included (20)
- Core: `main.cpp`, `systemcontainer.h`, `types.h`, `taskmgr.h`, `ledbuffer.h`
- Drivers/Graphics: `screen.cpp`, `hub75gfx.cpp`, `LV_Helper.cpp`, `audio.cpp`
- Comms: `network.cpp`, `socketserver.cpp`, `webserver.cpp`, `jsonserializer.cpp`, `improvserial.h`
- Effects/Utils: `remotecontrol.cpp`, `ntptimeclient.cpp`, `debug_cli.cpp`, `effectmanager.cpp`
- Effect Headers: `PatternAnimatedGIF.h`, `particles.h`

---

## Future Path: Why not `std::print`?

While the amount of explicit casting is admittedly "noisy," it is currently the most flash-efficient way to achieve strict type safety. 

We acknowledge that C++23's `std::print` and `std::format` provide a much cleaner syntax that handles these type identities automatically. However, even in GCC 14, the standard library implementation of these features often brings in significant overhead (locales, complex transitives) that can "blow out" flash size on constrained ESP32 targets.

Until the toolchain's support for `std::print` matures to be as lean as `printf`, these explicit "Type Safety contracts" are the necessary evil to keep the build both warning-clean and small enough to fit.

[X] I read the contribution guidelines in [CONTRIBUTING.md](https://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
[X] I understand the BlinkenPerBit metric, and maximized it in this PR.
[X] I selected main as the target branch.
[X] All code herein is subjected to the license terms in [COPYING.txt](https://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).