### PR TITLE
Move build flags that are uniquely ours to build_src_flags

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -41,8 +41,7 @@ build_flags     = -std=gnu++2a
                   -ffunction-sections
                   -fdata-sections
                   -include string.h
-
-build_src_flags = -Wformat=2                        ; Warnings for our code only, excluding libraries
+build_src_flags = -Wformat=2 ; Warnings for our code only, excluding libraries
                   -Wformat-truncation
                   -Wstack-usage=4096
 
@@ -70,22 +69,23 @@ graphics_deps       = https://github.com/PlummersSoftwareLLC/GifDecoder.git
                     QRCode               @ ^0.0.1
 
 oled_deps        = olikraus/U8g2                 @ ^2.36.12
-
-bounce_deps = thomasfredericks/Bounce2      @ ^2.72.0
+bounce_deps      = thomasfredericks/Bounce2      @ ^2.72.0
 
 ; Placeholder for legacy custom_*.ini references (IR remote flags removed)
 [remote_flags]
 build_flags     =
+build_src_flags =
 
 ; ===============
 ; Device sections
-;
 ; Sections starting with "dev_" contain general settings for a particular type of device.
 ; They extend the "base" config, both in general and in terms of build flags and dependencies,
 ; where applicable.
 
 [dev_esp32]
 extends         = base
+build_flags     = ${base.build_flags}
+build_src_flags = ${base.build_src_flags}
 board           = esp32dev
 monitor_speed   = 115200
 upload_speed    = 921600
@@ -98,6 +98,7 @@ board_build.f_cpu = 240000000L
 monitor_speed   = 115200
 upload_speed    = 1000000
 build_flags     = ${base.build_flags}
+build_src_flags = ${base.build_src_flags}
 
 [dev_adafruit_feather]
 extends         = dev_esp32_s3
@@ -105,10 +106,7 @@ board           = adafruit_feather_esp32s3_tft
 monitor_speed   = 115200
 upload_speed    = 1500000
 build_flags     = ${dev_esp32_s3.build_flags}
-                  -DUSE_SCREEN=1
-                  -DUSE_TFTSPI=1
                   -DUSER_SETUP_LOADED
-                  -DTOUCH_CS=0
                   -DST7789_2_DRIVER
                   -DTFT_WIDTH=135
                   -DTFT_HEIGHT=240
@@ -123,13 +121,18 @@ build_flags     = ${dev_esp32_s3.build_flags}
                   -DTFT_SCLK=36
                   -DLOAD_GLCD=1
                   -DLOAD_GFXFF=1
+                  -DSPI_FREQUENCY=27000000
+                  -DUSE_HSPI_PORT=1
+build_src_flags = ${dev_esp32_s3.build_src_flags}
+                  -DUSE_SCREEN=1
+                  -DUSE_TFTSPI=1
+                  -DTOUCH_CS=0
                   -DENABLE_WIFI=1
                   -DENABLE_OTA=1
-                  -DSPI_FREQUENCY=27000000
                   -DESP32FEATHERTFT=1
                   -DTOGGLE_BUTTON_0=0
-                  -DUSE_HSPI_PORT=1
                   -DLED_PIN0=5
+
 board_build.partitions = config/partitions_custom.csv
 lib_deps        = ${dev_esp32_s3.lib_deps}
                   ${base.bounce_deps}
@@ -140,18 +143,21 @@ extends         = base
 board           = heltec_wifi_kit_32
 monitor_speed   = 115200
 upload_speed    = 921600
-build_flags     = -DUSE_SCREEN=1
+build_flags     = ${base.build_flags}
                   -DARDUINO_HELTEC_WIFI_KIT_32=1
-                  ${base.build_flags}
+build_src_flags = ${base.build_src_flags}
+                  -DUSE_SCREEN=1
 
 [dev_heltec_wifi_v2]
 extends         = dev_heltec_wifi
 board           = heltec_wifi_kit_32_v2
 monitor_speed   = 115200
 upload_speed    = 921600
-build_flags     = -DARDUINO_HELTEC_WIFI_KIT_32_V2=1
+build_flags     = ${dev_heltec_wifi.build_flags}
+                  -DARDUINO_HELTEC_WIFI_KIT_32_V2=1
+build_src_flags = ${dev_heltec_wifi.build_src_flags}
                   -DUSE_SSD1306=1
-                  ${dev_heltec_wifi.build_flags}
+
 lib_deps        = ${dev_heltec_wifi.lib_deps}
                   ${base.oled_deps}
                   heltecautomation/Heltec ESP32 Dev-Boards @ ^1.1.1
@@ -161,13 +167,15 @@ extends         = dev_esp32_s3
 board           = heltec_wifi_kit_32_V3
 monitor_speed   = 115200
 upload_speed    = 921600
-build_flags     = -DUSE_SCREEN=1
+build_flags     = ${dev_esp32_s3.build_flags}
                   -DARDUINO_HELTEC_WIFI_KIT_32=1
                   -DARDUINO_HELTEC_WIFI_KIT_32_V3=1
+build_src_flags = ${dev_esp32_s3.build_src_flags}
+                  -DUSE_SCREEN=1
                   -DUSE_SSD1306=1
                   -DTOGGLE_BUTTON_1=0
                   -DDEFAULT_INFO_PAGE=0
-                  ${dev_esp32_s3.build_flags}
+
 lib_deps        = ${dev_esp32_s3.lib_deps}
                   ${base.oled_deps}
                   ${base.bounce_deps}
@@ -176,17 +184,21 @@ lib_deps        = ${dev_esp32_s3.lib_deps}
 [dev_heltec_wifi_lora_v3]
 extends         = dev_esp32_s3
 board           = heltec_wifi_lora_32_V3
-build_flags     = -DUSE_SCREEN=1
+build_flags     = ${dev_esp32_s3.build_flags}
                   -DARDUINO_HELTEC_WIFI_KIT_32=1
                   -DARDUINO_HELTEC_WIFI_LORA_32_V3=1
+build_src_flags = ${dev_esp32_s3.build_src_flags}
+                  -DUSE_SCREEN=1
                   -DUSE_SSD1306=1
-                  ${dev_esp32_s3.build_flags}
+
 lib_deps        = ${dev_esp32_s3.lib_deps}
                   ${base.oled_deps}
                   heltecautomation/Heltec ESP32 Dev-Boards @ ^1.1.1
 
 [dev_lolin_d32_pro]
 extends         = base
+build_flags     = ${base.build_flags}
+build_src_flags = ${base.build_src_flags}
 board           = lolin_d32_pro
 monitor_speed   = 115200
 upload_speed    = 921600
@@ -195,10 +207,12 @@ upload_speed    = 921600
 extends         = base
 monitor_speed   = 115200
 upload_speed    = 1500000
