### PR TITLE
Reference

### DIFF
--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -208,7 +208,8 @@ public:
     bool SerializeToJSON(JsonObject& jsonObject) override;
 
     // Must provide at least one drawing instance, like the first matrix or strip we are drawing on
-    std::shared_ptr<GFXBase> g(int iChannel = 0) const;
+    GFXBase& g(int iChannel = 0);
+    const GFXBase& g(int iChannel = 0) const;
 
     // ShowVU - Control whether VU meter should be drawn.  Returns the previous state when set.
     virtual bool ShowVU(bool bShow);
@@ -219,8 +220,8 @@ public:
     // When a global color is set via the remote, we create a fill effect and assign it as the "remote effect"
     // which takes drawing precedence
 
-    void ApplyGlobalColor(CRGB color) const;
-    void ApplyGlobalPaletteColors() const;
+    void ApplyGlobalColor(CRGB color);
+    void ApplyGlobalPaletteColors();
 
     void ClearRemoteColor(bool retainRemoteEffect = false);
 
@@ -261,8 +262,8 @@ public:
 
     void CheckEffectTimerExpired();
 
-    void NextPalette() const;
-    void PreviousPalette() const;
+    void NextPalette();
+    void PreviousPalette();
     // Update to the next effect and abort the current effect.
 
     void NextEffect(bool skipSave = false);

--- a/include/effects/matrix/PatternAlienText.h
+++ b/include/effects/matrix/PatternAlienText.h
@@ -93,15 +93,15 @@ public:
   {
       x = leftMargin;
       y = topMargin;
-      g()->Clear();
+      g().Clear();
       debugW("Starting AlienText...");
   }
 
   void Draw() override
   {
-    std::shared_ptr<GFXBase> graphics = _GFX[0];
+    auto& graphics = g();
 
-    graphics->DimAll(245);
+    graphics.DimAll(245);
 
     CRGB color1 = RandomSaturatedColor();
 
@@ -120,11 +120,11 @@ public:
         if (random(0, 2) == 1)
           color = color1;
 
-        graphics->setPixel(x + i, y + j, color);
+        graphics.setPixel(x + i, y + j, color);
 
         if (drawMirror)
         {
-          graphics->setPixel(mirrorX, y + j, color);
+          graphics.setPixel(mirrorX, y + j, color);
         }
       }
     }

--- a/include/effects/matrix/PatternAnimatedGIF.h
+++ b/include/effects/matrix/PatternAnimatedGIF.h
@@ -163,7 +163,7 @@ class PatternAnimatedGIF : public EffectWithId<PatternAnimatedGIF>
 
     static void screenClearCallback(void)
     {
-        auto& g = *(g_ptrSystem->GetEffectManager().g());
+        auto& g = g_ptrSystem->GetEffectManager().g();
         g.Clear(g_gifDecoderState._bkColor);
     }
 
@@ -180,7 +180,7 @@ class PatternAnimatedGIF : public EffectWithId<PatternAnimatedGIF>
 
     static void drawPixelCallback(int16_t x, int16_t y, uint8_t red, uint8_t green, uint8_t blue)
     {
-        auto& g = *(g_ptrSystem->GetEffectManager().g(0));
+        auto& g = g_ptrSystem->GetEffectManager().g(0);
 
         // Apply scaling transformation
         int16_t scaledX = (int16_t)(x * g_gifDecoderState._scaleX) + g_gifDecoderState._offsetX;
@@ -256,7 +256,7 @@ public:
 
     void Start() override
     {
-        g()->Clear(_bkColor);
+        g().Clear(_bkColor);
 
         // Open the GIF and start decoding
 
@@ -338,7 +338,7 @@ public:
         // GIF doesn't use transparency.
 
         if (_preClear)
-            g()->Clear(_bkColor);
+            g().Clear(_bkColor);
 
         if (_gifReadyToDraw)
             g_ptrGIFDecoder->decodeFrame(false);

--- a/include/effects/matrix/PatternBounce.h
+++ b/include/effects/matrix/PatternBounce.h
@@ -107,7 +107,7 @@ public:
             boid.colorIndex = colorWidth * i;
             boid.maxforce = 10;
             boid.maxspeed = 10;
-            g()->_boids[i] = boid;
+            g()._boids[i] = boid;
         }
     }
 
@@ -116,13 +116,13 @@ public:
         // dim all pixels on the display
 
         // Blue columns only, and skip the first row of each column if the VU meter is being shown so we don't blend it onto ourselves
-        g()->blurColumns(g()->leds, MATRIX_WIDTH, MATRIX_HEIGHT, g_ptrSystem->GetEffectManager().IsVUVisible() ? 1 : 0, 200);
-        g()->DimAll(250);
+        g().blurColumns(g().leds, MATRIX_WIDTH, MATRIX_HEIGHT, g_ptrSystem->GetEffectManager().IsVUVisible() ? 1 : 0, 200);
+        g().DimAll(250);
 
         auto totalVelocity = 0.0;
         for (int i = 0; i < count; i++)
         {
-            Boid boid = g()->_boids[i];
+            Boid boid = g()._boids[i];
             boid.applyForce(gravity);
             boid.update();
             totalVelocity += abs(boid.velocity.y);
@@ -138,9 +138,9 @@ public:
                 boid.velocity.y *= -1.0;
             }
 
-            g()->setPixel((int)boid.location.x, (int)boid.location.y, g()->ColorFromCurrentPalette(boid.colorIndex));
+            g().setPixel((int)boid.location.x, (int)boid.location.y, g().ColorFromCurrentPalette(boid.colorIndex));
 
-            g()->_boids[i] = boid;
+            g()._boids[i] = boid;
         }
 
         // If the combined velocity of all the boids is less than 1.0, restart the animation.

--- a/include/effects/matrix/PatternCircuit.h
+++ b/include/effects/matrix/PatternCircuit.h
@@ -173,14 +173,14 @@ private:
             }
         }
 
-        void draw(std::shared_ptr<GFXBase> graphics, CRGB colors[SNAKE_LENGTH])
+        void draw(GFXBase& graphics, CRGB colors[SNAKE_LENGTH])
         {
             for (uint8_t i = 0; i < SNAKE_LENGTH; i++)
-                graphics->leds[XY(pixels[i].x, pixels[i].y)] = colors[i] %= (255 - i * (255 / SNAKE_LENGTH / 4));
+                graphics.leds[XY(pixels[i].x, pixels[i].y)] = colors[i] %= (255 - i * (255 / SNAKE_LENGTH / 4));
 
             uint8_t m = random(20, 100);
-            graphics->leds[XY(pixels[SNAKE_LENGTH - 1].x, pixels[SNAKE_LENGTH - 1].y)] = CRGB(0, m, 0); // End tail with random dark green
-            graphics->leds[XY(pixels[0].x, pixels[0].y)] = CRGB::White;                                 // Head end bright white dot
+            graphics.leds[XY(pixels[SNAKE_LENGTH - 1].x, pixels[SNAKE_LENGTH - 1].y)] = CRGB(0, m, 0); // End tail with random dark green
+            graphics.leds[XY(pixels[0].x, pixels[0].y)] = CRGB::White;                                 // Head end bright white dot
         }
     };
 
@@ -205,7 +205,7 @@ public:
         for (int i = 0; i < snakeCount; i++)
             snakes[i].reset();
         msStart = millis();
-        g()->Clear();
+        g().Clear();
     }
 
     void Draw() override
@@ -217,10 +217,10 @@ public:
 
         for (int i = 0; i < MATRIX_WIDTH * MATRIX_HEIGHT / 10; i++)
         {
-            g()->leds[XY(random(0, MATRIX_WIDTH), random(0, MATRIX_HEIGHT))].fadeToBlackBy(32);
+            g().leds[XY(random(0, MATRIX_WIDTH), random(0, MATRIX_HEIGHT))].fadeToBlackBy(32);
         }
 
-        // fill_palette(colors, SNAKE_LENGTH, initialHue++, 5, graphics->currentPalette, 255, LINEARBLEND);
+        // fill_palette(colors, SNAKE_LENGTH, initialHue++, 5, graphics.currentPalette, 255, LINEARBLEND);
         fill_palette(colors, SNAKE_LENGTH, 0, 4, ForestColors_p, 255, LINEARBLEND);
         for (int i = 0; i < snakeCount; i++)
         {

--- a/include/effects/matrix/PatternClock.h
+++ b/include/effects/matrix/PatternClock.h
@@ -84,8 +84,8 @@ class PatternClock : public EffectWithId<PatternClock>
 
         radius = std::min(MATRIX_WIDTH, MATRIX_HEIGHT) / 2 - 0.5;
 
-        g()->Clear();
-        g()->DrawSafeCircle(MATRIX_WIDTH/2, MATRIX_HEIGHT/2, 1, CRGB::Blue);
+        g().Clear();
+        g().DrawSafeCircle(MATRIX_WIDTH/2, MATRIX_HEIGHT/2, 1, CRGB::Blue);
 
         // Draw the hour ticks around the outside of the clock every 30 degrees
 
@@ -98,11 +98,11 @@ class PatternClock : public EffectWithId<PatternClock>
             int y2 = (MATRIX_CENTER_Y - round(cos(angle) * (radius - 4)));
             int x3 = (MATRIX_CENTER_X + round((sin(angle) * (radius - 1))));
             int y3 = (MATRIX_CENTER_Y - round(cos(angle) * (radius - 1)));
-            g()->drawLine(x2, y2, x3, y3, CRGB::Red);
+            g().drawLine(x2, y2, x3, y3, CRGB::Red);
         }
 
-        g()->DrawSafeCircle(MATRIX_WIDTH/2, MATRIX_HEIGHT/2, radius, CRGB::Blue);
-        g()->DrawSafeCircle(MATRIX_WIDTH/2, MATRIX_HEIGHT/2, radius+1, CRGB::Green);
+        g().DrawSafeCircle(MATRIX_WIDTH/2, MATRIX_HEIGHT/2, radius, CRGB::Blue);
+        g().DrawSafeCircle(MATRIX_WIDTH/2, MATRIX_HEIGHT/2, radius+1, CRGB::Green);
 
         // Draw the second hand
 
@@ -110,7 +110,7 @@ class PatternClock : public EffectWithId<PatternClock>
         angle = (angle / 57.29577951); // Convert degrees to radians
         int x3 = (MATRIX_CENTER_X + round(sin(angle) * (radius - 2)));
         int y3 = (MATRIX_CENTER_Y - round(cos(angle) * (radius - 2)));
-        g()->drawLine(MATRIX_CENTER_X, MATRIX_CENTER_Y, x3, y3, CRGB::White);
+        g().drawLine(MATRIX_CENTER_X, MATRIX_CENTER_Y, x3, y3, CRGB::White);
 
         // Draw the minute hand
 
@@ -118,7 +118,7 @@ class PatternClock : public EffectWithId<PatternClock>
         angle = (angle / 57.29577951); // Convert degrees to radians
         x3 = (MATRIX_CENTER_X + round(sin(angle) * (radius - 3)));
         y3 = (MATRIX_CENTER_Y - round(cos(angle) * (radius - 3)));
-        g()->drawLine(MATRIX_CENTER_X, MATRIX_CENTER_Y, x3, y3, CRGB::Yellow);
+        g().drawLine(MATRIX_CENTER_X, MATRIX_CENTER_Y, x3, y3, CRGB::Yellow);
 
         // Draw the  hour hand
 
@@ -126,7 +126,7 @@ class PatternClock : public EffectWithId<PatternClock>
         angle = (angle / 57.29577951); // Convert degrees to radians
         x3 = (MATRIX_CENTER_X + round(sin(angle) * (radius / 2 )));
         y3 = (MATRIX_CENTER_Y - round(cos(angle) * (radius / 2 )));
-        g()->drawLine(MATRIX_CENTER_X, MATRIX_CENTER_Y, x3, y3, CRGB::Yellow);
+        g().drawLine(MATRIX_CENTER_X, MATRIX_CENTER_Y, x3, y3, CRGB::Yellow);
 
         // Draw the sixtieths pixel
 
@@ -136,7 +136,7 @@ class PatternClock : public EffectWithId<PatternClock>
         int y2 = (MATRIX_CENTER_Y - round(cos(angle) * (radius - 1)));
         x3 = (MATRIX_CENTER_X + round((sin(angle) * (radius))));
         y3 = (MATRIX_CENTER_Y - round(cos(angle) * (radius)));
-        g()->drawLine(x2, y2, x3, y3, CRGB::White);
+        g().drawLine(x2, y2, x3, y3, CRGB::White);
 
     }
 };

