### PR TITLE
Partition -mfix-esp32-psram-cache-issue for correctness.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -224,7 +224,7 @@ board           = m5stick-c                         ; Requires the M5StickC Plus
 upload_speed    = 2000000
 build_flags     = -DM5STICKCPLUS2=1
                   ${dev_m5.build_flags}
-                  ${psram_flags.build_flags}
+                  ${psram_lx6_flags.build_flags}
 board_build.partitions = config/partitions_custom_8M.csv
 board_upload.flash_size = 8MB
 
@@ -233,7 +233,7 @@ extends         = dev_m5
 board           = m5stack-core2
 build_flags     = -DM5STACKCORE2=1
                   ${dev_m5.build_flags}
-                  ${psram_flags.build_flags}
+                  ${psram_lx6_flags.build_flags}
 board_build.partitions = config/partitions_custom_8M.csv
 board_upload.flash_size = 8MB
 
@@ -296,7 +296,7 @@ build_flags    = ${dev_esp32_s3.build_flags}
                  -DLED_PIN0=2
                  -DLV_CONF_PATH="../../../../include/amoled/lv_conf.h"
                  -DLV_CONF_INCLUDE_SIMPLE
-                 ${psram_flags.build_flags}
+                 ${psram_common_flags.build_flags}
 lib_deps       = ${dev_esp32_s3.lib_deps}
                  lewisxhe/SensorLib@^0.1.4
                  lewisxhe/XPowersLib@^0.2.1
@@ -315,9 +315,14 @@ lib_deps       = ${dev_esp32_s3.lib_deps}
 
 
 ; Build flags for use of PSRAM
-[psram_flags]
-build_flags     = -DUSE_PSRAM=1
-                  -DBOARD_HAS_PSRAM=1
+[psram_common_flags]
+build_flags      = -DUSE_PSRAM=1
+                   -DBOARD_HAS_PSRAM=1
+
+# Issue errata for rev 1.0 (obsolted early 2020) LX6 modules.
+# https://docs.espressif.com/projects/esp-chip-errata/en/latest/esp32/03-errata-description/esp32/cpu-read-and-write-errors-related-to-access-sequence.html
+[psram_lx6_flags]
+build_flags      = ${psram_common_flags.build_flags}
                   -mfix-esp32-psram-cache-issue
 
 ; Libs needed to link with a TTGO Module
@@ -405,7 +410,7 @@ build_flags     = -DPROJECT_NAME="\"Mesmerizer\""
                   -DIR_REMOTE_PIN=39
                   -DINPUT_PIN=36
                   -DTOGGLE_BUTTON_0=0
-                  ${psram_flags.build_flags}
+                  ${psram_lx6_flags.build_flags}
 
 lib_deps        = https://github.com/PlummersSoftwareLLC/SmartMatrix.git
                   ${base.graphics_deps}
@@ -686,7 +691,7 @@ extends         = dev_adafruit_feather
 build_flags     = -DLEDSTRIP=1
                   -DEFFECTS_MINIMAL=1
                   ${dev_adafruit_feather.build_flags}
-                  ${psram_flags.build_flags}
+                  ${psram_lx6_flags.build_flags}
 
 [env:ledstrip_feather_hexagon]
 extends         = dev_adafruit_feather
@@ -707,14 +712,14 @@ build_flags     = -DHEXAGON=1
                   -DHEX_MAX_DIMENSION=19
                   -DHEX_HALF_DIMENSION=10
                   ${dev_adafruit_feather.build_flags}
-                  ${psram_flags.build_flags}
+                  ${psram_lx6_flags.build_flags}
 
 [env:ledstrip_feather_wrover]
 extends         = dev_wrover
 build_flags     = -DLEDSTRIP=1
                   -DEFFECTS_MINIMAL=1
                   -DUSER_SETUP_LOADED
-                  ${psram_flags.build_flags}
+                  ${psram_lx6_flags.build_flags}
                   ${dev_wrover.build_flags}
 debug_init_break = tbreak setup
 
@@ -728,7 +733,7 @@ build_flags     = -DLEDSTRIP=1
 extends         = dev_tinypico
 build_flags     = -DLEDSTRIP=1
                   -DEFFECTS_MINIMAL=1
-                  ${psram_flags.build_flags}
+                  ${psram_lx6_flags.build_flags}
                   ${dev_tinypico.build_flags}
 
 ;=============
@@ -847,7 +852,7 @@ build_flags     = -DSPECTRUM=1
                   -DUSE_SCREEN=1
                   -DTFT_WIDTH=320
                   -DTFT_HEIGHT=480
-                  ${psram_flags.build_flags}
+                  ${psram_lx6_flags.build_flags}
                   ${dev_elecrow_mesmerizer.build_flags}
 lib_deps        = ${dev_elecrow_mesmerizer.lib_deps}
 
@@ -1054,7 +1059,7 @@ build_flags     = -DUMBRELLA=1
                   -DTOGGLE_BUTTON_0=0
                   -DEFFECTS_MINIMAL=1
                   -DUSE_SCREEN=0
-                  ${psram_flags.build_flags}
+                  ${psram_lx6_flags.build_flags}
                   ${dev_esp32.build_flags}
 lib_deps        = ${base.bounce_deps}
                   ${dev_esp32.lib_deps}
@@ -1146,7 +1151,7 @@ build_flags     = -DTTGO=1
                   ${dev_esp32.build_flags}
 lib_deps        = ${base.lib_deps}
                   ${base.bounce_deps}
-                  ${psram_flags.build_flags}
+                  ${psram_lx6_flags.build_flags}
                   ${ttgo_deps.lib_deps}
 
 [env:xmastrees]


### PR DESCRIPTION
Partition -mfix-esp32-psram-cache-issue for correctness.

## Description

Fixes builds on RISC-V targets. Focus a chip errta fix to apply to only
potentially affected chips.

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
