### PR TITLE
Fine tune stacks

### DIFF
--- a/include/taskmgr.h
+++ b/include/taskmgr.h
@@ -57,14 +57,14 @@ class LEDStripEffect;
 #define DEFAULT_STACK_SIZE (2048 + 512)
 
 #define IDLE_STACK_SIZE    2048
-#define DRAWING_STACK_SIZE 4096
-#define AUDIO_STACK_SIZE   4096
+#define DRAWING_STACK_SIZE 3072
+#define AUDIO_STACK_SIZE   3072
 #define JSON_STACK_SIZE    4096
-#define SOCKET_STACK_SIZE  4096
-#define NET_STACK_SIZE     8192
+#define SOCKET_STACK_SIZE  3072
+#define NET_STACK_SIZE     6144
 #define COLORDATA_STACK_SIZE 4096
-#define DEBUG_STACK_SIZE   8192                 // Needs a lot of stack for output if UpdateClockFromWeb is called from debugger
-#define REMOTE_STACK_SIZE  4096
+#define DEBUG_STACK_SIZE   4096                 // Needs a lot of stack for output if UpdateClockFromWeb is called from debugger
+#define REMOTE_STACK_SIZE  3072
 #define SCREEN_STACK_SIZE  8192
 
 class IdleTask
@@ -141,6 +141,7 @@ public:
     static void CheckHeap();
 
     void begin();
+    virtual String GetStackUsageSummary() const;
 
 };
 
@@ -209,6 +210,7 @@ public:
 
     void NotifyJSONWriterThread();
     void NotifyNetworkThread();
+    String GetStackUsageSummary() const override;
 
     // Effect threads run with NET priority and on the NET core by default. It seems a sensible choice
     //   because effect threads tend to pull things from the Internet that they want to show

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -700,6 +700,9 @@ void loop()
 
             const auto& taskManager = g_ptrSystem->GetTaskManager();
             strOutput += str_sprintf("CPU: %03.0f%%, %03.0f%%, FreeDraw: %4.3lf", taskManager.GetCPUUsagePercent(0), taskManager.GetCPUUsagePercent(1), g_Values.FreeDrawTime);
+            const auto stackUsage = taskManager.GetStackUsageSummary();
+            if (stackUsage.length() > 0)
+                strOutput += str_sprintf(" Stack: %s", stackUsage.c_str());
 
             debugI("%s", strOutput.c_str());
         }

--- a/src/taskmgr.cpp
+++ b/src/taskmgr.cpp
@@ -19,6 +19,25 @@
 
 #include <esp_task_wdt.h>
 
+namespace
+{
+    void AppendTaskStackUsage(String& output, const char* label, TaskHandle_t handle, size_t stackSizeBytes)
+    {
+        if (handle == nullptr)
+            return;
+
+        const auto freeWords = uxTaskGetStackHighWaterMark(handle);
+        const size_t freeBytes = static_cast<size_t>(freeWords) * sizeof(StackType_t);
+        const size_t clampedFreeBytes = std::min(freeBytes, stackSizeBytes);
+        const size_t usedBytes = stackSizeBytes - clampedFreeBytes;
+
+        if (!output.isEmpty())
+            output += ' ';
+
+        output += str_sprintf("%s:%zu/%zu", label, usedBytes, stackSizeBytes);
+    }
+}
+
 void IdleTask::ProcessIdleTime()
 {
     _lastMeasurement = millis();
@@ -87,6 +106,16 @@ void TaskManager::CheckHeap()
     {
         throw std::runtime_error("Heap FAILED checks!");
     }
+}
+
+String TaskManager::GetStackUsageSummary() const
+{
+    String output;
+
+    AppendTaskStackUsage(output, "Idle0", _hIdle0, IDLE_STACK_SIZE);
+    AppendTaskStackUsage(output, "Idle1", _hIdle1, IDLE_STACK_SIZE);
+
+    return output;
 }
 
 // NightDriverTaskManager
@@ -232,6 +261,30 @@ void NightDriverTaskManager::NotifyNetworkThread()
     debugW(">> Notifying Network Thread");
     // Wake up the network task if it's sleeping, or request another read cycle if it isn't
     xTaskNotifyGive(_taskNetwork);
+}
+
+String NightDriverTaskManager::GetStackUsageSummary() const
+{
+    String output = TaskManager::GetStackUsageSummary();
+
+    AppendTaskStackUsage(output, "Draw", _taskDraw, DRAWING_STACK_SIZE);
+    AppendTaskStackUsage(output, "Audio", _taskAudio, AUDIO_STACK_SIZE);
+    AppendTaskStackUsage(output, "Net", _taskNetwork, NET_STACK_SIZE);
+    AppendTaskStackUsage(output, "Sock", _taskSocket, SOCKET_STACK_SIZE);
+    AppendTaskStackUsage(output, "Dbg", _taskDebug, DEBUG_STACK_SIZE);
+    AppendTaskStackUsage(output, "Json", _taskJSONWriter, JSON_STACK_SIZE);
+    AppendTaskStackUsage(output, "Remote", _taskRemote, REMOTE_STACK_SIZE);
+    AppendTaskStackUsage(output, "Screen", _taskScreen, SCREEN_STACK_SIZE);
+    AppendTaskStackUsage(output, "Serial", _taskSerial, DEFAULT_STACK_SIZE);
+    AppendTaskStackUsage(output, "Color", _taskColorData, DEFAULT_STACK_SIZE);
+
+    for (const auto& effectTask : _vEffectTasks)
+    {
+        const char* taskName = pcTaskGetName(effectTask);
+        AppendTaskStackUsage(output, taskName ? taskName : "Effect", effectTask, DEFAULT_STACK_SIZE);
+    }
+
+    return output;
 }
 
 // Effect threads run with NET priority and on the NET core by default. It seems a sensible choice


### PR DESCRIPTION
## Description
Reduces stack usage, frees up about 10K of base RAM.  I tested all scenarios I could think of, including debugger commands like clock, etc....

Add instrumentation to the main printout for now so we can monitor stack

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).