--- a/include/effects/matrix/PatternCube.h
+++ b/include/effects/matrix/PatternCube.h
@@ -228,10 +228,10 @@ class PatternCube : public EffectWithId<PatternCube>
 
     void Draw() override
     {
-        g()->Clear();
+        g().Clear();
         zCamera = beatsin8(2, 100, 140);
         AngxSpeed = beatsin8(3, 3, 10) / 100.0f;
-        AngySpeed = g()->beatcos8(5, 3, 10) / 100.0f;
+        AngySpeed = g().beatcos8(5, 3, 10) / 100.0f;
 
         // Update values
         Angx += AngxSpeed;
@@ -258,25 +258,25 @@ class PatternCube : public EffectWithId<PatternCube>
         // Draw as many cubes as will fit horizontally, stepping by the smaller dimension
         for (int xOffset = 0; xOffset < MATRIX_WIDTH; xOffset += tileSize)
         {
-            CRGB color = g()->ColorFromCurrentPalette(hue + 64 + xOffset);
+            CRGB color = g().ColorFromCurrentPalette(hue + 64 + xOffset);
             // Backface
             EdgePoint *e;
             for (i = 0; i < 12; i++)
             {
                 e = edge + i;
                 if (!e->visible)
-                    g()->BresenhamLine(screen[e->x].x + xOffset, screen[e->x].y, screen[e->y].x + xOffset,
+                    g().BresenhamLine(screen[e->x].x + xOffset, screen[e->x].y, screen[e->y].x + xOffset,
                                        screen[e->y].y, color);
             }
 
-            color = g()->ColorFromCurrentPalette(hue + 128 + xOffset);
+            color = g().ColorFromCurrentPalette(hue + 128 + xOffset);
 
             // Frontface
             for (i = 0; i < 12; i++)
             {
                 e = edge + i;
                 if (e->visible)
-                    g()->BresenhamLine(screen[e->x].x + xOffset, screen[e->x].y, screen[e->y].x + xOffset,
+                    g().BresenhamLine(screen[e->x].x + xOffset, screen[e->x].y, screen[e->y].x + xOffset,
                                        screen[e->y].y, color);
             }
 

--- a/include/effects/matrix/PatternLife.h
+++ b/include/effects/matrix/PatternLife.h
@@ -259,9 +259,9 @@ public:
         for (int i = 0; i < MATRIX_WIDTH; i++) {
             for (int j = 0; j < MATRIX_HEIGHT; j++) {
                 if (world[i][j].brightness > 0)
-                    g()->leds[XY(i, j)] += g()->ColorFromCurrentPalette(world[i][j].hue * 4, world[i][j].brightness);
+                    g().leds[XY(i, j)] += g().ColorFromCurrentPalette(world[i][j].hue * 4, world[i][j].brightness);
                 else
-                    g()->leds[XY(i, j)] = CRGB::Black;
+                    g().leds[XY(i, j)] = CRGB::Black;
             }
         }
 
@@ -293,9 +293,9 @@ public:
             if (elapsed < flashTime)
             {
                 auto whiteColor = CRGB(0x60, 0x00, 0x00);
-                g()->fillRectangle(0, 0, MATRIX_WIDTH, MATRIX_HEIGHT, whiteColor);
+                g().fillRectangle(0, 0, MATRIX_WIDTH, MATRIX_HEIGHT, whiteColor);
             }
-            g()->DimAll(255 - 255*elapsed/resetTime);
+            g().DimAll(255 - 255*elapsed/resetTime);
 
             for (int x = 0; x < MATRIX_WIDTH; x++)
                 for (int y = 0; y < MATRIX_HEIGHT; y++)

--- a/include/effects/matrix/PatternMandala.h
+++ b/include/effects/matrix/PatternMandala.h
@@ -109,19 +109,21 @@ public:
 
     void Start() override
     {
+        auto& noise = g().GetNoise();
+
         // set to reasonable values to avoid a black out
-        g()->GetNoise().noisesmoothing = 100;
+        noise.noisesmoothing = 100;
 
         // just any free input pin
         // random16_add_entropy(analogRead(18));
 
         // fill coordinates with random values
         // set zoom levels
-        g()->GetNoise().noise_x = random16();
-        g()->GetNoise().noise_y = random16();
-        g()->GetNoise().noise_z = random16();
-        g()->GetNoise().noise_scale_x = 6000;
-        g()->GetNoise().noise_scale_y = 6000;
+        noise.noise_x = random16();
+        noise.noise_y = random16();
+        noise.noise_z = random16();
+        noise.noise_scale_x = 6000;
+        noise.noise_scale_y = 6000;
 
         // for the random movement
         dx = random8();
@@ -133,6 +135,9 @@ public:
 
     void Draw() override
     {
+        auto& graphics = g();
+        auto& noise = graphics.GetNoise();
+
         // a new parameter set every 30 seconds
         EVERY_N_SECONDS(30)
         {
@@ -140,38 +145,42 @@ public:
             dy = random16(500) - 250; // random16(2000) - 1000 is pretty fast but works fine, too
             dx = random16(500) - 250;
             dz = random16(500) - 250;
-            g()->GetNoise().noise_scale_x = random16(10000) + 2000;
-            g()->GetNoise().noise_scale_y = random16(10000) + 2000;
+            noise.noise_scale_x = random16(10000) + 2000;
+            noise.noise_scale_y = random16(10000) + 2000;
         }
 
-        g()->GetNoise().noise_y += dy * 4;
-        g()->GetNoise().noise_x += dx * 4;
-        g()->GetNoise().noise_z += dz * 4;
+        noise.noise_y += dy * 4;
+        noise.noise_x += dx * 4;
+        noise.noise_z += dz * 4;
 
-        g()->FillGetNoise();
+        graphics.FillGetNoise();
 
         ShowNoiseLayer(0, 1, 0);
 
-        g()->Caleidoscope3();
-        g()->Caleidoscope1();
+        graphics.Caleidoscope3();
+        graphics.Caleidoscope1();
     }
 
     // show just one layer
     void ShowNoiseLayer(uint8_t layer, uint8_t colorrepeat, uint8_t colorshift)
     {
+        auto& graphics = g();
+        const auto& noise = graphics.GetNoise();
+        const auto& palette = graphics.GetCurrentPalette();
+
         for (uint16_t i = 0; i < MATRIX_WIDTH; i++)
         {
             for (uint16_t j = 0; j < MATRIX_HEIGHT; j++)
             {
 
-                uint8_t color = g()->GetNoise().noise[i][j];
+                uint8_t color = noise.noise[i][j];
 
                 uint8_t bri = color;
 
                 // assign a color depending on the actual palette
-                CRGB pixel = ColorFromPalette(g()->GetCurrentPalette(), colorrepeat * (color + colorshift), bri);
+                CRGB pixel = ColorFromPalette(palette, colorrepeat * (color + colorshift), bri);
 
-                g()->leds[XY(i, j)] = pixel;
+                graphics.leds[XY(i, j)] = pixel;
             }
         }
     }

--- a/include/effects/matrix/PatternMaze.h
+++ b/include/effects/matrix/PatternMaze.h
@@ -239,8 +239,8 @@ private:
         shuffleDirections();
 
         CRGB color = chooseColor(index);
-        g()->drawPixel(imagePoint.x, imagePoint.y, color);
-        g()->drawPixel(MATRIX_WIDTH - 1 - imagePoint.x, imagePoint.y, color);
+        g().drawPixel(imagePoint.x, imagePoint.y, color);
+        g().drawPixel(MATRIX_WIDTH - 1 - imagePoint.x, imagePoint.y, color);
 
         for (int i = 0; i < 4; i++)
         {
@@ -254,8 +254,8 @@ private:
 
                 Point newImagePoint = imagePoint.Move(direction);
 
-                g()->drawPixel(newImagePoint.x, newImagePoint.y, color);
-                g()->drawPixel(MATRIX_WIDTH - 1 - newImagePoint.x, newImagePoint.y, color);
+                g().drawPixel(newImagePoint.x, newImagePoint.y, color);
+                g().drawPixel(MATRIX_WIDTH - 1 - newImagePoint.x, newImagePoint.y, color);
 
                 cellCount++;
                 cells[cellCount - 1] = newPoint;
@@ -268,8 +268,8 @@ private:
         if (index > -1) {
             Point finishedPoint = cells[index];
             imagePoint = createPoint(finishedPoint.x * 2, finishedPoint.y * 2);
-            g()->drawPixel(imagePoint.x, imagePoint.y, color);
-            g()->drawPixel(MATRIX_WIDTH - 1 - imagePoint.x, imagePoint.y, color);
+            g().drawPixel(imagePoint.x, imagePoint.y, color);
+            g().drawPixel(MATRIX_WIDTH - 1 - imagePoint.x, imagePoint.y, color);
 
             removeCell(index);
         }
@@ -285,7 +285,7 @@ public:
         if (cellCount < 1)
         {
             hue = random(256);
-            g()->Clear();
+            g().Clear();
 
             // reset the maze grid
             for (int y = 0; y < height; y++) {
@@ -324,7 +324,7 @@ public:
 
     void Start() override
     {
-        g()->Clear();
+        g().Clear();
     }
 };
 

--- a/include/effects/matrix/PatternMisc.h
+++ b/include/effects/matrix/PatternMisc.h
@@ -75,22 +75,22 @@ class PatternSunburst : public EffectWithId<PatternSunburst>
     void Draw() override
     {
         uint8_t dim = beatsin8(2, 210, 250);
-        g()->DimAll(dim);
+        g().DimAll(dim);
 
         for (int i = 2; i <= MATRIX_WIDTH / 2; i++)
         {
-            CRGB color = g()->ColorFromCurrentPalette((i - 2) * (240 / (MATRIX_WIDTH / 2)));
+            CRGB color = g().ColorFromCurrentPalette((i - 2) * (240 / (MATRIX_WIDTH / 2)));
 
             // The LIB8TION library defines beatsin8, but this needed beatcos8 which did not exist, so I
             // added it to the graphics interface rathe than adding it to a custom version of lib8tion
 
-            uint8_t x = g()->beatcos8((17 - i) * 2, MATRIX_CENTER_X - i, MATRIX_CENTER_X + i);
+            uint8_t x = g().beatcos8((17 - i) * 2, MATRIX_CENTER_X - i, MATRIX_CENTER_X + i);
             uint8_t y = beatsin8((17 - i) * 2, MATRIX_CENTER_Y - i, MATRIX_CENTER_Y + i);
 
             if (color.r != 0 || color.g != 0 || color.b != 0)
             {
-                if (g()->isValidPixel(x,y))
-                    g()->setPixel(x, y, color);
+                if (g().isValidPixel(x,y))
+                    g().setPixel(x, y, color);
             }
         }
     }
@@ -116,7 +116,7 @@ class PatternRose : public EffectWithId<PatternRose>
     void Draw() override
     {
         uint8_t dim = beatsin8(2, 170, 250);
-        g()->DimAll(dim);
+        g().DimAll(dim);
 
 
         for (uint16_t i = 0; i < MATRIX_HEIGHT; i++)
@@ -128,19 +128,19 @@ class PatternRose : public EffectWithId<PatternRose>
 
             if (i < 16)
             {
-                x = g()->beatcos8((i + 1) * 2, i, MATRIX_HEIGHT - i) + 16;
+                x = g().beatcos8((i + 1) * 2, i, MATRIX_HEIGHT - i) + 16;
                 y = beatsin8((i + 1) * 2, i, MATRIX_HEIGHT - i);
-                color = g()->ColorFromCurrentPalette(i * 14);
+                color = g().ColorFromCurrentPalette(i * 14);
             }
             else
             {
                 x = beatsin8((32 - i) * 2, MATRIX_WIDTH - i, i + 1) + 16;
-                y = g()->beatcos8((32 - i) * 2, MATRIX_WIDTH - i, i + 1);
-                color = g()->ColorFromCurrentPalette((31 - i) * 14);
+                y = g().beatcos8((32 - i) * 2, MATRIX_WIDTH - i, i + 1);
+                color = g().ColorFromCurrentPalette((31 - i) * 14);
             }
 
-            if (g()->isValidPixel(x, y))
-                g()->setPixel(x, y, color);
+            if (g().isValidPixel(x, y))
+                g().setPixel(x, y, color);
         }
     }
 };
@@ -155,7 +155,7 @@ class PatternPinwheel : public EffectWithId<PatternPinwheel>
 
     void Start() override
     {
-        g()->Clear();
+        g().Clear();
     }
 
     virtual size_t DesiredFramesPerSecond() const override
@@ -176,11 +176,11 @@ class PatternPinwheel : public EffectWithId<PatternPinwheel>
             uint8_t y = 0;
 
             x = beatsin8((64 - i) * 2, MATRIX_HEIGHT - i, i + 1) + 16;
-            y = g()->beatcos8((64 - i) * 2, MATRIX_HEIGHT - i, i + 1);
-            color = g()->ColorFromCurrentPalette((64 - i) * 14);
+            y = g().beatcos8((64 - i) * 2, MATRIX_HEIGHT - i, i + 1);
+            color = g().ColorFromCurrentPalette((64 - i) * 14);
 
-            if (g()->isValidPixel(x, y))
-                g()->setPixel(x, y, color);
+            if (g().isValidPixel(x, y))
+                g().setPixel(x, y, color);
         }
     }
 };
@@ -204,24 +204,24 @@ public:
     {
         // dim all pixels on the display slightly
         // to 250/255 (98%) of their current brightness
-        g()->DimAll(250);
+        g().DimAll(250);
 
         // the Effects class has some sample oscillators
         // that move from 0 to 255 at different speeds
-        g()->MoveOscillators();
+        g().MoveOscillators();
 
         // the horizontal position of the head of the infinity sign
         // oscillates from 0 to the maximum horizontal and back
-        int x = (MATRIX_WIDTH - 1) - g()->p[1];
+        int x = (MATRIX_WIDTH - 1) - g().p[1];
 
         // the vertical position of the head oscillates up and down
 
         const int ymargin = 6;
-        int y = map8(sin8(g()->osci[3]), ymargin, MATRIX_HEIGHT - ymargin);
+        int y = map8(sin8(g().osci[3]), ymargin, MATRIX_HEIGHT - ymargin);
 
         // the hue oscillates from 0 to 255, overflowing back to 0
 
-        uint8_t hue = sin8(g()->osci[5]);
+        uint8_t hue = sin8(g().osci[5]);
 
         // draw a pixel at x,y using a color from the current palette
         if (_lastX == -1)
@@ -230,11 +230,11 @@ public:
             _lastY = y;
         }
 
-        g()->drawLine(_lastX, _lastY, x, y, g()->ColorFromCurrentPalette(hue));
+        g().drawLine(_lastX, _lastY, x, y, g().ColorFromCurrentPalette(hue));
         _lastX = x;
         _lastY = y;
 
-        //g()->setPixel(x, y, g()->ColorFromCurrentPalette(hue));
+        //g().setPixel(x, y, g().ColorFromCurrentPalette(hue));
 
     }
 };
@@ -270,8 +270,8 @@ public:
         {
             for (uint16_t y = 0; y < MATRIX_HEIGHT; y++)
             {
-                g()->leds[XY(x, y)] = (x ^ y ^ flip) < count
-                    ? g()->ColorFromCurrentPalette(((x ^ y) << 2) + generation)
+                g().leds[XY(x, y)] = (x ^ y ^ flip) < count
+                    ? g().ColorFromCurrentPalette(((x ^ y) << 2) + generation)
                     : CRGB::Black;
             }
         }

--- a/include/effects/matrix/PatternNoiseSmearing.h
+++ b/include/effects/matrix/PatternNoiseSmearing.h
@@ -74,7 +74,7 @@ class PatternRainbowFlag : public EffectWithId<PatternRainbowFlag>
 
     void Draw() override
     {
-        g()->DimAll(10);
+        g().DimAll(10);
 
         CRGB rainbow[7] = {CRGB::Red, CRGB::Orange, CRGB::Yellow, CRGB::Green, CRGB::Blue, CRGB::Violet};
 
@@ -86,7 +86,7 @@ class PatternRainbowFlag : public EffectWithId<PatternRainbowFlag>
             {
                 for (uint16_t x = 0; x < MATRIX_WIDTH; x++)
                 {
-                    g()->leds[XY(x, y)] += rainbow[c];
+                    g().leds[XY(x, y)] += rainbow[c];
                 }
 
                 y++;
@@ -96,14 +96,14 @@ class PatternRainbowFlag : public EffectWithId<PatternRainbowFlag>
         }
 
         // Noise
-        g()->SetNoise(1000, 1000, 0, 4000, 4000);
-        g()->FillGetNoise();
+        g().SetNoise(1000, 1000, 0, 4000, 4000);
+        g().FillGetNoise();
 
-        g()->MoveX(8);
-        // g()->MoveFractionalNoiseY<NoiseApproach::One>(8);
+        g().MoveX(8);
+        // g().MoveFractionalNoiseY<NoiseApproach::One>(8);
 
-        g()->MoveY(3);
-        g()->MoveFractionalNoiseX<NoiseApproach::MRI>(4);
+        g().MoveY(3);
+        g().MoveFractionalNoiseX<NoiseApproach::MRI>(4);
     }
 };
 #endif

--- a/include/effects/matrix/PatternPongClock.h
+++ b/include/effects/matrix/PatternPongClock.h
@@ -134,24 +134,24 @@ class PatternPongClock : public EffectWithId<PatternPongClock>
         const time_t ttime = time(0);
         const tm *local_time = localtime(&ttime);
 
-        g()->Clear();
+        g().Clear();
 
         // draw pitch centre line
         for (uint16_t y = 0; y < MATRIX_HEIGHT; y += 2)
-            g()->setPixel(MATRIX_WIDTH / 2, y, 0x6666);
+            g().setPixel(MATRIX_WIDTH / 2, y, 0x6666);
 
         // draw hh:mm separator colon that blinks once per second
 
         if (local_time->tm_sec % 2 == 0)
         {
-            g()->setPixel(MATRIX_WIDTH / 2, 4, RED16);
-            g()->setPixel(MATRIX_WIDTH / 2, 6, RED16);
+            g().setPixel(MATRIX_WIDTH / 2, 4, RED16);
+            g().setPixel(MATRIX_WIDTH / 2, 6, RED16);
         }
 
         // Render HH:MM using Adafruit_GFX font via GFXBase
-        g()->setFont(&Apple5x7);
-        g()->setTextWrap(false);
-        g()->setTextColor(WHITE16);
+        g().setFont(&Apple5x7);
+        g().setTextWrap(false);
+        g().setTextColor(WHITE16);
 
         // The compiler warns that with a nul terminator, 4 bytes could be needed; allocate 4
         char buffer[4];
@@ -161,18 +161,18 @@ class PatternPongClock : public EffectWithId<PatternPongClock>
 
         // Hours (left side)
         sprintf(buffer, "%2d", hours);
-        g()->getTextBounds(buffer, 0, 0, &bx, &by, &bw, &bh);
+        g().getTextBounds(buffer, 0, 0, &bx, &by, &bw, &bh);
         int16_t hoursX = (MATRIX_WIDTH / 2) - 2 - bw;
         int16_t baselineY = bh+2; // draw so the text's top is near y=0
-        g()->setCursor(hoursX, baselineY);
-        g()->print(buffer);
+        g().setCursor(hoursX, baselineY);
+        g().print(buffer);
 
         // Minutes (right side)
         sprintf(buffer, "%02d", mins);
-        g()->getTextBounds(buffer, 0, 0, &bx, &by, &bw, &bh);
+        g().getTextBounds(buffer, 0, 0, &bx, &by, &bw, &bh);
         int16_t minsX = (MATRIX_WIDTH / 2) + 2;
-        g()->setCursor(minsX, baselineY);
-        g()->print(buffer);
+        g().setCursor(minsX, baselineY);
+        g().print(buffer);
 
         // if restart flag is 1, set up a new game
         if (restart)
@@ -319,7 +319,7 @@ class PatternPongClock : public EffectWithId<PatternPongClock>
         }
 
         // draw bat 1
-        g()->fillRectangle(BAT1_X - 1, bat1_y, BAT1_X + 1, bat1_y + BAT_HEIGHT, CRGB::White);
+        g().fillRectangle(BAT1_X - 1, bat1_y, BAT1_X + 1, bat1_y + BAT_HEIGHT, CRGB::White);
 
         // move bat 2 towards target (don't go any further or bat will move off screen)
         // if bat y greater than target y move down until hit 0