-build_flags     = -DUSE_SCREEN=1
-                  ${base.build_flags}
+build_flags     = ${base.build_flags}
+build_src_flags = ${base.build_src_flags}
+                  -DUSE_SCREEN=1
                   -DTOGGLE_BUTTON_0=37
                   -DTOGGLE_BUTTON_1=39
+
 lib_deps        = ${base.lib_deps}
                   ${base.bounce_deps}
                   m5stack/M5Unified @ ^0.2.7
@@ -206,33 +220,37 @@ lib_deps        = ${base.lib_deps}
 [dev_m5stick_c]
 extends         = dev_m5
 board           = m5stick-c
-build_flags     = -DM5STICKC=1
-                  ${dev_m5.build_flags}
+build_flags     = ${dev_m5.build_flags}
+build_src_flags = ${dev_m5.build_src_flags}
+                  -DM5STICKC=1
 board_build.partitions = config/partitions_custom_noota.csv
 
 [dev_m5stick_c_plus]
 extends         = dev_m5
 board           = m5stick-c                         ; Requires the M5StickC Plus (note the Plus)
-build_flags     = -DM5STICKCPLUS=1
-                  ${dev_m5.build_flags}
+build_flags     = ${dev_m5.build_flags}
+build_src_flags = ${dev_m5.build_src_flags}
+                  -DM5STICKCPLUS=1
 board_build.partitions = config/partitions_custom_noota.csv
 
 [dev_m5stick_c_plus2]
 extends         = dev_m5
 board           = m5stick-c                         ; Requires the M5StickC Plus2 (note the Plus2)
 upload_speed    = 2000000
-build_flags     = -DM5STICKCPLUS2=1
-                  ${dev_m5.build_flags}
+build_flags     = ${dev_m5.build_flags}
                   ${psram_lx6_flags.build_flags}
+build_src_flags = ${dev_m5.build_src_flags}
+                  -DM5STICKCPLUS2=1
 board_build.partitions = config/partitions_custom_8M.csv
 board_upload.flash_size = 8MB
 
 [dev_m5stack]
 extends         = dev_m5
 board           = m5stack-core2
-build_flags     = -DM5STACKCORE2=1
-                  ${dev_m5.build_flags}
+build_flags     = ${dev_m5.build_flags}
                   ${psram_lx6_flags.build_flags}
+build_src_flags = ${dev_m5.build_src_flags}
+                  -DM5STACKCORE2=1
 board_build.partitions = config/partitions_custom_8M.csv
 board_upload.flash_size = 8MB
 
@@ -241,19 +259,24 @@ extends         = dev_esp32_s3
 board           = esp32-s3-devkitc-1
 monitor_speed   = 115200
 upload_speed    = 1500000
+build_flags     = ${dev_esp32_s3.build_flags}
+build_src_flags = ${dev_esp32_s3.build_src_flags}
 lib_deps        = ${dev_esp32_s3.lib_deps}
                   ${base.oled_deps}
                   lovyan03/LovyanGFX @ ^1.1.7
-build_flags     = ${dev_esp32_s3.build_flags}
 
 [dev_tinypico]
 extends         = base
+build_flags     = ${base.build_flags}
+build_src_flags = ${base.build_src_flags}
 board           = tinypico
 monitor_speed   = 115200
 upload_speed    = 1500000
 
 [dev_wrover]
 extends         = base
+build_flags     = ${base.build_flags}
+build_src_flags = ${base.build_src_flags}
 board           = esp-wrover-kit
 monitor_speed   = 115200
 upload_speed    = 1500000
@@ -262,6 +285,8 @@ lib_deps        = ${base.lib_deps}
 
 [dev_mesmerizer]
 extends         = dev_wrover
+build_flags     = ${dev_wrover.build_flags}
+build_src_flags = ${dev_wrover.build_src_flags}
 board           = esp-wrover-kit
 upload_speed    = 4000000
 monitor_speed   = 115200
@@ -271,31 +296,31 @@ board_upload.flash_size = 8MB
 [dev_lilygo_tdisplay_s3]
 extends         = dev_esp32_s3
 board           = esp32-s3-devkitc-1
-build_flags     = -DLILYGOTDISPLAYS3=1
+build_flags     = ${dev_esp32_s3.build_flags}
+build_src_flags = ${dev_esp32_s3.build_src_flags}
+                  -DLILYGOTDISPLAYS3=1
                   -DPIN_SDA=21
                   -DTOGGLE_BUTTON_0=0
                   -DTOGGLE_BUTTON_1=14
-                  ${dev_esp32_s3.build_flags}
 libs_deps       = ${base.bounce_deps}
 
-
 [dev_lilygo_amoled]
-
 extends        = dev_esp32_s3
 board          = lilygo-t-amoled
 monitor_speed  = 115200
 upload_speed   = 1500000
 build_flags    = ${dev_esp32_s3.build_flags}
-                 -DLILYGO_TDISPLAY_AMOLED_SERIES=1
-                 -DARDUINO_USB_CDC_ON_BOOT=1
-                 -DAMOLED_S3=1
-                 -DUSE_SCREEN=1
-                 -DTOGGLE_BUTTON_0=21
-                 -DTOGGLE_BUTTON_1=0
-                 -DLED_PIN0=2
-                 -DLV_CONF_PATH="../../../../include/amoled/lv_conf.h"
-                 -DLV_CONF_INCLUDE_SIMPLE
-                 ${psram_common_flags.build_flags}
+                  -DARDUINO_USB_CDC_ON_BOOT=1
+                  -DLV_CONF_PATH="../../../../include/amoled/lv_conf.h"
+                  -DLV_CONF_INCLUDE_SIMPLE
+                  ${psram_common_flags.build_flags}
+build_src_flags = ${dev_esp32_s3.build_src_flags}
+                  -DLILYGO_TDISPLAY_AMOLED_SERIES=1
+                  -DAMOLED_S3=1
+                  -DUSE_SCREEN=1
+                  -DTOGGLE_BUTTON_0=21
+                  -DTOGGLE_BUTTON_1=0
+                  -DLED_PIN0=2
 lib_deps       = ${dev_esp32_s3.lib_deps}
                  lewisxhe/SensorLib@^0.1.4
                  lewisxhe/XPowersLib@^0.2.1
@@ -305,33 +330,32 @@ lib_deps       = ${dev_esp32_s3.lib_deps}
 
 ; ===================
 ; Capability sections
-;
 ; The following sections contain build flags and/or dependencies to enable a particular capability
 ; or module in specific environments. They applicable option(s) - build_flags, lib_deps or both -
 ; are included in the environments in question.
 ;
 ; Note that these sections do not extend "base", as they are basically feature toggles.
 
