### PR TITLE
Network: Resolve socket race condition and NTP initialization issues

### DIFF
--- a/src/network.cpp
+++ b/src/network.cpp
@@ -265,15 +265,16 @@ namespace nd_network
         bPreviousConnection = true;
         bReportedDisconnected = false;
 
-        #if INCOMING_WIFI_ENABLED
-            g_ptrSystem->GetSocketServer().release();
-            if (false == g_ptrSystem->GetSocketServer().begin())
-                throw std::runtime_error("Could not start socket server!");
-        #endif
         #if ENABLE_OTA
             SetupOTA(String(WiFi.getHostname()));
         #endif
         #if ENABLE_NTP
+            static bool bUdpInitialized = false;
+            if (!bUdpInitialized)
+            {
+                l_Udp.begin(1234);     // Use a fixed local port for NTP responses
+                bUdpInitialized = true;
+            }
             NTPTimeClient::UpdateClockFromWeb(&l_Udp);
         #endif
         #if ENABLE_WEBSERVER
@@ -796,9 +797,16 @@ void IRAM_ATTR SocketServerTaskEntry(void *)
             auto &socketServer = g_ptrSystem->GetSocketServer();
 
             socketServer.release();
-            socketServer.begin();
-            socketServer.ProcessIncomingConnectionsLoop();
-            debugV("Socket connection closed.  Retrying...");
+            if (socketServer.begin())
+            {
+                socketServer.ProcessIncomingConnectionsLoop();
+                debugV("Socket connection closed.  Retrying...");
+            }
+            else
+            {
+                debugE("Failed to start socket server, retrying in 5 seconds...");
+                delay(5000);
+            }
         }
         delay(500);
     }

--- a/src/socketserver.cpp
+++ b/src/socketserver.cpp
@@ -100,7 +100,7 @@ bool SocketServer::begin()
     int opt = 1;
     if (setsockopt(_server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)))
     {
-        perror("setsockopt");
+        debugE("setsockopt SO_REUSEADDR failed on socket %d: %s (%d)", _server_fd, strerror(errno), errno);
         release();
         return false;
     }
@@ -112,16 +112,18 @@ bool SocketServer::begin()
 
     if (bind(_server_fd, (struct sockaddr *)&_address, sizeof(_address)) < 0)       // Bind socket to port
     {
-        perror("bind failed\n");
+        debugE("bind failed on port %d, socket %d: %s (%d)", _port, _server_fd, strerror(errno), errno);
         release();
         return false;
     }
     if (listen(_server_fd, 6) < 0)                                                  // Start listening for connections
     {
-        perror("listen failed\n");
+        debugE("listen failed on port %d, socket %d: %s (%d)", _port, _server_fd, strerror(errno), errno);
         release();
         return false;
     }
+
+    debugI("Socket server %d listening on port %d", _server_fd, _port);
     return true;
 }
 
@@ -240,10 +242,10 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
     int new_socket = -1;
 
     // Accept loop: wait for an incoming connection, sleeping between polls to avoid busy-spinning
-    int addrlen = sizeof(_address);
+    socklen_t addrlen = sizeof(_address);
     while (new_socket < 0)
     {
-        new_socket = accept(_server_fd, (struct sockaddr *)&_address, (socklen_t*)&addrlen);
+        new_socket = accept(_server_fd, (struct sockaddr *)&_address, &addrlen);
         if (new_socket < 0)
         {
             if (errno == EAGAIN || errno == EWOULDBLOCK)
@@ -251,7 +253,7 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
                 delay(100); // No connection yet, yield and retry
                 continue;
             }
-            debugE("Error accepting data: %s", strerror(errno));
+            debugE("Socket server %d failed to accept connection: %s (%d)", _server_fd, strerror(errno), errno);
             return false;
         }
     }


### PR DESCRIPTION
Fix startup race on socket server, ensure NTP is bound to a socket on startup.

I've seen this rarely on LX6, but LX7 shows it most of the time:

E][ND] Error accepting data: Bad file number
[  7584][E][WiFiUdp.cpp:221] parsePacket(): could not receive data: 9
[W][ND] NTP clock: Raw values sec=1987110204, usec=462660


- Hardened SocketServerTaskEntry by ensuring socketServer.begin() succeeds before entering the processing loop. This prevents EINVAL/EBADF errors when the network stack is unstable during early boot.
- Added explicit l_Udp.begin() with a static initialization guard in ConnectToWiFi to ensure the NTP client has a bound socket for receiving responses.
- Replaced perror with debugE and improved socket error logging to include the file descriptor and raw errno, providing better diagnostic clarity during network failures.
- Removed redundant SocketServer start in ConnectToWiFi to prevent multiple simultaneous listeners on the same port.

Tested: Boot of tinyled (well, tinyled running ledstrip-feather because tinyled is in that branch over there...) and Mesmerizer. Conirmed absence of error, happy colorserver, ntp on both.

## Description
<!-- Clearly describe the purpose of the change/improvement you're proposing or feature you're aiming to add. -->

## Contributing requirements
<!-- Make sure your PR conforms to the requirements set out in CONTRIBUTING.md: -->

<!-- 
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).