@@ -336,7 +336,7 @@ class PatternPongClock : public EffectWithId<PatternPongClock>
             bat2_update = 1;
         }
 
-        g()->fillRectangle(BAT2_X + 1, bat2_y, BAT2_X + 3, bat2_y + BAT_HEIGHT, CRGB::White);
+        g().fillRectangle(BAT2_X + 1, bat2_y, BAT2_X + 3, bat2_y + BAT_HEIGHT, CRGB::White);
 
         // update the ball position using the velocity
         ballpos_x = ballpos_x + ballvel_x;
@@ -472,8 +472,8 @@ class PatternPongClock : public EffectWithId<PatternPongClock>
         uint8_t plot_x = (int)(ballpos_x + 0.5f);
         uint8_t plot_y = (int)(ballpos_y + 0.5f);
 
-        if (g()->isValidPixel(plot_x, plot_y))
-            g()->setPixel(plot_x, plot_y, WHITE16);
+        if (g().isValidPixel(plot_x, plot_y))
+            g().setPixel(plot_x, plot_y, WHITE16);
 
         // check if a bat missed the ball. if it did, reset the game.
         if (ballpos_x < 0 || ballpos_x > MATRIX_WIDTH)

--- a/include/effects/matrix/PatternPulse.h
+++ b/include/effects/matrix/PatternPulse.h
@@ -80,9 +80,9 @@ class PatternPulse : public EffectWithId<PatternPulse>
 
     void Draw() override
     {
-        auto graphics = g();
+        auto& graphics = g();
 
-        graphics->DimAll(245);
+        graphics.DimAll(245);
 
         if (step == -1)
         {
@@ -94,7 +94,7 @@ class PatternPulse : public EffectWithId<PatternPulse>
 
         if (step == 0)
         {
-            graphics->DrawSafeCircle(centerX, centerY, step, graphics->to16bit(graphics->ColorFromCurrentPalette(hue)));
+            graphics.DrawSafeCircle(centerX, centerY, step, graphics.to16bit(graphics.ColorFromCurrentPalette(hue)));
             step++;
         }
         else
@@ -102,12 +102,12 @@ class PatternPulse : public EffectWithId<PatternPulse>
             if (step < maxSteps)
             {
                 // initial pulse
-                graphics->DrawSafeCircle(centerX, centerY, step, graphics->to16bit(ColorFromPalette(RainbowColors_p, hue, pow(fadeRate, step - 2) * 255)));
+                graphics.DrawSafeCircle(centerX, centerY, step, graphics.to16bit(ColorFromPalette(RainbowColors_p, hue, pow(fadeRate, step - 2) * 255)));
 
                 // secondary pulse
                 if (step > 5)
                 {
-                    graphics->DrawSafeCircle(centerX, centerY, step - 3, graphics->to16bit(ColorFromPalette(RainbowColors_p, hue, pow(fadeRate, step - 2) * 255)));
+                    graphics.DrawSafeCircle(centerX, centerY, step - 3, graphics.to16bit(ColorFromPalette(RainbowColors_p, hue, pow(fadeRate, step - 2) * 255)));
                 }
                 step++;
             }
@@ -181,7 +181,7 @@ class PatternPulsar : public BeatEffectBase, public EffectWithId<PatternPulsar> 
         const int maxNewStarsPerFrame = 8;
         for (int i = 0; i < maxNewStarsPerFrame; i++)
             if (random(4) < g_Analyzer.VURatio())
-                g()->drawPixel(random(MATRIX_WIDTH), random(MATRIX_HEIGHT), RandomSaturatedColor());
+                g().drawPixel(random(MATRIX_WIDTH), random(MATRIX_HEIGHT), RandomSaturatedColor());
 
 
         for (auto pop = _pops.begin(); pop != _pops.end();)
@@ -196,7 +196,7 @@ class PatternPulsar : public BeatEffectBase, public EffectWithId<PatternPulsar> 
 
             if (pop->step == 0)
             {
-                g()->DrawSafeCircle(pop->centerX, pop->centerY, pop->step, g()->to16bit(g()->ColorFromCurrentPalette(pop->hue)));
+                g().DrawSafeCircle(pop->centerX, pop->centerY, pop->step, g().to16bit(g().ColorFromCurrentPalette(pop->hue)));
                 pop->step++;
                 pop++;
             }
@@ -205,11 +205,11 @@ class PatternPulsar : public BeatEffectBase, public EffectWithId<PatternPulsar> 
                 if (pop->step < pop->maxSteps)
                 {
                     // initial pulse
-                    g()->DrawSafeCircle(pop->centerX, pop->centerY, pop->step, g()->to16bit(g()->ColorFromCurrentPalette(pop->hue, pow(fadeRate, pop->step - 1) * 255)));
+                    g().DrawSafeCircle(pop->centerX, pop->centerY, pop->step, g().to16bit(g().ColorFromCurrentPalette(pop->hue, pow(fadeRate, pop->step - 1) * 255)));
 
                     // secondary pulse
                     if (pop->step > 3)
-                        g()->DrawSafeCircle(pop->centerX, pop->centerY, pop->step - 3, g()->to16bit(g()->ColorFromCurrentPalette(pop->hue, pow(fadeRate, pop->step - 2) * 255)));
+                        g().DrawSafeCircle(pop->centerX, pop->centerY, pop->step - 3, g().to16bit(g().ColorFromCurrentPalette(pop->hue, pow(fadeRate, pop->step - 2) * 255)));
 
                     // This looks like PDP-11 code to me.  double post-inc for the win!
                     pop++->step++;

--- a/include/effects/matrix/PatternQR.h
+++ b/include/effects/matrix/PatternQR.h
@@ -85,7 +85,7 @@ public:
             lastData = sIP;
             qrcode_initText(&qrcode, qrcodeData, qrVersion, ECC_LOW, sIP.c_str());
         }
-        g()->fillScreen(g()->to16bit(CRGB::DarkBlue));
+        g().fillScreen(g().to16bit(CRGB::DarkBlue));
         const int leftMargin = MATRIX_CENTER_X - qrcode.size / 2;
         const int topMargin = 4;
         const int borderSize = 2;
@@ -105,7 +105,7 @@ public:
 
         for (uint8_t y = startY; y < endY; y++) {
             for (uint8_t x = startX; x < endX; x++) {
-                g()->setPixel(leftMargin + x, topMargin + y, (qrcode_getModule(&qrcode, x, y) ? foregroundColor : BLACK16));
+                g().setPixel(leftMargin + x, topMargin + y, (qrcode_getModule(&qrcode, x, y) ? foregroundColor : BLACK16));
             }
         }
     }

--- a/include/effects/matrix/PatternRadar.h
+++ b/include/effects/matrix/PatternRadar.h
@@ -70,17 +70,17 @@ public:
 
   void Draw() override
   {
-    auto graphics = (GFXBase *)_GFX[0].get();
-    graphics->DimAll(254);
+    auto& graphics = g();
+    graphics.DimAll(254);
 
     for (int offset = 0; offset < MATRIX_CENTER_X; offset++)
     {
       uint8_t hue = 255 - (offset * 16 + hueoffset);
-      CRGB color = graphics->ColorFromCurrentPalette(hue);
-      uint8_t x = graphics->mapcos8(theta, offset, (MATRIX_WIDTH - 1) - offset);
-      uint8_t y = graphics->mapsin8(theta, offset, (MATRIX_HEIGHT - 1) - offset);
-      uint16_t xzy = graphics->xy(x, y);
-      graphics->leds[xzy] = color;
+      CRGB color = graphics.ColorFromCurrentPalette(hue);
+      uint8_t x = graphics.mapcos8(theta, offset, (MATRIX_WIDTH - 1) - offset);
+      uint8_t y = graphics.mapsin8(theta, offset, (MATRIX_HEIGHT - 1) - offset);
+      uint16_t xzy = graphics.xy(x, y);
+      graphics.leds[xzy] = color;
 
       EVERY_N_MILLIS(25)
       {

--- a/include/effects/matrix/PatternSM2DDPR.h
+++ b/include/effects/matrix/PatternSM2DDPR.h
@@ -70,7 +70,7 @@ class PatternSM2DDPR : public EffectWithId<PatternSM2DDPR> {
                 }
 
                 int hue = ::map(dist, radius, -3, 125, 255);
-                g()->leds[XY(x, y)] = CHSV(hue, 255, brightness);
+                g().leds[XY(x, y)] = CHSV(hue, 255, brightness);
             }
         }
     }

--- a/include/effects/matrix/PatternSMAmberRain.h
+++ b/include/effects/matrix/PatternSMAmberRain.h
@@ -77,8 +77,8 @@ class PatternSMAmberRain : public EffectWithId<PatternSMAmberRain>
                     brightness = 255.0 * fraction;
                 }
 
-                if (g()->isValidPixel(index))
-                    g()->leds[index] += CHSV(hue, 255, brightness);
+                if (g().isValidPixel(index))
+                    g().leds[index] += CHSV(hue, 255, brightness);
             }
         }
     }
@@ -90,7 +90,7 @@ class PatternSMAmberRain : public EffectWithId<PatternSMAmberRain>
 
     void Start() override
     {
-        g()->Clear();
+        g().Clear();
         for (int i = 0; i < NUMBER_OF_CIRCLES; i++)
         {
             circles[i].reset();

--- a/include/effects/matrix/PatternSMBlurringColors.h
+++ b/include/effects/matrix/PatternSMBlurringColors.h
@@ -154,7 +154,7 @@ class PatternSMBlurringColors : public EffectWithId<PatternSMBlurringColors>
 
     void Start() override
     {
-        g()->Clear();
+        g().Clear();
 
         enlargedObjectNUM = (Scale + 5U); // / 99.0 * (AVAILABLE_BOID_COUNT) ;
         if (enlargedObjectNUM > AVAILABLE_BOID_COUNT)
@@ -182,7 +182,7 @@ class PatternSMBlurringColors : public EffectWithId<PatternSMBlurringColors>
     {
         step = deltaValue; // counter of the number of particles in the
                            // queue for nucleation in this loop
-        g()->blur2d(g()->leds, MATRIX_WIDTH, 0, MATRIX_HEIGHT, 0, 27);
+        g().blur2d(g().leds, MATRIX_WIDTH, 0, MATRIX_HEIGHT, 0, 27);
 
         // go over particles and update matrix cells on the way
         for (auto& powder_item : _powder_items)
@@ -199,7 +199,7 @@ class PatternSMBlurringColors : public EffectWithId<PatternSMBlurringColors>
                 CRGB baseRGB = CHSV(powder_item._hue, 255, 255);
 
                 baseRGB.nscale8(powder_item._state); // equivalent
-                g()->drawPixelXYF_Wu(powder_item._position_x, MATRIX_HEIGHT - 1 - powder_item._position_y, baseRGB);
+                g().drawPixelXYF_Wu(powder_item._position_x, MATRIX_HEIGHT - 1 - powder_item._position_y, baseRGB);
             }
         }
     }

--- a/include/effects/matrix/PatternSMFire2021.h
+++ b/include/effects/matrix/PatternSMFire2021.h
@@ -23,9 +23,14 @@ class PatternSMFire2021 : public EffectWithId<PatternSMFire2021>
     PatternSMFire2021() : EffectWithId<PatternSMFire2021>("Fireplace") {}
     PatternSMFire2021(const JsonObjectConst &jsonObject) : EffectWithId<PatternSMFire2021>(jsonObject) {}
 
+    size_t DesiredFramesPerSecond() const override
+    {
+        return 60;
+    }
+
     void Start() override
     {
-        g()->Clear();
+        g().Clear();
         if (Scale > 100U)
             Scale = 100U; // чтобы не было проблем при прошивке без очистки памяти
         deltaValue = Scale * 0.0899; // /100.0F * ((sizeof(palette_arr)
@@ -41,23 +46,31 @@ class PatternSMFire2021 : public EffectWithId<PatternSMFire2021>
 
     void Draw() override
     {
+        auto& graphics = g();
+        auto* leds = graphics.leds;
+
+        CRGB fireColors[256];
+        fireColors[0] = CRGB::Black;
+
+        for (uint16_t col = 1; col < 256; col++)
+        {
+            const uint8_t bri = 256 - (col * 0.2f);
+            fireColors[col] = GetBlackBodyHeatColor(col / 255.0f, graphics.ColorFromCurrentPalette(0, bri)).fadeToBlackBy(255 - bri);
+        }
+
         ff_x += step; // static uint32_t t += speed;
         for (unsigned x = 0; x < MATRIX_WIDTH; x++)
         {
             for (unsigned y = 0; y < MATRIX_HEIGHT; y++)
             {
-                int16_t Bri = inoise8(x * deltaValue, (y * deltaValue) - ff_x, ff_z) - (y * (255 / MATRIX_HEIGHT));
-                uint8_t Col = Bri; // inoise8(x * deltaValue, (y * deltaValue) - ff_x, ff_z) - (y * (255 / MATRIX_HEIGHT));
-                if (Bri < 0)
-                    Bri = 0;
-                if (Bri != 0)
-                    Bri = 256 - (Bri * 0.2);
+                const int16_t bri = inoise8(x * deltaValue, (y * deltaValue) - ff_x, ff_z) - (y * (255 / MATRIX_HEIGHT));
+                const uint8_t col = bri;
 
                 // Get the flame color using the black body radiation approximation, but when the palette is paused
                 // we make flame in that base color instead of the normal red
                 // NightDriver mod - invert Y argument.
 
-                nblend(g()->leds[XY(x, MATRIX_HEIGHT - 1 - y)], GetBlackBodyHeatColor(Col/255.0f, g()->ColorFromCurrentPalette(0, Bri)).fadeToBlackBy(255-Bri), pcnt);
+                nblend(leds[XY(x, MATRIX_HEIGHT - 1 - y)], bri > 0 ? fireColors[col] : CRGB::Black, pcnt);
             }
         }
 

--- a/include/effects/matrix/PatternSMFlowFields.h
+++ b/include/effects/matrix/PatternSMFlowFields.h
@@ -32,7 +32,7 @@ class PatternSMFlowFields : public EffectWithId<PatternSMFlowFields>
 
     void Start() override
     {
-        g()->Clear();
+        g().Clear();
 
         x = random16();
         y = random16();
@@ -64,7 +64,7 @@ class PatternSMFlowFields : public EffectWithId<PatternSMFlowFields>
                 boid.location.x = random(COLS);
                 boid.location.y = 0;
             }
-            g()->drawPixelXYF_Wu(boid.location.x, boid.location.y, g()->ColorFromCurrentPalette(boid.hue, 255, LINEARBLEND));
+            g().drawPixelXYF_Wu(boid.location.x, boid.location.y, g().ColorFromCurrentPalette(boid.hue, 255, LINEARBLEND));
         }
         fadeAllChannelsToBlackBy(15);
 

--- a/include/effects/matrix/PatternSMGamma.h
+++ b/include/effects/matrix/PatternSMGamma.h
@@ -16,7 +16,7 @@ class PatternSMGamma : public EffectWithId<PatternSMGamma>
 
     void Start() override
     {
-        g()->Clear();
+        g().Clear();
     }
 
     void Draw() override
@@ -44,9 +44,9 @@ class PatternSMGamma : public EffectWithId<PatternSMGamma>
             for (uint y = 0; y < MATRIX_HEIGHT; y++)
             {
                 int index = XY(x, y);
-                g()->leds[index].b = exp_gamma[sin8((x - 8) * cos8((y + 20) * 4) / 4 + a)];
-                g()->leds[index].g = exp_gamma[(sin8(x * 16 + a / 3) + cos8(y * 8 + a / 2)) / 2];
-                g()->leds[index].r = exp_gamma[sin8(cos8(x * 8 + a / 3) + sin8(y * 8 + a / 4) + a)];
+                g().leds[index].b = exp_gamma[sin8((x - 8) * cos8((y + 20) * 4) / 4 + a)];
+                g().leds[index].g = exp_gamma[(sin8(x * 16 + a / 3) + cos8(y * 8 + a / 2)) / 2];
+                g().leds[index].r = exp_gamma[sin8(cos8(x * 8 + a / 3) + sin8(y * 8 + a / 4) + a)];
             }
         }
     }

--- a/include/effects/matrix/PatternSMHolidayLights.h
+++ b/include/effects/matrix/PatternSMHolidayLights.h
@@ -33,14 +33,14 @@ class PatternSMHolidayLights : public EffectWithId<PatternSMHolidayLights>
         uint16_t idx = random16(NUM_LEDS);
         for (unsigned i = 0; i < scaleToNumLeds; i++)
             if (random8() < density)
