### PR TITLE
Optimize WB2812B Draw Path

### DIFF
--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -162,6 +162,15 @@ public:
     static const uint16_t kMatrixWidth = MATRIX_WIDTH;                                  // known working for actual matrix effects: 32, 64, 96, 128
     static const uint16_t kMatrixHeight = MATRIX_HEIGHT;                                // known working for actual matrix effects: 16, 32, 48, 64
 
+    static inline void FadePixelInPlace(CRGB& pixel, uint8_t fadeValue) noexcept
+    {
+        const uint8_t scale = 255 - fadeValue;
+        const uint16_t scaleFixed = static_cast<uint16_t>(scale) + 1;
+        pixel.r = static_cast<uint8_t>((static_cast<uint16_t>(pixel.r) * scaleFixed) >> 8);
+        pixel.g = static_cast<uint8_t>((static_cast<uint16_t>(pixel.g) * scaleFixed) >> 8);
+        pixel.b = static_cast<uint8_t>((static_cast<uint16_t>(pixel.b) * scaleFixed) >> 8);
+    }
+
     // A 3-byte struct will have one byte of padding so each element
     // begins on a NA boundary. Making this
     // struct __attribute__((packed)) PolarMap

--- a/include/globals.h
+++ b/include/globals.h
@@ -92,7 +92,15 @@
 #include <mutex>
 extern std::mutex g_buffer_mutex;
 
-// Protects against drawing during config changes and vice versa
+// Protects the active render/configuration pipeline so runtime topology/output changes
+// cannot reconfigure device buffers while a frame is being prepared, drawn, or emitted.
+// Splitting this into two mutexes (render and effect manager) allows effects to change without 
+// blocking the entire render pipeline, which is important for effects that need to update every 
+// frame like the spectrum analyzer, but it looks redundant in many cases when acquried!
+
+extern std::recursive_mutex g_render_mutex;
+
+// Protects effect state transitions and effect-manager mutations.
 extern std::recursive_mutex g_effect_manager_mutex;
 
 #include <FastLED.h>

--- a/include/globals.h
+++ b/include/globals.h
@@ -96,7 +96,7 @@ extern std::mutex g_buffer_mutex;
 // cannot reconfigure device buffers while a frame is being prepared, drawn, or emitted.
 // Splitting this into two mutexes (render and effect manager) allows effects to change without 
 // blocking the entire render pipeline, which is important for effects that need to update every 
-// frame like the spectrum analyzer, but it looks redundant in many cases when acquried!
+// frame like the spectrum analyzer, but it looks redundant in many cases when acquired!
 
 extern std::recursive_mutex g_render_mutex;
 

--- a/include/ws281xoutputmanager.h
+++ b/include/ws281xoutputmanager.h
@@ -49,7 +49,7 @@ class WS281xOutputManager
     ~WS281xOutputManager();
 
     bool ApplyConfig(const DeviceConfig& config, const std::vector<std::shared_ptr<GFXBase>>& devices, String* errorMessage = nullptr);
-    void Show(const std::vector<std::shared_ptr<GFXBase>>& devices, uint16_t pixelsDrawn, uint8_t brightness);
+    void Show(const std::vector<std::shared_ptr<GFXBase>>& devices, uint16_t pixelsDrawn, uint8_t brightness, uint8_t fader);
     void Reset();
 
     size_t GetActiveChannelCount() const { return _activeChannelCount; }

--- a/platformio.ini
+++ b/platformio.ini
@@ -517,6 +517,7 @@ build_src_flags = ${dev_m5stick_c.build_src_flags}
                   -DENABLE_NTP=1
                   -DENABLE_OTA=1
                   -DENABLE_REMOTE=1