-
 ; Build flags for use of PSRAM
 [psram_common_flags]
-build_flags      = -DUSE_PSRAM=1
-                   -DBOARD_HAS_PSRAM=1
+build_flags     = -DUSE_PSRAM=1
+                  -DBOARD_HAS_PSRAM=1
+build_src_flags =
 
-# Issue errata for rev 1.0 (obsolted early 2020) LX6 modules.
 # https://docs.espressif.com/projects/esp-chip-errata/en/latest/esp32/03-errata-description/esp32/cpu-read-and-write-errors-related-to-access-sequence.html
 [psram_lx6_flags]
-build_flags      = ${psram_common_flags.build_flags}
+build_flags     = ${psram_common_flags.build_flags}
                   -mfix-esp32-psram-cache-issue
+build_src_flags =
 
-; Libs needed to link with a TTGO Module
 [ttgo_deps]
+build_flags     =
+build_src_flags =
 lib_deps        = https://github.com/Xinyuan-LilyGO/TTGO-T-Display
                   bodmer/TFT_eSPI @ ^2.5.43
 
 ; ================================================================
 ; Basic environment section, automatically inherited by all others
-;
 
 [env]
 platform        = platformio/espressif32 @ ^6.12.0
@@ -350,8 +374,10 @@ board_build.embed_txtfiles = config/timezones.json
 
 ; ================================================================
 ; Shared embed assets (avoid duplication across projects)
-;
+
 [embed_matrix_assets]
+build_flags     =
+build_src_flags =
 board_build.embed_files = assets/bmp/brokenclouds.jpg
                           assets/bmp/brokencloudsnight.jpg
                           assets/bmp/clearsky.jpg
@@ -386,7 +412,8 @@ board_build.embed_files = assets/bmp/brokenclouds.jpg
 ;
 
 [mesmerizer_config]
-build_flags     = -DPROJECT_NAME="\"Mesmerizer\""
+build_flags     = ${psram_lx6_flags.build_flags}
+build_src_flags = -DPROJECT_NAME="\"Mesmerizer\""
                   -DMESMERIZER=1
                   -DSHOW_FPS_ON_MATRIX=0
                   -DUSE_HUB75=1
@@ -409,7 +436,6 @@ build_flags     = -DPROJECT_NAME="\"Mesmerizer\""
                   -DIR_REMOTE_PIN=39
                   -DINPUT_PIN=36
                   -DTOGGLE_BUTTON_0=0
-                  ${psram_lx6_flags.build_flags}
 
 lib_deps        = https://github.com/PlummersSoftwareLLC/SmartMatrix.git
                   ${base.graphics_deps}
@@ -418,22 +444,16 @@ lib_deps        = https://github.com/PlummersSoftwareLLC/SmartMatrix.git
 
 board_build.embed_files = ${embed_matrix_assets.board_build.embed_files}
 
-; =====================
-; Base Board Environments - REMOVED
-;
-; These intermediate sections have been eliminated. Device sections now include
-; their board definitions, and project environments extend dev_* sections directly.
-
 ; ====================
 ; Project Environments
 ;
 ; These define specific projects with their base board type, project defines, and effect sets
 
-;=========
-
 [env:demo]
 extends         = dev_esp32
-build_flags     = -DDEMO=1
+build_flags     = ${dev_esp32.build_flags}
+build_src_flags = ${dev_esp32.build_src_flags}
+                  -DDEMO=1
                   -DEFFECTS_DEMO=1
                   -DPROJECT_NAME="\"Demo\""
                   -DMATRIX_WIDTH=144
@@ -446,26 +466,30 @@ build_flags     = -DDEMO=1
                   -DENABLE_OTA=0
                   -DENABLE_WEBSERVER=0
                   -DLED_PIN0=5
-                  ${dev_esp32.build_flags}
 
-; The _v2 and _v3 envs are intended for on-going development efforts by the project maintainers. 
+; The _v2 and _v3 envs are intended for on-going development efforts by the project maintainers.
 ; Use them at your own risk.
-
 [env:demo_v2]
 extends         = env:demo
+build_flags     = ${env:demo.build_flags}
+build_src_flags = ${env:demo.build_src_flags}
 platform        = platformio/espressif32 @ ^6.12.0
 
 [env:demo_v3]
 extends         = env:demo
+build_flags     = ${env:demo.build_flags}
+build_src_flags = ${env:demo.build_src_flags}
 platform        = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30-2/platform-espressif32.zip
 board_build.partitions = config/partitions_custom_noota_v3.csv
+
 ; This is the basic DEMO project again, but expanded to work on the M5, which means it can draw to
 ; the built in LCD.  It's made so that you can connect to the small 4-pin connector on the M5,
 ; so it sends power and ground as well as data on PIN 32.
-
 [env:m5demo]
 extends         = dev_m5stick_c
-build_flags     = -DM5DEMO=1
+build_flags     = ${dev_m5stick_c.build_flags}
+build_src_flags = ${dev_m5stick_c.build_src_flags}
+                  -DM5DEMO=1
                   -DEFFECTS_DEMO=1
                   -DPROJECT_NAME="\"M5Demo\""
                   -DMATRIX_WIDTH=144*5+38
@@ -484,11 +508,9 @@ build_flags     = -DM5DEMO=1
                   -DCOLORDATA_SERVER_ENABLED=0
                   -DLED_PIN0=32
 
-                  ${dev_m5stick_c.build_flags}
-
-; Base configuration for M5 matrix demo environments
 [m5demobase]
-build_flags     = -DUSE_MATRIX=1
+build_flags     =
+build_src_flags = -DUSE_MATRIX=1
                   -DUSE_HUB75=0
                   -DUSE_WS281X=1
                   -DNUM_CHANNELS=1
@@ -513,29 +535,36 @@ build_flags     = -DUSE_MATRIX=1
                   -DLED_PIN0=-1
                   -DDEFAULT_INFO_PAGE=2
                   -DNUM_BANDS=16
+
 lib_deps        = ${base.graphics_deps}
 board_build.embed_files = ${embed_matrix_assets.board_build.embed_files}
 
 ; M5Stick C Plus demo - extends the base matrix demo configuration
 [env:m5plusdemo]
 extends         = dev_m5stick_c_plus2
-build_flags     = -DPROJECT_NAME="\"M5Plus2Demo\""
-                  ${dev_m5stick_c_plus2.build_flags}
+build_flags     = ${dev_m5stick_c_plus2.build_flags}
                   ${m5demobase.build_flags}
+build_src_flags = ${dev_m5stick_c_plus2.build_src_flags}
+                  ${m5demobase.build_src_flags}
+                  -DPROJECT_NAME="\"M5Plus2Demo\""
+
 lib_deps        = ${dev_m5stick_c_plus2.lib_deps}
                   ${m5demobase.lib_deps}
 board_build.embed_files = ${m5demobase.board_build.embed_files}
 