-                if ((g()->getPixel(idx).r + g()->getPixel(idx).g + g()->getPixel(idx).b) < 10)
-                    g()->leds[idx] = random(48, 16777216);
+                if ((g().getPixel(idx).r + g().getPixel(idx).g + g().getPixel(idx).b) < 10)
+                    g().leds[idx] = random(48, 16777216);
     }
 
     void addGlitter(uint8_t chanceOfGlitter)
     {
         if (random8() < chanceOfGlitter)
-            g()->leds[random16(NUM_LEDS)] = random(0, 16777215);
+            g().leds[random16(NUM_LEDS)] = random(0, 16777215);
     }
 
     void spruce()
@@ -65,26 +65,26 @@ class PatternSMHolidayLights : public EffectWithId<PatternSMHolidayLights>
         if (effId == 2)
         {
             // Draw a pixel with certain conditions if 'effId' is 2.
-            g()->drawPixelXYF_Wu(x / 4 + height_adj, (float)(MATRIX_HEIGHT - 1 - i),
+            g().drawPixelXYF_Wu(x / 4 + height_adj, (float)(MATRIX_HEIGHT - 1 - i),
                                  random8(10) == 0 ? CHSV(random8(), random8(32, 255), 255)
                                      : CHSV(100, 255, ::map(speed, 1, 255, 128, 100)));
         }
         else
         {
             // Draw a pixel with different color conditions if 'effId' is not 2.
-            g()->drawPixelXYF_Wu(x / 4 + height_adj, (float)(MATRIX_HEIGHT - 1 - i), CHSV(hue + i * z, 255, 255));
+            g().drawPixelXYF_Wu(x / 4 + height_adj, (float)(MATRIX_HEIGHT - 1 - i), CHSV(hue + i * z, 255, 255));
         }
     }
 
     // Set a specific LED color based on some conditions and time.
     if (!(MATRIX_WIDTH & 0x01))
     {
-        g()->leds[XY(MATRIX_WIDTH / 2 - ((millis() >> 9) & 0x01 ? 1 : 0), minDim - 1 - ((millis() >> 8) & 0x01 ? 1 : 0))] =
+        g().leds[XY(MATRIX_WIDTH / 2 - ((millis() >> 9) & 0x01 ? 1 : 0), minDim - 1 - ((millis() >> 8) & 0x01 ? 1 : 0))] =
             CHSV(0, 255, 255);
     }
     else
     {
-        g()->leds[XY(MATRIX_WIDTH / 2, minDim - 1)] = CHSV(0, (millis() >> 9) & 0x01 ? 0 : 255, 255);
+        g().leds[XY(MATRIX_WIDTH / 2, minDim - 1)] = CHSV(0, (millis() >> 9) & 0x01 ? 0 : 255, 255);
     }
 
     // If 'glitch' is true, call the 'confetti' function.
@@ -100,7 +100,7 @@ class PatternSMHolidayLights : public EffectWithId<PatternSMHolidayLights>
 
     void Start() override
     {
-        g()->Clear();
+        g().Clear();
     }
 
     void Draw() override

--- a/include/effects/matrix/PatternSMHypnosis.h
+++ b/include/effects/matrix/PatternSMHypnosis.h
@@ -19,7 +19,7 @@ class PatternSMHypnosis : public EffectWithId<PatternSMHypnosis>
 
     void Start() override
     {
-        g()->Clear();
+        g().Clear();
     }
 
     uint16_t t = 0;
@@ -31,8 +31,8 @@ class PatternSMHypnosis : public EffectWithId<PatternSMHypnosis>
 
         for (uint x = 0; x < MATRIX_WIDTH; x++)
             for (uint y = 0; y < MATRIX_HEIGHT; y++)
-                g()->leds[XY(x, y)] = ColorFromPalette(g()->IsPalettePaused()
-                                      ? g()->GetCurrentPalette()
+                g().leds[XY(x, y)] = ColorFromPalette(g().IsPalettePaused()
+                                      ? g().GetCurrentPalette()
                                       : RainbowStripeColors_p, t / 2 + rMap[x][y].scaled_radius + rMap[x][y].angle, sin8(rMap[x][y].angle + (rMap[x][y].scaled_radius * 2) - t));
     }
 };

--- a/include/effects/matrix/PatternSMMetaBalls.h
+++ b/include/effects/matrix/PatternSMMetaBalls.h
@@ -32,7 +32,7 @@ class PatternSMMetaBalls : public EffectWithId<PatternSMMetaBalls>
 
     void Start() override
     {
-        g()->Clear();
+        g().Clear();
     }
 
     void Draw() override
@@ -52,11 +52,11 @@ class PatternSMMetaBalls : public EffectWithId<PatternSMMetaBalls>
                     sum = qadd8(sum, dist(i, j, bx[a], by[a]));
                 }
                 // HeatColors2_p peaks with blue instead of white and looks nicer for this effect
-                g()->leds[XY(i, j)] = ColorFromPalette(HeatColors2_p, sum + 220, 254, LINEARBLEND);
+                g().leds[XY(i, j)] = ColorFromPalette(HeatColors2_p, sum + 220, 254, LINEARBLEND);
             }
         }
 
-        g()->blur2d(g()->leds, MATRIX_WIDTH - 1, 0, MATRIX_HEIGHT - 1, 0, 32);
+        g().blur2d(g().leds, MATRIX_WIDTH - 1, 0, MATRIX_HEIGHT - 1, 0, 32);
         fadeAllChannelsToBlackBy(10);
     }
 };

--- a/include/effects/matrix/PatternSMNoise.h
+++ b/include/effects/matrix/PatternSMNoise.h
@@ -396,7 +396,7 @@ class PatternSMNoise : public EffectWithId<PatternSMNoise>
 
     void Start() override
     {
-        g()->Clear();
+        g().Clear();
         noisex = random16();
         noisey = random16();
         noisez = random16();
@@ -593,7 +593,7 @@ class PatternSMNoise : public EffectWithId<PatternSMNoise>
                 CRGB color = ColorFromPalette(palette, index, bri);
                 uint16_t n = XY(i, j);
 
-                g()->leds[n] = color;
+                g().leds[n] = color;
             }
         }
         ihue += 1;

--- a/include/effects/matrix/PatternSMPicasso3in1.h
+++ b/include/effects/matrix/PatternSMPicasso3in1.h
@@ -109,14 +109,14 @@ class PatternSMPicasso3in1 : public EffectWithId<PatternSMPicasso3in1>
 
         for (uint8_t i = 0; i < enlargedObjectNUM - 2U; i += 2)
         {
-            g()->drawLine(trackingObjects[i].posX, trackingObjects[i].posY, trackingObjects[i + 1U].posX,
+            g().drawLine(trackingObjects[i].posX, trackingObjects[i].posY, trackingObjects[i + 1U].posX,
                      trackingObjects[i + 1U].posY, CHSV(trackingObjects[i].hue, 255U, 255U));
             // DrawLine(trackingObjectPosX[i], trackingObjectPosY[i],
             // trackingObjectPosX[i+1U], trackingObjectPosY[i+1U],
             // ColorFromPalette(*curPalette, trackingObjectHue[i]));
         }
 
-        g()->BlurFrame(80);
+        g().BlurFrame(80);
     }
 
     void PicassoRoutine2()
@@ -124,27 +124,27 @@ class PatternSMPicasso3in1 : public EffectWithId<PatternSMPicasso3in1>
         PicassoGenerate(false);
         PicassoPosition();
 
-        g()->DimAll(180);
+        g().DimAll(180);
 
         for (uint8_t i = 0; i < enlargedObjectNUM - 1U; i++)
-            g()->drawLine(trackingObjects[i].posX, trackingObjects[i].posY, trackingObjects[i + 1U].posX,
+            g().drawLine(trackingObjects[i].posX, trackingObjects[i].posY, trackingObjects[i + 1U].posX,
                       trackingObjects[i + 1U].posY, CHSV(trackingObjects[i].hue, 255U, 255U));
 
         EVERY_N_MILLIS(20000)
         {
             PicassoGenerate(true);
         }
-        g()->BlurFrame(80);
+        g().BlurFrame(80);
     }
 
     void PicassoRoutine3()
     {
         PicassoGenerate(false);
         PicassoPosition();
-        g()->DimAll(180);
+        g().DimAll(180);
 
         for (uint8_t i = 0; i < enlargedObjectNUM - 2U; i += 2)
-            g()->DrawSafeCircle(fabs(trackingObjects[i].posX - trackingObjects[i + 1U].posX),
+            g().DrawSafeCircle(fabs(trackingObjects[i].posX - trackingObjects[i + 1U].posX),
                        fabs(trackingObjects[i].posY - trackingObjects[i + 1U].posX),
                        fabs(trackingObjects[i].posX - trackingObjects[i].posY), CHSV(trackingObjects[i].hue, 255U, 255U));
 
@@ -152,7 +152,7 @@ class PatternSMPicasso3in1 : public EffectWithId<PatternSMPicasso3in1>
         {
             PicassoGenerate(true);
         }
-        g()->BlurFrame(80);
+        g().BlurFrame(80);
     }
 
   public:
@@ -207,7 +207,7 @@ class PatternSMPicasso3in1 : public EffectWithId<PatternSMPicasso3in1>
 
     void Start() override
     {
-        g()->Clear();
+        g().Clear();
 	    Scale = _scale;
         RecalibrateDrawnObjects();
     }

--- a/include/effects/matrix/PatternSMRadialFire.h
+++ b/include/effects/matrix/PatternSMRadialFire.h
@@ -13,7 +13,7 @@ class PatternSMRadialFire : public EffectWithId<PatternSMRadialFire>
 
     void Start() override
     {
-        g()->Clear();
+        g().Clear();
     }
 
     void Draw() override
@@ -47,8 +47,8 @@ class PatternSMRadialFire : public EffectWithId<PatternSMRadialFire>
 
                 // Step 2: Choose base color depending on palette state
                 CRGB baseColor;
-                if (g()->IsPalettePaused())
-                    baseColor = g()->ColorFromCurrentPalette(Col);
+                if (g().IsPalettePaused())
+                    baseColor = g().ColorFromCurrentPalette(Col);
                 else
                     baseColor = CRGB::Red;
 
@@ -57,7 +57,7 @@ class PatternSMRadialFire : public EffectWithId<PatternSMRadialFire>
 
                 // Step 4: Fade color based on brightness
                 CRGB color = heatColor.fadeToBlackBy(255 - Bri);
-                nblend(g()->leds[XY(x, y)], color, speed);
+                nblend(g().leds[XY(x, y)], color, speed);
             }
         }
     }

--- a/include/effects/matrix/PatternSMRadialWave.h
+++ b/include/effects/matrix/PatternSMRadialWave.h
@@ -19,7 +19,7 @@ class PatternSMRadialWave : public EffectWithId<PatternSMRadialWave>
 
     void Start() override
     {
-        g()->Clear();
+        g().Clear();
     }
 
     void Draw() override
@@ -34,7 +34,7 @@ class PatternSMRadialWave : public EffectWithId<PatternSMRadialWave>
             {
                 uint8_t angle = rMap[x][y].angle;
                 uint8_t radius = rMap[x][y].scaled_radius;
-                g()->leds[XY(x, y)] = CHSV(t + radius, 255, sin8(t * 4 + sin8(t * 4 - radius) + angle * 3));
+                g().leds[XY(x, y)] = CHSV(t + radius, 255, sin8(t * 4 + sin8(t * 4 - radius) + angle * 3));
             }
         }
     }

--- a/include/effects/matrix/PatternSMRainbowTunnel.h
+++ b/include/effects/matrix/PatternSMRainbowTunnel.h
@@ -14,7 +14,7 @@ class PatternSMRainbowTunnel : public EffectWithId<PatternSMRainbowTunnel>
 
     void Start() override
     {
-        g()->Clear();
+        g().Clear();
     }
 
     void Draw() override
@@ -34,7 +34,7 @@ class PatternSMRainbowTunnel : public EffectWithId<PatternSMRainbowTunnel>
             {
                 uint8_t angle = rMap[x][y].angle;
                 uint8_t radius = rMap[x][y].scaled_radius;
-                g()->leds[XY(x, y)] =
+                g().leds[XY(x, y)] =
                     CHSV((angle * scaleX) - t + (radius * scaleY), 255, constrain(radius * 3, 0, 255));
             }
         }

--- a/include/effects/matrix/PatternSMSmoke.h
+++ b/include/effects/matrix/PatternSMSmoke.h
@@ -32,7 +32,7 @@ public:
 
   void Start() override
   {
-    g()->Clear();
+    g().Clear();
   }
 
   void Draw() override
@@ -50,10 +50,10 @@ public:
 
       hue2++;
 
-    if (g()->IsPalettePaused())
+    if (g().IsPalettePaused())
     {
-      color = g()->ColorFromCurrentPalette(hue);
-      color2 = g()->ColorFromCurrentPalette(hue + 127);
+      color = g().ColorFromCurrentPalette(hue);
+      color2 = g().ColorFromCurrentPalette(hue + 127);
     }
     else
     {
@@ -70,10 +70,10 @@ public:
     // sky-written trailer of color.
     for (uint8_t y = 0; y < HEIGHT; y++)
     {
-      g()->leds[XY((deltaHue + y + 1U) % WIDTH, HEIGHT - 1U - y)] += color;
-      g()->leds[XY((deltaHue + y) % WIDTH, HEIGHT - 1U - y)] += color2; // color2
-      g()->leds[XY((deltaHue2 + y) % WIDTH, y)] += color;
-      g()->leds[XY((deltaHue2 + y + 1U) % WIDTH, y)] += color2; // color2
+      g().leds[XY((deltaHue + y + 1U) % WIDTH, HEIGHT - 1U - y)] += color;
+      g().leds[XY((deltaHue + y) % WIDTH, HEIGHT - 1U - y)] += color2; // color2
+      g().leds[XY((deltaHue2 + y) % WIDTH, y)] += color;
+      g().leds[XY((deltaHue2 + y + 1U) % WIDTH, y)] += color2; // color2
     }
 
     EVERY_N_MILLISECONDS(100)
@@ -82,16 +82,16 @@ public:
       // Calling SetNoise() in here will index past what was
       // FillGetNoised, which returns slowly scrolling bars
       // of black along X and Y axes.
-      g()->FillGetNoise();
-      // g()->SetNoise(1, 1, 1, 4, 4);
+      g().FillGetNoise();
+      // g().SetNoise(1, 1, 1, 4, 4);
     }
 
     // Lower number for thicker, more static fog. Higher for more wisp.
     // Smearing 1 was the minimal fix that cured the vertical bars.
-    g()->MoveFractionalNoiseX(1);
-    g()->MoveFractionalNoiseY(1);
+    g().MoveFractionalNoiseX(1);
+    g().MoveFractionalNoiseY(1);
     // Without this, we get tornadoes where the diagonals cross as there's
     // an excess of set pixels there.
-    g()->BlurFrame(10);
+    g().BlurFrame(10);
   }
 };

--- a/include/effects/matrix/PatternSMSpiroPulse.h
+++ b/include/effects/matrix/PatternSMSpiroPulse.h
@@ -25,7 +25,7 @@ class PatternSMSpiroPulse : public EffectWithId<PatternSMSpiroPulse>
 
     void Start() override
     {
-        g()->Clear();
+        g().Clear();
     }
 
     void Draw() override
