### PR TITLE
Bump action versions away from deprecated NodeJS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 
@@ -35,10 +35,10 @@ jobs:
         envname: ${{ fromJson(needs.collect-environments.outputs.envs) }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 
@@ -65,3 +65,4 @@ jobs:
     with:
       release-name: ${{ github.ref_name }} commit ${{ github.sha }}
     secrets: inherit
+    

--- a/.github/workflows/web_installer.yml
+++ b/.github/workflows/web_installer.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 
@@ -40,10 +40,10 @@ jobs:
         envname: ${{ fromJson(needs.determine-projects.outputs.envs) }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -62,7 +62,7 @@ jobs:
         run: python tools/installer_buildenv.py ${{ matrix.envname }} ${{ needs.determine-projects.outputs.version }}
 
       - name: Store build output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           overwrite: true
           path: build
@@ -75,16 +75,16 @@ jobs:
 
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - run: mkdir -p build
 
     - name: Retrieve composer input
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         path: build
         merge-multiple: true


### PR DESCRIPTION
## Description

This bumps the version of relevant GitHub Actions to ones that use a non-deprecated version of NodeJS. This is necessary as GitHub will [remove support for NodeJS 20 actions](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) within the next couple of months. 

Closes #838.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).