-; The _v2 and _v3 envs are intended for on-going development efforts by the project maintainers. 
+; The _v2 and _v3 envs are intended for on-going development efforts by the project maintainers.
 ; Use them at your own risk.
-
 [env:m5plusdemo_v2]
 extends         = env:m5plusdemo
+build_flags     = ${env:m5plusdemo.build_flags}
+build_src_flags = ${env:m5plusdemo.build_src_flags}
 board           = m5stick-c
 platform        = platformio/espressif32 @ ^6.12.0
 
 [env:m5plusdemo_v3]
 extends         = env:m5plusdemo
+build_flags     = ${env:m5plusdemo.build_flags}
+build_src_flags = ${env:m5plusdemo.build_src_flags}
 board           = m5stick-c
 board_build.variant = m5stack_stickc_plus2
 platform        = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30-2/platform-espressif32.zip
@@ -543,7 +572,9 @@ board_build.partitions = config/partitions_custom_8M_v3.csv
 
 [env:pdpwopr]
 extends         = dev_m5stick_c_plus2
-build_flags     = -DSPECTRUM=1
+build_flags     = ${dev_m5stick_c_plus2.build_flags}
+build_src_flags = ${dev_m5stick_c_plus2.build_src_flags}
+                  -DSPECTRUM=1
                   -DEFFECTS_PDPWOPR=1
                   -DPOWER_LIMIT_MW=1500
                   -DDEFAULT_EFFECT_INTERVAL=0
@@ -566,14 +597,14 @@ build_flags     = -DSPECTRUM=1
                   -DMATRIX_HEIGHT=16
                   -DNUM_BANDS=16
                   -DSHOW_VU_METER=0
-                  ${dev_m5stick_c_plus2.build_flags}
 
-; Also one for the M5Stack Core2
 [env:m5stackdemo]
 extends         = dev_m5stack
-build_flags     = -DPROJECT_NAME="\"M5StackDemo\""
-                  ${dev_m5stack.build_flags}
+build_flags     = ${dev_m5stack.build_flags}
                   ${m5demobase.build_flags}
+build_src_flags = ${dev_m5stack.build_src_flags}
+                  -DPROJECT_NAME="\"M5StackDemo\""
+
 lib_deps        = ${dev_m5stack.lib_deps}
                   ${m5demobase.lib_deps}
 board_build.embed_files = ${m5demobase.board_build.embed_files}
@@ -581,53 +612,59 @@ board_build.embed_files = ${m5demobase.board_build.embed_files}
 ; Now for the Heltec, with WiFi and webserver enabled
 [env:heltecdemo]
 extends         = dev_heltec_wifi
-build_flags     = -DDEMO=1
+build_flags     = ${dev_heltec_wifi.build_flags}
+build_src_flags = ${dev_heltec_wifi.build_src_flags}
+                  -DDEMO=1
                   -DEFFECTS_DEMO=1
                   -DENABLE_WIFI=1
-                  ${dev_heltec_wifi.build_flags}
+
 lib_deps        = ${dev_heltec_wifi.lib_deps}
-                  ${base.oled_deps} # inherited from dev_heltec_wifi
+                  ${base.oled_deps}
 
 ; Now for Heltec V2, which has 8M flash
 [env:heltecv2demo]
 extends         = dev_heltec_wifi_v2
-build_flags     = -DDEMO=1
+build_flags     = ${dev_heltec_wifi_v2.build_flags}
+build_src_flags = ${dev_heltec_wifi_v2.build_src_flags}
+                  -DDEMO=1
                   -DEFFECTS_DEMO=1
                   -DENABLE_WIFI=1
-                  ${dev_heltec_wifi_v2.build_flags}
 
-; Heltec V3 board, which is an S3 with USB-C
 [env:heltecv3demo]
 extends         = dev_heltec_wifi_v3
-build_flags     = -DDEMO=1
+build_flags     = ${dev_heltec_wifi_v3.build_flags}
+build_src_flags = ${dev_heltec_wifi_v3.build_src_flags}
+                  -DDEMO=1
                   -DEFFECTS_DEMO=1
                   -DENABLE_WIFI=1
                   -DROTATE_SCREEN=1
-                  ${dev_heltec_wifi_v3.build_flags}
 
-; Heltec LoRa V3 board, which is an S3 with USB-C and LoRa
 [env:helteclorav3demo]
 extends         = dev_heltec_wifi_lora_v3
-build_flags     = -DDEMO=1
+build_flags     = ${dev_heltec_wifi_lora_v3.build_flags}
+build_src_flags = ${dev_heltec_wifi_lora_v3.build_src_flags}
+                  -DDEMO=1
                   -DEFFECTS_DEMO=1
                   -DENABLE_WIFI=1
                   -DENABLE_AUDIO=0
-                  ${dev_heltec_wifi_lora_v3.build_flags}
 
-; LILYGO T-Display-S3
 [env:lilygo-tdisplay-s3-demo]
 extends         = dev_lilygo_tdisplay_s3
-build_flags     = -DDEMO=1
+build_flags     = ${dev_lilygo_tdisplay_s3.build_flags}
+build_src_flags = ${dev_lilygo_tdisplay_s3.build_src_flags}
+                  -DDEMO=1
                   -DEFFECTS_DEMO=1
                   -DENABLE_WIFI=1
                   -DUSE_SCREEN=0
-                  ${dev_lilygo_tdisplay_s3.build_flags}
+
 lib_deps        = ${base.bounce_deps}
                   ${dev_lilygo_tdisplay_s3.lib_deps}
 
 [env:demo_amoled]
 extends         = dev_lilygo_amoled
-build_flags     = -DDEMO=1
+build_flags     = ${dev_lilygo_amoled.build_flags}
+build_src_flags = ${dev_lilygo_amoled.build_src_flags}
+                  -DDEMO=1
                   -DEFFECTS_DEMO=1
                   -DPROJECT_NAME="\"M5Demo\""
                   -DMATRIX_WIDTH=144*5+38
@@ -650,13 +687,12 @@ build_flags     = -DDEMO=1
                   -DUSE_I2S_AUDIO=1
                   -DI2S_BCLK_PIN=39
                   -DI2S_WS_PIN=42
-                  ${dev_lilygo_amoled.build_flags}
-
-;=============
 
 [env:ledstrip]
 extends         = dev_heltec_wifi
-build_flags     = -DLEDSTRIP=1
+build_flags     = ${dev_heltec_wifi.build_flags}
+build_src_flags = ${dev_heltec_wifi.build_src_flags}
+                  -DLEDSTRIP=1
                   -DPROJECT_NAME='"Ledstrip"'
                   -DENABLE_WEBSERVER=0
                   -DENABLE_WIFI=1