@@ -55,7 +55,7 @@ class PatternSMSpiroPulse : public EffectWithId<PatternSMSpiroPulse>
         float radY = CalcRad * CenterY / 2;
         for (uint8_t i = 0; i < AM; i++)
         {
-            g()->drawPixelXYF_Wu((CenterX + sin(t + (Angle * i)) * radX),
+            g().drawPixelXYF_Wu((CenterX + sin(t + (Angle * i)) * radX),
                 MATRIX_HEIGHT - 1 - (CenterY + cos(t + (Angle * i)) * radY),
                 ColorFromPalette(HeatColors_p, t * 10 + ((256 / AM) * i)));
         }

--- a/include/effects/matrix/PatternSMStarDeep.h
+++ b/include/effects/matrix/PatternSMStarDeep.h
@@ -55,7 +55,7 @@ class PatternSMStarDeep : public EffectWithId<PatternSMStarDeep>
     {
         if (numPoints == 0) return;
 
-        const CRGB starColor = g()->IsPalettePaused() ? g()->ColorFromCurrentPalette(colorIndex) : ColorFromPalette(*curPalette, colorIndex);
+        const CRGB starColor = g().IsPalettePaused() ? g().ColorFromCurrentPalette(colorIndex) : ColorFromPalette(*curPalette, colorIndex);
         const uint8_t angle_step = 255 / numPoints;
 
         for (uint8_t i = 0; i < numPoints; i++)
@@ -79,7 +79,7 @@ class PatternSMStarDeep : public EffectWithId<PatternSMStarDeep>
 
     // Custom line drawing function.
     // This implementation is kept for its specific visual characteristics ("funky wrapping corners"),
-    // which differ from the standard g()->DrawLine().
+    // which differ from the standard g().DrawLine().
     void DrawStarLine(int x1, int y1, int x2, int y2, CRGB color)
     {
         int x, y;
@@ -108,9 +108,9 @@ class PatternSMStarDeep : public EffectWithId<PatternSMStarDeep>
         for (x = x1; x <= x2; x++)
         {
             if (isSteep)
-                g()->drawPixel(y, MATRIX_HEIGHT - 1 - x, color);
+                g().drawPixel(y, MATRIX_HEIGHT - 1 - x, color);
             else
-                g()->drawPixel(x, MATRIX_HEIGHT - 1 - y, color);
+                g().drawPixel(x, MATRIX_HEIGHT - 1 - y, color);
             err -= dy;
             if (err < 0)
             {
@@ -122,7 +122,7 @@ class PatternSMStarDeep : public EffectWithId<PatternSMStarDeep>
 
     void Start() override
     {
-        g()->Clear();
+        g().Clear();
 
         // Set an initial location and movement vector for the animation center.
         driftx = random8(4, MATRIX_WIDTH - 4);
@@ -149,7 +149,7 @@ class PatternSMStarDeep : public EffectWithId<PatternSMStarDeep>
 
     void Draw() override
     {
-        g()->DimAll(175U);
+        g().DimAll(175U);
         counter++;
 
         // Update drift center position, bouncing off the edges of the defined drift area.

--- a/include/effects/matrix/PatternSMStrobeDiffusion.h
+++ b/include/effects/matrix/PatternSMStrobeDiffusion.h
@@ -80,7 +80,7 @@ class PatternSMStrobeDiffusion : public EffectWithId<PatternSMStrobeDiffusion>
     {
         //  	  FPSdelay = 25U; // LOW_DELAY;
         //    hue2 = 1;
-        g()->Clear();
+        g().Clear();
     }
 
     // =========== Christmas Tree ===========
@@ -104,7 +104,7 @@ class PatternSMStrobeDiffusion : public EffectWithId<PatternSMStrobeDiffusion>
                 snowAt(x, y) = snowAt(x, y - 1);
                 if (snowAt(x, y) > 0)
                 {
-                    g()->drawPixel(x, y, CHSV(170, 5U, 127 + random8(128)));
+                    g().drawPixel(x, y, CHSV(170, 5U, 127 + random8(128)));
                 }
             }
         }
@@ -139,8 +139,8 @@ class PatternSMStrobeDiffusion : public EffectWithId<PatternSMStrobeDiffusion>
         {
             // diffusion ---
             // The offset is to skip the VU meter.
-            g()->blur2d(g()->leds, MATRIX_WIDTH, 0, MATRIX_HEIGHT, top_line_offset, beatsin8(3, 64, 80));
-            // g()->blur2d(g()->leds, MATRIX_WIDTH, 0, MATRIX_HEIGHT, top_line_offset,
+            g().blur2d(g().leds, MATRIX_WIDTH, 0, MATRIX_HEIGHT, top_line_offset, beatsin8(3, 64, 80));
+            // g().blur2d(g().leds, MATRIX_WIDTH, 0, MATRIX_HEIGHT, top_line_offset,
             // 24);
             FPSdelay = LOW_DELAY;
             STEP = 1U;
@@ -156,12 +156,12 @@ class PatternSMStrobeDiffusion : public EffectWithId<PatternSMStrobeDiffusion>
             // strob -------
             if (Scale > 25)
             {
-                g()->DimAll(200);
+                g().DimAll(200);
                 FPSdelay = 30;
             }
             else
             {
-                g()->DimAll(24);
+                g().DimAll(24);
                 FPSdelay = 40;
             }
         }
@@ -183,22 +183,22 @@ class PatternSMStrobeDiffusion : public EffectWithId<PatternSMStrobeDiffusion>
             {
                 if ((step % STEP) == 0)
                 { // small layers
-                    g()->drawPixel(MATRIX_WIDTH - 1, y * 3 + DELTA, CHSV(step, 255U, 255U));
+                    g().drawPixel(MATRIX_WIDTH - 1, y * 3 + DELTA, CHSV(step, 255U, 255U));
                 }
                 else
                 {
-                    g()->drawPixel(MATRIX_WIDTH - 1, y * 3 + DELTA, CHSV(170U, 255U, 1U));
+                    g().drawPixel(MATRIX_WIDTH - 1, y * 3 + DELTA, CHSV(170U, 255U, 1U));
                 }
             }
             else
             {
                 if ((step % STEP) == 0)
                 { // big layers
-                    g()->drawPixel(0, y * 3 + DELTA, CHSV((step + deltaHue), 255U, 255U));
+                    g().drawPixel(0, y * 3 + DELTA, CHSV((step + deltaHue), 255U, 255U));
                 }
                 else
                 {
-                    g()->drawPixel(0, y * 3 + DELTA, CHSV(0U, 255U, 0U));
+                    g().drawPixel(0, y * 3 + DELTA, CHSV(0U, 255U, 0U));
                 }
             }
 
@@ -207,11 +207,11 @@ class PatternSMStrobeDiffusion : public EffectWithId<PatternSMStrobeDiffusion>
             {
                 if (dir)
                 { // <==
-                    g()->drawPixel(x, y * 3 + DELTA, g()->getPixel(x, y * 3 + DELTA));
+                    g().drawPixel(x, y * 3 + DELTA, g().getPixel(x, y * 3 + DELTA));
                 }
                 else
                 { // ==>
-                    g()->drawPixel(MATRIX_WIDTH - x, y * 3 + DELTA, g()->getPixel(MATRIX_WIDTH - x, y * 3 + DELTA));
+                    g().drawPixel(MATRIX_WIDTH - x, y * 3 + DELTA, g().getPixel(MATRIX_WIDTH - x, y * 3 + DELTA));
                 }
             }
             dir = !dir;

--- a/include/effects/matrix/PatternSMSupernova.h
+++ b/include/effects/matrix/PatternSMSupernova.h
@@ -21,13 +21,13 @@ public:
     {
         std::for_each(_debris_items.begin(), _debris_items.end(),
 		              [](DebrisItem& debris_item) { debris_item.Clear(); });
-        g()->Clear();
+        g().Clear();
     }
 
     void Draw() override
     {
         step = -1;
-        g()->DimAll(200);
+        g().DimAll(200);
 
         for (auto& debris_item : _debris_items) {
             if (!debris_item._is_shift && step) {
@@ -36,9 +36,9 @@ public:
             }
 
             if (debris_item._is_shift && ParticlesUpdate(debris_item)) {
-                CRGB baseRGB = ColorFromPalette(g()->IsPalettePaused() ? g()->GetCurrentPalette() : HeatColors_p, debris_item._hue, 255, LINEARBLEND);
+                CRGB baseRGB = ColorFromPalette(g().IsPalettePaused() ? g().GetCurrentPalette() : HeatColors_p, debris_item._hue, 255, LINEARBLEND);
                 baseRGB.nscale8(debris_item._state);
-                g()->drawPixelXYF_Wu(debris_item._position_x, debris_item._position_y, baseRGB);
+                g().drawPixelXYF_Wu(debris_item._position_x, debris_item._position_y, baseRGB);
             }
         }
     }

--- a/include/effects/matrix/PatternSMTwister.h
+++ b/include/effects/matrix/PatternSMTwister.h
@@ -20,15 +20,15 @@ class PatternSMTwister : public EffectWithId<PatternSMTwister>
         {
             uint8_t dx = lerp8by8(x1, x, i * 255 / steps);
             uint16_t index = XY(dx, y);
-            g()->leds[index] = color;
+            g().leds[index] = color;
             if (grad)
-                g()->leds[index] %=
+                g().leds[index] %=
                     (sin8(numline * 8 + side * 64 + a + sinOff) + i * 255 / steps) / 2; // for draw gradient line
         }
         if (dot)
         { // add white point at the ends of line
-            g()->leds[XY(x, y)] = CRGB::Black;
-            g()->leds[XY(x1, y)] = CRGB::Black;
+            g().leds[XY(x, y)] = CRGB::Black;
+            g().leds[XY(x1, y)] = CRGB::Black;
         }
     }
 
@@ -39,13 +39,13 @@ class PatternSMTwister : public EffectWithId<PatternSMTwister>
 
     void Start() override
     {
-        g()->Clear();
+        g().Clear();
     }
 
     void Draw() override
     {
         uint16_t a = millis() / 10;
-        g()->Clear();
+        g().Clear();
 
         for (uint16_t i = 0; i < MATRIX_HEIGHT; i++)
         {

--- a/include/effects/matrix/PatternSMWalkingMachine.h
+++ b/include/effects/matrix/PatternSMWalkingMachine.h
@@ -31,12 +31,12 @@ class PatternSMWalkingMachine : public EffectWithId<PatternSMWalkingMachine>
 
     void Start() override
     {
-        g()->Clear();
+        g().Clear();
     }
 
     void Draw() override
     {
-        g()->Clear();
+        g().Clear();
 
         for (uint8_t i = 0; i < 7; i++)
         {
@@ -45,8 +45,8 @@ class PatternSMWalkingMachine : public EffectWithId<PatternSMWalkingMachine>
         }
         for (uint8_t i = 0; i < 7; i++)
         {
-            g()->drawSafeFilledCircleF(dot[i].posX, dot[i].posY, 4, CHSV(i * 32, 255, 255));
-            g()->drawLineF(dot[i].posX, dot[i].posY, dot[(i + 1) % 7].posX, dot[(i + 1) % 7].posY, CHSV(i * 32, 255, 255),
+            g().drawSafeFilledCircleF(dot[i].posX, dot[i].posY, 4, CHSV(i * 32, 255, 255));
+            g().drawLineF(dot[i].posX, dot[i].posY, dot[(i + 1) % 7].posX, dot[(i + 1) % 7].posY, CHSV(i * 32, 255, 255),
                       CHSV(((i + 1) % 7) * 32, 255, 255));
         }
     }

--- a/include/effects/matrix/PatternSerendipity.h
+++ b/include/effects/matrix/PatternSerendipity.h
@@ -149,24 +149,24 @@ class PatternSerendipity : public EffectWithId<PatternSerendipity>
 
     void Draw() override
     {
-        auto graphics = g();
+        auto& graphics = g();
 
         // manage the Oszillators
         UpdateTimers();
 
         // draw just a line defined by 5 oszillators
 
-        graphics->drawLine(
+        graphics.drawLine(
             multiTimer[3].count, // x1
             multiTimer[4].count, // y1
             multiTimer[0].count, // x2
             multiTimer[1].count, // y2
             CRGB(CHSV(multiTimer[2].count, 255, 255)));
 
-        graphics->BlurFrame(50);
+        graphics.BlurFrame(50);
 
         // increase the contrast
-//        graphics->DimAll(252);
+//        graphics.DimAll(252);
         return;
     }
 };

--- a/include/effects/matrix/PatternSpin.h
+++ b/include/effects/matrix/PatternSpin.h
@@ -87,9 +87,9 @@ class PatternSpin : public EffectWithId<PatternSpin>
 
     void Draw() override
     {
-        g()->DimAll(190);
+        g().DimAll(190);
 
-        CRGB color = g()->ColorFromCurrentPalette(speed * 8);
+        CRGB color = g().ColorFromCurrentPalette(speed * 8);
 
         // start position
         int x;
@@ -108,8 +108,8 @@ class PatternSpin : public EffectWithId<PatternSpin>
             x = (int) (MATRIX_CENTER_X + radius * cos(radians));
             y = (int) (MATRIX_CENTER_Y - radius * sin(radians));
 
-            g()->drawPixel(x, y, color);
-            g()->drawPixel(y, x, color);
+            g().drawPixel(x, y, color);
+            g().drawPixel(y, x, color);
 
             tempDegrees += 1;
             if (tempDegrees >= 360)

--- a/include/effects/matrix/PatternSpiro.h
+++ b/include/effects/matrix/PatternSpiro.h
@@ -94,8 +94,8 @@ public:
   }
   void Draw() override
   {
-    auto graphics = g();
-    graphics->DimAll(253);
+    auto& graphics = g();
+    graphics.DimAll(253);
 
     // effects.ShowFrame();
 
@@ -103,14 +103,14 @@ public:
 
     for (int i = 0; i < spirocount; i++)
     {
-      uint8_t x = graphics->mapsin8(theta1 + i * spirooffset, minx, maxx);
-      uint8_t y = graphics->mapcos8(theta1 + i * spirooffset, miny, maxy);
+      uint8_t x = graphics.mapsin8(theta1 + i * spirooffset, minx, maxx);
+      uint8_t y = graphics.mapcos8(theta1 + i * spirooffset, miny, maxy);
 
-      uint8_t x2 = graphics->mapsin8(theta2 + i * spirooffset, x - radiusx, x + radiusx);
-      uint8_t y2 = graphics->mapcos8(theta2 + i * spirooffset, y - radiusy, y + radiusy);
+      uint8_t x2 = graphics.mapsin8(theta2 + i * spirooffset, x - radiusx, x + radiusx);
+      uint8_t y2 = graphics.mapcos8(theta2 + i * spirooffset, y - radiusy, y + radiusy);
 
-      CRGB color = graphics->ColorFromCurrentPalette(hueoffset + i * spirooffset, 128);
-      graphics->leds[graphics->xy(x2, y2)] += color;
+      CRGB color = graphics.ColorFromCurrentPalette(hueoffset + i * spirooffset, 128);
+      graphics.leds[graphics.xy(x2, y2)] += color;
 
       if (x2 == MATRIX_CENTER_X && y2 == MATRIX_CENTER_Y)
         change = true;

--- a/include/effects/matrix/PatternStocks.h
+++ b/include/effects/matrix/PatternStocks.h
@@ -429,15 +429,17 @@ public:
 
     void UpdateQuoteDisplay()
     {
+        auto& graphics = g();
+
         textSymbol.UpdatePos();
         textPrice.UpdatePos();
         textChange.UpdatePos();
         textVolume.UpdatePos();
 
-        textSymbol.Draw(g().get());
-        textPrice.Draw(g().get());
-        textChange.Draw(g().get());
-        textVolume.Draw(g().get());
+        textSymbol.Draw(&graphics);
+        textPrice.Draw(&graphics);
+        textChange.Draw(&graphics);
+        textVolume.Draw(&graphics);
 
         if (stockData.empty())
             return;
@@ -486,9 +488,9 @@ public:
                     // Now draw from bottom up to breakeven in red, and from breakeven to top in green
 
                     if (currentStock.points[i].val < breakeven)
-                        g()->drawLine(x0, breakevenY, x1, y1, CRGB::Red);
+                        graphics.drawLine(x0, breakevenY, x1, y1, CRGB::Red);
                     else
-                        g()->drawLine(x0, y0, x1, breakevenY, CRGB::Green);
+                        graphics.drawLine(x0, y0, x1, breakevenY, CRGB::Green);
                 }
             }
         }
@@ -501,8 +503,9 @@ public:
 
     void Draw() override
     {
-        g()->fillScreen(BLACK16);
-        g()->fillRect(0, 0, MATRIX_WIDTH, 9, g()->to16bit(CRGB(0,0,128)));
+        auto& graphics = g();
+        graphics.fillScreen(BLACK16);
+        graphics.fillRect(0, 0, MATRIX_WIDTH, 9, graphics.to16bit(CRGB(0,0,128)));
 
         // Periodically refetch the stock data from the server
 

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -221,18 +221,18 @@ class PatternSubscribers : public EffectWithId<PatternSubscribers>
 
     void Draw() override
     {
-        g()->Clear(backgroundColor);
+        g().Clear(backgroundColor);
 
         // Draw a border around the edge of the panel
-        g()->drawRect(0, 1, MATRIX_WIDTH - 1, MATRIX_HEIGHT - 2, g()->to16bit(borderColor));
+        g().drawRect(0, 1, MATRIX_WIDTH - 1, MATRIX_HEIGHT - 2, g().to16bit(borderColor));
 
         // Use the centralized Apple5x7 Adafruit font
-        g()->setFont(&Apple5x7);
+        g().setFont(&Apple5x7);
 
         // Draw the channel name
-        g()->setTextColor(g()->to16bit(CRGB::White));
-        g()->setCursor(2, 10);
-        g()->print(youtubeChannelName.c_str());
+        g().setTextColor(g().to16bit(CRGB::White));
+        g().setCursor(2, 10);
+        g().print(youtubeChannelName.c_str());
 
         // Start in the middle of the panel and then back up a half a row to center vertically,
         // then back up left one half a char for every 10s digit in the subscriber count.  This
@@ -245,7 +245,7 @@ class PatternSubscribers : public EffectWithId<PatternSubscribers>
         // Use getTextBounds to get the actual dimensions of the subscriber text
         int16_t x1, y1;
         uint16_t textWidth, textHeight;
-        g()->getTextBounds(pszText, 0, 0, &x1, &y1, &textWidth, &textHeight);
+        g().getTextBounds(pszText, 0, 0, &x1, &y1, &textWidth, &textHeight);
 
         // Center the text horizontally and vertically on the screen
         // Note: y1 is typically negative (above baseline), so we need to account for that
@@ -253,15 +253,15 @@ class PatternSubscribers : public EffectWithId<PatternSubscribers>
         int y = (MATRIX_HEIGHT / 2) - (textHeight / 2) - y1;  // Properly center vertically
 
         // Draw shadow effect by printing in black at offset positions, then white on top
-        g()->setTextColor(g()->to16bit(CRGB::Black));
-        g()->setCursor(x-1, y);   g()->print(pszText);
-        g()->setCursor(x+1, y);   g()->print(pszText);
-        g()->setCursor(x, y-1);   g()->print(pszText);
-        g()->setCursor(x, y+1);   g()->print(pszText);
+        g().setTextColor(g().to16bit(CRGB::Black));
+        g().setCursor(x-1, y);   g().print(pszText);
+        g().setCursor(x+1, y);   g().print(pszText);
+        g().setCursor(x, y-1);   g().print(pszText);
+        g().setCursor(x, y+1);   g().print(pszText);
 
-        g()->setTextColor(g()->to16bit(CRGB::White));
-        g()->setCursor(x, y);
-        g()->print(pszText);
+        g().setTextColor(g().to16bit(CRGB::White));
+        g().setCursor(x, y);
+        g().print(pszText);
     }
 
     // Extension override to serialize our settings on top of those from LEDStripEffect

--- a/include/effects/matrix/PatternSwirl.h
+++ b/include/effects/matrix/PatternSwirl.h
@@ -72,24 +72,24 @@ class PatternSwirl : public EffectWithId<PatternSwirl>
 
     void drawAt(int i, int j, CRGB color)
     {
-        g()->leds[XY(i, j - 1)] += color;
-        g()->leds[XY(i, j + 1)] += color;
-        g()->leds[XY(i - 1, j)] += color;
-        g()->leds[XY(i + 1, j)] += color;
+        g().leds[XY(i, j - 1)] += color;
+        g().leds[XY(i, j + 1)] += color;
+        g().leds[XY(i - 1, j)] += color;
+        g().leds[XY(i + 1, j)] += color;
         color.maximizeBrightness();
-        g()->leds[XY(i, j)] += color;
+        g().leds[XY(i, j)] += color;
     }
 
     void Draw() override
     {
-        auto graphics = g();
+        auto& graphics = g();
         // Apply some blurring to whatever's already on the matrix
         // Note that we never actually clear the matrix, we just constantly
         // blur it repeatedly.  Since the blurring is 'lossy', there's
         // an automatic trend toward black -- by design.
 
         uint8_t blurAmount = beatsin8(2, 15, 255);
-        graphics->BlurFrame(blurAmount);
+        graphics.BlurFrame(blurAmount);
 
         // Use two out-of-sync sine waves
         uint8_t i = beatsin8(27, borderWidth, MATRIX_WIDTH - 1 - borderWidth);
@@ -101,13 +101,13 @@ class PatternSwirl : public EffectWithId<PatternSwirl>
         // The color of each point shifts over time, each at a different speed.
         uint16_t ms = millis();
 
-        drawAt(i, j, graphics->ColorFromCurrentPalette(ms / 11));
-        drawAt(i, j, graphics->ColorFromCurrentPalette(ms / 11));
-        drawAt(j * 2, i / 2, graphics->ColorFromCurrentPalette(ms / 13));
-        drawAt(nj * 2, ni / 2, graphics->ColorFromCurrentPalette(ms / 29));
-        drawAt(ni, nj, graphics->ColorFromCurrentPalette(ms / 17));
-        drawAt(i, nj, graphics->ColorFromCurrentPalette(ms / 37));
-        drawAt(ni, j, graphics->ColorFromCurrentPalette(ms / 41));
+        drawAt(i, j, graphics.ColorFromCurrentPalette(ms / 11));
+        drawAt(i, j, graphics.ColorFromCurrentPalette(ms / 11));
+        drawAt(j * 2, i / 2, graphics.ColorFromCurrentPalette(ms / 13));
+        drawAt(nj * 2, ni / 2, graphics.ColorFromCurrentPalette(ms / 29));
+        drawAt(ni, nj, graphics.ColorFromCurrentPalette(ms / 17));
+        drawAt(i, nj, graphics.ColorFromCurrentPalette(ms / 37));
+        drawAt(ni, j, graphics.ColorFromCurrentPalette(ms / 41));
     }
 };
 

--- a/include/effects/matrix/PatternWave.h
+++ b/include/effects/matrix/PatternWave.h
@@ -101,7 +101,7 @@ public:
 
     void Draw() override
     {
-        auto graphics = g();
+        auto& graphics = g();
 
         int n = 0;
 
@@ -111,9 +111,9 @@ public:
                     n = quadwave8(x * 2 + theta) / scale;
                     if (n < MATRIX_HEIGHT)
                     {
-                        graphics->setPixel(x, n, graphics->ColorFromCurrentPalette(x + hue));
+                        graphics.setPixel(x, n, graphics.ColorFromCurrentPalette(x + hue));
                         if (waveCount == 2)
-                            graphics->setPixel(x, maxY - n, graphics->ColorFromCurrentPalette(x + hue));
+                            graphics.setPixel(x, maxY - n, graphics.ColorFromCurrentPalette(x + hue));
                     }
                 }
                 break;
@@ -123,9 +123,9 @@ public:
                     n = quadwave8(y * 2 + theta) / scale;
                     if (n < MATRIX_WIDTH)
                     {
-                        graphics->setPixel(n, y, graphics->ColorFromCurrentPalette(y + hue));
+                        graphics.setPixel(n, y, graphics.ColorFromCurrentPalette(y + hue));
                         if (waveCount == 2)
-                            graphics->setPixel(maxX - n, y, graphics->ColorFromCurrentPalette(y + hue));
+                            graphics.setPixel(maxX - n, y, graphics.ColorFromCurrentPalette(y + hue));
                     }
                 }
                 break;
@@ -135,9 +135,9 @@ public:
                     n = quadwave8(x * 2 - theta) / scale;
                     if (n < MATRIX_HEIGHT)
                     {
-                        graphics->setPixel(x, n, graphics->ColorFromCurrentPalette(x + hue));
+                        graphics.setPixel(x, n, graphics.ColorFromCurrentPalette(x + hue));
                         if (waveCount == 2)
-                            graphics->setPixel(x, maxY - n, graphics->ColorFromCurrentPalette(x + hue));
+                            graphics.setPixel(x, maxY - n, graphics.ColorFromCurrentPalette(x + hue));
                     }
                 }
                 break;
@@ -147,15 +147,15 @@ public:
                     n = quadwave8(y * 2 - theta) / scale;
                     if (n < MATRIX_WIDTH)
                     {
-                        graphics->setPixel(n, y, graphics->ColorFromCurrentPalette(y + hue));
+                        graphics.setPixel(n, y, graphics.ColorFromCurrentPalette(y + hue));
                         if (waveCount == 2)
-                            graphics->setPixel(maxX - n, y, graphics->ColorFromCurrentPalette(y + hue));
+                            graphics.setPixel(maxX - n, y, graphics.ColorFromCurrentPalette(y + hue));
                     }
                 }
                 break;
         }
 
-        graphics->DimAll(254);
+        graphics.DimAll(254);
 
         if (thetaUpdate >= thetaUpdateFrequency) {
             thetaUpdate = 0;

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -490,9 +490,9 @@ public:
         const int fontWidth  = 5;
         const int xHalf      = MATRIX_WIDTH / 2 - 1;
 
-        g()->fillScreen(BLACK16);
-        g()->fillRect(0, 0, MATRIX_WIDTH, 9, g()->to16bit(CRGB(0,0,128)));
-        g()->setFont(&Apple5x7);
+        g().fillScreen(BLACK16);
+        g().fillRect(0, 0, MATRIX_WIDTH, 9, g().to16bit(CRGB(0,0,128)));
+        g().setFont(&Apple5x7);
 
         auto now = system_clock::now();
 
@@ -529,14 +529,14 @@ public:
         // Print the town/city name
         int x = 0;
         int y = fontHeight + 1;
-        g()->setCursor(x, y);
-        g()->setTextColor(WHITE16);
+        g().setCursor(x, y);
+        g().setTextColor(WHITE16);
         String showLocation = strLocation;
         showLocation.toUpperCase();
         if (g_ptrSystem->GetDeviceConfig().GetOpenWeatherAPIKey().isEmpty())
-            g()->print("No API Key");
+            g().print("No API Key");
         else
-            g()->print((strLocationName.isEmpty() ? showLocation : strLocationName).substring(0, (MATRIX_WIDTH - 2 * fontWidth)/fontWidth));
+            g().print((strLocationName.isEmpty() ? showLocation : strLocationName).substring(0, (MATRIX_WIDTH - 2 * fontWidth)/fontWidth));
 
         // Display the temperature, right-justified
 
@@ -544,17 +544,17 @@ public:
         {
             String strTemp((int)temperature);
             x = MATRIX_WIDTH - fontWidth * strTemp.length();
-            g()->setCursor(x, y);
-            g()->setTextColor(g()->to16bit(CRGB(192,192,192)));
-            g()->print(strTemp);
+            g().setCursor(x, y);
+            g().setTextColor(g().to16bit(CRGB(192,192,192)));
+            g().print(strTemp);
         }
 
         // Draw the separator lines
 
         y+=1;
 
-        g()->drawLine(0, y, MATRIX_WIDTH-1, y, CRGB(0,0,128));
-        g()->drawLine(xHalf, y, xHalf, MATRIX_HEIGHT-1, CRGB(0,0,128));
+        g().drawLine(0, y, MATRIX_WIDTH-1, y, CRGB(0,0,128));
+        g().drawLine(xHalf, y, xHalf, MATRIX_HEIGHT-1, CRGB(0,0,128));
         y+=2 + fontHeight;
 
         // Figure out which day of the week it is
@@ -565,17 +565,17 @@ public:
         const char * pszTomorrow = pszDaysOfWeek[ (todayTime->tm_wday + 1) % 7 ];
 
         // Draw the day of the week and tomorrow's day as well
-        g()->setTextColor(WHITE16);
-        g()->setCursor(0, MATRIX_HEIGHT);
-        g()->print(pszToday);
-        g()->setCursor(xHalf+2, MATRIX_HEIGHT);
-        g()->print(pszTomorrow);
+        g().setTextColor(WHITE16);
+        g().setCursor(0, MATRIX_HEIGHT);
+        g().print(pszToday);
+        g().setCursor(xHalf+2, MATRIX_HEIGHT);
+        g().print(pszTomorrow);
 
         // Draw the temperature in lighter white
 
         if (dataReady)
         {
-            g()->setTextColor(g()->to16bit(CRGB(192,192,192)));
+            g().setTextColor(g().to16bit(CRGB(192,192,192)));
             String strHi((int) highToday);
             String strLo((int) loToday);
 
@@ -583,12 +583,12 @@ public:
 
             x = xHalf - fontWidth * strHi.length();
             y = MATRIX_HEIGHT - fontHeight;
-            g()->setCursor(x,y);
-            g()->print(strHi);
+            g().setCursor(x,y);
+            g().print(strHi);
             x = xHalf - fontWidth * strLo.length();
             y+= fontHeight;
-            g()->setCursor(x,y);
-            g()->print(strLo);
+            g().setCursor(x,y);
+            g().print(strLo);
 
             // Draw tomorrow's HI and LO temperatures
 
@@ -596,12 +596,12 @@ public:
             strLo = String((int)loTomorrow);
             x = MATRIX_WIDTH - fontWidth * strHi.length();
             y = MATRIX_HEIGHT - fontHeight;
-            g()->setCursor(x,y);
-            g()->print(strHi);
+            g().setCursor(x,y);
+            g().print(strHi);
             x = MATRIX_WIDTH - fontWidth * strLo.length();
             y+= fontHeight;
-            g()->setCursor(x,y);
-            g()->print(strLo);
+            g().setCursor(x,y);
+            g().print(strLo);
         }
     }
 };

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -320,7 +320,7 @@ class SpectrumAnalyzerEffect : public EffectWithId<SpectrumAnalyzerEffect>, virt
 
     void DrawBar(const uint8_t iBar, CRGB baseColor, int offset = 0)
     {
-        auto pGFXChannel = g();
+        auto& pGFXChannel = g();
         int value, value2;
 
         static_assert(!(NUM_BANDS & 1));     // We assume an even number of bars because we peek ahead from an odd one below
@@ -336,25 +336,25 @@ class SpectrumAnalyzerEffect : public EffectWithId<SpectrumAnalyzerEffect>, virt
             // bar 16, for example, it will take all of bar 4 and none of bar 5.  For bar 17, it will take 3/4 of bar 4 and 1/4 of bar 5.
 
             int ib = iBar % barsPerBand;
-            value  = (g_Analyzer.Peak2Decay(iBand) * (barsPerBand - ib) + g_Analyzer.Peak2Decay(iNextBand) * (ib) ) / barsPerBand * (pGFXChannel->height() - 1);
-            value2 = (g_Analyzer.Peak2Decay(iBand) * (barsPerBand - ib) + g_Analyzer.Peak2Decay(iNextBand) * (ib) ) / barsPerBand *  pGFXChannel->height();
+            value  = (g_Analyzer.Peak2Decay(iBand) * (barsPerBand - ib) + g_Analyzer.Peak2Decay(iNextBand) * (ib) ) / barsPerBand * (pGFXChannel.height() - 1);
+            value2 = (g_Analyzer.Peak2Decay(iBand) * (barsPerBand - ib) + g_Analyzer.Peak2Decay(iNextBand) * (ib) ) / barsPerBand *  pGFXChannel.height();
         }
         else
         {
             // One to one case, just use the actual band value we mapped to
 
-            value  = g_Analyzer.Peak2Decay(iBand) * (pGFXChannel->height() - 1);
-            value2 = g_Analyzer.Peak2Decay(iBand) *  pGFXChannel->height();
+            value  = g_Analyzer.Peak2Decay(iBand) * (pGFXChannel.height() - 1);
+            value2 = g_Analyzer.Peak2Decay(iBand) *  pGFXChannel.height();
         }
 
 
-        if (value > pGFXChannel->height())
-            value = pGFXChannel->height();
+        if (value > pGFXChannel.height())
+            value = pGFXChannel.height();
 
-        if (value2 > pGFXChannel->height())
-            value2 = pGFXChannel->height();
+        if (value2 > pGFXChannel.height())
+            value2 = pGFXChannel.height();
 
-        int barWidth  = pGFXChannel->width() / _numBars;
+        int barWidth  = pGFXChannel.width() / _numBars;
         int xOffset   = iBar * barWidth;
 
         // The top of the bar is normally just matrix height less the value.  Here, however, we "enhance" the bar by pulsing it a bit with
@@ -366,14 +366,14 @@ class SpectrumAnalyzerEffect : public EffectWithId<SpectrumAnalyzerEffect>, virt
         value *= g_Analyzer.BeatEnhance(BARBEAT_ENHANCE);
         value2 *= g_Analyzer.BeatEnhance(BARBEAT_ENHANCE);
 
-        int yOffset   = pGFXChannel->height() - value ;
-        int yOffset2  = pGFXChannel->height() - value2 ;
+        int yOffset   = pGFXChannel.height() - value ;
+        int yOffset2  = pGFXChannel.height() - value2 ;
 
         offset %= MATRIX_WIDTH;
 
-        for (int y = yOffset2; y < pGFXChannel->height(); y++)
+        for (int y = yOffset2; y < pGFXChannel.height(); y++)
             for (int x = xOffset; x < xOffset + barWidth; x++)
-                g()->setPixel((x - offset + MATRIX_WIDTH) % MATRIX_WIDTH, y, baseColor);
+                pGFXChannel.setPixel((x - offset + MATRIX_WIDTH) % MATRIX_WIDTH, y, baseColor);
 
         // We draw the highlight in white, but if its falling at a different rate than the bar itself,
         // it indicates a free-floating highlight, and those get faded out based on age
@@ -398,11 +398,11 @@ class SpectrumAnalyzerEffect : public EffectWithId<SpectrumAnalyzerEffect>, virt
                 float agePercent = (float) msPeakAge / (float) MILLIS_PER_SECOND;
                 uint8_t fadeAmount = std::min(255.0f, agePercent * 256);
                 colorHighlight.fadeToBlackBy(fadeAmount);
-                pGFXChannel->drawLine(xOffset, max(0, yOffset-1), xOffset + barWidth - 1, max(0, yOffset-1), colorHighlight);
+                pGFXChannel.drawLine(xOffset, max(0, yOffset-1), xOffset + barWidth - 1, max(0, yOffset-1), colorHighlight);
             }
             else
             {
-                pGFXChannel->drawLine(xOffset, max(0, yOffset2-1), xOffset + barWidth - 1, max(0, yOffset2-1), colorHighlight);
+                pGFXChannel.drawLine(xOffset, max(0, yOffset2-1), xOffset + barWidth - 1, max(0, yOffset2-1), colorHighlight);
             }
         }
     }
