### PR TITLE
Fix: Boot Stabilization (SIOF & ESP32-P4 Network)

### DIFF
--- a/include/effects/matrix/PatternAnimatedGIF.h
+++ b/include/effects/matrix/PatternAnimatedGIF.h
@@ -103,18 +103,22 @@ struct GIFInfo : public EmbeddedFile
     {}
 };
 
-static const std::map<GIFIdentifier, const GIFInfo, std::less<GIFIdentifier>, psram_allocator<std::pair<const GIFIdentifier, const GIFInfo>>> AnimatedGIFs =
+static const std::map<GIFIdentifier, const GIFInfo, std::less<GIFIdentifier>, psram_allocator<std::pair<const GIFIdentifier, const GIFInfo>>>& GetAnimatedGIFs()
 {
-    // Banana has 8 frames.  Most music is around 120BPM, so we need to play each frame for 1/15th of a second to somewhat align with a typical beat
-    { GIFIdentifier::Banana,       GIFInfo(banana_start,      banana_end,      32, 32, 10 ) },      //  4 KB
-    { GIFIdentifier::Nyancat,      GIFInfo(nyancat_start,     nyancat_end,     64, 32, 18 ) },      // 20 KB
-    { GIFIdentifier::Pacman,       GIFInfo(pacman_start,      pacman_end,      64, 12, 20 ) },      // 36 KB
-    { GIFIdentifier::Atomic,       GIFInfo(atomic_start,      atomic_end,      32, 32, 60 ) },      // 21 KB
-    { GIFIdentifier::ColorSphere,  GIFInfo(colorsphere_start, colorsphere_end, 32, 32, 16 ) },      // 52 KB
-    { GIFIdentifier::ThreeRings,   GIFInfo(threerings_start,  threerings_end,  64, 32, 24 ) },      //  9 KB
-    { GIFIdentifier::Tesseract,    GIFInfo(tesseract_start,   tesseract_end,   40, 32, 40 ) },      // 24 KB
-    { GIFIdentifier::Firelog,      GIFInfo(firelog_start,     firelog_end,     64, 32, 16 ) },      // 24 KB
-};
+    static const std::map<GIFIdentifier, const GIFInfo, std::less<GIFIdentifier>, psram_allocator<std::pair<const GIFIdentifier, const GIFInfo>>> AnimatedGIFs =
+    {
+        // Banana has 8 frames.  Most music is around 120BPM, so we need to play each frame for 1/15th of a second to somewhat align with a typical beat
+        { GIFIdentifier::Banana,       GIFInfo(banana_start,      banana_end,      32, 32, 10 ) },      //  4 KB
+        { GIFIdentifier::Nyancat,      GIFInfo(nyancat_start,     nyancat_end,     64, 32, 18 ) },      // 20 KB
+        { GIFIdentifier::Pacman,       GIFInfo(pacman_start,      pacman_end,      64, 12, 20 ) },      // 36 KB
+        { GIFIdentifier::Atomic,       GIFInfo(atomic_start,      atomic_end,      32, 32, 60 ) },      // 21 KB
+        { GIFIdentifier::ColorSphere,  GIFInfo(colorsphere_start, colorsphere_end, 32, 32, 16 ) },      // 52 KB
+        { GIFIdentifier::ThreeRings,   GIFInfo(threerings_start,  threerings_end,  64, 32, 24 ) },      //  9 KB
+        { GIFIdentifier::Tesseract,    GIFInfo(tesseract_start,   tesseract_end,   40, 32, 40 ) },      // 24 KB
+        { GIFIdentifier::Firelog,      GIFInfo(firelog_start,     firelog_end,     64, 32, 16 ) },      // 24 KB
+    };
+    return AnimatedGIFs;
+}
 
 // The decoder needs us to track some state, but there's only one instance of the decoder, and
 // we can't pass it a pointer to our state because the callback doesn't allow you to pass any
@@ -140,7 +144,11 @@ g_gifDecoderState;
 // We dynamically allocate the GIF decoder because it's pretty big and we don't want to waste the base
 // ram on it.  This way it, and the GIFs it decodes, can live in PSRAM.
 