@@ -678,22 +714,25 @@ build_flags     = -DLEDSTRIP=1
                   -DRING_SIZE_3=8
                   -DRING_SIZE_4=16
                   -DEFFECTS_MINIMAL=1
-                  ${dev_heltec_wifi.build_flags}
+
 lib_deps        = ${dev_heltec_wifi.lib_deps}
-                  ${base.oled_deps} # inherited from dev_heltec_wifi
+                  ${base.oled_deps}
 
 ; ledstrip_feather is based off ledstrip but intended for the ESP32S3 TFT Feather from Adafruit with 2MB PSRAM
-
 [env:ledstrip_feather]
 extends         = dev_adafruit_feather
-build_flags     = -DLEDSTRIP=1
-                  -DEFFECTS_MINIMAL=1
-                  ${dev_adafruit_feather.build_flags}
+build_flags     = ${dev_adafruit_feather.build_flags}
                   ${psram_lx6_flags.build_flags}
+build_src_flags = ${dev_adafruit_feather.build_src_flags}
+                  -DLEDSTRIP=1
+                  -DEFFECTS_MINIMAL=1
 
 [env:ledstrip_feather_hexagon]
 extends         = dev_adafruit_feather
-build_flags     = -DHEXAGON=1
+build_flags     = ${dev_adafruit_feather.build_flags}
+                  ${psram_lx6_flags.build_flags}
+build_src_flags = ${dev_adafruit_feather.build_src_flags}
+                  -DHEXAGON=1
                   -DEFFECTS_HEXAGON=1
                   -DPROJECT_NAME="\"Feather Hexagon\""
                   -DENABLE_WIFI=1
@@ -709,36 +748,38 @@ build_flags     = -DHEXAGON=1
                   -DDEFAULT_EFFECT_INTERVAL=1000*20
                   -DHEX_MAX_DIMENSION=19
                   -DHEX_HALF_DIMENSION=10
-                  ${dev_adafruit_feather.build_flags}
-                  ${psram_lx6_flags.build_flags}
 
 [env:ledstrip_feather_wrover]
 extends         = dev_wrover
-build_flags     = -DLEDSTRIP=1
-                  -DEFFECTS_MINIMAL=1
+build_flags     = ${dev_wrover.build_flags}
                   -DUSER_SETUP_LOADED
                   ${psram_lx6_flags.build_flags}
-                  ${dev_wrover.build_flags}
+build_src_flags = ${dev_wrover.build_src_flags}
+                  -DLEDSTRIP=1
+                  -DEFFECTS_MINIMAL=1
+
 debug_init_break = tbreak setup
 
 [env:ledstriplite]
 extends         = dev_esp32
-build_flags     = -DLEDSTRIP=1
+build_flags     = ${dev_esp32.build_flags}
+build_src_flags = ${dev_esp32.build_src_flags}
+                  -DLEDSTRIP=1
                   -DEFFECTS_MINIMAL=1
-                  ${dev_esp32.build_flags}
 
 [env:ledstrip_pico]
 extends         = dev_tinypico
-build_flags     = -DLEDSTRIP=1
-                  -DEFFECTS_MINIMAL=1
+build_flags     = ${dev_tinypico.build_flags}
                   ${psram_lx6_flags.build_flags}
-                  ${dev_tinypico.build_flags}
-
-;=============
+build_src_flags = ${dev_tinypico.build_src_flags}
+                  -DLEDSTRIP=1
+                  -DEFFECTS_MINIMAL=1
 
 [env:spectrum]
 extends         = dev_m5stick_c_plus
-build_flags     = -DSPECTRUM=1
+build_flags     = ${dev_m5stick_c_plus.build_flags}
+build_src_flags = ${dev_m5stick_c_plus.build_src_flags}
+                  -DSPECTRUM=1
                   -DEFFECTS_SPECTRUM=1
                   -DPROJECT_NAME="\"Spectrum\""
                   -DENABLE_AUDIOSERIAL=0
@@ -762,13 +803,13 @@ build_flags     = -DSPECTRUM=1
                   -DMATRIX_WIDTH=48
                   -DMATRIX_HEIGHT=16
                   -DNUM_BANDS=16
-
                   -DSHOW_VU_METER=1
-                  ${dev_m5stick_c_plus.build_flags}
 
 [env:spectrum2]
 extends         = dev_m5stick_c_plus2
-build_flags     = -DSPECTRUM=1
+build_flags     = ${dev_m5stick_c_plus2.build_flags}
+build_src_flags = ${dev_m5stick_c_plus2.build_src_flags}
+                  -DSPECTRUM=1
                   -DEFFECTS_FULLMATRIX=1
                   -DUSE_MATRIX=1
                   -DPROJECT_NAME="\"Spectrum2\""
@@ -793,27 +834,33 @@ build_flags     = -DSPECTRUM=1
                   -DMATRIX_HEIGHT=16
                   -DNUM_BANDS=16
                   -DSHOW_VU_METER=1
-                  ${dev_m5stick_c_plus2.build_flags}
+
 lib_deps        = ${base.graphics_deps}
                   ${dev_m5stick_c_plus2.lib_deps}
 board_build.embed_files = ${m5demobase.board_build.embed_files}
 
-; The _v2 and _v3 envs are intended for on-going development efforts by the project maintainers. 
+; The _v2 and _v3 envs are intended for on-going development efforts by the project maintainers.
 ; Use them at your own risk.
-
 [env:spectrum2_v2]
 extends         = env:spectrum2
+build_flags     = ${env:spectrum2.build_flags}
+build_src_flags = ${env:spectrum2.build_src_flags}
 platform        = platformio/espressif32 @ ^6.12.0
 
 [env:spectrum2_v3]
 extends         = env:spectrum2
-platform        = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30-2/platform-espressif32.zip
+build_flags     = ${env:spectrum2.build_flags}
+build_src_flags = ${env:spectrum2.build_src_flags}
+board           = m5stick-c
 board_build.variant = m5stack_stickc_plus2
+platform        = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30-2/platform-espressif32.zip
 board_build.partitions = config/partitions_custom_8M_v3.csv
 
 [env:helmet]
 extends         = dev_m5stick_c_plus
-build_flags     = -DHELMET=1
+build_flags     = ${dev_m5stick_c_plus.build_flags}
+build_src_flags = ${dev_m5stick_c_plus.build_src_flags}
+                  -DHELMET=1
                   -DEFFECTS_SPECTRUM=1
                   -DSHOW_VU_METER=1
                   -DPROJECT_NAME="\"Helmet\""