+                  -DIR_REMOTE_PIN=26
                   -DENABLE_AUDIO=1
                   -DCOLORDATA_SERVER_ENABLED=1
                   -DDEFAULT_EFFECT_INTERVAL=0

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -285,12 +285,12 @@ void IRAM_ATTR DrawLoopTaskEntry(void *)
         uint16_t localPixelsDrawn   = 0;
         uint16_t wifiPixelsDrawn    = 0;
         double frameStartTime       = g_Values.AppTime.FrameStartTime();
-        auto& graphics = *g_ptrSystem->GetDevices()[0];
 
         {
             // Hold the render mutex for the frame pipeline so runtime topology/output
             // changes cannot reconfigure the active buffers mid-frame.
             std::lock_guard<std::recursive_mutex> renderGuard(g_render_mutex);
+            auto& graphics = *g_ptrSystem->GetDevices()[0];
 
             graphics.PrepareFrame();
 

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -226,8 +226,8 @@ void ShowOnboardRGBLED()
             ledcWrite(2, 255 - c.g);
             ledcWrite(3, 255 - c.b);
         #else
-            int iLed = g_ptrSystem->GetEffectManager().g().GetLEDCount() / 2;
-            const auto& graphics = g_ptrSystem->GetEffectManager().g();
+            const auto& graphics = *g_ptrSystem->GetDevices()[0];
+            int iLed = graphics.GetLEDCount() / 2;
             ledcWrite(1, 255 - graphics.leds[iLed].r); // write red component to channel 1, etc.
             ledcWrite(2, 255 - graphics.leds[iLed].g);
             ledcWrite(3, 255 - graphics.leds[iLed].b);
@@ -285,10 +285,12 @@ void IRAM_ATTR DrawLoopTaskEntry(void *)
         uint16_t localPixelsDrawn   = 0;
         uint16_t wifiPixelsDrawn    = 0;
         double frameStartTime       = g_Values.AppTime.FrameStartTime();
+        auto& graphics = *g_ptrSystem->GetDevices()[0];
 
         {
-            std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
-            auto& graphics = g_ptrSystem->GetEffectManager().g();
+            // Hold the render mutex for the frame pipeline so runtime topology/output
+            // changes cannot reconfigure the active buffers mid-frame.
+            std::lock_guard<std::recursive_mutex> renderGuard(g_render_mutex);
 
             graphics.PrepareFrame();
 

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -130,6 +130,7 @@ void InitEffectsManager()
 
 void EffectManager::StartEffect()
 {
+    std::lock_guard<std::recursive_mutex> renderGuard(g_render_mutex);
     std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
 
     // If there's a temporary effect override from the remote control active, we start that, else
@@ -236,6 +237,8 @@ EffectManager::~EffectManager()
 
 void EffectManager::SetTempEffect(std::shared_ptr<LEDStripEffect> effect)
 {
+    std::lock_guard<std::recursive_mutex> renderGuard(g_render_mutex);
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     _tempEffect = effect;
 }
 
@@ -334,6 +337,7 @@ const String & EffectManager::GetCurrentEffectName() const
 
 void EffectManager::SetCurrentEffectIndex(size_t i)
 {
+    std::lock_guard<std::recursive_mutex> renderGuard(g_render_mutex);
     std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
 
     if (i >= _vEffects.size())
@@ -972,6 +976,7 @@ bool EffectManager::DeleteEffect(size_t index)
 
 void EffectManager::CheckEffectTimerExpired()
 {
+    std::lock_guard<std::recursive_mutex> renderGuard(g_render_mutex);
     std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
 
     if (IsIntervalEternal() && !GetCurrentEffect().HasMaximumEffectTime())
@@ -995,6 +1000,7 @@ void EffectManager::CheckEffectTimerExpired()
 
 void EffectManager::NextEffect(bool skipSave)
 {
+    std::lock_guard<std::recursive_mutex> renderGuard(g_render_mutex);
     std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
 
     auto enabled = AreEffectsEnabled();
@@ -1016,6 +1022,7 @@ void EffectManager::NextEffect(bool skipSave)
 
 void EffectManager::PreviousEffect()
 {
+    std::lock_guard<std::recursive_mutex> renderGuard(g_render_mutex);
     std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
 
     auto enabled = AreEffectsEnabled();
@@ -1041,6 +1048,7 @@ void EffectManager::PreviousEffect()
 
 void EffectManager::Update()
 {
+    std::lock_guard<std::recursive_mutex> renderGuard(g_render_mutex);
     std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
 
     if ((_gfx[0])->GetLEDCount() == 0)

--- a/src/gfxbase.cpp
+++ b/src/gfxbase.cpp
@@ -271,22 +271,12 @@ void GFXBase::setPixel(int16_t x, int r, int g, int b)
 
 void GFXBase::fadePixelToBlackBy(int16_t x, int16_t y, uint8_t fadeValue) noexcept
 {
-    CRGB &px = leds[XY(x, y)];
-    const uint8_t scale = 255 - fadeValue;
-    const uint16_t scale_fixed = (uint16_t)scale + 1;
-    px.r = (uint8_t)((((uint16_t)px.r) * scale_fixed) >> 8);
-    px.g = (uint8_t)((((uint16_t)px.g) * scale_fixed) >> 8);
-    px.b = (uint8_t)((((uint16_t)px.b) * scale_fixed) >> 8);
+    FadePixelInPlace(leds[XY(x, y)], fadeValue);
 }
 
 void GFXBase::fadePixelToBlackBy(int16_t i, uint8_t fadeValue) noexcept
 {
-    CRGB &px = leds[i];
-    const uint8_t scale = 255 - fadeValue;
-    const uint16_t scale_fixed = (uint16_t)scale + 1;
-    px.r = (uint8_t)((((uint16_t)px.r) * scale_fixed) >> 8);
-    px.g = (uint8_t)((((uint16_t)px.g) * scale_fixed) >> 8);
-    px.b = (uint8_t)((((uint16_t)px.b) * scale_fixed) >> 8);
+    FadePixelInPlace(leds[i], fadeValue);
 }
 
 void GFXBase::DrawSafeCircle(int centerX, int centerY, int radius, CRGB color) noexcept

--- a/src/ledstripeffect.cpp
+++ b/src/ledstripeffect.cpp
@@ -233,8 +233,14 @@ void LEDStripEffect::fillSolidOnAllChannels(CRGB color, int iStart, int numToFil
 
     for (auto& device : _GFX)
     {
-        for (int i = iStart; i < iStart + numToFill; i+= everyN)
-            device->setPixel(i, color);
+        if (everyN == 1)
+        {
+            fill_solid(device->leds + iStart, numToFill, color);
+            continue;
+        }
+
+        for (int i = iStart; i < iStart + numToFill; i += everyN)
+            device->leds[i] = color;
     }
 }
 
@@ -311,15 +317,15 @@ void LEDStripEffect::fadePixelToBlackOnAllChannelsBy(int pixel, uint8_t fadeValu
 void LEDStripEffect::fadeAllChannelsToBlackBy(uint8_t fadeValue) const
 {
     for (auto& device : _GFX)
-        for (int i = 0; i < (int)_cLEDs; i++)
-            device->fadePixelToBlackBy(i, fadeValue);
+        for (size_t i = 0; i < _cLEDs; ++i)
+            GFXBase::FadePixelInPlace(device->leds[i], fadeValue);
 }
 
 void LEDStripEffect::setAllOnAllChannels(uint8_t r, uint8_t g, uint8_t b) const
 {
+    const CRGB color(r, g, b);
     for (auto& device : _GFX)
-        for (int i = 0; i < (int)_cLEDs; i++)
-            device->setPixel(i, r, g, b);
+        fill_solid(device->leds, _cLEDs, color);
 }
 
 // setPixelOnAllChannels

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -238,6 +238,7 @@ void onReceiveESPNOW(const uint8_t *macAddr, const uint8_t *data, int dataLen);
 
 DRAM_ATTR std::unique_ptr<SystemContainer> g_ptrSystem;
 DRAM_ATTR std::mutex g_buffer_mutex;
+DRAM_ATTR std::recursive_mutex g_render_mutex;
 DRAM_ATTR std::recursive_mutex g_effect_manager_mutex;
 
 // The one and only instance of ImprovSerial.  We instantiate it as the type needed

--- a/src/systemcontainer.cpp
+++ b/src/systemcontainer.cpp
@@ -297,7 +297,7 @@ int SystemContainer::GetConfiguredAudioInputPin() const
 
 bool SystemContainer::ApplyRuntimeConfiguration(String* errorMessage)
 {
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
 
     auto& config = GetDeviceConfig();
 

--- a/src/ws281xgfx.cpp
+++ b/src/ws281xgfx.cpp
@@ -153,15 +153,13 @@ void WS281xGFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsD
         auto& graphics = effectManager.g(i);
         const auto ledCount = graphics.GetLEDCount();
         const auto activePixels = std::min<size_t>(pixelsDrawn, ledCount);
-
-        fadeLightBy(graphics.leds, activePixels, 255 - deviceConfig.GetBrightness());
         if (activePixels < ledCount)
             fill_solid(graphics.leds + activePixels, ledCount - activePixels, CRGB::Black);
     }
 
     static auto lastDrawTime = millis();
     auto& outputManager = g_ptrSystem->GetWS281xOutputManager();
-    outputManager.Show(g_ptrSystem->GetDevices(), pixelsDrawn, g_Values.Fader);
+    outputManager.Show(g_ptrSystem->GetDevices(), pixelsDrawn, deviceConfig.GetBrightness(), g_Values.Fader);
     g_Values.FPS = 1000.0 / max(1UL, millis() - lastDrawTime);
     lastDrawTime = millis();
     #ifdef POWER_LIMIT_MW

--- a/src/ws281xoutputmanager.cpp
+++ b/src/ws281xoutputmanager.cpp
@@ -110,34 +110,60 @@ namespace
         *itemNum = outputItems;
     }
 
-    // Runtime color order is a settings concern rather than a template concern,
-    // so we materialize the final byte order explicitly into the per-channel
-    // output buffer before handing bytes to the RMT driver.
+    template <uint8_t RIndex, uint8_t GIndex, uint8_t BIndex>
+    void PackChannelPixels(uint8_t* output,
+                           const CRGB* source,
+                           size_t activeLedCount,
+                           size_t pixelsToShow,
+                           uint8_t brightness,
+                           uint8_t fader)
+    {
+        for (size_t pixelIndex = 0; pixelIndex < activeLedCount; ++pixelIndex)
+        {
+            CRGB color = pixelIndex < pixelsToShow ? source[pixelIndex] : CRGB::Black;
 
-    void WriteColorOrderedBytes(uint8_t* dest, const CRGB& color, DeviceConfig::WS281xColorOrder colorOrder)
+            // Preserve the compiled-path semantics without first mutating the effect buffer:
+            // scale by configured brightness, then apply the global master fader.
+            nscale8x3_video(color.r, color.g, color.b, brightness);
+            nscale8x3_video(color.r, color.g, color.b, fader);
+
+            const size_t offset = pixelIndex * 3;
+            output[offset + RIndex] = color.r;
+            output[offset + GIndex] = color.g;
+            output[offset + BIndex] = color.b;
+        }
+    }
+
+    void PackChannelPixelsForColorOrder(uint8_t* output,
+                                        const CRGB* source,
+                                        size_t activeLedCount,
+                                        size_t pixelsToShow,
+                                        uint8_t brightness,
+                                        uint8_t fader,
+                                        DeviceConfig::WS281xColorOrder colorOrder)
     {
         switch (colorOrder)
         {
             case DeviceConfig::WS281xColorOrder::RGB:
-                dest[0] = color.r; dest[1] = color.g; dest[2] = color.b;
+                PackChannelPixels<0, 1, 2>(output, source, activeLedCount, pixelsToShow, brightness, fader);
                 return;
             case DeviceConfig::WS281xColorOrder::RBG:
-                dest[0] = color.r; dest[1] = color.b; dest[2] = color.g;
+                PackChannelPixels<0, 2, 1>(output, source, activeLedCount, pixelsToShow, brightness, fader);
                 return;
             case DeviceConfig::WS281xColorOrder::GRB:
-                dest[0] = color.g; dest[1] = color.r; dest[2] = color.b;
+                PackChannelPixels<1, 0, 2>(output, source, activeLedCount, pixelsToShow, brightness, fader);
                 return;
             case DeviceConfig::WS281xColorOrder::GBR:
-                dest[0] = color.g; dest[1] = color.b; dest[2] = color.r;
+                PackChannelPixels<2, 0, 1>(output, source, activeLedCount, pixelsToShow, brightness, fader);
                 return;
             case DeviceConfig::WS281xColorOrder::BRG:
-                dest[0] = color.b; dest[1] = color.r; dest[2] = color.g;
+                PackChannelPixels<1, 2, 0>(output, source, activeLedCount, pixelsToShow, brightness, fader);
                 return;
             case DeviceConfig::WS281xColorOrder::BGR:
-                dest[0] = color.b; dest[1] = color.g; dest[2] = color.r;
+                PackChannelPixels<2, 1, 0>(output, source, activeLedCount, pixelsToShow, brightness, fader);
                 return;
             default:
-                dest[0] = color.g; dest[1] = color.r; dest[2] = color.b;
+                PackChannelPixels<1, 0, 2>(output, source, activeLedCount, pixelsToShow, brightness, fader);
                 return;
         }
     }
@@ -363,7 +389,7 @@ bool WS281xOutputManager::ApplyConfig(const DeviceConfig& config, const std::vec
     return true;
 }
 
-void WS281xOutputManager::Show(const std::vector<std::shared_ptr<GFXBase>>& devices, uint16_t pixelsDrawn, uint8_t brightness)
+void WS281xOutputManager::Show(const std::vector<std::shared_ptr<GFXBase>>& devices, uint16_t pixelsDrawn, uint8_t brightness, uint8_t fader)
 {
     // The same mutex used by ApplyConfig() keeps live transport mutations from
     // colliding with the draw loop while it is filling buffers or transmitting.
@@ -374,7 +400,6 @@ void WS281xOutputManager::Show(const std::vector<std::shared_ptr<GFXBase>>& devi
         return;
 
     const size_t pixelsToShow = std::min(static_cast<size_t>(pixelsDrawn), _activeLEDCount);
-    const uint8_t scale = brightness;
 
     // First build packed output bytes for every active channel.  The GFX layer
     // owns CRGB frame buffers; the runtime transport owns these temporary-once-
@@ -388,12 +413,7 @@ void WS281xOutputManager::Show(const std::vector<std::shared_ptr<GFXBase>>& devi
 
         const auto& device = devices[channelIndex];
         auto* output = state.outputBytes.get();
-        for (size_t pixelIndex = 0; pixelIndex < _activeLEDCount; ++pixelIndex)
-        {
-            CRGB color = pixelIndex < pixelsToShow ? device->leds[pixelIndex] : CRGB::Black;
-            nscale8x3_video(color.r, color.g, color.b, scale);
-            WriteColorOrderedBytes(output + (pixelIndex * 3), color, _colorOrder);
-        }
+        PackChannelPixelsForColorOrder(output, device->leds, _activeLEDCount, pixelsToShow, brightness, fader, _colorOrder);
     }
 
     const auto showStartMicros = micros();


### PR DESCRIPTION
## Description
This make the locking more fine-grained on the render path, and it optimizes the brightness calc by doing it on the fly rather than as a seperate pass ever Show() call.

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).