-const std::unique_ptr<GifDecoder<MATRIX_WIDTH, MATRIX_HEIGHT, 16, true>> g_ptrGIFDecoder = make_unique_psram<GifDecoder<MATRIX_WIDTH, MATRIX_HEIGHT, 16, true>>();
+static GifDecoder<MATRIX_WIDTH, MATRIX_HEIGHT, 16, true>& GetGIFDecoder()
+{
+    static const std::unique_ptr<GifDecoder<MATRIX_WIDTH, MATRIX_HEIGHT, 16, true>> g_ptrGIFDecoder = make_unique_psram<GifDecoder<MATRIX_WIDTH, MATRIX_HEIGHT, 16, true>>();
+    return *g_ptrGIFDecoder;
+}
 
 // PatternAnimatedGIF
 //
@@ -260,8 +268,8 @@ public:
 
         // Open the GIF and start decoding
 
-        auto gif = AnimatedGIFs.find(_gifIndex);
-        if (gif == AnimatedGIFs.end())
+        auto gif = GetAnimatedGIFs().find(_gifIndex);
+        if (gif == GetAnimatedGIFs().end())
             throw std::runtime_error(str_sprintf("Unable to locate GIF by index %d in the map.", (int) _gifIndex).c_str());
 
         // Set up the gifDecoderState with all of the context that it will need to decode and
@@ -310,12 +318,12 @@ public:
 
         // Set the GIF decoder callbacks to our static functions
 
-        g_ptrGIFDecoder->setScreenClearCallback( screenClearCallback );
-        g_ptrGIFDecoder->setUpdateScreenCallback( updateScreenCallback );
-        g_ptrGIFDecoder->setDrawPixelCallback( drawPixelCallback );
-        g_ptrGIFDecoder->setDrawLineCallback( drawLineCallback );
+        GetGIFDecoder().setScreenClearCallback( screenClearCallback );
+        GetGIFDecoder().setUpdateScreenCallback( updateScreenCallback );
+        GetGIFDecoder().setDrawPixelCallback( drawPixelCallback );
+        GetGIFDecoder().setDrawLineCallback( drawLineCallback );
 
-        _gifReadyToDraw = (ERROR_NONE == g_ptrGIFDecoder->startDecoding((uint8_t *) gif->second.contents, gif->second.length));
+        _gifReadyToDraw = (ERROR_NONE == GetGIFDecoder().startDecoding((uint8_t *) gif->second.contents, gif->second.length));
         if (!_gifReadyToDraw)
             debugW("Failed to start decoding GIF");
     }
@@ -341,7 +349,7 @@ public:
             g()->Clear(_bkColor);
 
         if (_gifReadyToDraw)