@@ -837,60 +884,68 @@ build_flags     = -DHELMET=1
                   -DFAN_SIZE=MATRIX_HEIGHT
                   -DNUM_BANDS=16
                   -DLED_FAN_OFFSET_BU=6
-                  ${dev_m5stick_c_plus.build_flags}
 
 [env:spectrum_elecrow]
 extends         = dev_elecrow_mesmerizer
-build_flags     = -DSPECTRUM=1
+build_flags     = ${dev_elecrow_mesmerizer.build_flags}
+                  -DTFT_WIDTH=320
+                  -DTFT_HEIGHT=480
+                  ${psram_lx6_flags.build_flags}
+build_src_flags = ${dev_elecrow_mesmerizer.build_src_flags}
+                  -DSPECTRUM=1
                   -DEFFECTS_SPECTRUM=1
                   -DSHOW_VU_METER=1
                   -DENABLE_AUDIO=1
                   -DELECROW=1
                   -DUSE_I2S_AUDIO=1
                   -DUSE_SCREEN=1
-                  -DTFT_WIDTH=320
-                  -DTFT_HEIGHT=480
-                  ${psram_lx6_flags.build_flags}
-                  ${dev_elecrow_mesmerizer.build_flags}
+
 lib_deps        = ${dev_elecrow_mesmerizer.lib_deps}
 
 ; Same as Spectrum but using a non-Plus M5 Stick (older version with smaller screen)
 [env:spectrumlite]
 extends         = dev_m5stick_c
-build_flags     = -DSPECTRUM=1
+build_flags     = ${dev_m5stick_c.build_flags}
+build_src_flags = ${dev_m5stick_c.build_src_flags}
+                  -DSPECTRUM=1
                   -DEFFECTS_SPECTRUM=1
                   -DENABLE_AUDIO=1
-                  ${dev_m5stick_c.build_flags}
 
-; And again, for the Wrover
 [env:spectrum_wrover_kit]
 extends         = dev_wrover
-build_flags     = -DSPECTRUM=1
+build_flags     = ${dev_wrover.build_flags}
+build_src_flags = ${dev_wrover.build_src_flags}
+                  -DSPECTRUM=1
                   -DEFFECTS_SPECTRUM=1
                   -DUSE_SCREEN=1
                   -DSPECTRUM_WROVER_KIT=1
                   -DENABLE_AUDIO=1
-                  ${dev_wrover.build_flags}
+
 lib_deps        = ${dev_wrover.lib_deps}
 debug_init_break = tbreak setup
 
 ;===============
-
 [env:mesmerizer]
 extends         = dev_mesmerizer
 build_flags     = ${dev_mesmerizer.build_flags}
+                  ${mesmerizer_config.build_flags}
+build_src_flags = ${dev_mesmerizer.build_src_flags}
+                  ${mesmerizer_config.build_src_flags}
                   -DMESMERIZER=1
                   -DEFFECTS_MESMERIZER=1
-                  ${mesmerizer_config.build_flags}
+
 lib_deps        = ${mesmerizer_config.lib_deps}
 board_build.embed_files = ${mesmerizer_config.board_build.embed_files}
 
 [env:mesmerizer_lolin]
 extends         = dev_lolin_d32_pro
 build_flags     = ${dev_lolin_d32_pro.build_flags}
+                  ${mesmerizer_config.build_flags}
+build_src_flags = ${dev_lolin_d32_pro.build_src_flags}
+                  ${mesmerizer_config.build_src_flags}
                   -DMESMERIZER=1
                   -DEFFECTS_MESMERIZER=1
-                  ${mesmerizer_config.build_flags}
+
 lib_deps        = ${mesmerizer_config.lib_deps}
                   ${base.bounce_deps}
 board_build.embed_files = ${mesmerizer_config.board_build.embed_files}
@@ -900,7 +955,9 @@ board_build.embed_files = ${mesmerizer_config.board_build.embed_files}
 
 [env:laserline]
 extends         = dev_m5stick_c_plus
-build_flags     = -DLASERLINE=1
+build_flags     = ${dev_m5stick_c_plus.build_flags}
+build_src_flags = ${dev_m5stick_c_plus.build_src_flags}
+                  -DLASERLINE=1
                   -DEFFECTS_MINIMAL=1
                   -DPROJECT_NAME="\"Laser Line\""
                   -DENABLE_AUDIOSERIAL=0
@@ -918,13 +975,13 @@ build_flags     = -DLASERLINE=1
                   -DMATRIX_WIDTH=700
                   -DMATRIX_HEIGHT=1
                   -DLED_FAN_OFFSET_BU=6
-
                   -DLED_PIN0=32
-                  ${dev_m5stick_c_plus.build_flags}
 
 [env:lantern]
 extends         = dev_m5stick_c
-build_flags     = -DLANTERN=1
+build_flags     = ${dev_m5stick_c.build_flags}
+build_src_flags = ${dev_m5stick_c.build_src_flags}
+                  -DLANTERN=1
                   -DEFFECTS_MINIMAL=1
                   -DPROJECT_NAME="\"Lantern\""
                   -DNUM_FANS=1
@@ -946,11 +1003,11 @@ build_flags     = -DLANTERN=1
                   -DENABLE_WEBSERVER=0
                   -DDEFAULT_EFFECT_INTERVAL=1000*60*60*24
 
-                  ${dev_m5stick_c.build_flags}
-
 [env:pdpgrid]
 extends         = dev_m5stick_c_plus2
-build_flags     = -DPDPGRID=1
+build_flags     = ${dev_m5stick_c_plus2.build_flags}
+build_src_flags = ${dev_m5stick_c_plus2.build_src_flags}
+                  -DPDPGRID=1
                   -DEFFECTS_MINIMAL=1
                   -DPROJECT_NAME="\"PDPGrid\""
                   -DNUM_FANS=1
@@ -973,11 +1030,11 @@ build_flags     = -DPDPGRID=1
                   -DLED_PIN0=32
                   -DDEFAULT_EFFECT_INTERVAL=0
 
-                  ${dev_m5stick_c_plus2.build_flags}
-
 [env:treeset]
 extends         = dev_esp32
-build_flags     = -DTREESET=1
+build_flags     = ${dev_esp32.build_flags}
+build_src_flags = ${dev_esp32.build_src_flags}
+                  -DTREESET=1
                   -DEFFECTS_MINIMAL=1
                   -DPROJECT_NAME="\"Treeset\""
                   -DENABLE_WIFI=1
@@ -1000,11 +1057,12 @@ build_flags     = -DTREESET=1
                   -DIR_REMOTE_PIN=25
                   -DLED_FAN_OFFSET_BU=12
                   -DTOGGLE_BUTTON=37
-                  ${dev_esp32.build_flags}
 
 [env:chieftain]
 extends         = dev_tinypico