@@ -499,7 +499,7 @@ class SpectrumAnalyzerEffect : public EffectWithId<SpectrumAnalyzerEffect>, virt
         if (_bScrollBars)
             _offset++;
 
-        auto pGFXChannel = _GFX[0];
+        auto& pGFXChannel = g();
 
         if (_colorScrollSpeed > 0)
         {
@@ -512,7 +512,7 @@ class SpectrumAnalyzerEffect : public EffectWithId<SpectrumAnalyzerEffect>, virt
         if (_fadeRate)
             fadeAllChannelsToBlackBy(_fadeRate);
         else
-            pGFXChannel->Clear();
+            pGFXChannel.Clear();
 
         for (int i = 0; i < _numBars; i++)
         {
@@ -523,11 +523,11 @@ class SpectrumAnalyzerEffect : public EffectWithId<SpectrumAnalyzerEffect>, virt
             // on the USA flag solid red rather than pinkish...
 
             // A paused palette overrides everything else
-            if (pGFXChannel->IsPalettePaused())
+            if (pGFXChannel.IsPalettePaused())
             {
                 // We don't use the color offset when the palette is paused
                 int q = ::map(i, 0, _numBars, 0, 240);
-                DrawBar(i, pGFXChannel->ColorFromCurrentPalette(q % 240, 255, _colorScrollSpeed > 0 ? LINEARBLEND : NOBLEND), _offset);
+                DrawBar(i, pGFXChannel.ColorFromCurrentPalette(q % 240, 255, _colorScrollSpeed > 0 ? LINEARBLEND : NOBLEND), _offset);
             }
             else
             {
@@ -584,6 +584,8 @@ class WaveformEffectBase : public EffectWithId<TEffect>
 
     void DrawSpike(int x, float v, bool bErase = true)
     {
+        auto& graphics = LEDStripEffect::g();
+
         v = std::min(v, 1.0f);
         v = std::max(v, 0.0f);
 
@@ -608,10 +610,10 @@ class WaveformEffectBase : public EffectWithId<TEffect>
                 if (y < 2 || y > (MATRIX_HEIGHT - 2))
                     color  = CRGB::Red;
                 else
-                    color = LEDStripEffect::g()->ColorFromCurrentPalette(255 - index + ms / 11, 255, LINEARBLEND);
+                    color = graphics.ColorFromCurrentPalette(255 - index + ms / 11, 255, LINEARBLEND);
             }
 
-            bErase ? LEDStripEffect::g()->setPixel(x, y, color) : LEDStripEffect::g()->drawPixel(x, y, color);
+            bErase ? graphics.setPixel(x, y, color) : graphics.drawPixel(x, y, color);
 
         }
         _iColorOffset = (_iColorOffset + _increment) % 255;
@@ -627,7 +629,7 @@ class WaveformEffectBase : public EffectWithId<TEffect>
     virtual void Draw() override
     {
         int top = g_ptrSystem->GetEffectManager().IsVUVisible() ? 1 : 0;
-        LEDStripEffect::g()->MoveInwardX(top);                            // Start on Y=1 so we don't shift the VU meter
+        this->g().MoveInwardX(top);                            // Start on Y=1 so we don't shift the VU meter
         DrawSpike(MATRIX_WIDTH-1, g_Analyzer.VURatio()/2.0);
         DrawSpike(0, g_Analyzer.VURatio()/2.0);
     }
@@ -693,26 +695,26 @@ class GhostWave : public WaveformEffectBase<GhostWave>
 
     virtual void Draw() override
     {
+        auto& graphics = g();
         auto& effectManager = g_ptrSystem->GetEffectManager();
         int top = effectManager.IsVUVisible() ? 1 : 0;
 
-        g()->MoveOutwardsX(top);
+        graphics.MoveOutwardsX(top);
 
         if (_fade)
-            g()->DimAll(255-_fade);
+            graphics.DimAll(255-_fade);
 
         if (_blur)
-            g()->blur2d(g()->leds, MATRIX_WIDTH, 0, MATRIX_HEIGHT, 1, _blur);
+            graphics.blur2d(graphics.leds, MATRIX_WIDTH, 0, MATRIX_HEIGHT, 1, _blur);
 
         // VURatio is too fast, VURatioFade looks too slow, but averaged between them is just right
 
-        float audioLevel = (g_Analyzer.VURatioFade() + g_Analyzer.VURatio()) / 2;
-
+        float audioLevel = (g_Analyzer.VURatioFade() + g_Analyzer.VURatio() * 2) / 3;
         // Offsetting by 0.25, which is a very low ratio, helps keep the line thin when sound is low
         //audioLevel = (audioLevel - 0.25) / 1.75;
 
         // Now pulse it by some amount based on the beat
-        audioLevel = audioLevel * g_Analyzer.BeatEnhance(SPECTRUMBARBEAT_ENHANCE);
+        // audioLevel = audioLevel * g_Analyzer.BeatEnhance(SPECTRUMBARBEAT_ENHANCE);
 
         DrawSpike(MATRIX_WIDTH/2, audioLevel, _erase);
         DrawSpike(MATRIX_WIDTH/2-1, audioLevel, _erase);
@@ -780,6 +782,8 @@ class SpectrumBarEffect : public EffectWithId<SpectrumBarEffect>, public BeatEff
 
     void DrawGraph()
     {
+        auto& graphics = g();
+
         ProcessAudio();
 
         constexpr size_t halfHeight = MATRIX_HEIGHT / 2;
@@ -811,12 +815,12 @@ class SpectrumBarEffect : public EffectWithId<SpectrumBarEffect>, public BeatEff
             if (x1 < 0 || x2 >= MATRIX_WIDTH)
                 break;
 
-            CRGB  color = g()->IsPalettePaused() ? g()->ColorFromCurrentPalette() : CHSV(hue + iBand * _hueStep, 255, 255);
+            CRGB  color = graphics.IsPalettePaused() ? graphics.ColorFromCurrentPalette() : CHSV(hue + iBand * _hueStep, 255, 255);
 
-            g()->drawLine(x1, top, x1, bottom, color);
-            g()->drawLine(x2, top, x2, bottom, color);
+            graphics.drawLine(x1, top, x1, bottom, color);
+            graphics.drawLine(x2, top, x2, bottom, color);
         }
-        g()->drawLine(0, halfHeight, MATRIX_WIDTH - 1, halfHeight, CRGB::Grey);
+        graphics.drawLine(0, halfHeight, MATRIX_WIDTH - 1, halfHeight, CRGB::Grey);
      }
 
     virtual void Start() override
@@ -829,7 +833,7 @@ class SpectrumBarEffect : public EffectWithId<SpectrumBarEffect>, public BeatEff
 
         // This effect doesn't clear during drawing, so we need to clear to start the frame
 
-        g()->Clear();
+        g().Clear();
     }
 
     virtual void Draw() override
@@ -837,7 +841,7 @@ class SpectrumBarEffect : public EffectWithId<SpectrumBarEffect>, public BeatEff
         // Rather than clearing the screen, we fade it out quickly, which gives a nice persistence of vision effect
         // as the bars fade back to black once the line has receeded
 
-        g()->DimAll(200);
+        g().DimAll(200);
         DrawGraph();
     }
 };