-            g_ptrGIFDecoder->decodeFrame(false);
+            GetGIFDecoder().decodeFrame(false);
 
     }
 };

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -100,27 +100,31 @@ extern const uint8_t thunderstorm_night_end[]       asm("_binary_assets_bmp_thun
 
 static constexpr auto pszDaysOfWeek = to_array( { "SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT" } );
 
-static std::map<const String, EmbeddedFile, std::less<const String>, psram_allocator<std::pair<const String, EmbeddedFile>>> weatherIcons =
+static std::map<const String, EmbeddedFile, std::less<const String>, psram_allocator<std::pair<const String, EmbeddedFile>>>& GetWeatherIcons()
 {
-    { "01d", EmbeddedFile(clearsky_start, clearsky_end) },
-    { "02d", EmbeddedFile(fewclouds_start, fewclouds_end) },
-    { "03d", EmbeddedFile(scatteredclouds_start, scatteredclouds_end) },
-    { "04d", EmbeddedFile(brokenclouds_start, brokenclouds_end) },
-    { "09d", EmbeddedFile(showerrain_start, showerrain_end) },
-    { "10d", EmbeddedFile(rain_start, rain_end) },
-    { "11d", EmbeddedFile(thunderstorm_start, thunderstorm_end) },
-    { "13d", EmbeddedFile(snow_start, snow_end) },
-    { "50d", EmbeddedFile(mist_start, mist_end) },
-    { "01n", EmbeddedFile(clearsky_night_start, clearsky_night_end) },
-    { "02n", EmbeddedFile(fewclouds_night_start, fewclouds_night_end) },
-    { "03n", EmbeddedFile(scatteredclouds_night_start, scatteredclouds_night_end) },
-    { "04n", EmbeddedFile(brokenclouds_night_start, brokenclouds_night_end) },
-    { "09n", EmbeddedFile(showerrain_night_start, showerrain_night_end) },
-    { "10n", EmbeddedFile(rain_night_start, rain_night_end) },
-    { "11n", EmbeddedFile(thunderstorm_night_start, thunderstorm_night_end) },
-    { "13n", EmbeddedFile(snow_night_start, snow_night_end) },
-    { "50n", EmbeddedFile(mist_night_start, mist_night_end) }
-};
+    static std::map<const String, EmbeddedFile, std::less<const String>, psram_allocator<std::pair<const String, EmbeddedFile>>> weatherIcons =
+    {
+        { "01d", EmbeddedFile(clearsky_start, clearsky_end) },
+        { "02d", EmbeddedFile(fewclouds_start, fewclouds_end) },
+        { "03d", EmbeddedFile(scatteredclouds_start, scatteredclouds_end) },
+        { "04d", EmbeddedFile(brokenclouds_start, brokenclouds_end) },
+        { "09d", EmbeddedFile(showerrain_start, showerrain_end) },
+        { "10d", EmbeddedFile(rain_start, rain_end) },
+        { "11d", EmbeddedFile(thunderstorm_start, thunderstorm_end) },
+        { "13d", EmbeddedFile(snow_start, snow_end) },
+        { "50d", EmbeddedFile(mist_start, mist_end) },
+        { "01n", EmbeddedFile(clearsky_night_start, clearsky_night_end) },
+        { "02n", EmbeddedFile(fewclouds_night_start, fewclouds_night_end) },
+        { "03n", EmbeddedFile(scatteredclouds_night_start, scatteredclouds_night_end) },
+        { "04n", EmbeddedFile(brokenclouds_night_start, brokenclouds_night_end) },
+        { "09n", EmbeddedFile(showerrain_night_start, showerrain_night_end) },
+        { "10n", EmbeddedFile(rain_night_start, rain_night_end) },
+        { "11n", EmbeddedFile(thunderstorm_night_start, thunderstorm_night_end) },
+        { "13n", EmbeddedFile(snow_night_start, snow_night_end) },
+        { "50n", EmbeddedFile(mist_night_start, mist_night_end) }
+    };
+    return weatherIcons;
+}
 
 /**
  * @brief This class implements the Weather Data effect
@@ -510,16 +514,16 @@ public:
         }
 
         // Draw the graphics
-        auto iconEntry = weatherIcons.find(iconToday);
-        if (iconEntry != weatherIcons.end())
+        auto iconEntry = GetWeatherIcons().find(iconToday);
+        if (iconEntry != GetWeatherIcons().end())
         {
             auto icon = iconEntry->second;
             if (JDR_OK != TJpgDec.drawJpg(0, 10, icon.contents, icon.length))        // Draw the image
                 debugW("Could not display icon %s", iconToday.c_str());
         }
 
-        iconEntry = weatherIcons.find(iconTomorrow);
-        if (iconEntry != weatherIcons.end())
+        iconEntry = GetWeatherIcons().find(iconTomorrow);
+        if (iconEntry != GetWeatherIcons().end())
         {
             auto icon = iconEntry->second;
             if (JDR_OK != TJpgDec.drawJpg(xHalf+1, 10, icon.contents, icon.length))        // Draw the image

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -108,7 +108,7 @@ class CWebServer
         }
     };
 
-    static std::vector<SettingSpec, psram_allocator<SettingSpec>> mySettingSpecs;
+    static std::vector<SettingSpec, psram_allocator<SettingSpec>>& GetMySettingSpecs();
     static std::vector<std::reference_wrapper<SettingSpec>> deviceSettingSpecs;
     static const std::map<String, ValueValidator> settingValidators;
 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -89,17 +89,57 @@ struct NetworkReader::ReaderEntry
 
 static DRAM_ATTR WiFiUDP l_Udp;              // UDP object used for NNTP, etc
 
+#include <atomic>
+
+static std::atomic<bool> l_bWifiDriverReady{false};
+
+static bool l_cachedMacAddress_valid = false;
+static String l_cachedMacAddress;
+
+static bool l_cachedMacAddressPretty_valid = false;
+static String l_cachedMacAddressPretty;
+
 String get_mac_address()
 {
+  if (l_cachedMacAddress_valid)
+    return l_cachedMacAddress;
+
+#if ENABLE_WIFI
+  if (l_bWifiDriverReady)
+  {
+    uint8_t mac[6];
+    WiFi.macAddress(mac);
+    l_cachedMacAddress = str_sprintf("%02x%02x%02x%02x%02x%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    l_cachedMacAddress_valid = true;
+    return l_cachedMacAddress;
+  }
+#endif
+
+  // Fallback if driver not ready (e.g. early boot on P4)
   uint8_t mac[6];
-  WiFi.macAddress(mac);
+  get_mac_address_raw(mac);
   return str_sprintf("%02x%02x%02x%02x%02x%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 }
 
 String get_mac_address_pretty()
 {
+  if (l_cachedMacAddressPretty_valid)
+    return l_cachedMacAddressPretty;
+
+#if ENABLE_WIFI
+  if (l_bWifiDriverReady)
+  {
+    uint8_t mac[6];
+    WiFi.macAddress(mac);
+    l_cachedMacAddressPretty = str_sprintf("%02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    l_cachedMacAddressPretty_valid = true;
+    return l_cachedMacAddressPretty;
+  }
+#endif
+
+  // Fallback if driver not ready
   uint8_t mac[6];
-  WiFi.macAddress(mac);
+  get_mac_address_raw(mac);
   return str_sprintf("%02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
 }
 
@@ -418,6 +458,17 @@ void IRAM_ATTR RemoteLoopEntry(void *)
     // that were saved from an earlier call if no/nullptr arguments are passed.
     WiFiConnectResult ConnectToWiFi(const String* ssid = nullptr, const String* password = nullptr)
     {
+        static bool eventRegistered = false;
+        if (!eventRegistered)
+        {
+            WiFi.onEvent([](arduino_event_id_t event, arduino_event_info_t info) {
+                if (event == ARDUINO_EVENT_WIFI_READY) {
+                    l_bWifiDriverReady = true;
+                }
+            });
+            eventRegistered = true;
+        }
+
         static bool bPreviousConnection = false;
         static unsigned long millisAtLastAttempt = 0;
         static unsigned long retryDelay = WIFI_WAIT_INIT;

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -57,7 +57,11 @@ const std::map<String, CWebServer::ValueValidator> CWebServer::settingValidators
     { DeviceConfig::BrightnessTag,        [](const String& value) { return g_ptrSystem->GetDeviceConfig().ValidateBrightness(value); } }
 };
 
-std::vector<SettingSpec, psram_allocator<SettingSpec>> CWebServer::mySettingSpecs = {};
+std::vector<SettingSpec, psram_allocator<SettingSpec>>& CWebServer::GetMySettingSpecs()
+{
+    static std::vector<SettingSpec, psram_allocator<SettingSpec>> instance;
+    return instance;
+}
 std::vector<std::reference_wrapper<SettingSpec>> CWebServer::deviceSettingSpecs{};
 
 // Member function template specializations
@@ -479,13 +483,13 @@ const std::vector<std::reference_wrapper<SettingSpec>> & CWebServer::LoadDeviceS
 {
     if (deviceSettingSpecs.empty())
     {
-        mySettingSpecs.emplace_back(
+        GetMySettingSpecs().emplace_back(
             "effectInterval",
             "Effect interval",
             "The duration in milliseconds that an individual effect runs, before the next effect is activated.",
             SettingSpec::SettingType::PositiveBigInteger
         );
-        deviceSettingSpecs.insert(deviceSettingSpecs.end(), mySettingSpecs.begin(), mySettingSpecs.end());
+        deviceSettingSpecs.insert(deviceSettingSpecs.end(), GetMySettingSpecs().begin(), GetMySettingSpecs().end());
 
         auto deviceConfigSpecs = g_ptrSystem->GetDeviceConfig().GetSettingSpecs();
         deviceSettingSpecs.insert(deviceSettingSpecs.end(), deviceConfigSpecs.begin(), deviceConfigSpecs.end());


### PR DESCRIPTION
## Description
This PR addresses critical boot stability issues for the ESP32-P4 and other environments:
1. **Network Initialization Crash**: Fixes a fatal `nullptr` dereference on the ESP32-P4 caused by polling the MAC address before the ESP32-C6 companion chip is initialized, by utilizing a driver readiness event listener and caching the MAC.
2. **Static Initialization Order Fiasco (SIOF)**: Migrates several global statics relying on `psram_allocator` to "Construct-On-First-Use" (Meyer's Singleton) patterns. This prevents PSRAM allocation crashes before system memory initialization is fully complete. Affected components: `AnimatedGIFs`, `g_ptrGIFDecoder`, `weatherIcons`, and `mySettingSpecs`.

## Contributing requirements
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).