-build_flags     = -DCHIEFTAIN=1
+build_flags     = ${dev_tinypico.build_flags}
+build_src_flags = ${dev_tinypico.build_src_flags}
+                  -DCHIEFTAIN=1
                   -DPROJECT_NAME='"Chieftain"'
                   -DENABLE_WIFI=1
                   -DINCOMING_WIFI_ENABLED=1
@@ -1024,11 +1082,13 @@ build_flags     = -DCHIEFTAIN=1
                   -DRING_SIZE_3=8
                   -DRING_SIZE_4=16
                   -DEFFECTS_MINIMAL=1
-                  ${dev_tinypico.build_flags}
 
 [env:umbrella]
 extends         = dev_esp32
-build_flags     = -DUMBRELLA=1
+build_flags     = ${dev_esp32.build_flags}
+                  ${psram_lx6_flags.build_flags}
+build_src_flags = ${dev_esp32.build_src_flags}
+                  -DUMBRELLA=1
                   -DPROJECT_NAME='"Umbrella"'
                   -DCOLOR_ORDER=EOrder::RGB
                   -DENABLE_WIFI=1
@@ -1057,14 +1117,15 @@ build_flags     = -DUMBRELLA=1
                   -DTOGGLE_BUTTON_0=0
                   -DEFFECTS_MINIMAL=1
                   -DUSE_SCREEN=0
-                  ${psram_lx6_flags.build_flags}
-                  ${dev_esp32.build_flags}
+
 lib_deps        = ${base.bounce_deps}
                   ${dev_esp32.lib_deps}
 
 [env:hexagon]
 extends         = dev_esp32
-build_flags     = -DHEXAGON=1
+build_flags     = ${dev_esp32.build_flags}
+build_src_flags = ${dev_esp32.build_src_flags}
+                  -DHEXAGON=1
                   -DEFFECTS_HEXAGON=1
                   -DPROJECT_NAME="\"Hexagon\""
                   -DENABLE_WEBSERVER=1
@@ -1080,13 +1141,13 @@ build_flags     = -DHEXAGON=1
                   -DDEFAULT_EFFECT_INTERVAL=1000*20
                   -DHEX_MAX_DIMENSION=19
                   -DHEX_HALF_DIMENSION=10
-                  ${dev_esp32.build_flags}
 
 [env:generic]
 extends         = dev_esp32
-build_flags     = -DGENERIC=1
+build_flags     = ${dev_esp32.build_flags}
+build_src_flags = ${dev_esp32.build_src_flags}
+                  -DGENERIC=1
                   -DEFFECTS_MINIMAL=1
-                  ${dev_esp32.build_flags}
 
 [env:ttgo]
 extends         = dev_esp32
@@ -1100,17 +1161,12 @@ upload_flags    = --before
 board_build.flash_mode = dio
 board_build.flash_freq = 40m
 
-build_flags     = -DTTGO=1
-                  -DEFFECTS_TTGO=1
-                  -DUSE_SCREEN=1
-                  -DDEFAULT_INFO_PAGE=1
-                  -DUSE_TFTSPI=1
+build_flags     = ${dev_esp32.build_flags}
                   -DUSER_SETUP_LOADED
                   -DST7789_DRIVER
                   -DTFT_SDA_READ
                   -DTFT_WIDTH=135
                   -DTFT_HEIGHT=240
-                  -DCGRAM_OFFSET
                   -DTFT_CS=5
                   -DTFT_DC=16
                   -DTFT_RST=23
@@ -1121,6 +1177,13 @@ build_flags     = -DTTGO=1
                   -DTFT_BACKLIGHT_ON=HIGH
                   -DSPI_FREQUENCY=40000000
                   -DSPI_READ_FREQUENCY=6000000
+build_src_flags = ${dev_esp32.build_src_flags}
+                  -DTTGO=1
+                  -DEFFECTS_TTGO=1
+                  -DUSE_SCREEN=1
+                  -DDEFAULT_INFO_PAGE=1
+                  -DUSE_TFTSPI=1
+                  -DCGRAM_OFFSET
                   -DPROJECT_NAME="\"TTGO\""
                   -DENABLE_WIFI=1
                   -DINCOMING_WIFI_ENABLED=1
@@ -1146,7 +1209,7 @@ build_flags     = -DTTGO=1
                   -DIR_REMOTE_PIN=22
                   -DLED_FAN_OFFSET_BU=6
                   -DTOGGLE_BUTTON_0=35
-                  ${dev_esp32.build_flags}
+
 lib_deps        = ${base.lib_deps}
                   ${base.bounce_deps}
                   ${psram_lx6_flags.build_flags}
@@ -1154,7 +1217,9 @@ lib_deps        = ${base.lib_deps}
 
 [env:xmastrees]
 extends         = dev_m5stick_c_plus
-build_flags     = -DXMASTREES=1
+build_flags     = ${dev_m5stick_c_plus.build_flags}
+build_src_flags = ${dev_m5stick_c_plus.build_src_flags}
+                  -DXMASTREES=1
                   -DEFFECTS_MINIMAL=1
                   -DPROJECT_NAME="\"X-mas Trees\""
                   -DENABLE_WIFI=1
@@ -1177,11 +1242,11 @@ build_flags     = -DXMASTREES=1
                   -DIR_REMOTE_PIN=25
                   -DLED_FAN_OFFSET_BU=6
 
-                  ${dev_m5stick_c_plus.build_flags}
-
 [env:insulators]
 extends         = dev_m5stick_c_plus
-build_flags     = -DINSULATORS=1
+build_flags     = ${dev_m5stick_c_plus.build_flags}
+build_src_flags = ${dev_m5stick_c_plus.build_src_flags}
+                  -DINSULATORS=1
                   -DPROJECT_NAME='"Insulators"'
                   -DENABLE_WIFI=0
                   -DINCOMING_WIFI_ENABLED=0
@@ -1201,13 +1266,13 @@ build_flags     = -DINSULATORS=1
                   -DENABLE_AUDIO=1
                   -DIR_REMOTE_PIN=26
                   -DLED_FAN_OFFSET_BU=6
-
                   -DEFFECTS_MINIMAL=1
-                  ${dev_m5stick_c_plus.build_flags}
 
 [env:single_insulator]
 extends         = dev_m5stick_c_plus
-build_flags     = -DSINGLE_INSULATOR=1
+build_flags     = ${dev_m5stick_c_plus.build_flags}
+build_src_flags = ${dev_m5stick_c_plus.build_src_flags}
+                  -DSINGLE_INSULATOR=1
                   -DEFFECTS_MINIMAL=1
                   -DPROJECT_NAME="\"Single Insulator\""
                   -DENABLE_WIFI=0
