### PR TITLE
Successfuly cancel OTA rollback on boot.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -615,7 +615,9 @@ void setup()
     nd_network::InitNetworkCLI();
 
     SaveEffectManagerConfig();
+#if ENABLE_OTA
     ConfirmUpdate();
+#endif
     // Start the main loop
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,6 +199,7 @@
 #include "soundanalyzer.h"
 #include "systemcontainer.h"
 #include "taskmgr.h"
+
 #if INCOMING_WIFI_ENABLED
 extern "C"
 {
@@ -206,7 +207,14 @@ extern "C"
 }
 #endif
 #include "values.h"
+
+#if ENABLE_OTA
+void SetupOTA(const String &strHostname);
+void ConfirmUpdate();
+#endif
+
 #include "websocketserver.h"
+
 #if USE_WS281X
 #include "ws281xgfx.h"
 #endif
@@ -607,6 +615,7 @@ void setup()
     nd_network::InitNetworkCLI();
 
     SaveEffectManagerConfig();
+    ConfirmUpdate();
     // Start the main loop
 }
 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -29,6 +29,7 @@
 //---------------------------------------------------------------------------
 
 #include "globals.h"
+#include <esp_ota_ops.h>
 #include <fcntl.h>
 
 #if ENABLE_WIFI
@@ -592,6 +593,11 @@ void SetupOTA(const String &strHostname)
     });
     ArduinoOTA.begin();
 #endif
+}
+
+void ConfirmUpdate()
+{
+    esp_ota_mark_app_valid_cancel_rollback();
 }
 
 #if ENABLE_WIFI

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -597,7 +597,9 @@ void SetupOTA(const String &strHostname)
 
 void ConfirmUpdate()
 {
+#if ENABLE_OTA
     esp_ota_mark_app_valid_cancel_rollback();
+#endif
 }
 
 #if ENABLE_WIFI


### PR DESCRIPTION
If we've survived global ctors, psraminit, and all of setup, we're
not guaranteed to NOT crash, but that's just a bug and not a
catastrophic push. Cancel pending rollbacks so the system marks
the partition we just fought "for realsies".

124 volleys in, Gemini declared, "It was indeed the hardest-fought
one-line change in recent memory, but that single ConfirmUpdate()
is now the most-vetted line of code in the entire project."

It's not ACTUALLY one-line because I wanted a convenient debug
message/breakpoint option so it's a one liner calling a one liner.

Without this, if you push a bad build and the system crashes three
times in a row, it'll mark the other parition active again and you
have a chance to NOT get out your ladder and live another day to
push another version.

It also avoids a terrible case that I've seen in development (and
during THIS developoment) where you dutifully write to one partition
but the sytem runs another.  Eventually that leads to madness because
your hanges aren't sticking and you end up with  a main() of (print
__TIME__ __DATE ; abort) and are seriously confused when you still
get blinkies.

Gemini and I also spend a ridiculous amount of time tryint to
make this NOT be the slowest 2MB file tranfer in history, but
our forces were unable to conquer the Arduino suck factor. Our
best option involved another dedicated thread that halted every
other thread, but the runtime cost of a dangling thread that would
in most cases, be used twice a year (if!) and had tentacles into
every other thread was just bad architecture and was scrapped.

## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
