### PR TITLE
Fix: LED buffer crash and fade logic overflow #842

### DIFF
--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -93,6 +93,7 @@ uint16_t WiFiDraw()
             if (pBuffer)
             {
                 l_usLastWifiDraw = micros();
+                g_Values.Fader = 255;
                 debugV("Calling LEDBuffer::Draw from wire with %d/%d pixels.", pixelsDrawn, NUM_LEDS);
                 pBuffer->DrawBuffer();
                 // In case we drew some pixels and then drew 0 due a failure, we want to return a positive

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -1021,11 +1021,11 @@ void EffectManager::ApplyFadeLogic()
 
     if (e < msFadeTime)
     {
-        g_Values.Fader = 255 * (e / msFadeTime); // Fade in
+        g_Values.Fader = 255.0f * ((float)e / msFadeTime); // Fade in
     }
     else if (r < msFadeTime)
     {
-        g_Values.Fader = 255 * (r / msFadeTime); // Fade out
+        g_Values.Fader = 255.0f * ((float)r / msFadeTime); // Fade out
     }
     else
     {

--- a/src/ledbuffer.cpp
+++ b/src/ledbuffer.cpp
@@ -113,10 +113,9 @@ LEDBufferManager::LEDBufferManager(uint32_t cBuffers, const std::shared_ptr<GFXB
 
 double LEDBufferManager::AgeOfOldestBuffer() const
 {
-    if (false == IsEmpty())
-    {
-        auto pOldest = PeekOldestBuffer();
-        return (pOldest->Seconds() + pOldest->MicroSeconds() / MICROS_PER_SECOND) - g_Values.AppTime.CurrentTime();
+    auto pOldest = PeekOldestBuffer();
+    if (pOldest) {
+        return (pOldest->Seconds() + pOldest->MicroSeconds() / (float)MICROS_PER_SECOND) - g_Values.AppTime.CurrentTime();
     }
     else
     {
@@ -126,10 +125,9 @@ double LEDBufferManager::AgeOfOldestBuffer() const
 
 double LEDBufferManager::AgeOfNewestBuffer() const
 {
-    if (false == IsEmpty())
-    {
-        auto pNewest = PeekNewestBuffer();
-        return (pNewest->Seconds() + pNewest->MicroSeconds() / MICROS_PER_SECOND) - g_Values.AppTime.CurrentTime();
+    auto pNewest = PeekNewestBuffer();
+    if (pNewest) {
+        return (pNewest->Seconds() + pNewest->MicroSeconds() / (float)MICROS_PER_SECOND) - g_Values.AppTime.CurrentTime();
     }
     else
     {


### PR DESCRIPTION
Two fixes for two rare problems.

First, a crash.

AgeOfOldestBuffer, AgeOfOldestBuffer each called PeekOldestBuffer() 
called IsEmpty() to see if there was a buffer. It then called PeekOldestBuffer 
which called PeekOldestBuffer which called IsEmpty(), returning null if it was.
The caller bravely assumed from the first IsEmpty that it would ALWAYS get a non-null.
If the queue drained between these two times, the Peek would get a null, which 
we then dereferenced  to get  Seconds() and MicrosSeconds, leading to a device crash.

Once that crash was fixed, we saw the strips would rarely come back
from an idle state once ndsscpp had paused (perhaps it was daytime)
and then resumed.

Once LocalDraw() would take back over, GetTimeUsedByCurrentEffect() would
be huge because ndscpp had been driving the show. NextEffect() would
get triggered, but ApplyFadeLogic would come in, find GetTimeUsedByCurrentEffect
was huge, but incurred integer overflow, causing Fader to be set to 0.
This meant preview would show we were drawing - and we were dutifullying
filling and draining leds[], but Fader was stuck at 0, so we were nailed
to brightness 0.

See #842 for stack traces and disassembly. WIth this in place, I've
gone from 6-8 resets a day and dozens of connection resets per day
to exactly zero of each, observed for > 48 hours of uptime on 
two strips.


Over 2 days of uptime. Before this, I was observing 6-8 crashes per day per strip.

(echo uptime ; saleep 1 ) | telnet 192.168.2.103 ; (echo uptime ; sleep 1) | telnet 192.168.2.116
Trying 192.168.2.103...
Connected to esp32c6-171588.localdomain.
Escape character is '^]'.
> uptime
Showing uptime...
Uptime: 2 days, 06:56:16
Last boot reason: (3): Software Restart
> Connection closed by foreign host.
Trying 192.168.2.116...
Connected to esp32c6-170b54.localdomain.
Escape character is '^]'.
> uptime
Showing uptime...
Uptime: 2 days, 06:55:47
Last boot reason: (3): Software Restart
> Connection closed by foreign host.

pkill ndscpp ; make && SPDLOG_LEVEL=debug ./ndscpp
make: Nothing to be done for `all'.
[2026-04-21 07:05:55.606] [console] [debug] Adding canvas Cabinets...
[2026-04-21 07:05:55.607] [console] [debug] Connecting canvases...
[2026-04-21 07:05:55.607] [console] [debug] Starting socket channel for 192.168.2.103 [Cabinet Left]
[2026-04-21 07:05:55.607] [console] [debug] Starting socket channel for 192.168.2.116 [Cabinet Right]
[2026-04-21 07:05:55.607] [console] [debug] Starting canvases...
[2026-04-21 07:05:55.607] [console] [debug] Starting effects manager with 4 effects tracking at 30 FPS
[2026-04-21 07:05:55.607] [console] [debug] Updated solar cache for day 110: Sunrise 06:06:23, Sunset 19:25:53
[2026-04-21 07:05:55.607] [console] [info] No scheduled items are active for canvas 'Cabinets'. Interpolating to black.
[2026-04-21 07:05:55.608] [console] [debug] Attempting to connect to 192.168.2.116 [Cabinet Right]
[2026-04-21 07:05:55.608] [console] [debug] Attempting to connect to 192.168.2.103 [Cabinet Left]
[2026-04-21 07:05:55.622] [console] [info] Connected to 192.168.2.103:49152 [Cabinet Left]
[2026-04-21 07:05:55.623] [console] [info] Connected to 192.168.2.116:49152 [Cabinet Right]
[2026-04-21 19:05:53.377] [console] [info] Switching to effect 'Sunset Glow' based on schedule.
[2026-04-21 20:05:54.004] [console] [info] Switching to effect 'Evening Aurora' based on schedule.
[2026-04-22 00:00:00.006] [console] [debug] Updated solar cache for day 111: Sunrise 06:05:08, Sunset 19:26:44
[2026-04-22 01:30:01.016] [console] [info] Switching to effect 'Nightlight Starfield' based on schedule.
[2026-04-22 06:05:09.015] [console] [info] Switching to effect 'Morning Wake' based on schedule.
[2026-04-22 06:35:09.010] [console] [info] No scheduled items are active for canvas 'Cabinets'. Interpolating to black.

Closes #842.

## Description
See https://github.com/PlummersSoftwareLLC/NightDriverStrip/issues/842  for analysis

## Contributing requirements
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