@@ -1224,11 +1289,12 @@ build_flags     = -DSINGLE_INSULATOR=1
                   -DENABLE_AUDIO=1
                   -DLED_FAN_OFFSET_BU=6
                   -DLED_PIN0=26
-                  ${dev_m5stick_c_plus.build_flags}
 
 [env:magicmirror]
 extends         = dev_m5stick_c
-build_flags     = -DMAGICMIRROR=1
+build_flags     = ${dev_m5stick_c.build_flags}
+build_src_flags = ${dev_m5stick_c.build_src_flags}
+                  -DMAGICMIRROR=1
                   -DPROJECT_NAME='"Magic Mirror"'
                   -DENABLE_WIFI=0
                   -DINCOMING_WIFI_ENABLED=0
@@ -1246,11 +1312,13 @@ build_flags     = -DMAGICMIRROR=1
                   -DIR_REMOTE_PIN=15
                   -DLED_FAN_OFFSET_BU=6
                   -DEFFECTS_MINIMAL=1
-                  ${dev_m5stick_c.build_flags}
 
 [env:atomlight]
 extends         = dev_esp32
-build_flags     = -DATOMLIGHT=1
+build_flags     = ${dev_esp32.build_flags}
+                  -UUSE_SCREEN              ; Unset USE_SCREEN that is set in the device build flags.
+build_src_flags = ${dev_esp32.build_src_flags}
+                  -DATOMLIGHT=1
                   -DEFFECTS_MINIMAL=1
                   -DPROJECT_NAME="\"Atom Light\""
                   -DENABLE_WIFI=1
@@ -1274,13 +1342,12 @@ build_flags     = -DATOMLIGHT=1
                   -DLED_PIN2=17
                   -DLED_PIN3=18
                   -DDEFAULT_EFFECT_INTERVAL=1000*60*5
-                  ${dev_esp32.build_flags}
-                  -UUSE_SCREEN                      ; Unset USE_SCREEN that is set in the device build flags.
-                                                    ; The ATOMLIGHT project really prefers not to use it.
 
 [env:spirallamp]
 extends         = dev_m5stick_c_plus
-build_flags     = -DSPIRALLAMP=1
+build_flags     = ${dev_m5stick_c_plus.build_flags}
+build_src_flags = ${dev_m5stick_c_plus.build_src_flags}
+                  -DSPIRALLAMP=1
                   -DPROJECT_NAME='"Spiral Light"'
                   -DENABLE_WIFI=1
                   -DINCOMING_WIFI_ENABLED=1
@@ -1304,11 +1371,14 @@ build_flags     = -DSPIRALLAMP=1
                   -DLED_PIN1=33
                   -DDEFAULT_EFFECT_INTERVAL=300000
                   -DEFFECTS_MINIMAL=1
-                  ${dev_m5stick_c_plus.build_flags}
 
 [env:platecover]
 extends         = dev_m5stick_c_plus
-build_flags     = -DPLATECOVER=1
+build_flags     = ${dev_m5stick_c_plus.build_flags}
+                  -DFASTLED_EXPERIMENTAL_ESP32_RGBW_ENABLED=1
+                  -DFASTLED_EXPERIMENTAL_ESP32_RGBW_MODE=kRGBWMaxBrightness
+build_src_flags = ${dev_m5stick_c_plus.build_src_flags}
+                  -DPLATECOVER=1
                   -DPROJECT_NAME='"Plate Cover"'
                   -DENABLE_ESPNOW=1
                   -DENABLE_WIFI=0
@@ -1324,19 +1394,17 @@ build_flags     = -DPLATECOVER=1
                   -DENABLE_AUDIO=1
                   -DUSE_SCREEN=1
                   -DFAN_SIZE=40
-
                   -DLED_PIN0=32
                   -DDEFAULT_EFFECT_INTERVAL=0
                   -DEFFECTS_MINIMAL=1
-                  -DFASTLED_EXPERIMENTAL_ESP32_RGBW_ENABLED=1
-                  -DFASTLED_EXPERIMENTAL_ESP32_RGBW_MODE=kRGBWMaxBrightness
                   -DCOLOR_ORDER=EOrder::BRG
                   -DLEDTYPE=WS2812
-                  ${dev_m5stick_c_plus.build_flags}
 
 [env:fanset]
 extends         = dev_m5stick_c_plus
-build_flags     = -DFANSET=1
+build_flags     = ${dev_m5stick_c_plus.build_flags}
+build_src_flags = ${dev_m5stick_c_plus.build_src_flags}
+                  -DFANSET=1
                   -DEFFECTS_FAN=1
                   -DPROJECT_NAME="\"Fan set\""
                   -DENABLE_AUDIOSERIAL=0
@@ -1366,12 +1434,13 @@ build_flags     = -DFANSET=1
                   -DLED_FAN_OFFSET_BU=3
                   -DMATRIX_HEIGHT=1
 
-                  ${dev_m5stick_c_plus.build_flags}
 monitor_filters = esp32_exception_decoder
 
 [env:wroverkit]
 extends         = dev_wrover
-build_flags     = -DWROVERKIT=1
+build_flags     = ${dev_wrover.build_flags}
+build_src_flags = ${dev_wrover.build_src_flags}
+                  -DWROVERKIT=1
                   -DPROJECT_NAME='"WROVER Kit"'
                   -DMATRIX_WIDTH=144
                   -DMATRIX_HEIGHT=1
@@ -1389,11 +1458,12 @@ build_flags     = -DWROVERKIT=1
                   -DWAIT_FOR_WIFI=0
                   -DLED_PIN0=5
                   -DENABLE_WEBSERVER=1
-                  ${dev_wrover.build_flags}
 
 [env:cube]
 extends         = dev_m5stick_c_plus
-build_flags     = -DCUBE=1
+build_flags     = ${dev_m5stick_c_plus.build_flags}
+build_src_flags = ${dev_m5stick_c_plus.build_src_flags}
+                  -DCUBE=1
                   -DPROJECT_NAME='"Cube"'
                   -DENABLE_WIFI=1
                   -DINCOMING_WIFI_ENABLED=1
@@ -1417,4 +1487,3 @@ build_flags     = -DCUBE=1
                   -DENABLE_OTA=0
                   -DCOLOR_ORDER=EOrder::RGB
                   -DEFFECTS_MINIMAL=1
-                  ${dev_m5stick_c_plus.build_flags}


### PR DESCRIPTION
This prevents recompilation of the entire world when you change
the IR remote pin. We just don't need to recompile vfs.o and spi.o
in the base HAL, for example.

Yes, this is ugly. Welcome to platformio.

Tested:
pio config before and after
Use custom python to identify flags that are uniquely ours vs.
platform flags.
Full builds.

## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