@@ -883,7 +887,7 @@ class AudioSpikeEffect : public EffectWithId<AudioSpikeEffect>
         {
             uint8_t y1 = ::map(data[offset+x], 0, 2500, 0, MATRIX_HEIGHT);
             CRGB color = ColorFromPalette(spectrumBasicColors, (y1 * 4) + colorOffset, 255, NOBLEND);
-            g()->drawLine(x, lastY, x+1, y1, color);
+            g().drawLine(x, lastY, x+1, y1, color);
             lastY = y1;
         }
         offset += MATRIX_WIDTH;

--- a/include/effects/strip/faneffects.h
+++ b/include/effects/strip/faneffects.h
@@ -411,7 +411,7 @@ class FanBeatEffect : public EffectWithId<FanBeatEffect>
 
     CRGB c = CHSV(random(0, 255), 255, 255);
     for (int i = NUM_FANS * FAN_SIZE; i < NUM_LEDS; i++)
-      g()->setPixel(i, c);
+      g().setPixel(i, c);
   }
 
   void DrawEffect()

--- a/include/effects/strip/meteoreffect.h
+++ b/include/effects/strip/meteoreffect.h
@@ -102,8 +102,8 @@ class MeteorChannel
 
     virtual void Draw(LEDStripEffect* owner)
     {
-        auto pGFX = owner->g(0);
-        const int ledCount = static_cast<int>(pGFX->GetLEDCount());
+        auto& gfx = owner->g(0);
+        const int ledCount = static_cast<int>(gfx.GetLEDCount());
         static CHSV hsv;
         hsv.val = 255;
         hsv.sat = 255;
@@ -154,7 +154,7 @@ class MeteorChannel
                     hsv2rgb_rainbow(hsv, rgb);
 
                     // Blend with current pixel from primary device, then set on all channels
-                    CRGB c = pGFX->getPixel(x);
+                    CRGB c = gfx.getPixel(x);
                     nblend(c, rgb, 75);
                     owner->setPixelOnAllChannels(x, c);
                 }

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -725,7 +725,7 @@ class OuterHexRingEffect : public EffectWithId<OuterHexRingEffect>
         fadeAllChannelsToBlackBy(75);
 
         CRGB color = ColorFromPalette(RainbowColors_p, indent*32 + colorOffset);
-        hg().fillHexRing(indent, color);
+        hg()->fillHexRing(indent, color);
     }
 };
 #endif // HEXAGON

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -590,13 +590,13 @@ class PDPGridEffect : public EffectWithId<PDPGridEffect>
 
     virtual void Start() override
     {
-        g()->Clear();
+        g().Clear();
     }
 
     virtual void Draw() override
     {
         fadeAllChannelsToBlackBy(60);
-        g()->MoveY(1);
+        g().MoveY(1);
         for (int x = 0; x < MATRIX_WIDTH; x++)
         {
             // Pick a color, CRGB::Red 90% of the time, CRGB::Green 10% of the time
@@ -677,7 +677,7 @@ class PDPCMXEffect : public EffectWithId<PDPCMXEffect>
 
     virtual void Start() override
     {
-        g()->Clear();
+        g().Clear();
     }
 
     virtual void Draw() override
@@ -725,7 +725,7 @@ class OuterHexRingEffect : public EffectWithId<OuterHexRingEffect>
         fadeAllChannelsToBlackBy(75);
 
         CRGB color = ColorFromPalette(RainbowColors_p, indent*32 + colorOffset);
-        hg()->fillHexRing(indent, color);
+        hg().fillHexRing(indent, color);
     }
 };
 #endif // HEXAGON

--- a/include/effects/strip/stareffect.h
+++ b/include/effects/strip/stareffect.h
@@ -489,7 +489,7 @@ class StarEffectBase : public EffectWithId<StarEffectBase<StarType, TEffect>>
         }
         else
         {
-            LEDStripEffect::g()->blurRows(LEDStripEffect::g()->leds, MATRIX_WIDTH, MATRIX_HEIGHT, 0, _blurFactor * 255);
+            LEDStripEffect::g().blurRows(LEDStripEffect::g().leds, MATRIX_WIDTH, MATRIX_HEIGHT, 0, _blurFactor * 255);
             LEDStripEffect::fadeAllChannelsToBlackBy(55 * (2.0 - g_Analyzer.VURatioFade()));
         }
 

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -185,7 +185,12 @@ public:
     virtual ~GFXBase() override;
 
     #if USE_NOISE
-    Noise &GetNoise() const
+    Noise &GetNoise()
+    {
+        return *_ptrNoise;
+    }
+
+    const Noise &GetNoise() const
     {
         return *_ptrNoise;
     }

--- a/include/ledstripeffect.h
+++ b/include/ledstripeffect.h
@@ -136,7 +136,8 @@ class LEDStripEffect : public IJSONSerializable
     virtual void Start() {}                                         // Optional method called when time to clean/init the effect
     virtual void Draw() = 0;                                        // Your effect must implement these
 
-    std::shared_ptr<GFXBase> g(size_t channel = 0) const;
+    GFXBase& g(size_t channel = 0);
+    const GFXBase& g(size_t channel = 0) const;
 
     #if HEXAGON
       std::shared_ptr<HexagonGFX> hg(size_t channel = 0);

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@
 ; mesmerizer    HUB75 info panel with audio effects, weather, info, etc
 
 [platformio]
-default_envs = mesmerizer
+default_envs =
 build_cache_dir = .pio/build_cache
 extra_configs =
     custom_*.ini ; This file can be created in the root directory to store user defined devices and environments.
@@ -30,8 +30,8 @@ extra_configs =
 ; Options that are used (or extended) in all device sections (and hence environments) are defined here
 
 [base]
-upload_port     = /dev/cu.usbserial-712401
-monitor_port    = /dev/cu.usbserial-712401
+upload_port     =
+monitor_port    =
 build_type      = release
 upload_speed    = 2000000
 monitor_speed   = 115200

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@
 ; mesmerizer    HUB75 info panel with audio effects, weather, info, etc
 
 [platformio]
-default_envs =
+default_envs = mesmerizer
 build_cache_dir = .pio/build_cache
 extra_configs =
     custom_*.ini ; This file can be created in the root directory to store user defined devices and environments.
@@ -30,8 +30,8 @@ extra_configs =
 ; Options that are used (or extended) in all device sections (and hence environments) are defined here
 
 [base]
-upload_port     =
-monitor_port    =
+upload_port     = /dev/cu.usbserial-712401
+monitor_port    = /dev/cu.usbserial-712401
 build_type      = release
 upload_speed    = 2000000
 monitor_speed   = 115200

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -67,7 +67,7 @@ void IRAM_ATTR AudioSamplerTaskEntry(void *)
         // VURatio with a fadeout
 
         static auto lastVU = 0.0f;
-        constexpr auto VU_DECAY_PER_SECOND = 3.00;
+        constexpr auto VU_DECAY_PER_SECOND = 6.00;
 
         // Get the elapsed time since the last frame. We'll calculate this at the right spot from the first loop onwards
         static auto frameDurationSeconds = (millis() - lastFrame) / 1000.0;

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -226,9 +226,10 @@ void ShowOnboardRGBLED()
             ledcWrite(3, 255 - c.b);
         #else
             int iLed = NUM_LEDS / 2;
-            ledcWrite(1, 255 - graphics->leds[iLed].r); // write red component to channel 1, etc.
-            ledcWrite(2, 255 - graphics->leds[iLed].g);
-            ledcWrite(3, 255 - graphics->leds[iLed].b);
+            const auto& graphics = g_ptrSystem->GetEffectManager().g();
+            ledcWrite(1, 255 - graphics.leds[iLed].r); // write red component to channel 1, etc.
+            ledcWrite(2, 255 - graphics.leds[iLed].g);
+            ledcWrite(3, 255 - graphics.leds[iLed].b);
         #endif
     #endif
 }
@@ -284,9 +285,9 @@ void IRAM_ATTR DrawLoopTaskEntry(void *)
         uint16_t wifiPixelsDrawn    = 0;
         double frameStartTime       = g_Values.AppTime.FrameStartTime();
 
-        auto graphics = g_ptrSystem->GetEffectManager().GetBaseGraphics()[0];
+        auto& graphics = g_ptrSystem->GetEffectManager().g();
 
-        graphics->PrepareFrame();
+        graphics.PrepareFrame();
 
         if (nd_network::IsWiFiConnected())
             wifiPixelsDrawn = WiFiDraw();
@@ -311,7 +312,7 @@ void IRAM_ATTR DrawLoopTaskEntry(void *)
             g_ptrSystem->GetEffectManager().ReportNewFrameAvailable();
         }
 
-        graphics->PostProcessFrame(localPixelsDrawn, wifiPixelsDrawn);
+        graphics.PostProcessFrame(localPixelsDrawn, wifiPixelsDrawn);
 
         // Delay at least 2ms and not more than 1s until next frame is due
 

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -135,8 +135,8 @@ void EffectManager::StartEffect()
     std::shared_ptr<LEDStripEffect> & effect = _tempEffect ? _tempEffect : _vEffects[_iCurrentEffect];
 
     #if USE_HUB75
-        auto pMatrix = std::static_pointer_cast<HUB75GFX>(_gfx[0]);
-        pMatrix->SetCaption(effect->FriendlyName(), CAPTION_TIME);
+        auto& matrix = static_cast<HUB75GFX&>(*_gfx[0]);
+        matrix.SetCaption(effect->FriendlyName(), CAPTION_TIME);
     #endif
 
     effect->Start();
@@ -238,9 +238,14 @@ void EffectManager::AddEffectEventListener(IEffectEventListener& listener)
 }
 
 // Must provide at least one drawing instance, like the first matrix or strip we are drawing on
-std::shared_ptr<GFXBase> EffectManager::g(int iChannel) const
+GFXBase& EffectManager::g(int iChannel)
 {
-    return _gfx[iChannel];
+    return *_gfx[iChannel];
+}
+
+const GFXBase& EffectManager::g(int iChannel) const
+{
+    return *_gfx[iChannel];
 }
 
 bool EffectManager::IsEffectEnabled(size_t i) const
@@ -353,17 +358,16 @@ bool EffectManager::IsIntervalEternal() const
     return _effectInterval == 0;
 }
 
-void EffectManager::NextPalette() const
+void EffectManager::NextPalette()
 {
     debugV("EffectManager::NextPalette");
-    auto g = _gfx[0].get();
-    g->CyclePalette(1);
+    g().CyclePalette(1);
 }
 
-void EffectManager::PreviousPalette() const
+void EffectManager::PreviousPalette()
 {
     debugV("EffectManager::PreviousPalette");
-    g()->CyclePalette(-1);
+    g().CyclePalette(-1);
 }
 
 void EffectManager::LoadDefaultEffects()
@@ -602,7 +606,7 @@ void EffectManager::ClearRemoteColor(bool retainRemoteEffect)
         _tempEffect = nullptr;
 
     #if USE_HUB75
-        g()->PausePalette(false);
+        g().PausePalette(false);
     #endif
 
     g_ptrSystem->GetDeviceConfig().ClearApplyGlobalColors();
@@ -613,7 +617,7 @@ void EffectManager::ClearRemoteColor(bool retainRemoteEffect)
 // When a global color is set via the remote, we create a fill effect and assign it as the "remote effect"
 // which takes drawing precedence
 
-void EffectManager::ApplyGlobalColor(CRGB color) const
+void EffectManager::ApplyGlobalColor(CRGB color)
 {
     debugI("Setting Global Color: %08lX\n", (unsigned long)(uint32_t)color);
 
@@ -623,10 +627,10 @@ void EffectManager::ApplyGlobalColor(CRGB color) const
     ApplyGlobalPaletteColors();
 }
 
-void EffectManager::ApplyGlobalPaletteColors() const
+void EffectManager::ApplyGlobalPaletteColors()
 {
     #if USE_HUB75
-        auto  pMatrix = g();
+        auto& pMatrix = g();
         auto& deviceConfig = g_ptrSystem->GetDeviceConfig();
         auto& globalColor = deviceConfig.GlobalColor();
         auto& secondColor = deviceConfig.SecondColor();
@@ -636,15 +640,15 @@ void EffectManager::ApplyGlobalPaletteColors() const
         if (secondColor == globalColor)
         {
             CHSV hsv = rgb2hsv_approximate(globalColor);
-            pMatrix->setPalette(CRGBPalette16(globalColor, CRGB(CHSV(hsv.hue + 64, 255, 255))));
+            pMatrix.setPalette(CRGBPalette16(globalColor, CRGB(CHSV(hsv.hue + 64, 255, 255))));
         }
         else
         {
             // But if we have two different colors, we create a palette spread between them
-            pMatrix->setPalette(CRGBPalette16(secondColor, globalColor));
+            pMatrix.setPalette(CRGBPalette16(secondColor, globalColor));
         }
 
-        pMatrix->PausePalette(true);
+        pMatrix.PausePalette(true);
     #endif
 }
 
@@ -1021,11 +1025,11 @@ void EffectManager::ApplyFadeLogic()
 
     if (e < msFadeTime)
     {
-        g_Values.Fader = 255 * (e / msFadeTime); // Fade in
+        g_Values.Fader = (255 * e) / msFadeTime; // Fade in
     }
     else if (r < msFadeTime)
     {
-        g_Values.Fader = 255 * (r / msFadeTime); // Fade out
+        g_Values.Fader = (255 * r) / msFadeTime; // Fade out
     }
     else
     {

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -288,8 +288,8 @@ void LoadEffectFactories()
         TJpgDec.setJpgScale(1);
         TJpgDec.setCallback([](int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t *bitmap)
         {
-            auto pgfx = g_ptrSystem->GetEffectManager().g();
-            pgfx->drawRGBBitmap(x, y, bitmap, w, h);
+            auto& gfx = g_ptrSystem->GetEffectManager().g();
+            gfx.drawRGBBitmap(x, y, bitmap, w, h);
             return true;
         });
 

--- a/src/gfxbase.cpp
+++ b/src/gfxbase.cpp
@@ -1404,7 +1404,7 @@ GFXBase::GFXBase(int w, int h) : Adafruit_GFX(w, h),
 // more than one matrix and some FastLED functions like blur2d, this would be why.
 uint16_t XY(uint8_t x, uint8_t y)
 {
-    static auto& g = *(g_ptrSystem->GetEffectManager().g());
+    static auto& g = g_ptrSystem->GetEffectManager().g();
     return g.xy(x, y);
 }
 

--- a/src/hub75gfx.cpp
+++ b/src/hub75gfx.cpp
@@ -73,7 +73,7 @@ void HUB75GFX::InitializeHardware(std::vector<std::shared_ptr<GFXBase>>& devices
     backgroundLayer.enableColorCorrection(true);
 
     // Starting an effect might need to draw, so we need to set the leds up before doing so
-    std::static_pointer_cast<HUB75GFX>(devices[0])->setLeds(GetMatrixBackBuffer());
+    static_cast<HUB75GFX&>(*devices[0]).setLeds(GetMatrixBackBuffer());
 }
 
 void HUB75GFX::SetBrightness(byte amount)
@@ -241,22 +241,22 @@ void HUB75GFX::PrepareFrame()
 
     EVERY_N_MILLIS(MILLIS_PER_FRAME)
     {
-        auto graphics = g_ptrSystem->GetEffectManager().g();
+        auto& graphics = g_ptrSystem->GetEffectManager().g();
 
         matrix.setCalcRefreshRateDivider(MATRIX_CALC_DIVIDER);
         matrix.setRefreshRate(MATRIX_REFRESH_RATE);
 
-        auto pMatrix = std::static_pointer_cast<HUB75GFX>(g_ptrSystem->GetEffectManager().GetBaseGraphics()[0]);
-        pMatrix->setLeds(GetMatrixBackBuffer());
+        auto& pMatrix = static_cast<HUB75GFX&>(graphics);
+        pMatrix.setLeds(GetMatrixBackBuffer());
 
         // We set ourselves to the lower of the fader value or the brightness value,
         // so that we can fade between effects without having to change the brightness
         // setting.
 
-        if (g_ptrSystem->GetEffectManager().GetCurrentEffect().ShouldShowTitle() && pMatrix->GetCaptionTransparency() > 0.00)
+        if (g_ptrSystem->GetEffectManager().GetCurrentEffect().ShouldShowTitle() && pMatrix.GetCaptionTransparency() > 0.00)
         {
             titleLayer.setFont(font3x5);
-            uint8_t brite = (uint8_t)(pMatrix->GetCaptionTransparency() * 255.0);
+            uint8_t brite = (uint8_t)(pMatrix.GetCaptionTransparency() * 255.0);
             debugV("Caption: %d", brite);
 
             rgb24 chromaKeyColor = rgb24(255, 0, 255);
@@ -269,7 +269,7 @@ void HUB75GFX::PrepareFrame()
             const size_t kCharWidth = 6;
             const size_t kCharHeight = 10;
 
-            const auto caption = pMatrix->GetCaption();
+            const auto caption = pMatrix.GetCaption();
 
             int y = MATRIX_HEIGHT - 2 - kCharHeight;
             int w = caption.length() * kCharWidth;
@@ -328,12 +328,12 @@ void HUB75GFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDr
     if ((localPixelsDrawn + wifiPixelsDrawn) == 0)
         return;
 
-    auto pMatrix = std::static_pointer_cast<HUB75GFX>(g_ptrSystem->GetEffectManager().g());
+    auto& pMatrix = static_cast<HUB75GFX&>(g_ptrSystem->GetEffectManager().g());
 
     constexpr auto kCaptionPower = 500;                                                 // A guess as the power the caption will consume
-    g_Values.MatrixPowerMilliwatts = pMatrix->EstimatePowerDraw();                             // What our drawn pixels will consume
+    g_Values.MatrixPowerMilliwatts = pMatrix.EstimatePowerDraw();                             // What our drawn pixels will consume
 
-    if (pMatrix->GetCaptionTransparency() > 0)
+    if (pMatrix.GetCaptionTransparency() > 0)
         g_Values.MatrixPowerMilliwatts += kCaptionPower;
 
     const double kMaxPower = g_ptrSystem->GetDeviceConfig().GetPowerLimit();
@@ -356,7 +356,7 @@ void HUB75GFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDr
     auto targetBrightness = min({ g_ptrSystem->GetDeviceConfig().GetBrightness(), g_Values.Fader, g_Values.MatrixScaledBrightness });
 
     debugV("MW: %lu, Setting Scaled Brightness to: %lu", (unsigned long)g_Values.MatrixPowerMilliwatts, (unsigned long)targetBrightness);
-    pMatrix->SetBrightness(targetBrightness);
+    pMatrix.SetBrightness(targetBrightness);
 
     #if SHOW_FPS_ON_MATRIX
         // Display status on bottom of matrix in format FPS: 00 CPU0: 000 CPU1: 000 Aud: 00
@@ -368,7 +368,7 @@ void HUB75GFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDr
         backgroundLayer.drawString(2, MATRIX_HEIGHT  - 6, rgb24(255, 255, 255), rgb24(0, 0, 0), output.c_str());
     #endif
 
-    MatrixSwapBuffers((wifiPixelsDrawn > 0) || g_ptrSystem->GetEffectManager().GetCurrentEffect().RequiresDoubleBuffering() || pMatrix->GetCaptionTransparency() > 0.0);
+    MatrixSwapBuffers((wifiPixelsDrawn > 0) || g_ptrSystem->GetEffectManager().GetCurrentEffect().RequiresDoubleBuffering() || pMatrix.GetCaptionTransparency() > 0.0);
 
     FastLED.countFPS();
 }

--- a/src/ledstripeffect.cpp
+++ b/src/ledstripeffect.cpp
@@ -132,9 +132,14 @@ bool LEDStripEffect::Init(std::vector<std::shared_ptr<GFXBase>>& gfx)
 }
 
 // Must provide at least one drawing instance, like the first matrix or strip we are drawing on
-std::shared_ptr<GFXBase> LEDStripEffect::g(size_t channel) const
+GFXBase& LEDStripEffect::g(size_t channel)
 {
-    return _GFX[channel];
+    return *_GFX[channel];
+}
+
+const GFXBase& LEDStripEffect::g(size_t channel) const
+{
+    return *_GFX[channel];
 }
 
 #if HEXAGON

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -695,7 +695,8 @@ void IRAM_ATTR ColorDataTaskEntry(void *)
         if (socket < 0)
             socket = _viewer.CheckForConnection();
 
-        auto leds = effectManager.g()->leds;
+        auto& graphics = effectManager.g();
+        auto leds = graphics.leds;
 
         if (frameEventListener.CheckAndClearNewFrameAvailable() && leds != nullptr)
         {
@@ -705,8 +706,8 @@ void IRAM_ATTR ColorDataTaskEntry(void *)
                 // Potentially too large for the stack, so we allocate it on the heap instead
                 std::unique_ptr<ColorDataPacket> pPacket = std::make_unique<ColorDataPacket>();
                 pPacket->header = COLOR_DATA_PACKET_HEADER;
-                pPacket->width  = effectManager.g()->width();
-                pPacket->height = effectManager.g()->height();
+                pPacket->width  = graphics.width();
+                pPacket->height = graphics.height();
                 memcpy(pPacket->colors, leds, sizeof(CRGB) * NUM_LEDS);
 
                 if (!_viewer.SendPacket(socket, pPacket.get(), sizeof(ColorDataPacket)))

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -507,8 +507,8 @@ public:
 
         // Fetch current graphics buffer
         auto &effectManager = g_ptrSystem->GetEffectManager();
-        auto gfx = effectManager.g();
-        if (!gfx || gfx->leds == nullptr)
+        auto& gfx = effectManager.g();
+        if (gfx.leds == nullptr)
             return;
 
         // Blit: draw each LED as a scale x scale rectangle (direct buffer reads, no per-dest-pixel loop)
@@ -533,14 +533,14 @@ public:
                 if (MATRIX_HEIGHT == 1) // Single row strip - wrap it
                 {
                     if (ledIndex < MATRIX_WIDTH)
-                        c = gfx->leds[ledIndex];
+                        c = gfx.leds[ledIndex];
                     else
                         c = CRGB::Black; // Padding if we run out of LEDs
                     ledIndex++;
                 }
                 else // Real matrix
                 {
-                    c = gfx->leds[XY(x, y)];
+                    c = gfx.leds[XY(x, y)];
                 }
 
                 uint16_t c16 = display.to16bit(c);

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -565,7 +565,7 @@ void CWebServer::SetSettings(AsyncWebServerRequest * pRequest)
 
 bool CWebServer::CheckAndGetSettingsEffect(AsyncWebServerRequest * pRequest, std::shared_ptr<LEDStripEffect> & effect, bool post)
 {
-    auto effectsList = g_ptrSystem->GetEffectManager().EffectsList();
+    const auto& effectsList = g_ptrSystem->GetEffectManager().EffectsList();
     auto effectIndex = GetEffectIndexFromParam(pRequest, post);
 
     if (effectIndex < 0 || effectIndex >= effectsList.size())

--- a/src/ws281xgfx.cpp
+++ b/src/ws281xgfx.cpp
@@ -153,7 +153,7 @@ void WS281xGFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsD
 
     for (int i = 0; i < NUM_CHANNELS; i++)
     {
-        FastLED[i].setLeds(effectManager.g(i)->leds, pixelsDrawn);
+        FastLED[i].setLeds(effectManager.g(i).leds, pixelsDrawn);
         fadeLightBy(FastLED[i].leds(), FastLED[i].size(), 255 - g_ptrSystem->GetDeviceConfig().GetBrightness());
     }
     FastLED.show(g_Values.Fader); //Shows the pixels
@@ -164,7 +164,7 @@ void WS281xGFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsD
     #else
         g_Values.Brite = 100.0 * g_ptrSystem->GetDeviceConfig().GetBrightness() / 255;
     #endif
-    g_Values.Watts = calculate_unscaled_power_mW(effectManager.g()->leds, pixelsDrawn) / 1000; // 1000 for mw->W
+    g_Values.Watts = calculate_unscaled_power_mW(effectManager.g().leds, pixelsDrawn) / 1000; // 1000 for mw->W
 }
 
 #if HEXAGON


### PR DESCRIPTION
## Description
This makes g() a reference instead of a vtable pointer lookup.  It also fixes the blanking during effect cross-fading.  I can't prove it, but I suspect this is much more efficient.

The bulk of the change is the one change to g() and then everywhere that calls it, which is pretty much a mechanical replacement.

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).