### PR TITLE
Dynamic allocation of services, new ITask, IService models

### DIFF
--- a/include/audioserialbridge.h
+++ b/include/audioserialbridge.h
@@ -2,9 +2,9 @@
 
 //+--------------------------------------------------------------------------
 //
-// File:        RemoteControl.h
+// File:        audioserialbridge.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
+// NightDriverStrip - (c) 2026 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -22,58 +22,37 @@
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
 //
-//
 // Description:
 //
-//    Handles a simple IR remote for changing effects, brightness, etc.
+//    AudioSerialBridge sends compact spectrum/VU packets at 2400 baud out
+//    Serial2 (and optionally a TCP socket for the VICE C64 emulator) so
+//    the PETROCK project on a connected Commodore 64/PET can render the
+//    visualization. Gated by ENABLE_AUDIOSERIAL.
 //
-// History:     Jul-17-2021     Davepl      Documented
+//    Inherits ITaskService for the standard launch/shutdown discipline.
+//    The task body lives in audio.cpp alongside the VICE socket helper.
+//
+// History:     May-04-2026         Davepl      Created
+//
 //---------------------------------------------------------------------------
 
 #include "globals.h"
 
-#if ENABLE_REMOTE
+#if ENABLE_AUDIOSERIAL
 
 #include "itaskservice.h"
 
-struct RemoteColorCode
+class AudioSerialBridge : public ITaskService
 {
-    uint32_t code;
-    CRGB     color;
-    uint8_t  hue;
-    const char* name;
-};
-
-// Pimpl to hide RMT driver details from the 115 files including this header
-class RemoteControlImpl;
-
-// RemoteControl
-//
-// Polls an IR receiver for remote codes and dispatches them to effect/config
-// changes. Inherits ITaskService so the polling task lifecycle, shutdown
-// signaling, and force-delete fallback are shared with the other task-owning
-// services rather than reimplemented here.
-
-class RemoteControl : public ITaskService
-{
-  private:
-    std::unique_ptr<RemoteControlImpl> _pImpl;
-
   public:
-    RemoteControl();
-    ~RemoteControl() override;
+    AudioSerialBridge() = default;
+    ~AudioSerialBridge() override { Stop(); }
 
-    // IService::Name
-    const char* Name() const override { return "RemoteControl"; }
-
-    bool begin();
-    void end();
-    void handle();
+    const char* Name() const override { return "AudioSerialBridge"; }
 
   protected:
-    // ITaskService hooks
     TaskConfig GetTaskConfig() const override;
     void Run() override;
 };
 
-#endif
+#endif // ENABLE_AUDIOSERIAL

--- a/include/audioservice.h
+++ b/include/audioservice.h
@@ -1,0 +1,183 @@
+#pragma once
+
+//+--------------------------------------------------------------------------
+//
+// File:        audioservice.h
+//
+// NightDriverStrip - (c) 2026 Plummer's Software LLC.  All Rights Reserved.
+//
+// This file is part of the NightDriver software project.
+//
+//    NightDriver is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    NightDriver is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with Nightdriver.  It is normally found in copying.txt
+//    If not, see <https://www.gnu.org/licenses/>.
+//
+// Description:
+//
+//    AudioService owns the audio sampler task and the I2S/ADC hardware
+//    lifecycle. It can be started, stopped, restarted, and reconfigured at
+//    runtime so changes to the audio input pin no longer require a reboot.
+//
+//    The compile-time audio mode (analog ADC, I2S external mic, M5 onboard)
+//    is still selected at build time because the SoundAnalyzer template
+//    binding and ESP-IDF driver paths are bound to that mode. The
+//    runtime-mutable surface is the input pin and the enabled flag.
+//    AudioConfig::FromCompileDefaults() reproduces the existing macro-driven
+//    behavior so first boot looks exactly like before.
+//
+//    The global g_Analyzer instance remains the in-process source of audio
+//    telemetry; AudioService just controls when its hardware is installed
+//    and when its sampler task is running. When audio is stopped or
+//    unavailable, AudioService::Source() returns a silent stub so effects
+//    see VU/peaks/beats == zero rather than stale or undefined values.
+//
+// History:     May-04-2026         Davepl      Created
+//
+//---------------------------------------------------------------------------
+
+#include "globals.h"
+
+#include "itaskservice.h"   // includes iservice.h
+#include "soundanalyzer.h"
+
+// IAudioSource is a stable read-only interface effects can hold instead of
+// reaching for the g_Analyzer global. It's a type alias of the existing
+// ISoundAnalyzer interface so the migration is mechanical when we get to it.
+
+using IAudioSource = ISoundAnalyzer;
+
+// AudioConfig
+//
+// Runtime-mutable audio configuration. The mode/sampleRate/I2S pin fields
+// are diagnostic and will not change live in this build target since the
+// driver path is bound at compile time, but they're carried in the config
+// so the SetupUI and Reconfigure() reflect a consistent picture.
+
+struct AudioConfig
+{
+    enum class Mode
+    {
+        Disabled,           // ENABLE_AUDIO is 0 in this build
+        AnalogADC,          // I2S-ADC built-in path (ESP32 only)
+        I2SExternal,        // External digital mic (INMP441 etc.)
+        M5Onboard           // M5Unified-managed mic
+    };
+
+    bool   enabled       = false;
+    Mode   mode          = Mode::Disabled;
+    int    inputPin      = -1;     // ADC pin, or I2S DIN pin in I2S mode. -1 disables hardware.
+    int    bclkPin       = -1;     // I2S only
+    int    wsPin         = -1;     // I2S only
+    int    dataPin       = -1;     // I2S only (typically equal to inputPin)
+    int    sampleRate    = 24000;  // SoundAnalyzerBase::SAMPLING_FREQUENCY
+
+    // Build a config that mirrors the existing compile-time defaults.
+
+    static AudioConfig FromCompileDefaults();
+
+    // Overlay the persisted audio input pin (if a DeviceConfig is reachable)
+    // onto a compile-defaults base. Used by Start() so the very first audio
+    // session honors the user's last-saved pin without a manual Reconfigure.
+    
+    static AudioConfig FromCurrentSettings();
+
+    // Human-readable mode name. Mirrors DeviceConfig::GetAudioInputModeName().
+    
+    const char* ModeName() const;
+};
+
+// AudioService
+//
+// Lifecycle manager for the audio engine. Construction is cheap; nothing is
+// allocated or installed until Start() is called.
+//
+// Two complete class definitions live below, gated by ENABLE_AUDIO at file
+// scope. The shape mirrors the SoundAnalyzer pattern in soundanalyzer.h: the
+// public surface is identical between the two variants so callers don't need
+// to #if their use sites, but each variant's method bodies are unconditional
+// rather than dotted with inline preprocessor branches.
+
+#if ENABLE_AUDIO
+
+class AudioService : public ITaskService
+{
+  public:
+    AudioService();
+    ~AudioService() override;
+
+    AudioService(const AudioService&) = delete;
+    AudioService& operator=(const AudioService&) = delete;
+
+    // IService::Name
+    const char* Name() const override { return "AudioService"; }
+
+    // Service-specific. Stops the audio engine if running, applies the new
+    // config, and restarts if newConfig.enabled is true.
+    bool Reconfigure(const AudioConfig& newConfig);
+
+    // Audio-enabled builds always report available, regardless of running state.
+    bool IsAvailable() const { return true; }
+
+    const AudioConfig& Config() const { return _config; }
+
+    // Read-only audio source. Always non-null. When audio is stopped or
+    // unavailable, the returned source reports zero VU / silent peaks /
+    // no beats so effects can run safely.
+    IAudioSource& Source() const;
+
+  protected:
+    // ITaskService hooks
+    TaskConfig GetTaskConfig() const override;
+    bool OnBeforeStart() override;
+    void Run() override;
+    void OnAfterStop() override;
+
+  private:
+    AudioConfig _config{};
+};
+
+#else // !ENABLE_AUDIO
+
+// Stub variant: same public surface, but every operation is a safe no-op and
+// Source() returns the silent fallback. Callers that ask "is audio available?"
+// get false; callers that try to Start get a clean false back rather than a
+// runtime error.
+
+class AudioService : public IService
+{
+  public:
+    AudioService() = default;
+    ~AudioService() override = default;
+
+    AudioService(const AudioService&) = delete;
+    AudioService& operator=(const AudioService&) = delete;
+
+    bool Start() override;
+    void Stop() override                          {}
+    bool Restart() override                       { return false; }
+    bool IsRunning() const override               { return false; }
+    const char* Name() const override             { return "AudioService"; }
+
+    bool Reconfigure(const AudioConfig& newConfig);
+
+    bool IsAvailable() const                      { return false; }
+
+    const AudioConfig& Config() const             { return _config; }
+
+    IAudioSource& Source() const;
+
+  private:
+    AudioConfig _config{};
+};
+
+#endif // ENABLE_AUDIO

--- a/include/colorstreamerservice.h
+++ b/include/colorstreamerservice.h
@@ -2,9 +2,9 @@
 
 //+--------------------------------------------------------------------------
 //
-// File:        RemoteControl.h
+// File:        colorstreamerservice.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
+// NightDriverStrip - (c) 2026 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -22,58 +22,36 @@
 //    along with Nightdriver.  It is normally found in copying.txt
 //    If not, see <https://www.gnu.org/licenses/>.
 //
-//
 // Description:
 //
-//    Handles a simple IR remote for changing effects, brightness, etc.
+//    ColorStreamerService pushes per-frame LED color data out over a
+//    TCP socket (LEDViewer protocol) and/or the WebSocket frame channel
+//    so external tools and the local web UI can preview the strip.
+//    Gated by COLORDATA_SERVER_ENABLED. Inherits ITaskService for
+//    lifecycle. Implementation lives in network.cpp alongside the
+//    LEDViewer + frame-event-listener machinery.
 //
-// History:     Jul-17-2021     Davepl      Documented
+// History:     May-04-2026         Davepl      Created
+//
 //---------------------------------------------------------------------------
 
 #include "globals.h"
 
-#if ENABLE_REMOTE
+#if COLORDATA_SERVER_ENABLED
 
 #include "itaskservice.h"
 
-struct RemoteColorCode
+class ColorStreamerService : public ITaskService
 {
-    uint32_t code;
-    CRGB     color;
-    uint8_t  hue;
-    const char* name;
-};
-
-// Pimpl to hide RMT driver details from the 115 files including this header
-class RemoteControlImpl;
-
-// RemoteControl
-//
-// Polls an IR receiver for remote codes and dispatches them to effect/config
-// changes. Inherits ITaskService so the polling task lifecycle, shutdown
-// signaling, and force-delete fallback are shared with the other task-owning
-// services rather than reimplemented here.
-
-class RemoteControl : public ITaskService
-{
-  private:
-    std::unique_ptr<RemoteControlImpl> _pImpl;
-
   public:
-    RemoteControl();
-    ~RemoteControl() override;
+    ColorStreamerService() = default;
+    ~ColorStreamerService() override { Stop(); }
 
-    // IService::Name
-    const char* Name() const override { return "RemoteControl"; }
-
-    bool begin();
-    void end();
-    void handle();
+    const char* Name() const override { return "ColorStreamerService"; }
 
   protected:
-    // ITaskService hooks
     TaskConfig GetTaskConfig() const override;
     void Run() override;
 };
 
-#endif
+#endif // COLORDATA_SERVER_ENABLED

--- a/include/debugconsole.h
+++ b/include/debugconsole.h
@@ -1,0 +1,72 @@
+#pragma once
+
+//+--------------------------------------------------------------------------
+//
+// File:        debugconsole.h
+//
+// NightDriverStrip - (c) 2026 Plummer's Software LLC.  All Rights Reserved.
+//
+// This file is part of the NightDriver software project.
+//
+//    NightDriver is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    NightDriver is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with Nightdriver.  It is normally found in copying.txt
+//    If not, see <https://www.gnu.org/licenses/>.
+//
+// Description:
+//
+//    DebugConsole runs the BSD-socket telnet server that gives remote
+//    debug access to the chip. Inherits ITaskService for lifecycle.
+//    Implementation lives in telnetserver.cpp alongside the protocol
+//    handling helpers.
+//
+// History:     May-04-2026         Davepl      Created
+//
+//---------------------------------------------------------------------------
+
+#include "globals.h"
+
+#if ENABLE_WIFI
+
+#include <atomic>
+
+#include "itaskservice.h"
+
+class DebugConsole : public ITaskService
+{
+  public:
+    DebugConsole() = default;
+    ~DebugConsole() override { Stop(); }
+
+    const char* Name() const override { return "DebugConsole"; }
+
+  protected:
+    TaskConfig GetTaskConfig() const override;
+    void Run() override;
+
+    // Close the listening (and any active client) socket from the Stop() thread
+    // so accept()/recv() return promptly and Run() can observe ShouldShutdown().
+
+    void OnBeforeWaitForStop() override;
+
+  private:
+    
+  // Both fds are set by Run() and may be cleared by OnBeforeWaitForStop()
+    // running on a different task. atomic<int> gives us a lock-free
+    // exchange so we never call close() twice on the same fd.  I can't 
+    // believe POSIX doesn't define an invalid handle constant, but here we are.
+
+    std::atomic<int> _listenFd{-1};
+    std::atomic<int> _clientFd{-1};
+};
+
+#endif // ENABLE_WIFI

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -366,7 +366,17 @@ class DeviceConfig : public IJSONSerializable
             return false;
         #endif
     }
-    bool SupportsLiveAudioInputReconfigure() const { return false; }
+
+    // True when AudioService can install/uninstall the audio driver at runtime.
+    // Today this matches the SupportsConfigurableAudioInputPin set: M5 onboard
+    // audio is managed by M5Unified itself, and the analog ADC path uses a
+    // fixed channel, so neither benefits from a live restart.
+
+    bool SupportsLiveAudioInputReconfigure() const
+    {
+        return SupportsConfigurableAudioInputPin();
+    }
+
     String GetAudioInputModeName() const
     {
         #if !ENABLE_AUDIO

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -161,6 +161,17 @@ public:
 
     void ReportNewFrameAvailable();
     void AddFrameEventListener(IFrameEventListener& listener);
+    
+    // RemoveFrameEventListener
+    //
+    // Removes a previously registered frame event listener by address.
+    // Safe to call even if the listener was never registered (no-op).
+    // Required for any listener whose lifetime is shorter than the
+    // EffectManager's (e.g. a listener owned by a service that can be
+    // Stop()-ed and have its task exit), since EffectManager stores
+    // listeners by reference.
+
+    void RemoveFrameEventListener(IFrameEventListener& listener);
     void AddEffectEventListener(IEffectEventListener& listener);
 
     void LoadDefaultEffects();

--- a/include/effects/matrix/Boid.h
+++ b/include/effects/matrix/Boid.h
@@ -102,7 +102,7 @@ class Boid
     uint8_t colorIndex = 0;
     float mass;
 
-    boolean enabled = true;
+    bool enabled = true;
 
     Boid() {}
 

--- a/include/effects/matrix/Geometry.h
+++ b/include/effects/matrix/Geometry.h
@@ -60,7 +60,7 @@ struct Vertex
 struct EdgePoint
 {
     int x, y;
-    boolean visible;
+    bool visible;
 
     EdgePoint()
     {

--- a/include/effects/matrix/PatternSpiro.h
+++ b/include/effects/matrix/PatternSpiro.h
@@ -79,9 +79,9 @@ private:
 
   uint8_t spirocount = 1;
   uint8_t spirooffset = 256 / spirocount;
-  boolean spiroincrement = false;
+  bool spiroincrement = false;
 
-  boolean handledChange = false;
+  bool handledChange = false;
 
 public:
 
@@ -99,7 +99,7 @@ public:
 
     // effects.ShowFrame();
 
-    boolean change = false;
+    bool change = false;
 
     for (int i = 0; i < spirocount; i++)
     {

--- a/include/iservice.h
+++ b/include/iservice.h
@@ -1,0 +1,92 @@
+#pragma once
+
+//+--------------------------------------------------------------------------
+//
+// File:        iservice.h
+//
+// NightDriverStrip - (c) 2026 Plummer's Software LLC.  All Rights Reserved.
+//
+// This file is part of the NightDriver software project.
+//
+//    NightDriver is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    NightDriver is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with Nightdriver.  It is normally found in copying.txt
+//    If not, see <https://www.gnu.org/licenses/>.
+//
+// Description:
+//
+//    IService is a tiny lifecycle interface shared by classes in NightDriver
+//    that own a FreeRTOS task, a hardware driver, or a network endpoint.
+//    Adopting it gives those classes a uniform Start/Stop discipline and
+//    lets orchestration code (boot sequencing, shutdown for OTA, a "services"
+//    debug command, etc.) treat them generically.
+//
+//    Deliberately small. The interface does NOT include:
+//
+//      - Reconfigure(...) or any config accessor — config types differ per
+//        service, so they stay on the concrete class.
+//      - Resource handles (sockets, task handles, web routes) — also concrete.
+//      - State machines beyond running / not-running — anything richer is
+//        the implementer's business.
+//
+//    Lifecycle contract for implementers:
+//
+//      - The constructor must NOT install hardware, allocate large buffers,
+//        launch tasks, or open sockets. Construction is metadata-only.
+//      - Start() may install/allocate/launch/open. Returns true if running
+//        after the call. Calling Start() while already running is a no-op
+//        that returns true.
+//      - Stop() must be idempotent and safe against partial state. It must
+//        wait for any owned task to exit cleanly (with a timeout fallback)
+//        before releasing shared hardware resources.
+//      - IsRunning() reflects the live state visible to other threads.
+//        Implementers typically back this with std::atomic<bool>.
+//      - Name() returns a short, stable identifier suitable for log lines
+//        and CLI output (e.g. "AudioService", "JSONWriter").
+//
+//    Restart() has a default implementation of Stop() then Start(); override
+//    only if a service can do something cheaper than a full cycle.
+//
+// History:     May-04-2026         Davepl      Created
+//
+//---------------------------------------------------------------------------
+
+class IService
+{
+  public:
+    virtual ~IService() = default;
+
+    // Idempotent. Returns true if the service is running after the call.
+    
+    virtual bool Start() = 0;
+
+    // Idempotent. Releases owned resources and waits for owned tasks to exit.
+    
+    virtual void Stop() = 0;
+
+    // Reflects the live running state. Cheap to call from any thread.
+    
+    virtual bool IsRunning() const = 0;
+
+    // Short stable identifier for logging and diagnostics. Should be a
+    // string literal so the returned pointer outlives the service.
+
+    virtual const char* Name() const = 0;
+
+    // Default Stop()+Start() cycle. Override for cheaper service-specific paths.
+    
+    virtual bool Restart()
+    {
+        Stop();
+        return Start();
+    }
+};

--- a/include/itaskservice.h
+++ b/include/itaskservice.h
@@ -1,0 +1,167 @@
+#pragma once
+
+//+--------------------------------------------------------------------------
+//
+// File:        itaskservice.h
+//
+// NightDriverStrip - (c) 2026 Plummer's Software LLC.  All Rights Reserved.
+//
+// This file is part of the NightDriver software project.
+//
+//    NightDriver is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    NightDriver is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with Nightdriver.  It is normally found in copying.txt
+//    If not, see <https://www.gnu.org/licenses/>.
+//
+// Description:
+//
+//    ITaskService is the intermediate base class for IService implementers
+//    that own a FreeRTOS task. It captures the standard launch / shutdown
+//    discipline (atomics for run state, signal-and-wait shutdown, force-
+//    delete fallback) in exactly one place so individual services like
+//    AudioService, JSONWriter, SocketServer, and RemoteControl don't each
+//    reimplement it.
+//
+//    A service that wants its own task should:
+//
+//      1. Inherit from ITaskService instead of directly from IService.
+//      2. Implement GetTaskConfig() to specify the task's name, stack size,
+//         priority, and core. The shutdown timeout has a sensible default
+//         and only needs to be overridden when the task can block longer
+//         (e.g. SocketServer with its accept timeout).
+//      3. Implement Run() — the task body. Run() should poll
+//         ShouldShutdown() between iterations and return when it sees true,
+//         which triggers the rest of the cleanup automatically.
+//      4. Optionally override OnBeforeStart() to gate the start (return
+//         false to abort, e.g. when AudioConfig::enabled is false), or
+//         OnBeforeWaitForStop() to break the task out of a blocking call
+//         (e.g. close the listening socket so accept() returns), or
+//         OnAfterStop() to release service-specific resources after the
+//         task has confirmed exit (e.g. uninstall the I2S driver).
+//
+//    Start() and Stop() are marked final so a derived class can't acci-
+//    dentally override the lifecycle and break the contract.
+//
+//    IMPORTANT - destruction discipline:
+//
+//      Every concrete derived class MUST call Stop() from its own destructor
+//      *before* any derived state is torn down. Without that, the base
+//      destructor would be the one calling Stop(), but by the time the base
+//      runs the derived vtable has already been swapped out -- so virtual
+//      hooks like OnBeforeWaitForStop() and OnAfterStop() would no longer
+//      dispatch to the derived overrides, leaving the task blocked on a
+//      socket/recv/etc. with no way to be unblocked. The boilerplate is just:
+//
+//          ~MyService() override { Stop(); }
+//
+//      Stop() is idempotent and a no-op when the task isn't running, so it's
+//      always safe to call.
+//
+// History:     May-04-2026         Davepl      Created
+//
+//---------------------------------------------------------------------------
+
+#include "globals.h"
+
+#include <atomic>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+#include "iservice.h"
+
+class ITaskService : public IService
+{
+  public:
+
+    // IService lifecycle. Final so derived classes use the hooks below
+    // rather than reimplement the discipline.
+
+    bool Start() override final;
+    void Stop()  override final;
+    bool IsRunning() const override final { return _running.load(); }
+
+    // Restart() retains the IService default (Stop then Start).
+
+  protected:
+
+    struct TaskConfig
+    {
+        const char*  taskName             = "ITaskService";
+        size_t       stackSize            = 4096;
+        UBaseType_t  priority             = tskIDLE_PRIORITY + 1;
+        BaseType_t   core                 = tskNO_AFFINITY;
+
+        // How long Stop() waits for Run() to return after the shutdown
+        // signal is raised. The default fits services whose loops yield
+        // every few milliseconds; raise it for tasks that may block
+        // longer if needed.
+
+        uint32_t     shutdownTimeoutMs    = 1000;
+    };
+
+    // Derived class must implement these.
+
+    virtual TaskConfig GetTaskConfig() const = 0;
+    virtual void Run() = 0;
+
+    // Optional hooks. Defaults are no-ops / accept-start.
+
+    // Called from Start() before xTaskCreatePinnedToCore. Return false to
+    // decline the start (e.g. when configuration is missing or audio is
+    // disabled in this run). Logging is the implementer's responsibility.
+
+    virtual bool OnBeforeStart()       { return true; }
+
+    // Called from Stop() after the shutdown flag is raised but before
+    // waiting for the task to acknowledge. Use to break the task out of
+    // a blocking call: close a listening socket, abort an I2S read, etc.
+
+    virtual void OnBeforeWaitForStop() {}
+
+    // Called from Stop() once the task has confirmed exit (or been force-
+    // deleted on timeout). Use for service-specific resource teardown:
+    // uninstalling I2S/ADC drivers, releasing buffers, etc. Always runs,
+    // even on the force-delete path, so it must be safe against partial
+    // task progress.
+
+    virtual void OnAfterStop()         {}
+
+    // The task body polls this between iterations to detect a graceful
+    // shutdown. Once it returns true, Run() should clean up any local
+    // state and return; the framework handles vTaskDelete from there.
+
+    bool ShouldShutdown() const { return _shutdownRequested.load(); }
+
+    // Wake the owned task via xTaskNotifyGive. Useful for services whose
+    // Run() loop sleeps in ulTaskNotifyTake and needs an external nudge
+    // (e.g. JSONWriter, NetworkReader). Safe to call before Start() or
+    // after Stop() — both are no-ops.
+
+    void WakeTask() const
+    {
+        if (_taskHandle != nullptr)
+            xTaskNotifyGive(_taskHandle);
+    }
+
+  private:
+
+    // FreeRTOS task entry point. Casts back to ITaskService* and dispatches
+    // to Run(). Records exit, then parks until Stop() deletes the task from
+    // the caller's thread.
+
+    static void TaskEntryThunk(void* p);
+
+    TaskHandle_t       _taskHandle = nullptr;
+    std::atomic<bool>  _running{false};
+    std::atomic<bool>  _shutdownRequested{false};
+    std::atomic<bool>  _taskExited{false};
+};

--- a/include/jsonserializer.h
+++ b/include/jsonserializer.h
@@ -39,6 +39,8 @@
 #include <mutex>
 #include <vector>
 
+#include "itaskservice.h"
+
 template <class E>
 constexpr auto to_value(E e) noexcept
 {
@@ -87,24 +89,38 @@ bool RemoveJSONFile(const String & fileName);
 
 #define JSON_WRITER_DELAY 3000
 
-class JSONWriter
-{
-    // We allow the main JSON Writer task entry point function to access private members
-    friend void JSONWriterTaskEntry(void *);
+// JSONWriter
+//
+// Background SPIFFS writer. Implementers register a write callback once and
+// call FlagWriter / FlushWrites when something has been mutated; the writer
+// task batches flagged writes through JSON_WRITER_DELAY of quiet time so
+// rapid mutations don't thrash the flash. Inherits ITaskService so launch
+// and shutdown discipline are shared with the other task-owning services.
 
+class JSONWriter : public ITaskService
+{
   private:
 
     struct WriterEntry;
 
     std::vector<std::shared_ptr<WriterEntry>> writers;
     mutable std::mutex       writersMutex;
-    std::atomic_ulong        latestFlagMs;
-    std::atomic_bool         flushRequested;
-    std::atomic_bool         haltWrites;
+    std::atomic_ulong        latestFlagMs{0};
+    std::atomic_bool         flushRequested{false};
+    std::atomic_bool         haltWrites{false};
+
+    // Wakes the writer task from its long ulTaskNotifyTake. Used both by
+    // FlagWriter/FlushWrites (the public API) and by Stop() (via
+    // OnBeforeWaitForStop) to break the task out of its blocking wait.
+    
+    void NotifyTask();
 
   public:
     JSONWriter();
-    ~JSONWriter();
+    ~JSONWriter() override;
+
+    // IService::Name
+    const char* Name() const override { return "JSONWriter"; }
 
     // Add a writer to the collection. Returns the index of the added writer, for use with FlagWriter()
     size_t RegisterWriter(const std::function<void()>& writer);
@@ -114,4 +130,10 @@ class JSONWriter
 
     // Flush pending writes now
     void FlushWrites(bool halt = false);
+
+  protected:
+    // ITaskService hooks
+    TaskConfig GetTaskConfig() const override;
+    void Run() override;
+    void OnBeforeWaitForStop() override;
 };

--- a/include/ledstripeffect.h
+++ b/include/ledstripeffect.h
@@ -308,7 +308,7 @@ class LEDStripEffect : public IJSONSerializable
 //
 // debug_log_type_token_once<T> (enabled when EFFECT_ID_DEBUG is true):
 // - Prints the raw token string and the computed EffectId once per T per translation unit.
-// - Uses a function-local static boolean to ensure "log once" behavior for each instantiation.
+// - Uses a function-local static bool to ensure "log once" behavior for each instantiation.
 // - Note: because this is a header-only template with a function-local static, if the same T is instantiated
 //   in multiple translation units, each TU may log once.
 //

--- a/include/nd_network.h
+++ b/include/nd_network.h
@@ -30,6 +30,7 @@
 
 #include "globals.h"
 #include "esp_mac.h"
+#include "itaskservice.h"
 #include "types.h"
 
 #include <atomic>
@@ -73,8 +74,6 @@ namespace nd_network
     enum class WiFiConnectResult { Connected, Disconnected, NoCredentials };
     enum WifiCredSource { ImprovCreds = 0, CompileTimeCreds = 1 };
 
-    // Lifecycle & Loop
-    void NetworkHandlingLoopEntry(void *);
     void InitNetworkCLI();
 
     // Configuration & Connection
@@ -122,11 +121,13 @@ namespace nd_network
     // Allows functions to be registered that are called at regular intervals and/or on request, in the
     // background. As the name of the class implies, this is intended to be used to execute network
     // requests, like for effects that require data from RESTful APIs.
-    class NetworkReader
-    {
-        // We allow the main network task entry point function to access private members
-        friend void NetworkHandlingLoopEntry(void *);
+    //
+    // Inherits ITaskService: NetworkReader owns the network handling task that
+    // also drives WiFi reconnect/OTA/mDNS pumping. Run() is the absorbed
+    // body of what used to be NetworkHandlingLoopEntry.
 
+    class NetworkReader : public ITaskService
+    {
     public:
         struct ReaderEntry;
 
@@ -134,6 +135,10 @@ namespace nd_network
         std::vector<std::shared_ptr<ReaderEntry>> readers;
 
     public:
+
+        ~NetworkReader() override { Stop(); }
+        const char* Name() const override { return "NetworkReader"; }
+
         // Add a reader to the collection. Returns the index of the added reader, for use with FlagReader().
         //   Note that if an interval (in ms) is specified, the reader will run for the first time after
         //   the interval has passed, unless "true" is passed to the last parameter.
@@ -144,6 +149,11 @@ namespace nd_network
 
         // Cancel a reader. After this, it will no longer be invoked.
         void CancelReader(size_t index);
+
+    protected:
+        // ITaskService hooks
+        TaskConfig GetTaskConfig() const override;
+        void Run() override;
     };
 #endif
 
@@ -157,7 +167,6 @@ using nd_network::UpdateNTPTime;
 using nd_network::ReadWiFiConfig;
 using nd_network::WriteWiFiConfig;
 using nd_network::ClearWiFiConfig;
-using nd_network::NetworkHandlingLoopEntry;
 
 #if ENABLE_WIFI
     using nd_network::NetworkReader;
@@ -166,5 +175,4 @@ using nd_network::NetworkHandlingLoopEntry;
 
 // Helper prototypes used by network.cpp
 void SetupOTA(const String &strHostname);
-void IRAM_ATTR RemoteLoopEntry(void *);
 String urlEncode(const String &str);

--- a/include/renderservice.h
+++ b/include/renderservice.h
@@ -2,9 +2,9 @@
 
 //+--------------------------------------------------------------------------
 //
-// File:        drawing.h
+// File:        renderservice.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
+// NightDriverStrip - (c) 2026 Plummer's Software LLC.  All Rights Reserved.
 //
 // This file is part of the NightDriver software project.
 //
@@ -24,16 +24,30 @@
 //
 // Description:
 //
-//    Drawing loop declarations.
+//    RenderService is the heart of the system: the per-frame rendering
+//    loop that pulls from either incoming WiFi color data or the local
+//    EffectManager and pushes pixels to the GFXBase devices. Pinned to
+//    DRAWING_CORE at DRAWING_PRIORITY. Inherits ITaskService for the
+//    standard lifecycle. Implementation lives in drawing.cpp alongside
+//    WiFiDraw / LocalDraw / CalcDelayUntilNextFrame.
 //
-// History:     May-11-2021         Davepl      Commented
+// History:     May-04-2026         Davepl      Created
 //
 //---------------------------------------------------------------------------
 
-// NOTE: This header is intentionally minimal. The historical free-function
-// drawing entry point (DrawLoopTaskEntry) was migrated into RenderService and
-// is now hosted by ITaskService::Run(). No symbols are currently exported
-// from drawing.cpp; this header is retained as a stable include site for any
-// future drawing-related declarations and to avoid breaking #includes in
-// downstream code. Do not add `#include "globals.h"` here -- pull what you
-// actually need at the call site.
+#include "globals.h"
+
+#include "itaskservice.h"
+
+class RenderService : public ITaskService
+{
+  public:
+    RenderService() = default;
+    ~RenderService() override { Stop(); }
+
+    const char* Name() const override { return "RenderService"; }
+
+  protected:
+    TaskConfig GetTaskConfig() const override;
+    void Run() override;
+};

--- a/include/screen.h
+++ b/include/screen.h
@@ -43,6 +43,7 @@
 #include <vector>
 
 #include "gfxbase.h"
+#include "itaskservice.h"
 
 class Screen;
 std::unique_ptr<Screen> CreateHardwareScreen(int w, int h);
@@ -81,7 +82,7 @@ class Page
 // - screen_tft.h
 // - screen_amoled.h
 
-class Screen : public GFXBase
+class Screen : public GFXBase, public ITaskService
 {
   public:
     static std::mutex _screenMutex;
@@ -89,6 +90,9 @@ class Screen : public GFXBase
     Screen(int w, int h) : GFXBase(w, h)
     {
     }
+
+    // IService::Name. Used by ITaskService for log lines.
+    const char* Name() const override { return "Screen"; }
 
     // Some devices, like the OLED, require that you send the whole buffer at once, but others do not.  The default impl is to do nothing.
 
@@ -130,12 +134,15 @@ class Screen : public GFXBase
     // Render the current page into this screen.
     void Update(bool bRedraw);
 
-    // Run the screen update loop (button handling + periodic redraw)
-    void RunUpdateLoop();
-
     // Flip to the next page and handle effect-rotation pause/resume semantics.
     // Safe to call from button handlers.
     static void FlipToNextPage();
+
+  protected:
+    // ITaskService hooks. Run() is the screen update loop (button handling
+    // + periodic redraw); GetTaskConfig() supplies the FreeRTOS task config.
+    TaskConfig GetTaskConfig() const override;
+    void Run() override;
 
   private:
     // Cached screen refresh FPS (updated each loop iteration)

--- a/include/socketserver.h
+++ b/include/socketserver.h
@@ -32,9 +32,12 @@
 
 #include "globals.h"
 
+#include <atomic>
 #include <memory>
 #include <netinet/in.h>
 #include <sys/socket.h>
+
+#include "itaskservice.h"
 
 #define STANDARD_DATA_HEADER_SIZE   24                                             // Size of the header for expanded data
 #define COMPRESSED_HEADER_SIZE      16                                             // Size of the header for compressed data
@@ -81,15 +84,24 @@ static_assert( sizeof(SocketResponse) == 72, "SocketResponse struct size is not 
 
 // SocketServer
 //
-// Handles incoming connections from the server and pass the data that comes in
+// Handles incoming connections from the server and passes the data that comes
+// in. Inherits ITaskService so the accept/read loop, shutdown signaling, and
+// listening-socket teardown all share the standard service lifecycle.
 
-class SocketServer
+class SocketServer : public ITaskService
 {
 private:
 
     int                         _port;
     int                         _numLeds;
-    int                         _server_fd;
+
+    // Listening socket fd. atomic<int> because release() can be invoked from
+    // both the SocketServer task (Run/begin failure paths) and from the
+    // service-stop path (OnBeforeWaitForStop, called on the caller's thread).
+    // Using atomic exchange ensures only one of those callers actually
+    // close()s the descriptor; the other observes -1 and is a no-op.
+    
+    std::atomic<int>            _server_fd{-1};
     struct sockaddr_in          _address;
     std::unique_ptr<uint8_t []> _pBuffer;
     std::unique_ptr<uint8_t []> _abOutputBuffer;
@@ -99,11 +111,24 @@ public:
     size_t                      _cbReceived;
 
     SocketServer(int port, int numLeds);
+    ~SocketServer() override { Stop(); }
+
+    // IService::Name
+    const char* Name() const override { return "SocketServer"; }
+
     void release();
     bool begin();
     void ResetReadBuffer();
     void SetLEDCount(size_t numLeds) { _numLeds = numLeds; }
     size_t GetLEDCount() const { return _numLeds; }
+
+  protected:
+    // ITaskService hooks
+    TaskConfig GetTaskConfig() const override;
+    void Run() override;
+    void OnBeforeWaitForStop() override;
+
+  public:
 
     // ReadUntilNBytesReceived
     //

--- a/include/soundanalyzer.h
+++ b/include/soundanalyzer.h
@@ -163,8 +163,7 @@ inline constexpr AudioInputParams kParamsI2SExternal
   #define MIN_VU 0.05f
 #endif
 
-void AudioSamplerTaskEntry(void *);
-void AudioSerialTaskEntry(void *);
+// AudioSerialTaskEntry was migrated into AudioSerialBridge::Run() (ITaskService).
 
 #ifndef GAINDAMPEN
     #define GAINDAMPEN 10      // How slowly brackets narrow in for spectrum bands
@@ -349,9 +348,6 @@ class SoundAnalyzer : public ISoundAnalyzer // Non-audio case stub
 
 #else // Audio case
 
-void AudioSamplerTaskEntry(void *);
-void AudioSerialTaskEntry(void *);
-
 // SoundAnalyzerBase
 //
 // Non-template base class containing hardware-specific logic and shared state
@@ -371,6 +367,18 @@ class SoundAnalyzerBase : public ISoundAnalyzer
     virtual ~SoundAnalyzerBase();
 
     void InitAudioInput();
+
+    // Idempotent. Stops DMA and uninstalls the I2S/ADC driver if (and only if)
+    // InitAudioInput previously installed it. Safe to call multiple times.
+    // Used by AudioService::Stop() to release the hardware on disable/reconfigure
+    // without waiting for global destruction at program end.
+
+    void TeardownAudioInput();
+
+    // True between a successful InitAudioInput and the next TeardownAudioInput.
+
+    bool IsHardwareInstalled() const { return _hardwareInstalled; }
+
     void RunSamplerPass() override;
     void SimulateBeatPass() override;
     void SetPeakDecayRates(float r1, float r2) override;
@@ -509,10 +517,26 @@ class SoundAnalyzerBase : public ISoundAnalyzer
     // amt in [0..1] controls how strongly the ratio influences the result.
     float BeatEnhance(float amt);
 
+    // Zero out VU/peak/ratio state and clear the FFT buffers. Public so that
+    // AudioService::Stop() can leave g_Analyzer in a true "silent" state when
+    // audio is disabled or being reconfigured. Cheap, safe to call from any
+    // thread that already holds the analyzer's locking discipline.
+
+    void Reset();
+
+    // Public writeback setters for the audio task loops. Floats and ints
+    // are read atomically on Xtensa for naturally-aligned 4-byte values, so
+    // the many-readers / single-writer pattern needs no extra locking.
+    // Replaces the prior friend-based direct-member-access pattern that
+    // assumed AudioSamplerTaskEntry / AudioSerialTaskEntry were free
+    // functions.
+
+    void SetVURatio(float v)     { _VURatio = v; }
+    void SetVURatioFade(float v) { _VURatioFade = v; }
+    void SetAudioFPS(int fps)    { _AudioFPS = fps; }
+    void SetSerialFPS(int fps)   { _serialFPS = fps; }
+
   protected:
-    // Give internal audio task functions access to private members
-    friend void AudioSamplerTaskEntry(void *);
-    friend void AudioSerialTaskEntry(void *);
 
     float _VURatio = 1.0f;
     float _VURatioFade = 1.0f;
@@ -576,11 +600,16 @@ class SoundAnalyzerBase : public ISoundAnalyzer
     adc_continuous_handle_t _adc_handle = nullptr;
 #endif
 
+    // Tracked per-instance so AudioService::Stop can call TeardownAudioInput
+    // without risk of double-uninstalling the I2S/ADC driver. Set true on
+    // a successful InitAudioInput, cleared by TeardownAudioInput.
+
+    bool _hardwareInstalled = false;
+
     // The FFT object is now a member variable to avoid ctor/dtor overhead per frame.
     // Declaration order ensures _vReal and _vImaginary address are stable when _FFT is initialized.
     ArduinoFFT<float> _FFT;
 
-    void Reset();
     void FFT();
     void SampleAudio();
     void UpdateVU(float newval);

--- a/include/systemcontainer.h
+++ b/include/systemcontainer.h
@@ -47,13 +47,18 @@ class JSONWriter;
 class DeviceConfig;
 class LEDBuffer;
 class LEDBufferManager;
-class NightDriverTaskManager;
+class TaskManager;
 class RemoteControl;
 class Screen;
 class SocketServer;
 class WebSocketServer;
 class CWebServer;
 class WS281xOutputManager;
+class AudioService;
+class AudioSerialBridge;
+class DebugConsole;
+class ColorStreamerService;
+class RenderService;
 namespace nd_network { class NetworkReader; }
 using nd_network::NetworkReader;
 
@@ -72,7 +77,7 @@ class SystemContainer
     std::unique_ptr<DeviceContainer> _ptrDevices;
     std::unique_ptr<BufferManagerContainer> _ptrBufferManagers;
     std::unique_ptr<EffectManager> _ptrEffectManager;
-    std::unique_ptr<NightDriverTaskManager> _ptrTaskManager;
+    std::unique_ptr<TaskManager> _ptrTaskManager;
     std::unique_ptr<JSONWriter> _ptrJSONWriter;
     std::unique_ptr<DeviceConfig> _ptrDeviceConfig;
 
@@ -104,6 +109,27 @@ class SystemContainer
         std::unique_ptr<Screen> _ptrDisplay;
     #endif
 
+    // AudioService is constructed in audio-enabled and non-audio builds alike.
+    // The service exposes a stable interface and degrades to a silent stub
+    // when ENABLE_AUDIO is 0, which keeps consumers (e.g. webserver, drawing
+    // VU meter) free of #if guards.
+
+    std::unique_ptr<AudioService> _ptrAudioService;
+
+    #if ENABLE_AUDIOSERIAL
+        std::unique_ptr<AudioSerialBridge> _ptrAudioSerialBridge;
+    #endif
+
+    #if ENABLE_WIFI
+        std::unique_ptr<DebugConsole> _ptrDebugConsole;
+    #endif
+
+    #if COLORDATA_SERVER_ENABLED
+        std::unique_ptr<ColorStreamerService> _ptrColorStreamerService;
+    #endif
+
+    std::unique_ptr<RenderService> _ptrRenderService;
+
     // Helper method that checks if a pointer is initialized.
     void CheckPointer(bool initialized, const char* name) const;
 
@@ -129,9 +155,9 @@ class SystemContainer
     EffectManager& GetEffectManager() const;
 
     // TaskManager
-    NightDriverTaskManager& SetupTaskManager();
+    TaskManager& SetupTaskManager();
     bool HasTaskManager() const { return !!_ptrTaskManager; }
-    NightDriverTaskManager& GetTaskManager() const;
+    TaskManager& GetTaskManager() const;
 
     // Config objects
     void SetupConfig();
@@ -183,6 +209,35 @@ class SystemContainer
         bool HasDisplay() const { return !!_ptrDisplay; }
         Screen& GetDisplay() const;
     #endif
+
+    // AudioService. SetupAudioService() creates the service in stopped state;
+    // call Start() on the returned reference once DeviceConfig is available.
+
+    AudioService& SetupAudioService();
+    bool HasAudioService() const { return nullptr != _ptrAudioService; }
+    AudioService& GetAudioService() const;
+
+    #if ENABLE_AUDIOSERIAL
+        AudioSerialBridge& SetupAudioSerialBridge();
+        bool HasAudioSerialBridge() const { return nullptr != _ptrAudioSerialBridge; }
+        AudioSerialBridge& GetAudioSerialBridge() const;
+    #endif
+
+    #if ENABLE_WIFI
+        DebugConsole& SetupDebugConsole();
+        bool HasDebugConsole() const { return nullptr != _ptrDebugConsole; }
+        DebugConsole& GetDebugConsole() const;
+    #endif
+
+    #if COLORDATA_SERVER_ENABLED
+        ColorStreamerService& SetupColorStreamerService();
+        bool HasColorStreamerService() const { return nullptr != _ptrColorStreamerService; }
+        ColorStreamerService& GetColorStreamerService() const;
+    #endif
+
+    RenderService& SetupRenderService();
+    bool HasRenderService() const { return nullptr != _ptrRenderService; }
+    RenderService& GetRenderService() const;
 };
 
 extern std::unique_ptr<SystemContainer> g_ptrSystem;

--- a/include/taskmgr.h
+++ b/include/taskmgr.h
@@ -49,7 +49,9 @@
 #include <esp_arduino_version.h>
 #include <esp_task_wdt.h>
 #include <freertos/task.h>
+#include <functional>
 #include <utility>
+#include <vector>
 
 class LEDStripEffect;
 
@@ -104,12 +106,28 @@ class IdleTask
 
 // TaskManager
 //
-// TaskManager runs two tasks at just over idle priority that do nothing but try to burn CPU, and they
-// keep track of how much they can burn.   It's assumed that everything else runs at a higher priority
-// and thus they "starve" the idle tasks when doing work.
+// Owns the two pinned idle-priority "CPU monitor" tasks that measure how much
+// CPU the rest of the system *isn't* using, and the per-effect task launcher
+// (StartEffectThread) for effects that want to spin off their own background
+// thread. All project-level service threads (AudioService, AudioSerialBridge,
+// ColorStreamerService, DebugConsole, JSONWriter, NetworkReader,
+// RemoteControl, RenderService, Screen, SocketServer) live as Run() methods
+// on their respective IService classes via ITaskService and are launched
+// through g_ptrSystem->Get*().Start() — TaskManager doesn't track them.
 
 class TaskManager
 {
+public:
+    using EffectTaskFunction = std::function<void(LEDStripEffect&)>;
+
+    struct EffectTaskParams
+    {
+        EffectTaskFunction function;
+        LEDStripEffect* pEffect;
+
+        EffectTaskParams(EffectTaskFunction function, LEDStripEffect* pEffect);
+    };
+
 protected:
     TaskHandle_t _hIdle0 = nullptr;
     TaskHandle_t _hIdle1 = nullptr;
@@ -117,7 +135,14 @@ protected:
     IdleTask _taskIdle0;
     IdleTask _taskIdle1;
 
+private:
+    std::vector<TaskHandle_t> _vEffectTasks;
+
+    static void EffectTaskEntry(void *pVoid);
+
 public:
+    TaskManager() = default;
+    ~TaskManager();
 
     float GetCPUUsagePercent(int iCore = -1) const
     {
@@ -131,9 +156,6 @@ public:
             throw std::runtime_error("Invalid core passed to GetCPUUsagePercentCPU");
     }
 
-    TaskManager()
-    = default;
-
     // CheckHeap
     //
     // Quick and dirty debug test to make sure the heap has not been corrupted
@@ -141,74 +163,6 @@ public:
     static void CheckHeap();
 
     void begin();
-
-};
-
-// NightDriverTaskManager
-//
-// A superclass of the base TaskManager that knows how to start and track the tasks specific to this project
-
-void ScreenUpdateLoopEntry(void *);
-void AudioSerialTaskEntry(void *);
-void DrawLoopTaskEntry(void *);
-void AudioSamplerTaskEntry(void *);
-void DebugLoopTaskEntry(void *);
-void SocketServerTaskEntry(void *);
-void RemoteLoopEntry(void *);
-void JSONWriterTaskEntry(void *);
-void ColorDataTaskEntry(void *);
-
-#define DELETE_TASK(handle) if (handle != nullptr) vTaskDelete(handle)
-
-class NightDriverTaskManager : public TaskManager
-{
-public:
-
-    using EffectTaskFunction = std::function<void(LEDStripEffect&)>;
-
-    struct EffectTaskParams
-    {
-        EffectTaskFunction function;
-        LEDStripEffect* pEffect;
-
-        EffectTaskParams(EffectTaskFunction function, LEDStripEffect* pEffect);
-    };
-
-private:
-
-    TaskHandle_t _taskScreen        = nullptr;
-    TaskHandle_t _taskNetwork       = nullptr;
-    TaskHandle_t _taskDraw          = nullptr;
-    TaskHandle_t _taskDebug         = nullptr;
-    TaskHandle_t _taskAudio         = nullptr;
-    TaskHandle_t _taskRemote        = nullptr;
-    TaskHandle_t _taskSocket        = nullptr;
-    TaskHandle_t _taskSerial        = nullptr;
-    TaskHandle_t _taskColorData     = nullptr;
-    TaskHandle_t _taskJSONWriter    = nullptr;
-
-    std::vector<TaskHandle_t> _vEffectTasks;
-
-    static void EffectTaskEntry(void *pVoid);
-
-public:
-
-    ~NightDriverTaskManager();
-
-    void StartScreenThread();
-    void StartSerialThread();
-    void StartColorDataThread();
-    void StartDrawThread();
-    void StartAudioThread();
-    void StartNetworkThread();
-    void StartDebugThread();
-    void StartSocketThread();
-    void StartRemoteThread();
-    void StartJSONWriterThread();
-
-
-    void NotifyJSONWriterThread();
-    void NotifyNetworkThread();
 
     // Effect threads run with NET priority and on the NET core by default. It seems a sensible choice
     //   because effect threads tend to pull things from the Internet that they want to show

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -45,15 +45,17 @@
 
 #include <ArduinoJson.h>
 #include <ESPAsyncWebServer.h>
+#include <atomic>
 #include <map>
 
 #include "deviceconfig.h"
+#include "iservice.h"
 #include "jsonserializer.h"
 #include "nd_network.h"
 
 class LEDStripEffect;
 
-class CWebServer
+class CWebServer : public IService
 {
   public:
     static constexpr int HttpOk = 200;
@@ -114,6 +116,16 @@ class CWebServer
 
     AsyncWebServer _server;
     StaticStatistics _staticStats;
+    std::atomic<bool> _running{false};
+
+    // Sticky flag: AsyncWebServer::begin() registers a TCP listener inside
+    // LWIP and AsyncTCP that we cannot fully reset from this fork. Once we
+    // have called begin() the first time we remember it here so a Stop()
+    // followed by Start() can warn loudly rather than silently leak/double-
+    // bind the listening socket. (We still do the begin again because the
+    // AsyncTCP server is normally reused; this just surfaces the limitation.)
+    
+    std::atomic<bool> _everStarted{false};
 
     // Helper functions/templates
 
@@ -170,6 +182,14 @@ class CWebServer
     static bool ValidateLegacyDeviceSettings(AsyncWebServerRequest * pRequest, String* errorMessage = nullptr);
     static bool ValidateUnifiedDeviceSettings(JsonObjectConst device, String* errorMessage = nullptr);
     static bool SetSettingsIfPresent(AsyncWebServerRequest * pRequest, String* errorMessage = nullptr);
+
+    // Apply a new audio input pin to DeviceConfig and, when the build supports
+    // a live reconfigure, push it through AudioService::Reconfigure() without
+    // requiring a reboot. Reverts the persisted pin on failure. Safe to call
+    // whether or not g_ptrSystem / AudioService are present. Returns true if
+    // either the pin was unchanged or the live reconfigure succeeded.
+    
+    static bool ApplyAudioInputPinChange(int oldPin);
     static long GetEffectIndexFromParam(AsyncWebServerRequest * pRequest, bool post = false);
     static bool CheckAndGetSettingsEffect(AsyncWebServerRequest * pRequest, std::shared_ptr<LEDStripEffect> & effect, bool post = false);
     static void SendEffectSettingsResponse(AsyncWebServerRequest * pRequest, std::shared_ptr<LEDStripEffect> & effect);
@@ -222,12 +242,29 @@ class CWebServer
         : _server(NetworkPort::Webserver), _staticStats()
     {}
 
-    // begin - register page load handlers and start serving pages
+    ~CWebServer() override { Stop(); }
+
+    // IService lifecycle. Start delegates to begin() (which registers the
+    // route handlers and calls AsyncWebServer::begin); Stop ends the server.
+    // Idempotent on both sides.
+    bool Start() override;
+    void Stop() override;
+    bool IsRunning() const override   { return _running.load(); }
+    const char* Name() const override { return "WebServer"; }
+
+    // begin - register page load handlers and start serving pages.
+    // Retained for callers that already use the AsyncWebServer-style name;
+    // Start() invokes this internally.
     void begin();
 
     void AddWebSocket(AsyncWebSocket& webSocket)
     {
         _server.addHandler(&webSocket);
+    }
+
+    void RemoveWebSocket(AsyncWebSocket& webSocket)
+    {
+        _server.removeHandler(&webSocket);
     }
 };
 

--- a/include/websocketserver.h
+++ b/include/websocketserver.h
@@ -35,13 +35,35 @@
 
 #if WEB_SOCKETS_ANY_ENABLED
 
+#include <atomic>
+
 #include "effectmanager.h"
+#include "iservice.h"
 #include "webserver.h"
 
-class WebSocketServer : public IEffectEventListener
+// WebSocketServer
+//
+// Pushes frame and effect-change events to connected web clients. The
+// listening socket and per-handler routing live inside CWebServer's
+// underlying AsyncWebServer; this service is responsible for binding
+// its handlers when the bound CWebServer is running and unbinding them
+// on Stop. Lifecycle:
+//
+//   - Construction is metadata-only: no handlers are registered yet.
+//   - Start() requires the bound CWebServer to be running. It registers
+//     the handlers and flips IsRunning() to true.
+//   - Stop() closes any open client connections, removes the handlers,
+//     and flips IsRunning() to false so the next Start() is a clean re-bind.
+//
+// Always Start CWebServer before WebSocketServer, and Stop in reverse
+// order; otherwise Start() refuses (Stop is harmless).
+
+class WebSocketServer : public IEffectEventListener, public IService
 {
     AsyncWebSocket _colorDataSocket;
     AsyncWebSocket _effectChangeSocket;
+    CWebServer&    _webServer;
+    std::atomic<bool> _running{false};
     static constexpr size_t _maxColorNumberLen = sizeof(NAME_OF(16777215)) - 1; // (uint32_t)CRGB(255,255,255) == 16777215
     static constexpr size_t _maxCountLen = sizeof(NAME_OF(4294967295)) - 1;     // SIZE_MAX == 4294967295
 
@@ -49,16 +71,62 @@ public:
 
     WebSocketServer(CWebServer& webServer) :
         _colorDataSocket("/ws/frames"),
-        _effectChangeSocket("/ws/effects")
+        _effectChangeSocket("/ws/effects"),
+        _webServer(webServer)
     {
+        // Handler registration deferred to Start() so construction is
+        // metadata-only and IsRunning() reflects the actual bound state.
+    }
+
+    ~WebSocketServer() override { Stop(); }
+
+    // IService lifecycle. Start binds our handlers into the bound
+    // CWebServer and flips our running flag; Stop unbinds them. We track
+    // an independent running flag rather than aliasing CWebServer's so
+    // callers can distinguish "websockets configured" from "web server up".
+    bool Start() override
+    {
+        if (_running.load())
+            return true;
+        if (!_webServer.IsRunning())
+        {
+            debugW("WebSocketServer::Start ignored, bound CWebServer is not running");
+            return false;
+        }
+
         #if COLORDATA_WEB_SOCKET_ENABLED
-        webServer.AddWebSocket(_colorDataSocket);
+            _webServer.AddWebSocket(_colorDataSocket);
+        #endif
+        #if EFFECTS_WEB_SOCKET_ENABLED
+            _webServer.AddWebSocket(_effectChangeSocket);
         #endif
 
-        #if EFFECTS_WEB_SOCKET_ENABLED
-        webServer.AddWebSocket(_effectChangeSocket);
-        #endif
+        _running.store(true);
+        return true;
     }
+
+    void Stop() override
+    {
+        if (!_running.load())
+            return;
+
+        // Close any open client connections so they don't outlast the
+        // handler-removal step.
+        _colorDataSocket.closeAll();
+        _effectChangeSocket.closeAll();
+
+        #if COLORDATA_WEB_SOCKET_ENABLED
+            _webServer.RemoveWebSocket(_colorDataSocket);
+        #endif
+        #if EFFECTS_WEB_SOCKET_ENABLED
+            _webServer.RemoveWebSocket(_effectChangeSocket);
+        #endif
+
+        _running.store(false);
+    }
+
+    bool IsRunning() const override   { return _running.load(); }
+    const char* Name() const override { return "WebSocketServer"; }
 
     void CleanupClients()
     {

--- a/site/app.js
+++ b/site/app.js
@@ -745,7 +745,7 @@ $$$$$$$b   *u    ^$L            $$  $$$$$$$$$$$$u@       $$  d$$$$$$
     els.effectSettingsForm.replaceChildren(fragment);
   }
 
-  function buildSettingField(spec, currentValue, draftStore, errorSet, isEffectDialog) {
+  function buildSettingField(spec, currentValue, draftStore, errorMap, isEffectDialog) {
     const wrapper = document.createElement("div");
     const needsStackedLayout = spec.type === settingType.Palette;
     wrapper.className = "setting-row" + (needsStackedLayout ? " stacked" : "");
@@ -784,11 +784,11 @@ $$$$$$$b   *u    ^$L            $$  $$$$$$$$$$$$u@       $$  d$$$$$$
     const setFieldError = (hasError, message) => {
       const help = wrapper.querySelector(".field-help");
       if (hasError) {
-        errorSet.set(key, message);
+        errorMap.set(key, message);
         help.textContent = message;
         help.classList.add("field-error");
       } else {
-        errorSet.delete(key);
+        errorMap.delete(key);
         help.innerHTML = spec.description || "";
         help.classList.remove("field-error");
       }
@@ -855,7 +855,7 @@ $$$$$$$b   *u    ^$L            $$  $$$$$$$$$$$$u@       $$  d$$$$$$
       help.className = "field-help";
       help.innerHTML = (spec.description || "") + " Disable rotation to keep the current effect active indefinitely.";
       meta.appendChild(help);
-      applyStoredFieldError(wrapper, errorSet, key);
+      applyStoredFieldError(wrapper, errorMap, key);
 
       if (isEffectDialog) {
         wrapper.dataset.dialogField = "1";
@@ -1064,7 +1064,7 @@ $$$$$$$b   *u    ^$L            $$  $$$$$$$$$$$$u@       $$  d$$$$$$
     help.className = "field-help";
     help.innerHTML = spec.description || "";
     meta.appendChild(help);
-    applyStoredFieldError(wrapper, errorSet, key);
+    applyStoredFieldError(wrapper, errorMap, key);
 
     if (isEffectDialog) {
       wrapper.dataset.dialogField = "1";

--- a/site/app.js
+++ b/site/app.js
@@ -71,7 +71,7 @@ $$$$$$$b   *u    ^$L            $$  $$$$$$$$$$$$u@       $$  d$$$$$$
     effectIntervalPendingMs: null,
     effectDraft: {},
     deviceDraft: {},
-    deviceErrors: new Set(),
+    deviceErrors: new Map(),
     effectDialog: {
       open: false,
       effectIndex: null,
@@ -79,7 +79,7 @@ $$$$$$$b   *u    ^$L            $$  $$$$$$$$$$$$u@       $$  d$$$$$$
       specs: [],
       values: {},
       draft: {},
-      errors: new Set()
+      errors: new Map()
     },
     autoRefresh: true,
     statsRefreshSeconds: Number(localStorage.getItem("nd.statsRefreshSeconds") || 3),
@@ -784,7 +784,7 @@ $$$$$$$b   *u    ^$L            $$  $$$$$$$$$$$$u@       $$  d$$$$$$
     const setFieldError = (hasError, message) => {
       const help = wrapper.querySelector(".field-help");
       if (hasError) {
-        errorSet.add(key);
+        errorSet.set(key, message);
         help.textContent = message;
         help.classList.add("field-error");
       } else {
@@ -855,6 +855,7 @@ $$$$$$$b   *u    ^$L            $$  $$$$$$$$$$$$u@       $$  d$$$$$$
       help.className = "field-help";
       help.innerHTML = (spec.description || "") + " Disable rotation to keep the current effect active indefinitely.";
       meta.appendChild(help);
+      applyStoredFieldError(wrapper, errorSet, key);
 
       if (isEffectDialog) {
         wrapper.dataset.dialogField = "1";
@@ -1035,9 +1036,18 @@ $$$$$$$b   *u    ^$L            $$  $$$$$$$$$$$$u@       $$  d$$$$$$
         }
         control.value = currentDraft ?? "";
         control.readOnly = readOnly;
+        control.addEventListener("input", () => {
+          const validation = validateFieldValue(spec, control.value);
+          if (validation.valid) {
+            setDraftValue(coerceFieldValue(spec, control.value));
+          } else {
+            draftStore[key] = control.value;
+          }
+        });
         control.addEventListener("change", () => {
           const validation = validateFieldValue(spec, control.value);
           if (!validation.valid) {
+            draftStore[key] = control.value;
             setFieldError(true, validation.message);
             return;
           }
@@ -1054,12 +1064,27 @@ $$$$$$$b   *u    ^$L            $$  $$$$$$$$$$$$u@       $$  d$$$$$$
     help.className = "field-help";
     help.innerHTML = spec.description || "";
     meta.appendChild(help);
+    applyStoredFieldError(wrapper, errorSet, key);
 
     if (isEffectDialog) {
       wrapper.dataset.dialogField = "1";
     }
 
     return wrapper;
+  }
+
+  function applyStoredFieldError(wrapper, errorMap, key) {
+    if (!errorMap || !errorMap.has(key)) {
+      return;
+    }
+
+    const help = wrapper.querySelector(".field-help");
+    if (!help) {
+      return;
+    }
+
+    help.textContent = errorMap.get(key);
+    help.classList.add("field-error");
   }
 
   function validateFieldValue(spec, rawValue) {
@@ -1150,10 +1175,92 @@ $$$$$$$b   *u    ^$L            $$  $$$$$$$$$$$$u@       $$  d$$$$$$
     }
   }
 
-  async function applyDeviceSettings(rebootAfter) {
-    if (state.deviceErrors.size > 0) {
-      toast("Fix invalid settings before applying.", "error");
+  function collectDeviceValidationErrors() {
+    const errors = new Map();
+    const specs = getOrderedDeviceSettingSpecs();
+
+    specs.forEach((spec) => {
+      if (!Object.prototype.hasOwnProperty.call(state.deviceDraft, spec.name)) {
+        return;
+      }
+
+      const validation = validateFieldValue(spec, state.deviceDraft[spec.name]);
+      if (!validation.valid) {
+        errors.set(spec.name, validation.message);
+      }
+    });
+
+    addTopologyValidationErrors(errors);
+    return errors;
+  }
+
+  function addTopologyValidationErrors(errors) {
+    const maxLeds = getCompiledMaxLEDs();
+    if (!maxLeds) {
       return;
+    }
+
+    const width = Number(getDraftOrCurrentDeviceSetting("matrixWidth"));
+    const height = Number(getDraftOrCurrentDeviceSetting("matrixHeight"));
+    if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+      return;
+    }
+
+    const requestedLeds = width * height;
+    if (requestedLeds <= maxLeds) {
+      return;
+    }
+
+    const message = `Matrix dimensions ${width} x ${height} require ${requestedLeds} LEDs, but this firmware supports ${maxLeds}. Lower width/height or flash a build compiled for more LEDs.`;
+    if (!errors.has("matrixWidth")) {
+      errors.set("matrixWidth", message);
+    }
+    if (!errors.has("matrixHeight")) {
+      errors.set("matrixHeight", message);
+    }
+  }
+
+  function getCompiledMaxLEDs() {
+    const topologyMax = Number((((state.unifiedSchema || {}).topology || {}).compiledMaxLEDs) || 0);
+    if (topologyMax > 0) {
+      return topologyMax;
+    }
+
+    const staticMax = Number((state.staticStats || {}).COMPILED_NUM_LEDS || 0);
+    return staticMax > 0 ? staticMax : 0;
+  }
+
+  function getDraftOrCurrentDeviceSetting(name) {
+    if (Object.prototype.hasOwnProperty.call(state.deviceDraft, name)) {
+      return state.deviceDraft[name];
+    }
+
+    const spec = getOrderedDeviceSettingSpecs().find((candidate) => candidate.name === name) || { name };
+    return getCurrentDeviceSettingValue(spec);
+  }
+
+  function summarizeValidationErrors(errorMap, specs) {
+    const specsByName = new Map((specs || []).map((spec) => [spec.name, spec]));
+    const entries = Array.from(errorMap.entries());
+    const visibleEntries = entries.slice(0, 4).map(([name, message]) => {
+      const spec = specsByName.get(name);
+      const label = spec ? (spec.friendlyName || spec.name) : name;
+      return `${label}: ${message}`;
+    });
+    const remaining = entries.length - visibleEntries.length;
+    return visibleEntries.join(" ") + (remaining > 0 ? ` ${remaining} more invalid setting${remaining === 1 ? "" : "s"}.` : "");
+  }
+
+  async function applyDeviceSettings(rebootAfter) {
+    const hadDeviceErrors = state.deviceErrors.size > 0;
+    state.deviceErrors = collectDeviceValidationErrors();
+    if (state.deviceErrors.size > 0) {
+      renderSettingsForm();
+      toast(`Fix invalid settings before applying. ${summarizeValidationErrors(state.deviceErrors, getOrderedDeviceSettingSpecs())}`, "error");
+      return;
+    }
+    if (hadDeviceErrors) {
+      renderSettingsForm();
     }
 
     const { legacyPayload, unifiedPayload } = splitDeviceDraftPayloads(state.deviceDraft);
@@ -1203,7 +1310,7 @@ $$$$$$$b   *u    ^$L            $$  $$$$$$$$$$$$u@       $$  d$$$$$$
         specs,
         values,
         draft: {},
-        errors: new Set()
+        errors: new Map()
       };
       renderEffectDialogForm();
       if (!els.effectSettingsDialog.open) {
@@ -1217,7 +1324,7 @@ $$$$$$$b   *u    ^$L            $$  $$$$$$$$$$$$u@       $$  d$$$$$$
   function closeEffectDialog() {
     state.effectDialog.open = false;
     state.effectDialog.draft = {};
-    state.effectDialog.errors = new Set();
+    state.effectDialog.errors = new Map();
     if (els.effectSettingsDialog.open) {
       els.effectSettingsDialog.close();
     }
@@ -1229,7 +1336,7 @@ $$$$$$$b   *u    ^$L            $$  $$$$$$$$$$$$u@       $$  d$$$$$$
       return;
     }
     if (dialog.errors.size > 0) {
-      toast("Fix invalid effect settings before applying.", "error");
+      toast(`Fix invalid effect settings before applying. ${summarizeValidationErrors(dialog.errors, dialog.specs)}`, "error");
       return;
     }
     const payload = { effectIndex: dialog.effectIndex, ...dialog.draft };

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -40,80 +40,16 @@
 #include <unistd.h>
 
 #if ENABLE_AUDIO
+#include "audioserialbridge.h"
 #include "nd_network.h"
 #include "soundanalyzer.h"
 #include "systemcontainer.h"
+#include "taskmgr.h"     // AUDIOSERIAL_PRIORITY / AUDIOSERIAL_CORE / DEFAULT_STACK_SIZE
 #include "time_utils.h"
 
-// AudioSamplerTaskEntry
-// A background task that samples audio, computes the VU, stores it for effect use, etc.
-
-void IRAM_ATTR AudioSamplerTaskEntry(void *)
-{
-    debugI(">>> Sampler Task Started");
-
-    // M5 boards sample through M5.Mic/M5Unified, not the generic AUDIO_INPUT_PIN path.
-    // Only configure AUDIO_INPUT_PIN for the external mic configurations that actually consume it.
-    #if !USE_M5
-    const auto audioInputPin = g_ptrSystem->GetConfiguredAudioInputPin();
-    if (audioInputPin >= 0)
-        pinMode(audioInputPin, INPUT);
-    #endif
-
-    g_Analyzer.InitAudioInput();
-
-    for (;;)
-    {
-        auto lastFrame = millis();
-
-        g_Analyzer.RunSamplerPass();
-        g_Analyzer.UpdatePeakData();
-        g_Analyzer.DecayPeaks();
-
-        // VURatio with a fadeout
-
-        static auto lastVU = 0.0f;
-        constexpr auto VU_DECAY_PER_SECOND = 9.00;
-
-        // Get the elapsed time since the last frame. We'll calculate this at the right spot from the first loop onwards
-        static auto frameDurationSeconds = (millis() - lastFrame) / 1000.0;
-
-        // Fade out the VU ratio
-
-        if (g_Analyzer.VURatio() > lastVU)
-            lastVU = g_Analyzer.VURatio();
-        else
-            lastVU -= frameDurationSeconds * VU_DECAY_PER_SECOND;
-
-        g_Analyzer._VURatioFade = std::clamp(lastVU, 0.0f, 2.0f);
-
-        // Instantaneous VURatio
-
-        assert(g_Analyzer.PeakVU() >= g_Analyzer.MinVU());
-
-        g_Analyzer._VURatio = (g_Analyzer.PeakVU() == g_Analyzer.MinVU()) ?
-                                0.0 :
-                                (g_Analyzer.VU() - g_Analyzer.MinVU()) / std::max(g_Analyzer.PeakVU() - g_Analyzer.MinVU(), (float) MIN_VU) * 2.0f;
-
-        debugV("VU: %f\n", g_Analyzer.VU());
-        debugV("PeakVU: %f\n", g_Analyzer.PeakVU());
-        debugV("MinVU: %f\n", g_Analyzer.MinVU());
-        debugV("VURatio: %f\n", g_Analyzer.VURatio());
-        debugV("VURatioFade: %f\n", g_Analyzer.VURatioFade());
-
-        // Delay enough time to yield 60fps max
-        // We wait a minimum even if busy so we don't Bogart the CPU
-
-        constexpr auto kMaxFPS = 60;
-        const auto targetDelay = PERIOD_FROM_FREQ(kMaxFPS) * MILLIS_PER_SECOND / MICROS_PER_SECOND;
-        delay(max(1.0, targetDelay - (millis() - lastFrame)));
-
-        auto duration = millis() - lastFrame;
-        frameDurationSeconds = duration / 1000.0;
-        g_Analyzer._AudioFPS = FPS(duration);
-        debugV("AudioFPS: %d\n", g_Analyzer.AudioFPS());
-    }
-}
+// The audio sampler loop body has moved into AudioService::Run() (an
+// ITaskService-managed task). This file now hosts only the optional
+// AudioSerialBridge service, gated by ENABLE_AUDIOSERIAL.
 
 #if ENABLE_AUDIOSERIAL
 
@@ -243,12 +179,25 @@ struct SerialData
     uint8_t tail;               // (0x0D)
 };
 
-void IRAM_ATTR AudioSerialTaskEntry(void *)
-{
-    //  SoftwareSerial Serial64(SERIAL_PINRX, SERIAL_PINTX);
-    debugI(">>> Sampler Task Started");
+// AudioSerialBridge ITaskService hooks
+//
+// Start/Stop/IsRunning are inherited final from ITaskService; this class
+// only supplies the task config and the C64/PET serial output loop body.
 
-    SoundAnalyzer Analyzer;
+ITaskService::TaskConfig AudioSerialBridge::GetTaskConfig() const
+{
+    return TaskConfig {
+        "Audio Serial Loop",
+        DEFAULT_STACK_SIZE,
+        AUDIOSERIAL_PRIORITY,
+        AUDIOSERIAL_CORE,
+        500    // Stop timeout: loop yields every few ms.
+    };
+}
+
+void IRAM_ATTR AudioSerialBridge::Run()
+{
+    debugI(">>> Audio Serial Task Started");
 
 #if ENABLE_VICE_SERVER
     VICESocketServer socketServer(NetworkPort::VICESocketServer);
@@ -266,8 +215,9 @@ void IRAM_ATTR AudioSerialTaskEntry(void *)
     debugI("    Opened Serial2 on pins %d,%d\n", SERIAL_PINRX, SERIAL_PINTX);
 
     int socket = -1;
+    int lastFrame = millis();
 
-    for (;;)
+    while (!ShouldShutdown())
     {
         unsigned long startTime = millis();
 
@@ -296,24 +246,9 @@ void IRAM_ATTR AudioSerialTaskEntry(void *)
         {
             Serial2.write((uint8_t *)&data, sizeof(data));
             // Serial2.flush(true);
-            static int lastFrame = millis();
-            g_Analyzer._serialFPS = FPS(lastFrame, millis());
+            g_Analyzer.SetSerialFPS(FPS(lastFrame, millis()));
             lastFrame = millis();
         }
-
-        /* PETROCK no longer sends these confirmation stars, but we could add it back...
-        // When the CBM processes a packet, it sends us a * to ACK.  We count those to determine the number
-        // of packets per second being processed
-
-        while (Serial2.available() > 0)
-        {
-            char read = Serial2.read();
-            Serial.print(read);
-            if (read == '*')
-            {
-            }
-        }
-        */
 
 #if ENABLE_VICE_SERVER
         // If we have a socket open, send our packet to its virtual serial port now as well.
@@ -341,6 +276,11 @@ void IRAM_ATTR AudioSerialTaskEntry(void *)
         else
             delay(1);
     }
+
+#if ENABLE_VICE_SERVER
+    if (socket >= 0)
+        close(socket);
+#endif
 }
 
 #endif // ENABLE_AUDIOSERIAL

--- a/src/audioservice.cpp
+++ b/src/audioservice.cpp
@@ -55,8 +55,17 @@
 namespace
 {
     // The fallback source returned by Source() when audio is stopped or
-    // unavailable. Implements ISoundAnalyzer with all-zero/false/empty returns
-    // so effects can call into it harmlessly.
+    // unavailable. Implements ISoundAnalyzer so effects can call into it
+    // harmlessly. The chosen "silent fallback" contract is:
+    //
+    //   VURatio / VURatioFade => 1.0f  (neutral — no scaling change)
+    //   VU / PeakVU / MinVU   => 0.0f  (truly silent)
+    //
+    // This matches SoundAnalyzerBase::Reset(), which also sets the ratio
+    // metrics to 1.0f. Effects that scale brightness/speed by VURatio treat
+    // 1.0f as "no change", so both access paths (AudioService::Source() and
+    // direct g_Analyzer reads) produce the same neutral behavior while audio
+    // is stopped or being reconfigured.
     class NullAudioSource : public ISoundAnalyzer
     {
       public:
@@ -71,9 +80,12 @@ namespace
         bool  IsRemoteAudioActive() const override { return false; }
 
         // --- VU Metrics ---
+        // VU/PeakVU/MinVU are zero (truly silent). VURatio and VURatioFade
+        // are 1.0f (neutral) so effects that scale by these values are
+        // unaffected, matching the behavior of SoundAnalyzerBase::Reset().
         float VU() const override { return 0.0f; }
-        float VURatio() const override { return 0.0f; }
-        float VURatioFade() const override { return 0.0f; }
+        float VURatio() const override { return 1.0f; }
+        float VURatioFade() const override { return 1.0f; }
         float PeakVU() const override { return 0.0f; }
         float MinVU() const override { return 0.0f; }
 

--- a/src/audioservice.cpp
+++ b/src/audioservice.cpp
@@ -1,0 +1,392 @@
+//+--------------------------------------------------------------------------
+//
+// File:        audioservice.cpp
+//
+// NightDriverStrip - (c) 2026 Plummer's Software LLC.  All Rights Reserved.
+//
+// This file is part of the NightDriver software project.
+//
+//    NightDriver is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    NightDriver is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with Nightdriver.  It is normally found in copying.txt
+//    If not, see <https://www.gnu.org/licenses/>.
+//
+// Description:
+//
+//    Implementation of AudioService and AudioConfig. The file is structured
+//    in three sections:
+//
+//      1. Shared support code (NullAudioSource, AudioConfig::ModeName) — no
+//         preprocessor branches.
+//      2. ENABLE_AUDIO == 1: real AudioService + the audio-enabled flavor of
+//         AudioConfig::FromCompileDefaults / FromCurrentSettings.
+//      3. ENABLE_AUDIO == 0: stub AudioService + minimal AudioConfig factories.
+//
+//    Method bodies inside each variant are unconditional, mirroring the
+//    pattern used by SoundAnalyzer in soundanalyzer.h.
+//
+//---------------------------------------------------------------------------
+
+#include "globals.h"
+
+#include <algorithm>     // std::clamp, std::max — used in Run()
+#include <cassert>       // assert()
+
+#include "audioservice.h"
+#include "deviceconfig.h"
+#include "soundanalyzer.h"
+#include "systemcontainer.h"
+#include "taskmgr.h"     // AUDIO_STACK_SIZE / AUDIO_PRIORITY / AUDIO_CORE
+#include "time_utils.h"  // FPS() — used by Run() to compute audio frame rate
+
+// ===========================================================================
+// 1. Shared support code (compiled in every build)
+// ===========================================================================
+
+namespace
+{
+    // The fallback source returned by Source() when audio is stopped or
+    // unavailable. Implements ISoundAnalyzer with all-zero/false/empty returns
+    // so effects can call into it harmlessly.
+    class NullAudioSource : public ISoundAnalyzer
+    {
+      public:
+        // --- Core Processing ---
+        void  RunSamplerPass() override {}
+        void  SimulateBeatPass() override {}
+        void  SetPeakDecayRates(float, float) override {}
+
+        // --- Telemetry & Status ---
+        int   AudioFPS() const override { return 0; }
+        int   SerialFPS() const override { return 0; }
+        bool  IsRemoteAudioActive() const override { return false; }
+
+        // --- VU Metrics ---
+        float VU() const override { return 0.0f; }
+        float VURatio() const override { return 0.0f; }
+        float VURatioFade() const override { return 0.0f; }
+        float PeakVU() const override { return 0.0f; }
+        float MinVU() const override { return 0.0f; }
+
+        // --- Spectral Data ---
+        // The shared empty Peaks/Beat instances are static so every Null
+        // source returns the same canonical empty value (and so the per-
+        // instance footprint stays at zero).
+        const PeakData& Peaks() const override { return EmptyPeaks(); }
+        float Peak1Decay(int) const override { return 0.0f; }
+        float Peak2Decay(int) const override { return 0.0f; }
+        unsigned long LastPeak1Time(int) const override { return 0; }
+        BeatInfo LastBeat() const override { return EmptyBeat(); }
+        BeatInfo LastNearBeat() const override { return EmptyBeat(); }
+
+        // --- Simulation & Testing ---
+        void  SetSimulateBeat(bool) override {}
+        void  SetSimulateBPM(int)  override {}
+        bool  GetSimulateBeat() const override { return false; }
+        int   GetSimulateBPM()  const override { return 0; }
+
+      private:
+        static const PeakData& EmptyPeaks()
+        {
+            static const PeakData s_empty{};
+            return s_empty;
+        }
+        static const BeatInfo& EmptyBeat()
+        {
+            static const BeatInfo s_empty{};
+            return s_empty;
+        }
+    };
+
+    NullAudioSource& GetNullSource()
+    {
+        static NullAudioSource s_nullSource;
+        return s_nullSource;
+    }
+}
+
+// AudioConfig::ModeName is shared because the Mode enum is shared.
+const char* AudioConfig::ModeName() const
+{
+    switch (mode)
+    {
+        case Mode::Disabled:    return "disabled";
+        case Mode::AnalogADC:   return "adc";
+        case Mode::I2SExternal: return "i2s";
+        case Mode::M5Onboard:   return "m5_internal";
+    }
+    return "unknown";
+}
+
+// ===========================================================================
+// 2. Audio-enabled variant
+// ===========================================================================
+
+#if ENABLE_AUDIO
+
+// AudioConfig::FromCompileDefaults
+//
+// Translate the existing compile-time audio macros into a runtime AudioConfig
+// so first boot looks exactly like before this refactor.
+AudioConfig AudioConfig::FromCompileDefaults()
+{
+    AudioConfig cfg{};
+    cfg.enabled    = true;
+    cfg.sampleRate = 24000; // matches SoundAnalyzerBase::SAMPLING_FREQUENCY
+    cfg.inputPin   = AUDIO_INPUT_PIN;
+
+    #if USE_M5
+        cfg.mode = AudioConfig::Mode::M5Onboard;
+    #elif USE_I2S_AUDIO || ELECROW
+        cfg.mode    = AudioConfig::Mode::I2SExternal;
+        #ifdef I2S_BCLK_PIN
+        cfg.bclkPin = I2S_BCLK_PIN;
+        #endif
+        #ifdef I2S_WS_PIN
+        cfg.wsPin   = I2S_WS_PIN;
+        #endif
+        #ifdef I2S_DATA_PIN
+        cfg.dataPin = I2S_DATA_PIN;
+        #else
+        cfg.dataPin = AUDIO_INPUT_PIN;
+        #endif
+    #else
+        cfg.mode = AudioConfig::Mode::AnalogADC;
+    #endif
+    return cfg;
+}
+
+AudioConfig AudioConfig::FromCurrentSettings()
+{
+    AudioConfig cfg = FromCompileDefaults();
+
+    // Overlay any persisted audio input pin from DeviceConfig if one is
+    // available. -1 is the sentinel meaning "use the compile default";
+    // anything >= 0 is a real GPIO and overrides.
+    if (g_ptrSystem && g_ptrSystem->HasDeviceConfig())
+    {
+        const int persistedPin = g_ptrSystem->GetDeviceConfig().GetAudioInputPin();
+        if (persistedPin >= 0)
+            cfg.inputPin = persistedPin;
+    }
+    return cfg;
+}
+
+AudioService::AudioService()
+{
+    // Construction is metadata-only per the IService contract, but the config
+    // needs to be in a sensible state from the start so callers can read
+    // Config() before the first Start/Reconfigure.
+    _config = AudioConfig::FromCompileDefaults();
+}
+
+AudioService::~AudioService()
+{
+    Stop();
+}
+
+IAudioSource& AudioService::Source() const
+{
+    if (IsRunning())
+        return g_Analyzer;
+    return GetNullSource();
+}
+
+// ---- ITaskService hooks ----
+
+ITaskService::TaskConfig AudioService::GetTaskConfig() const
+{
+    return TaskConfig {
+        "Audio Sampler Loop",
+        AUDIO_STACK_SIZE,
+        AUDIO_PRIORITY,
+        AUDIO_CORE,
+        750    // Stop timeout: I2S read uses a 100ms timeout, plus loop work.
+    };
+}
+
+// OnBeforeStart - validate the config and emit start diagnostics. Returning
+// false here aborts the launch (e.g. when audio is disabled in this run or
+// the pin is not configured). The config itself is no longer mutated here:
+// callers wanting the "current settings" semantics should call
+// Reconfigure(AudioConfig::FromCurrentSettings()) before Start().
+bool AudioService::OnBeforeStart()
+{
+    if (!_config.enabled)
+    {
+        debugI("Audio: Start() called but config marks audio disabled (pin=%d mode=%s)",
+               _config.inputPin, _config.ModeName());
+        return false;
+    }
+
+    debugI("Audio: starting (pin=%d mode=%s rate=%d)",
+           _config.inputPin, _config.ModeName(), _config.sampleRate);
+    return true;
+}
+
+// OnAfterStop - release the audio hardware and zero analyzer telemetry so
+// direct readers of g_Analyzer see safe defaults during a reconfigure.
+// Idempotent in both calls (TeardownAudioInput's _hardwareInstalled guard
+// and Reset's unconditional zero-out).
+void AudioService::OnAfterStop()
+{
+    g_Analyzer.TeardownAudioInput();
+    g_Analyzer.Reset();
+}
+
+// AudioService::Run - the audio sampler loop. Initializes the I2S/ADC input
+// on the task's own thread (some IDF drivers require that), then samples,
+// processes peaks, and updates VU/ratio telemetry until ShouldShutdown()
+// is true. ITaskService::TaskEntryThunk handles the post-Run vTaskDelete.
+void AudioService::Run()
+{
+    debugI(">>> Sampler Task Started");
+
+    // M5 boards sample through M5.Mic/M5Unified, not the generic AUDIO_INPUT_PIN
+    // path. Only configure the input pin for the external mic configurations
+    // that actually consume it.
+    #if !USE_M5
+    const auto audioInputPin = g_ptrSystem->GetConfiguredAudioInputPin();
+    if (audioInputPin >= 0)
+        pinMode(audioInputPin, INPUT);
+    #endif
+
+    g_Analyzer.InitAudioInput();
+
+    auto lastVU = 0.0f;
+    auto frameDurationSeconds = 0.016;
+    constexpr auto VU_DECAY_PER_SECOND = 9.00;
+    constexpr auto kMaxFPS = 60;
+
+    while (!ShouldShutdown())
+    {
+        auto lastFrame = millis();
+
+        g_Analyzer.RunSamplerPass();
+        g_Analyzer.UpdatePeakData();
+        g_Analyzer.DecayPeaks();
+
+        // Fade out the VURatio
+        if (g_Analyzer.VURatio() > lastVU)
+            lastVU = g_Analyzer.VURatio();
+        else
+            lastVU -= frameDurationSeconds * VU_DECAY_PER_SECOND;
+
+        g_Analyzer.SetVURatioFade(std::clamp(lastVU, 0.0f, 2.0f));
+
+        // Instantaneous VURatio
+        assert(g_Analyzer.PeakVU() >= g_Analyzer.MinVU());
+        g_Analyzer.SetVURatio((g_Analyzer.PeakVU() == g_Analyzer.MinVU())
+            ? 0.0f
+            : (g_Analyzer.VU() - g_Analyzer.MinVU())
+              / std::max(g_Analyzer.PeakVU() - g_Analyzer.MinVU(), (float) MIN_VU)
+              * 2.0f);
+
+        // Yield to share the CPU. We always wait at least kMinFrameDelay so
+        // we don't bogart the core even when sampling is fast.
+        const auto targetDelay = PERIOD_FROM_FREQ(kMaxFPS) * MILLIS_PER_SECOND / MICROS_PER_SECOND;
+        delay(std::max(1.0, targetDelay - (millis() - lastFrame)));
+
+        const auto duration = millis() - lastFrame;
+        frameDurationSeconds = duration / 1000.0;
+        g_Analyzer.SetAudioFPS(FPS(duration));
+    }
+}
+
+// AudioService::Reconfigure - service-specific. Stops if running, applies the
+// new config, and restarts when newConfig.enabled is true. The Start/Stop
+// inherited from ITaskService own all the lifecycle discipline. Short-
+// circuits when the requested config matches the current one and the
+// service is already in the desired running state, so an unrelated
+// settings PUT doesn't bounce a running sampler.
+
+bool AudioService::Reconfigure(const AudioConfig& newConfig)
+{
+    debugI("Audio: reconfigure requested (pin=%d mode=%s enabled=%d)",
+           newConfig.inputPin, newConfig.ModeName(), (int)newConfig.enabled);
+
+    auto sameConfig = [](const AudioConfig& a, const AudioConfig& b)
+    {
+        return a.enabled    == b.enabled
+            && a.mode       == b.mode
+            && a.inputPin   == b.inputPin
+            && a.bclkPin    == b.bclkPin
+            && a.wsPin      == b.wsPin
+            && a.dataPin    == b.dataPin
+            && a.sampleRate == b.sampleRate;
+    };
+
+    if (sameConfig(_config, newConfig) && IsRunning() == newConfig.enabled)
+    {
+        debugI("Audio: reconfigure is a no-op (config and running state unchanged)");
+        return true;
+    }
+
+    const bool wasRunning = IsRunning();
+    if (wasRunning)
+        Stop();
+
+    _config = newConfig;
+
+    if (!_config.enabled)
+    {
+        debugI("Audio: reconfigure leaves audio disabled");
+        return true;
+    }
+
+    if (!Start())
+    {
+        debugE("Audio: reconfigure failed to start with new settings");
+        return false;
+    }
+
+    debugI("Audio: reconfigure completed");
+    return true;
+}
+
+// ===========================================================================
+// 3. Audio-disabled stub variant
+// ===========================================================================
+
+#else // !ENABLE_AUDIO
+
+AudioConfig AudioConfig::FromCompileDefaults()
+{
+    AudioConfig cfg{};
+    cfg.enabled = false;
+    cfg.mode    = AudioConfig::Mode::Disabled;
+    return cfg;
+}
+
+AudioConfig AudioConfig::FromCurrentSettings()
+{
+    return FromCompileDefaults();
+}
+
+bool AudioService::Start()
+{
+    debugI("Audio: build has ENABLE_AUDIO=0, AudioService::Start is a no-op");
+    return false;
+}
+
+bool AudioService::Reconfigure(const AudioConfig&)
+{
+    debugI("Audio: Reconfigure ignored, ENABLE_AUDIO=0");
+    return false;
+}
+
+IAudioSource& AudioService::Source() const
+{
+    return GetNullSource();
+}
+
+#endif // ENABLE_AUDIO

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -41,7 +41,9 @@
 #include "ledbuffer.h"
 #include "nd_network.h"
 #include "ntptimeclient.h"
+#include "renderservice.h"
 #include "systemcontainer.h"
+#include "taskmgr.h"   // DRAWING_STACK_SIZE / DRAWING_PRIORITY / DRAWING_CORE
 
 #include "effects/matrix/spectrumeffects.h"
 
@@ -261,13 +263,35 @@ void ShowOnboardPixel()
     #endif
 }
 
-// DrawLoopTaskEntry
+// RenderService ITaskService hooks
 //
-// Main draw loop entry point
+// Start/Stop/IsRunning are inherited final from ITaskService; this class
+// only supplies the task config and the per-frame render loop body. The
+// render task is pinned to DRAWING_CORE because SmartMatrix and FastLED
+// both impose core affinity expectations on whatever drives them.
 
-void IRAM_ATTR DrawLoopTaskEntry(void *)
+ITaskService::TaskConfig RenderService::GetTaskConfig() const
 {
-    debugW(">> DrawLoopTaskEntry\n");
+    return TaskConfig {
+        "Draw Loop",
+        DRAWING_STACK_SIZE,
+        DRAWING_PRIORITY,
+        DRAWING_CORE,
+        2000   // Stop timeout: loop yields up to 1s in CalcDelayUntilNextFrame.
+    };
+}
+
+// RenderService::Run
+//
+// Main draw loop. Calls WiFiDraw / LocalDraw, runs PostProcessFrame, and
+// updates the FPS window. Holds the global render mutex for the duration
+// of each frame so runtime topology/output changes can't reconfigure the
+// active buffers mid-frame. Polls ShouldShutdown() between frames so a
+// Stop() in OTA / shutdown can break the loop cleanly.
+
+void IRAM_ATTR RenderService::Run()
+{
+    debugW(">> RenderService::Run\n");
 
     // If this board has an onboard RGB pixel, set it up now
 
@@ -281,7 +305,7 @@ void IRAM_ATTR DrawLoopTaskEntry(void *)
 
     debugW("Entering main draw loop!");
 
-    for (;;)
+    while (!ShouldShutdown())
     {
         g_Values.AppTime.NewFrame();
 

--- a/src/effectfactories.cpp
+++ b/src/effectfactories.cpp
@@ -68,7 +68,7 @@
 //            - An optional factory ID.
 //            It returns a reference to the NumberedFactory that was created around the
 //            DefaultEffectFactory.
-// IsEmpty: Returns a boolean indicating whether both defaultFactories and jsonFactories are empty.
+// IsEmpty: Returns a bool indicating whether both defaultFactories and jsonFactories are empty.
 // ClearDefaultFactories: Clears the vector of default factories and the hash string.
 // FactoryIDs: Returns a vector of the factory IDs from the default factories.
 // HashString (getter): Returns the stored hash string. Throws an error if it hasn't been set.

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -265,6 +265,21 @@ void EffectManager::AddFrameEventListener(IFrameEventListener& listener)
     _frameEventListeners.emplace_back(listener);
 }
 
+void EffectManager::RemoveFrameEventListener(IFrameEventListener& listener)
+{
+    // Match by address — reference_wrapper has no operator== so we compare
+    // the underlying object pointers. erase/remove_if so we drop every entry
+    // even if the same listener was registered more than once.
+    // Robert may have a better or less obtuse way to do this, but it works 
+    // and it's not like we have thousands of listeners.  Change at will!
+    
+    _frameEventListeners.erase(
+        std::remove_if(_frameEventListeners.begin(), _frameEventListeners.end(),
+                       [&](const std::reference_wrapper<IFrameEventListener>& w)
+                       { return &w.get() == &listener; }),
+        _frameEventListeners.end());
+}
+
 void EffectManager::AddEffectEventListener(IEffectEventListener& listener)
 {
     _effectEventListeners.emplace_back(listener);

--- a/src/itaskservice.cpp
+++ b/src/itaskservice.cpp
@@ -1,0 +1,170 @@
+//+--------------------------------------------------------------------------
+//
+// File:        itaskservice.cpp
+//
+// NightDriverStrip - (c) 2026 Plummer's Software LLC.  All Rights Reserved.
+//
+// This file is part of the NightDriver software project.
+//
+//    NightDriver is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    NightDriver is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU General Public License for more details.
+//
+//    You should have received a copy of the GNU General Public License
+//    along with Nightdriver.  It is normally found in copying.txt
+//    If not, see <https://www.gnu.org/licenses/>.
+//
+// Description:
+//
+//    Implementation of ITaskService. Captures the launch/shutdown discipline
+//    that used to be duplicated across AudioService, JSONWriter,
+//    SocketServer, and RemoteControl into one place.
+//
+//---------------------------------------------------------------------------
+
+#include "globals.h"
+
+#include <exception>
+
+#include "itaskservice.h"
+
+// ITaskService provides a Start() method that launches a FreeRTOS task running
+// the ITaskService::Run() method, and a Stop() method that signals the task to
+// exit and waits for it to do so, with a force-delete fallback if it doesn't
+// within a reasonable timeout. The task entry point is a static thunk that
+// casts the void* back to ITaskService* and calls Run(), with try/catch to
+// log any exceptions that escape from Run().
+
+bool ITaskService::Start()
+{
+    if (_running.load())
+    {
+        debugI("%s: Start() ignored, already running", Name());
+        return true;
+    }
+
+    if (!OnBeforeStart())
+    {
+        debugI("%s: Start() declined by OnBeforeStart hook", Name());
+        return false;
+    }
+
+    _shutdownRequested.store(false);
+    _taskExited.store(false);
+
+    const TaskConfig cfg = GetTaskConfig();
+
+    Serial.print( str_sprintf(">> Launching %s.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ",
+        cfg.taskName,
+        (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(),
+        (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
+
+    BaseType_t rc = xTaskCreatePinnedToCore(
+        TaskEntryThunk,
+        cfg.taskName,
+        cfg.stackSize,
+        this,                       // ITaskService*; thunk casts back
+        cfg.priority,
+        &_taskHandle,
+        cfg.core);
+
+    if (rc != pdPASS)
+    {
+        debugE("%s: xTaskCreatePinnedToCore failed (rc=%d)", Name(), (int)rc);
+        _taskHandle = nullptr;
+        return false;
+    }
+
+    _running.store(true);
+    return true;
+}
+
+void ITaskService::Stop()
+{
+    if (!_running.load() && _taskHandle == nullptr)
+        return;
+
+    debugI("%s: stop requested", Name());
+
+    if (_taskHandle != nullptr)
+    {
+        _shutdownRequested.store(true);
+
+        // Give the implementer a chance to break the task out of any
+        // blocking call (e.g. close a listening socket, abort an I2S read).
+
+        OnBeforeWaitForStop();
+
+        const uint32_t timeoutMs = GetTaskConfig().shutdownTimeoutMs;
+        const uint32_t deadline = millis() + timeoutMs;
+        while (!_taskExited.load() && (int32_t)(deadline - millis()) > 0)
+            delay(5);
+
+        if (!_taskExited.load())
+            debugW("%s: task did not exit gracefully within %lums; deleting forcibly",
+                   Name(), (unsigned long)timeoutMs);
+
+        // The task either acknowledged exit (and is now parked in
+        // TaskEntryThunk's vTaskDelay) or it never acknowledged. Either
+        // way, we delete it from this thread so the FreeRTOS task control
+        // block is reclaimed before this object is allowed to be destroyed.
+        vTaskDelete(_taskHandle);
+        _taskHandle = nullptr;
+    }
+
+    // Service-specific resource cleanup. Runs whether the task exited
+    // gracefully or was force-deleted, so implementers must keep it safe
+    // against partial task progress.
+    OnAfterStop();
+
+    _running.store(false);
+    _shutdownRequested.store(false);
+    _taskExited.store(false);
+    debugI("%s: stop completed", Name());
+}
+
+// TaskEntryThunk - static task entry point that casts the void* back to
+// ITaskService* and calls Run(), with try/catch to log any exceptions that
+// escape from Run(). Run() is expected to return when ShouldShutdown() is
+// true; Stop() waits for the exit signal and force-deletes the task if it
+// doesn't see one within shutdownTimeoutMs.
+//
+// The task does NOT self-delete: it signals exit, then sleeps forever.
+// Stop() always performs the vTaskDelete from the caller's thread. This
+// removes the classic FreeRTOS race where a self-deleting task races a
+// destructor that has already returned from Stop() — by the time we
+// vTaskDelete here, every member access on `self` has completed.
+
+void ITaskService::TaskEntryThunk(void* p)
+{
+    auto* self = static_cast<ITaskService*>(p);
+    if (self != nullptr)
+    {
+        try
+        {
+            self->Run();
+        }
+        catch (const std::exception& ex)
+        {
+            debugE("%s: Run() threw std::exception: %s", self->Name(), ex.what());
+        }
+        catch (...)
+        {
+            debugE("%s: Run() threw unknown exception", self->Name());
+        }
+        self->_taskExited.store(true);
+    }
+
+    // Park until Stop() reaps us. The block delay is long but bounded so
+    // the task wakes if FreeRTOS tick wraparound math ever surprises us;
+    // either way, control returns to the scheduler immediately.
+    
+    while (true)
+        vTaskDelay(pdMS_TO_TICKS(60 * 1000));
+}

--- a/src/jsonserializer.cpp
+++ b/src/jsonserializer.cpp
@@ -158,7 +158,37 @@ struct JSONWriter::WriterEntry
 };
 
 JSONWriter::JSONWriter() {}
-JSONWriter::~JSONWriter() {}
+JSONWriter::~JSONWriter() { Stop(); }
+
+// ITaskService hooks
+//
+// Start/Stop/IsRunning are inherited final from ITaskService; this class
+// only supplies the task config, the loop body, and the wake-on-stop hook.
+
+ITaskService::TaskConfig JSONWriter::GetTaskConfig() const
+{
+    return TaskConfig {
+        "JSON Writer Loop",
+        JSON_STACK_SIZE,
+        JSONWRITER_PRIORITY,
+        JSONWRITER_CORE,
+        1000   // Stop timeout: task wakes from ulTaskNotifyTake on the wake nudge.
+    };
+}
+
+void JSONWriter::OnBeforeWaitForStop()
+{
+    // Flush whatever is pending so a config change isn't lost on shutdown,
+    // and wake the task out of its long ulTaskNotifyTake so it sees the
+    // shutdown flag promptly.
+    flushRequested.store(true);
+    WakeTask();
+}
+
+void JSONWriter::NotifyTask()
+{
+    WakeTask();
+}
 
 bool BoolFromText(const String& text)
 {
@@ -267,7 +297,7 @@ void JSONWriter::FlagWriter(size_t index)
     entry->flag.store(true);
     latestFlagMs.store(millis());
 
-    g_ptrSystem->GetTaskManager().NotifyJSONWriterThread();
+    NotifyTask();
 }
 
 void JSONWriter::FlushWrites(bool halt)
@@ -277,13 +307,18 @@ void JSONWriter::FlushWrites(bool halt)
     flushRequested.store(true);
     haltWrites.store(halt);
 
-    g_ptrSystem->GetTaskManager().NotifyJSONWriterThread();
+    NotifyTask();
 }
 
-// JSONWriterTaskEntry
+// JSONWriter::Run
 //
-// Invoke functions that write serialized JSON objects to SPIFFS at request, with some delay
-void IRAM_ATTR JSONWriterTaskEntry(void *)
+// Invoke functions that write serialized JSON objects to SPIFFS at request,
+// with some delay. Wakes from ulTaskNotifyTake on either a flag/flush/stop
+// signal or the JSON_WRITER_DELAY hold-point timeout, then runs one pass
+// over the registered writers and goes back to sleep. Exits cleanly when
+// ShouldShutdown() is true so a config change isn't dropped between the
+// flush request and the actual disk write.
+void JSONWriter::Run()
 {
     for(;;)
     {
@@ -294,23 +329,22 @@ void IRAM_ATTR JSONWriterTaskEntry(void *)
             // Wait until we're woken up by a writer being flagged, or until we've reached the hold point
             ulTaskNotifyTake(pdTRUE, notifyWait);
 
-            if (!g_ptrSystem->HasJSONWriter())
-                continue;
-
-            auto& jsonWriter = g_ptrSystem->GetJSONWriter();
+            // Stop requested: drop straight into a final flush pass below.
+            if (ShouldShutdown())
+                break;
 
             // If a flush was requested then we execute pending writes now
-            if (jsonWriter.flushRequested.load())
+            if (flushRequested.load())
             {
-                jsonWriter.flushRequested.store(false);
+                flushRequested.store(false);
                 break;
             }
 
             // If writes are halted, we don't do anything
-            if (jsonWriter.haltWrites.load())
+            if (haltWrites.load())
                 continue;
 
-            unsigned long holdUntil = jsonWriter.latestFlagMs.load() + JSON_WRITER_DELAY;
+            unsigned long holdUntil = latestFlagMs.load() + JSON_WRITER_DELAY;
             unsigned long now = millis();
             if (now >= holdUntil)
                 break;
@@ -320,9 +354,8 @@ void IRAM_ATTR JSONWriterTaskEntry(void *)
 
         std::vector<std::shared_ptr<JSONWriter::WriterEntry>> writersSnapshot;
         {
-            auto& jsonWriter = g_ptrSystem->GetJSONWriter();
-            std::lock_guard<std::mutex> lock(jsonWriter.writersMutex);
-            writersSnapshot = jsonWriter.writers;
+            std::lock_guard<std::mutex> lock(writersMutex);
+            writersSnapshot = writers;
         }
 
         for (auto &entryPtr : writersSnapshot)
@@ -332,6 +365,12 @@ void IRAM_ATTR JSONWriterTaskEntry(void *)
             if (entry.flag.exchange(false))
                 entry.writer();
         }
+
+        // Honor the shutdown request after the flush pass so any pending writes
+        // are persisted before the task exits. ITaskService::TaskEntryThunk
+        // handles the actual NotifyTaskExited / vTaskDelete on return.
+        if (ShouldShutdown())
+            return;
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -177,8 +177,12 @@
 #if defined(TOGGLE_BUTTON_0) || defined(TOGGLE_BUTTON_1)
 #include "Bounce2.h"
 #endif
+#include "audioserialbridge.h"
+#include "audioservice.h"
+#include "colorstreamerservice.h"
 #include "console.h"
 #include "debug_cli.h"
+#include "debugconsole.h"
 #include "deviceconfig.h"
 #include "effectmanager.h"
 #include "gfxbase.h"
@@ -195,6 +199,9 @@
 #include "logger.h"
 #include "nd_network.h"
 #include "ntptimeclient.h"
+#include "remotecontrol.h"
+#include "renderservice.h"
+#include "screen.h"
 #include "socketserver.h"
 #include "soundanalyzer.h"
 #include "systemcontainer.h"
@@ -221,7 +228,7 @@ void ConfirmUpdate();
 
 
 
-void ScreenUpdateLoopEntry(void *);
+// ScreenUpdateLoopEntry was migrated into Screen::Run() (ITaskService).
 
 #if ENABLE_ESPNOW
 #include <esp_arduino_version.h>
@@ -609,10 +616,27 @@ void setup()
 
     // Start things that do not depend on the network
 
-    taskManager.StartDrawThread();
-    taskManager.StartScreenThread();
-    taskManager.StartAudioThread();
-    taskManager.StartRemoteThread();
+    g_ptrSystem->SetupRenderService().Start();
+
+    #if USE_SCREEN
+        if (g_ptrSystem->HasDisplay())
+            g_ptrSystem->GetDisplay().Start();
+    #endif
+
+    // Audio is owned by AudioService so it can be reconfigured at runtime
+    // (e.g. moving the I2S DIN pin from the SetupUI) without a reboot. We
+    // construct the service unconditionally so consumers can ask "is audio
+    // available?" via a stable interface, and start it now if this build
+    // has ENABLE_AUDIO. DeviceConfig has already been loaded above, so
+    // AudioConfig::FromCurrentSettings() picks up any persisted pin.
+
+    auto& audioService = g_ptrSystem->SetupAudioService();
+    audioService.Reconfigure(AudioConfig::FromCurrentSettings());
+
+    #if ENABLE_REMOTE
+        if (g_ptrSystem->HasRemoteControl())
+            g_ptrSystem->GetRemoteControl().Start();
+    #endif
 
     #if ENABLE_WIFI
         debugI("Making initial attempt to connect to WiFi.");
@@ -621,11 +645,25 @@ void setup()
 
     // Start the network-dependent services.  These will be NOPs on a non-wifi build.
 
-    taskManager.StartSerialThread();
-    taskManager.StartNetworkThread();
-    taskManager.StartColorDataThread();
-    taskManager.StartSocketThread();
-    taskManager.StartDebugThread();
+    #if ENABLE_AUDIOSERIAL
+        g_ptrSystem->SetupAudioSerialBridge().Start();
+    #endif
+    #if ENABLE_WIFI
+        // NetworkReader was constructed earlier (so effects could register).
+        // Start its task here, after WiFi credentials are loaded.
+        if (g_ptrSystem->HasNetworkReader())
+            g_ptrSystem->GetNetworkReader().Start();
+    #endif
+    #if COLORDATA_SERVER_ENABLED
+        g_ptrSystem->SetupColorStreamerService().Start();
+    #endif
+    #if INCOMING_WIFI_ENABLED
+        if (g_ptrSystem->HasSocketServer())
+            g_ptrSystem->GetSocketServer().Start();
+    #endif
+    #if ENABLE_WIFI
+        g_ptrSystem->SetupDebugConsole().Start();
+    #endif
 
     DebugCLI::InitDebugCLI();
     nd_network::InitNetworkCLI();

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -44,6 +44,7 @@
 #endif
 
 #include "colordata.h"
+#include "colorstreamerservice.h"
 #include "deviceconfig.h"
 #include "effectmanager.h"
 #include "ledbuffer.h"
@@ -304,7 +305,12 @@ namespace nd_network
             NTPTimeClient::UpdateClockFromWeb(&l_Udp);
         #endif
         #if ENABLE_WEBSERVER
-            g_ptrSystem->GetWebServer().begin();
+            g_ptrSystem->GetWebServer().Start();
+        #endif
+
+        #if WEB_SOCKETS_ANY_ENABLED
+            if (g_ptrSystem->HasWebSocketServer())
+                g_ptrSystem->GetWebSocketServer().Start();
         #endif
 
         return WiFiConnectResult::Connected;
@@ -440,7 +446,7 @@ namespace nd_network
         if (index < readers.size())
         {
             readers[index]->flag.store(true);
-            g_ptrSystem->GetTaskManager().NotifyNetworkThread();
+            WakeTask();
         }
     }
 
@@ -451,25 +457,50 @@ namespace nd_network
             auto &entry = *readers[index];
             entry.canceled.store(true);
             entry.readInterval.store(0);
-            entry.reader = nullptr;
+            entry.flag.store(false);
         }
     }
 
-    // NetworkHandlingLoopEntry
+    // NetworkReader ITaskService hooks
     //
-    // Thead entry point for the Networking task
-    // Pumps the various network loops and sets the time periodically, as well as reconnecting
-    // to WiFi if the connection drops.  Also pumps the OTA (Over the air updates) loop.
-    void NetworkHandlingLoopEntry(void *)
+    // Start/Stop/IsRunning are inherited final from ITaskService; this class
+    // only supplies the task config and the network handling loop body. The
+    // task drives WiFi reconnect, OTA pumping, mDNS, and the registered-reader
+    // dispatch (effects pulling data from RESTful APIs etc.).
+
+    ITaskService::TaskConfig NetworkReader::GetTaskConfig() const
     {
-        static unsigned long lastConnected = millis();
-        static unsigned long lastWebSocketCleanup = 0;
+        return TaskConfig {
+            "NetworkHandlingLoop",
+            NET_STACK_SIZE,
+            NET_PRIORITY,
+            NET_CORE,
+            2000   // Stop timeout: notifyWait can be up to ~1s.
+        };
+    }
+
+    // NetworkReader::Run
+    //
+    // Pumps the various network loops and sets the time periodically, as well
+    // as reconnecting to WiFi if the connection drops. Also pumps the OTA
+    // (Over the air updates) loop. Used to be the free function
+    // NetworkHandlingLoopEntry; absorbed here so the friend pattern goes away
+    // and the lifecycle is consistent with the other services.
+
+    void NetworkReader::Run()
+    {
+        unsigned long lastConnected = millis();
+        unsigned long lastWebSocketCleanup = 0;
         if (!MDNS.begin("esp32")) Serial.println("Error starting mDNS");
 
         TickType_t notifyWait = 0;
-        for (;;)
+        while (!ShouldShutdown())
         {
             ulTaskNotifyTake(pdTRUE, notifyWait);
+
+            if (ShouldShutdown())
+                break;
+
             EVERY_N_SECONDS(1)
             {
                 // While Improv is actively provisioning, it owns the WiFi
@@ -489,7 +520,8 @@ namespace nd_network
                             if (millis() - lastWebSocketCleanup >= 15000)
                             {
                                 lastWebSocketCleanup = millis();
-                                g_ptrSystem->GetWebSocketServer().CleanupClients();
+                                if (g_ptrSystem && g_ptrSystem->HasWebSocketServer())
+                                    g_ptrSystem->GetWebSocketServer().CleanupClients();
                             }
                         #endif
                     }
@@ -507,17 +539,16 @@ namespace nd_network
                 }
             }
 
-            if (!g_ptrSystem->HasNetworkReader() || !WiFi.isConnected())
+            if (!WiFi.isConnected())
             {
                 notifyWait = pdMS_TO_TICKS(1000);
                 continue;
             }
 
-            auto &networkReader = g_ptrSystem->GetNetworkReader();
             unsigned long now = millis();
             unsigned long nextEventMs = 1000;
 
-            for (auto &entryPtr : networkReader.readers)
+            for (auto &entryPtr : readers)
             {
                 auto &entry = *entryPtr;
                 if (entry.canceled.load()) continue;
@@ -535,12 +566,20 @@ namespace nd_network
 
                 if (entry.flag.exchange(false))
                 {
-                    entry.reader();
+                    if (entry.reader)
+                        entry.reader();
                     entry.lastReadMs.store(millis());
                 }
             }
             notifyWait = pdMS_TO_TICKS(nextEventMs);
         }
+
+        // Tear down mDNS so a subsequent Stop()/Start() cycle doesn't double-
+        // register the "esp32" hostname (the underlying mdns component will
+        // refuse to re-init while it still holds an active responder).
+        // I'm not convinced MDNS even works, but this is the polite thing to do if it does.
+
+        MDNS.end();
     }
 
     void DoStatsCommand(const DebugCLI::cli_argv &)
@@ -609,7 +648,9 @@ namespace nd_network
     int  GetLastWiFiDisconnectReason()     { return 0; }
     void ClearLastWiFiDisconnectReason()   {}
 
-    void NetworkHandlingLoopEntry(void *) { for (;;) delay(1000); }
+    // The network handling loop is gone in non-WiFi builds; NetworkReader
+    // is only declared when ENABLE_WIFI=1 (see nd_network.h).
+
     void InitNetworkCLI() {}
 
 #endif // ENABLE_WIFI
@@ -634,19 +675,7 @@ void onReceiveESPNOW(const uint8_t *macAddr, const uint8_t *data, int dataLen)
 }
 #endif
 
-#if ENABLE_REMOTE
-// RemoteLoopEntry
-//
-// If enabled, this is the main thread loop for the remote control.  It is initialized and then
-// called once every 20ms to pump its work queue and scan for new remote codes, etc.  If no
-// remote is being used, this code and thread doesn't exist in the build.
-void IRAM_ATTR RemoteLoopEntry(void *)
-{
-    auto &rc = g_ptrSystem->GetRemoteControl();
-    rc.begin();
-    while (true) { rc.handle(); delay(20); }
-}
-#endif
+// RemoteLoopEntry was migrated into RemoteControl::Run() (ITaskService).
 
 String urlEncode(const String &str)
 {
@@ -836,40 +865,26 @@ bool ProcessIncomingData(std::unique_ptr<uint8_t[]> &payloadData, size_t payload
     #endif
 }
 
-#if INCOMING_WIFI_ENABLED
-// SocketServerTaskEntry
-//
-// Repeatedly calls the code to open up a socket and receive new connections
-void IRAM_ATTR SocketServerTaskEntry(void *)
-{
-    for (;;)
-    {
-        if (WiFi.isConnected())
-        {
-            auto &socketServer = g_ptrSystem->GetSocketServer();
-
-            socketServer.release();
-            if (socketServer.begin())
-            {
-                socketServer.ProcessIncomingConnectionsLoop();
-                debugV("Socket connection closed.  Retrying...");
-            }
-            else
-            {
-                debugE("Failed to start socket server, retrying in 5 seconds...");
-                delay(5000);
-            }
-        }
-        delay(500);
-    }
-}
-#endif
+// SocketServerTaskEntry was migrated into SocketServer::Run() (ITaskService).
 
 #if COLORDATA_SERVER_ENABLED
-// ColorDataTaskEntry
+// ColorStreamerService ITaskService hooks
 //
-// The thread which serves requests for color data.
-void IRAM_ATTR ColorDataTaskEntry(void *)
+// Start/Stop/IsRunning are inherited final from ITaskService; this class
+// only supplies the task config and the per-frame color-streaming loop body.
+
+ITaskService::TaskConfig ColorStreamerService::GetTaskConfig() const
+{
+    return TaskConfig {
+        "ColorData Loop",
+        DEFAULT_STACK_SIZE,
+        COLORDATA_PRIORITY,
+        COLORDATA_CORE,
+        1500
+    };
+}
+
+void IRAM_ATTR ColorStreamerService::Run()
 {
     constexpr uint32_t kPreviewMaxFps          = 30;
     constexpr uint32_t kPreviewFrameIntervalMs = 1000 / kPreviewMaxFps;
@@ -883,15 +898,30 @@ void IRAM_ATTR ColorDataTaskEntry(void *)
 
     auto &effectManager = g_ptrSystem->GetEffectManager();
 #if COLORDATA_WEB_SOCKET_ENABLED
-    auto &webSocketServer = g_ptrSystem->GetWebSocketServer();
+    auto *webSocketServer =
+        (g_ptrSystem && g_ptrSystem->HasWebSocketServer()) ? &g_ptrSystem->GetWebSocketServer() : nullptr;
 #endif
 
     effectManager.AddFrameEventListener(frameEventListener);
 
-    for (;;)
+    // RAII guard: ensure we deregister the stack-local listener before Run()
+    // returns, so EffectManager doesn't keep a dangling reference_wrapper if
+    // this service is Stop()-ed and later restarted.  Claude found this!
+
+    struct ListenerGuard
     {
-        while (!WiFi.isConnected())
+        EffectManager&        mgr;
+        IFrameEventListener&  listener;
+        ~ListenerGuard() { mgr.RemoveFrameEventListener(listener); }
+    } listenerGuard{ effectManager, frameEventListener };
+
+    while (!ShouldShutdown())
+    {
+        while (!WiFi.isConnected() && !ShouldShutdown())
             delay(250);
+
+        if (ShouldShutdown())
+            return;
 
         if (!_viewer.begin())
         {
@@ -906,7 +936,7 @@ void IRAM_ATTR ColorDataTaskEntry(void *)
         }
     }
 
-    for (;;)
+    while (!ShouldShutdown())
     {
         if (socket < 0)
             socket = _viewer.CheckForConnection();
@@ -916,7 +946,7 @@ void IRAM_ATTR ColorDataTaskEntry(void *)
         const auto activeLEDCount = graphics.GetLEDCount();
 
 #if COLORDATA_WEB_SOCKET_ENABLED
-        wsListenersPresent = webSocketServer.HaveColorDataClients();
+        wsListenersPresent = webSocketServer && webSocketServer->HaveColorDataClients();
 #else
         wsListenersPresent = false;
 #endif
@@ -940,7 +970,7 @@ void IRAM_ATTR ColorDataTaskEntry(void *)
 #if COLORDATA_WEB_SOCKET_ENABLED
                 if (wsListenersPresent)
                 {
-                    webSocketServer.SendColorData(leds, activeLEDCount);
+                    webSocketServer->SendColorData(leds, activeLEDCount);
                 }
                 else
 #endif
@@ -968,6 +998,9 @@ void IRAM_ATTR ColorDataTaskEntry(void *)
         else
             delay(1000);
     }
+
+    if (socket >= 0)
+        close(socket);
 }
 #endif // COLORDATA_SERVER_ENABLED
 #endif // ENABLE_WIFI

--- a/src/remotecontrol.cpp
+++ b/src/remotecontrol.cpp
@@ -45,6 +45,7 @@
 #include "ledstripeffect.h"
 #include "remotecontrol.h"
 #include "systemcontainer.h"
+#include "taskmgr.h"   // REMOTE_STACK_SIZE / REMOTE_PRIORITY / REMOTE_CORE
 
 #include "effects/strip/misceffects.h"
 
@@ -337,11 +338,12 @@ private:
 // ---------------------------------------------------------
 
 RemoteControl::RemoteControl() : _pImpl(std::make_unique<RemoteControlImpl>(IR_REMOTE_PIN)) {}
-RemoteControl::~RemoteControl() = default;
+RemoteControl::~RemoteControl() { Stop(); }
 
 // begin
 //
-// Starts the IR remote task and sets up the IR receiver
+// Sets up the IR receiver hardware. Called from Run() once ITaskService::Start
+// has launched the polling task on its own FreeRTOS thread.
 
 bool RemoteControl::begin() {
     debugW("Native Remote Control Decoding Started (RMT Legacy)");
@@ -350,10 +352,45 @@ bool RemoteControl::begin() {
 
 // end
 //
-// Stops the IR remote task
+// Public-facing teardown. Used by the OTA "onStart" hook to make sure the IR
+// polling task isn't competing with the firmware update for CPU/RMT
+// resources. Delegates to the inherited ITaskService::Stop() so the
+// shutdown is the same idempotent path used during normal service teardown.
 
 void RemoteControl::end() {
     debugW("Native Remote Control Decoding Stopped");
+    Stop();
+}
+
+// ITaskService hooks
+//
+// Start/Stop/IsRunning are inherited final from ITaskService; this class only
+// supplies the task config and the IR polling loop body.
+
+ITaskService::TaskConfig RemoteControl::GetTaskConfig() const
+{
+    return TaskConfig {
+        "IR Remote Loop",
+        REMOTE_STACK_SIZE,
+        REMOTE_PRIORITY,
+        REMOTE_CORE,
+        250    // Stop timeout: polling loop yields every 20ms.
+    };
+}
+
+// RemoteControl::Run
+//
+// Initializes the IR receiver and then polls for codes every 20ms until
+// ShouldShutdown() is true. ITaskService::TaskEntryThunk handles the
+// post-Run vTaskDelete and running-state bookkeeping when this returns.
+void RemoteControl::Run()
+{
+    begin();
+    while (!ShouldShutdown())
+    {
+        handle();
+        delay(20);
+    }
 }
 
 #define BRIGHTNESS_STEP     20

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -443,6 +443,17 @@ public:
         g_ptrSystem->GetEffectManager().AddFrameEventListener(frameEventListener);
     }
 
+    ~EffectSimulatorPage() override
+    {
+        // Symmetry with the constructor: deregister so EffectManager can't
+        // hold a dangling reference if the page is ever destroyed (today
+        // the page is a static singleton so this is belt-and-suspenders, but
+        // the lifecycle contract is now correct should that change).
+
+        if (g_ptrSystem && g_ptrSystem->HasEffectManager())
+            g_ptrSystem->GetEffectManager().RemoveFrameEventListener(frameEventListener);
+    }
+
     std::string Name() const override { return "CurrentEffect"; }
 
     void Draw(Screen &display, bool bRedraw) override
@@ -701,15 +712,32 @@ void IRAM_ATTR Screen::Update(bool bRedraw)
     s_lastFrameMs = now;
 }
 
-// Screen::RunUpdateLoop
-// Displays statistics on the Heltec's built in OLED board.  If you are using a different board, you would simply get
-// rid of this or modify it to fit a screen you do have.  You could also try serial output, as it's on a low-pri thread
-// it shouldn't disturb the primary cores.
+// ITaskService hooks
+//
+// Start/Stop/IsRunning are inherited final from ITaskService; this class only
+// supplies the task config and the screen update loop body. The page-init
+// quirk (lazy button binding) is preserved verbatim — buttons can't attach
+// until pinModes are stable, which they are by the time Run() executes.
 
-void IRAM_ATTR Screen::RunUpdateLoop()
+ITaskService::TaskConfig Screen::GetTaskConfig() const
 {
-    // debugI(">> ScreenUpdateLoopEntry\n");
+    return TaskConfig {
+        "Screen Loop",
+        SCREEN_STACK_SIZE,
+        SCREEN_PRIORITY,
+        SCREEN_CORE,
+        500    // Stop timeout: loop yields every ~1ms.
+    };
+}
 
+// Screen::Run
+// Displays statistics on the Heltec's built in OLED board.  If you are using
+// a different board, you would simply get rid of this or modify it to fit a
+// screen you do have.  You could also try serial output, as it's on a low-pri
+// thread it shouldn't disturb the primary cores.
+
+void IRAM_ATTR Screen::Run()
+{
     bool bRedraw = true;
     // Lazy init of buttons when loop starts (after hardware/defines are known)
     static bool s_buttonsInited = false;
@@ -728,8 +756,7 @@ void IRAM_ATTR Screen::RunUpdateLoop()
         s_buttonsInited = true;
     }
 
-
-    for (;;)
+    while (!ShouldShutdown())
     {
         uint32_t frameStartTime = millis();
 
@@ -787,18 +814,6 @@ void IRAM_ATTR Screen::RunUpdateLoop()
         }
         bRedraw = false;
         delay(1);
-    }
-}
-
-// Thin wrapper to preserve the existing FreeRTOS task entry point name while
-// delegating to the new Screen::RunUpdateLoop() method.
-void IRAM_ATTR ScreenUpdateLoopEntry(void *)
-{
-    // Ensure the system and display are available
-    if (g_ptrSystem)
-    {
-        auto &display = g_ptrSystem->GetDisplay();
-        display.RunUpdateLoop();
     }
 }
 

--- a/src/socketserver.cpp
+++ b/src/socketserver.cpp
@@ -35,6 +35,7 @@
 #include "socketserver.h"
 #include "soundanalyzer.h"
 #include "systemcontainer.h"
+#include "taskmgr.h"   // SOCKET_STACK_SIZE / SOCKET_PRIORITY / SOCKET_CORE
 #include "values.h"
 
 #include <arpa/inet.h>
@@ -61,21 +62,79 @@ extern "C"
 SocketServer::SocketServer(int port, int numLeds) :
     _port(port),
     _numLeds(numLeds),
-    _server_fd(-1),
     _cbReceived(0)
 {
     _abOutputBuffer.reset( psram_allocator<uint8_t>().allocate(MAXIMUM_PACKET_SIZE+1) );        // +1 for uzlib one byte overreach bug
     memset(&_address, 0, sizeof(_address));
 }
 
+// ITaskService hooks
+//
+// Start/Stop/IsRunning are inherited final from ITaskService; this class only
+// supplies the task config, the accept loop body, and the listening-socket
+// shutdown nudge that breaks accept() out of its blocking call.
+
+ITaskService::TaskConfig SocketServer::GetTaskConfig() const
+{
+    return TaskConfig {
+        "Socket Server Loop",
+        SOCKET_STACK_SIZE,
+        SOCKET_PRIORITY,
+        SOCKET_CORE,
+        1500   // Stop timeout: accept() can block for ~1s before returning EBADF.
+    };
+}
+
+void SocketServer::OnBeforeWaitForStop()
+{
+    // Closing the listening socket from this thread breaks the task out of
+    // any blocking accept/read call so it can see ShouldShutdown() promptly.
+    release();
+}
+
+// SocketServer::Run
+//
+// Repeatedly opens the socket and processes incoming connections. Runs until
+// ShouldShutdown() is true; ITaskService::TaskEntryThunk handles the actual
+// vTaskDelete and the running-state bookkeeping when this returns.
+void SocketServer::Run()
+{
+    while (!ShouldShutdown())
+    {
+        if (nd_network::IsWiFiConnected())
+        {
+            release();
+            if (ShouldShutdown())
+                break;
+
+            if (begin())
+            {
+                ProcessIncomingConnectionsLoop();
+                debugV("Socket connection closed.  Retrying...");
+            }
+            else
+            {
+                debugE("Failed to start socket server, retrying in 5 seconds...");
+                delay(5000);
+            }
+        }
+        delay(500);
+    }
+
+    // Drop the listening socket if Stop() didn't already, so we leave the
+    // service in a clean state regardless of which path we exited through.
+    release();
+}
+
 void SocketServer::release()
 {
     _pBuffer.reset();
-    if (_server_fd >= 0)
-    {
-        close(_server_fd);
-        _server_fd = -1;
-    }
+    // Atomic exchange: only the caller that observed a non-negative fd does
+    // the close(). The other (Run loop vs. OnBeforeWaitForStop) sees -1 and
+    // becomes a no-op, eliminating a double-close race.
+    int fd = _server_fd.exchange(-1);
+    if (fd >= 0)
+        close(fd);
 }
 
 bool SocketServer::begin()
@@ -83,25 +142,31 @@ bool SocketServer::begin()
     _pBuffer.reset( psram_allocator<uint8_t>().allocate(MAXIMUM_PACKET_SIZE) );
     _cbReceived = 0;
 
-    // Creating socket file descriptor
-    if ((_server_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0)
+    // Build the socket on a local fd and only publish it into the atomic
+    // _server_fd member after listen() succeeds. That keeps release() (which
+    // can run on a different thread via OnBeforeWaitForStop) from closing a
+    // half-configured descriptor or racing with bind/listen.
+
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0)
     {
         debugE("socket error\n");
-        release();
+        _pBuffer.reset();
         return false;
     }
 
-    nd_network::SetSocketBlockingEnabled(_server_fd, false);
+    nd_network::SetSocketBlockingEnabled(fd, false);
 
     // When an error occurs, and we close and reopen the port, we need to specify reuse flags
     // or it might be too soon to use the port again, since close doesn't actually close it
     // until the socket is no longer in use.
 
     int opt = 1;
-    if (setsockopt(_server_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)))
+    if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)))
     {
-        debugE("setsockopt SO_REUSEADDR failed on socket %d: %s (%d)", _server_fd, strerror(errno), errno);
-        release();
+        debugE("setsockopt SO_REUSEADDR failed on socket %d: %s (%d)", fd, strerror(errno), errno);
+        close(fd);
+        _pBuffer.reset();
         return false;
     }
 
@@ -110,20 +175,23 @@ bool SocketServer::begin()
     _address.sin_addr.s_addr = INADDR_ANY;
     _address.sin_port = htons( _port );
 
-    if (bind(_server_fd, (struct sockaddr *)&_address, sizeof(_address)) < 0)       // Bind socket to port
+    if (bind(fd, (struct sockaddr *)&_address, sizeof(_address)) < 0)       // Bind socket to port
     {
-        debugE("bind failed on port %d, socket %d: %s (%d)", _port, _server_fd, strerror(errno), errno);
-        release();
+        debugE("bind failed on port %d, socket %d: %s (%d)", _port, fd, strerror(errno), errno);
+        close(fd);
+        _pBuffer.reset();
         return false;
     }
-    if (listen(_server_fd, 6) < 0)                                                  // Start listening for connections
+    if (listen(fd, 6) < 0)                                                  // Start listening for connections
     {
-        debugE("listen failed on port %d, socket %d: %s (%d)", _port, _server_fd, strerror(errno), errno);
-        release();
+        debugE("listen failed on port %d, socket %d: %s (%d)", _port, fd, strerror(errno), errno);
+        close(fd);
+        _pBuffer.reset();
         return false;
     }
 
-    debugI("Socket server %d listening on port %d", _server_fd, _port);
+    _server_fd.store(fd);
+    debugI("Socket server %d listening on port %d", fd, _port);
     return true;
 }
 
@@ -233,7 +301,8 @@ bool SocketServer::DecompressBuffer(const uint8_t * pBuffer, size_t cBuffer, uin
 
 bool SocketServer::ProcessIncomingConnectionsLoop()
 {
-    if (0 >= _server_fd)
+    int listen_fd = _server_fd.load();
+    if (0 >= listen_fd)
     {
         debugE("No _server_fd, returning.");
         return false;
@@ -245,7 +314,12 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
     socklen_t addrlen = sizeof(_address);
     while (new_socket < 0)
     {
-        new_socket = accept(_server_fd, (struct sockaddr *)&_address, &addrlen);
+        // Re-read each iteration so a release() from another thread (Stop)
+        // is observed as -1 and we exit promptly via EBADF/-1 fall-through.
+        listen_fd = _server_fd.load();
+        if (listen_fd < 0)
+            return false;
+        new_socket = accept(listen_fd, (struct sockaddr *)&_address, &addrlen);
         if (new_socket < 0)
         {
             if (errno == EAGAIN || errno == EWOULDBLOCK)
@@ -253,7 +327,7 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
                 delay(100); // No connection yet, yield and retry
                 continue;
             }
-            debugE("Socket server %d failed to accept connection: %s (%d)", _server_fd, strerror(errno), errno);
+            debugE("Socket server %d failed to accept connection: %s (%d)", listen_fd, strerror(errno), errno);
             return false;
         }
     }

--- a/src/soundanalyzer.cpp
+++ b/src/soundanalyzer.cpp
@@ -103,28 +103,71 @@ SoundAnalyzerBase::SoundAnalyzerBase()
 
 SoundAnalyzerBase::~SoundAnalyzerBase()
 {
+    TeardownAudioInput();
+}
+
+// TeardownAudioInput
+//
+// Idempotent counterpart to InitAudioInput. Called by AudioService::Stop()
+// during a runtime audio reconfigure, and also by ~SoundAnalyzerBase at
+// program end. The _hardwareInstalled guard makes double-uninstall safe.
+void SoundAnalyzerBase::TeardownAudioInput()
+{
+    if (!_hardwareInstalled)
+        return;
+
+    debugI("Audio: tearing down audio input driver");
+
 #if IS_IDF5
     // Stop the hardware first to kill any active DMA transfers
     if (_rx_handle)
     {
-        i2s_channel_disable(_rx_handle);
-        i2s_del_channel(_rx_handle);
+        const esp_err_t disableErr = i2s_channel_disable(_rx_handle);
+        if (disableErr != ESP_OK)
+            debugW("Audio: i2s_channel_disable returned %d", (int)disableErr);
+        const esp_err_t delErr = i2s_del_channel(_rx_handle);
+        if (delErr != ESP_OK)
+            debugW("Audio: i2s_del_channel returned %d", (int)delErr);
+        _rx_handle = nullptr;
     }
     if (_adc_handle)
     {
-        adc_continuous_stop(_adc_handle);
-        adc_continuous_deinit(_adc_handle);
+        const esp_err_t stopErr = adc_continuous_stop(_adc_handle);
+        if (stopErr != ESP_OK)
+            debugW("Audio: adc_continuous_stop returned %d", (int)stopErr);
+        const esp_err_t deinitErr = adc_continuous_deinit(_adc_handle);
+        if (deinitErr != ESP_OK)
+            debugW("Audio: adc_continuous_deinit returned %d", (int)deinitErr);
+        _adc_handle = nullptr;
     }
 #else
-    // Legacy cleanup - i2s_stop terminates DMA
-    i2s_stop(I2S_NUM_0);
-    i2s_driver_uninstall(I2S_NUM_0);
+    #if !USE_M5
+        // Legacy cleanup - i2s_stop terminates DMA. M5Unified manages its own
+        // mic teardown in M5.Mic.end() so we don't double-stop the I2S peripheral.
+        i2s_stop(I2S_NUM_0);
+        i2s_driver_uninstall(I2S_NUM_0);
+    #endif
 #endif
+
+#if USE_M5
+    M5.Mic.end();
+#endif
+
+    _hardwareInstalled = false;
 }
 
 // Reset
 //
-// Reset and clear the FFT buffers
+// Reset and clear the FFT buffers. Leaves the analyzer in a benign default
+// state: VU/ratio metrics restored to their startup values (1.0f) so any
+// effect that scales by VURatio() before the sampler has produced its first
+// frame still renders something visible rather than going dark or dividing
+// by zero. Beat detection is cleared. The audio sampler task overwrites
+// these on its first iteration so the values here only matter when audio
+// is stopped, has never been started, or is mid-reconfigure.
+// AudioService::Stop() relies on this to give direct g_Analyzer readers
+// safe-default values during a reconfigure.
+
 void SoundAnalyzerBase::Reset()
 {
     debugI("Audio analyzer full reset");
@@ -293,8 +336,17 @@ float SoundAnalyzerBase::BeatEnhance(float amt)
 // InitAudioInput
 //
 // Entry point for configuring board-specific audio input (M5, I2S Digital, or I2S ADC Analog).
+// Idempotent: if the hardware is already installed, this is a no-op so a stale Start()
+// after an aborted Stop() can't double-install the I2S/ADC driver.
+
 void SoundAnalyzerBase::InitAudioInput()
 {
+    if (_hardwareInstalled)
+    {
+        debugI("Audio: InitAudioInput skipped, hardware already installed");
+        return;
+    }
+
     const auto inputPin = GetConfiguredAudioInputPin();
 
     if (inputPin < 0)
@@ -316,6 +368,7 @@ void SoundAnalyzerBase::InitAudioInput()
     InitADC_Modern();
     InitADC_Legacy();
 #endif
+    _hardwareInstalled = true;
     debugV("InitAudioInput Complete\n");
 }
 

--- a/src/soundanalyzer.cpp
+++ b/src/soundanalyzer.cpp
@@ -159,14 +159,15 @@ void SoundAnalyzerBase::TeardownAudioInput()
 // Reset
 //
 // Reset and clear the FFT buffers. Leaves the analyzer in a benign default
-// state: VU/ratio metrics restored to their startup values (1.0f) so any
-// effect that scales by VURatio() before the sampler has produced its first
-// frame still renders something visible rather than going dark or dividing
-// by zero. Beat detection is cleared. The audio sampler task overwrites
-// these on its first iteration so the values here only matter when audio
-// is stopped, has never been started, or is mid-reconfigure.
-// AudioService::Stop() relies on this to give direct g_Analyzer readers
-// safe-default values during a reconfigure.
+// state using the shared "neutral fallback" contract:
+//   VURatio / VURatioFade => 1.0f  (neutral — effects scale by 1, no change)
+//   VU / PeakVU / MinVU   => 0.0f  (truly silent)
+//
+// This matches the NullAudioSource fallback returned by AudioService::Source()
+// when audio is stopped, so both access paths (g_Analyzer directly and via
+// AudioService::Source()) produce consistent behavior during reconfigure or
+// when audio has never been started. Beat detection is cleared. The audio
+// sampler task overwrites these on its first iteration.
 
 void SoundAnalyzerBase::Reset()
 {

--- a/src/systemcontainer.cpp
+++ b/src/systemcontainer.cpp
@@ -28,7 +28,12 @@
 //---------------------------------------------------------------------------
 
 #include "globals.h"
+#include "audioservice.h"
+#include "audioserialbridge.h"
+#include "colorstreamerservice.h"
+#include "debugconsole.h"
 #include "deviceconfig.h"
+#include "renderservice.h"
 #include "effectmanager.h"
 #include "gfxbase.h"
 #include "jsonserializer.h"
@@ -107,7 +112,7 @@ EffectManager& SystemContainer::GetEffectManager() const
     return *_ptrEffectManager;
 }
 
-NightDriverTaskManager& SystemContainer::GetTaskManager() const
+TaskManager& SystemContainer::GetTaskManager() const
 {
     CheckPointer(!!_ptrTaskManager, "TaskManager");
     return *_ptrTaskManager;
@@ -254,11 +259,11 @@ EffectManager& SystemContainer::SetupEffectManager(const ArduinoJson::JsonObject
 }
 
 // Creates, begins and returns the TaskManager
-NightDriverTaskManager& SystemContainer::SetupTaskManager()
+TaskManager& SystemContainer::SetupTaskManager()
 {
     if (!_ptrTaskManager)
     {
-        _ptrTaskManager = make_unique_psram<NightDriverTaskManager>();
+        _ptrTaskManager = make_unique_psram<TaskManager>();
         _ptrTaskManager->begin();
     }
 
@@ -275,11 +280,13 @@ void SystemContainer::SetupConfig()
         throw std::runtime_error("Attempt to setup config objects without TaskManager");
     }
 
-    // Create the JSON writer and start its background thread
+    // Create the JSON writer and start its background thread. JSONWriter is an
+    // IService so it owns its own task; we just call Start() here.
+    
     if (!_ptrJSONWriter)
     {
         _ptrJSONWriter = make_unique_psram<JSONWriter>();
-        _ptrTaskManager->StartJSONWriterThread();
+        _ptrJSONWriter->Start();
     }
 
     // Create and load device config from SPIFFS if possible
@@ -423,3 +430,74 @@ Screen& SystemContainer::SetupHardwareDisplay(int w, int h)
     return *_ptrDisplay;
 }
 #endif
+
+AudioService& SystemContainer::SetupAudioService()
+{
+    if (!_ptrAudioService)
+        _ptrAudioService = make_unique_psram<AudioService>();
+    return *_ptrAudioService;
+}
+
+AudioService& SystemContainer::GetAudioService() const
+{
+    CheckPointer(!!_ptrAudioService, "AudioService");
+    return *_ptrAudioService;
+}
+
+#if ENABLE_AUDIOSERIAL
+AudioSerialBridge& SystemContainer::SetupAudioSerialBridge()
+{
+    if (!_ptrAudioSerialBridge)
+        _ptrAudioSerialBridge = make_unique_psram<AudioSerialBridge>();
+    return *_ptrAudioSerialBridge;
+}
+
+AudioSerialBridge& SystemContainer::GetAudioSerialBridge() const
+{
+    CheckPointer(!!_ptrAudioSerialBridge, "AudioSerialBridge");
+    return *_ptrAudioSerialBridge;
+}
+#endif
+
+#if ENABLE_WIFI
+DebugConsole& SystemContainer::SetupDebugConsole()
+{
+    if (!_ptrDebugConsole)
+        _ptrDebugConsole = make_unique_psram<DebugConsole>();
+    return *_ptrDebugConsole;
+}
+
+DebugConsole& SystemContainer::GetDebugConsole() const
+{
+    CheckPointer(!!_ptrDebugConsole, "DebugConsole");
+    return *_ptrDebugConsole;
+}
+#endif
+
+#if COLORDATA_SERVER_ENABLED
+ColorStreamerService& SystemContainer::SetupColorStreamerService()
+{
+    if (!_ptrColorStreamerService)
+        _ptrColorStreamerService = make_unique_psram<ColorStreamerService>();
+    return *_ptrColorStreamerService;
+}
+
+ColorStreamerService& SystemContainer::GetColorStreamerService() const
+{
+    CheckPointer(!!_ptrColorStreamerService, "ColorStreamerService");
+    return *_ptrColorStreamerService;
+}
+#endif
+
+RenderService& SystemContainer::SetupRenderService()
+{
+    if (!_ptrRenderService)
+        _ptrRenderService = make_unique_psram<RenderService>();
+    return *_ptrRenderService;
+}
+
+RenderService& SystemContainer::GetRenderService() const
+{
+    CheckPointer(!!_ptrRenderService, "RenderService");
+    return *_ptrRenderService;
+}

--- a/src/taskmgr.cpp
+++ b/src/taskmgr.cpp
@@ -6,7 +6,10 @@
 //
 // Description:
 //
-//    Implementations for NightDriverTaskManager
+//    Implementations for TaskManager. Owns the two pinned idle-priority
+//    CPU-measurement tasks and the per-effect ad-hoc task launcher. All
+//    project-level service tasks live as Run() methods on their respective
+//    IService classes via ITaskService and are launched there.
 //
 // History:     Feb-25-2026         Created to thin taskmgr.h
 //
@@ -89,33 +92,21 @@ void TaskManager::CheckHeap()
     }
 }
 
-// NightDriverTaskManager
-//
-// A superclass of the base TaskManager that knows how to start and track the tasks specific to this project
-
-NightDriverTaskManager::EffectTaskParams::EffectTaskParams(EffectTaskFunction function, LEDStripEffect* pEffect)
+TaskManager::EffectTaskParams::EffectTaskParams(EffectTaskFunction function, LEDStripEffect* pEffect)
   : function(std::move(function)),
     pEffect(pEffect)
 {}
 
-NightDriverTaskManager::~NightDriverTaskManager()
+TaskManager::~TaskManager()
 {
     for (auto& task : _vEffectTasks)
         vTaskDelete(task);
 
-    DELETE_TASK(_taskDraw);
-    DELETE_TASK(_taskScreen);
-    DELETE_TASK(_taskRemote);
-    DELETE_TASK(_taskSerial);
-    DELETE_TASK(_taskColorData);
-    DELETE_TASK(_taskAudio);
-    DELETE_TASK(_taskSocket);
-    DELETE_TASK(_taskNetwork);
-    DELETE_TASK(_taskJSONWriter);
-    DELETE_TASK(_taskDebug);
+    // The two idle tasks are intentionally not deleted; they're the entire
+    // reason this object exists and they run for the lifetime of the chip.
 }
 
-void NightDriverTaskManager::EffectTaskEntry(void *pVoid)
+void TaskManager::EffectTaskEntry(void *pVoid)
 {
     auto *pTaskParams = static_cast<EffectTaskParams *>(pVoid);
 
@@ -128,116 +119,10 @@ void NightDriverTaskManager::EffectTaskEntry(void *pVoid)
     function(*pEffect);
 }
 
-void NightDriverTaskManager::StartScreenThread()
-{
-    #if USE_SCREEN
-        Serial.print( str_sprintf(">> Launching Screen Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
-        xTaskCreatePinnedToCore(ScreenUpdateLoopEntry, "Screen Loop", SCREEN_STACK_SIZE, nullptr, SCREEN_PRIORITY, &_taskScreen, SCREEN_CORE);
-        CheckHeap();
-    #endif
-}
-
-void NightDriverTaskManager::StartSerialThread()
-{
-    #if ENABLE_AUDIOSERIAL
-        Serial.print( str_sprintf(">> Launching Serial Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
-        xTaskCreatePinnedToCore(AudioSerialTaskEntry, "Audio Serial Loop", DEFAULT_STACK_SIZE, nullptr, AUDIOSERIAL_PRIORITY, &_taskSerial, AUDIOSERIAL_CORE);
-        CheckHeap();
-    #endif
-}
-
-void NightDriverTaskManager::StartColorDataThread()
-{
-    #if COLORDATA_SERVER_ENABLED
-        Serial.print( str_sprintf(">> Launching ColorData Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
-        xTaskCreatePinnedToCore(ColorDataTaskEntry, "ColorData Loop", DEFAULT_STACK_SIZE, nullptr, COLORDATA_PRIORITY, &_taskColorData, COLORDATA_CORE);
-        CheckHeap();
-    #endif
-}
-
-void NightDriverTaskManager::StartDrawThread()
-{
-    Serial.print( str_sprintf(">> Launching Drawing Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
-    xTaskCreatePinnedToCore(DrawLoopTaskEntry, "Draw Loop", DRAWING_STACK_SIZE, nullptr, DRAWING_PRIORITY, &_taskDraw, DRAWING_CORE);
-    CheckHeap();
-}
-
-void NightDriverTaskManager::StartAudioThread()
-{
-    #if ENABLE_AUDIO
-        Serial.print( str_sprintf(">> Launching Audio Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
-        xTaskCreatePinnedToCore(AudioSamplerTaskEntry, "Audio Sampler Loop", AUDIO_STACK_SIZE, nullptr, AUDIO_PRIORITY, &_taskAudio, AUDIO_CORE);
-        CheckHeap();
-    #endif
-}
-
-void NightDriverTaskManager::StartNetworkThread()
-{
-    #if ENABLE_WIFI
-        Serial.print( str_sprintf(">> Launching Network Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
-        xTaskCreatePinnedToCore(NetworkHandlingLoopEntry, "NetworkHandlingLoop", NET_STACK_SIZE, nullptr, NET_PRIORITY, &_taskNetwork, NET_CORE);
-        CheckHeap();
-    #endif
-}
-
-void NightDriverTaskManager::StartDebugThread()
-{
-    #if ENABLE_WIFI
-        Serial.print( str_sprintf(">> Launching Debug Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
-        xTaskCreatePinnedToCore(DebugLoopTaskEntry, "Debug Loop", DEBUG_STACK_SIZE, nullptr, DEBUG_PRIORITY, &_taskDebug, DEBUG_CORE);
-        CheckHeap();
-    #endif
-}
-
-void NightDriverTaskManager::StartSocketThread()
-{
-    #if INCOMING_WIFI_ENABLED
-        Serial.print( str_sprintf(">> Launching Socket Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
-        xTaskCreatePinnedToCore(SocketServerTaskEntry, "Socket Server Loop", SOCKET_STACK_SIZE, nullptr, SOCKET_PRIORITY, &_taskSocket, SOCKET_CORE);
-        CheckHeap();
-    #endif
-}
-
-void NightDriverTaskManager::StartRemoteThread()
-{
-    #if ENABLE_REMOTE
-        Serial.print( str_sprintf(">> Launching Remote Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
-        xTaskCreatePinnedToCore(RemoteLoopEntry, "IR Remote Loop", REMOTE_STACK_SIZE, nullptr, REMOTE_PRIORITY, &_taskRemote, REMOTE_CORE);
-        CheckHeap();
-    #endif
-}
-
-void NightDriverTaskManager::StartJSONWriterThread()
-{
-    Serial.print( str_sprintf(">> Launching JSON Writer Thread.  Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
-    xTaskCreatePinnedToCore(JSONWriterTaskEntry, "JSON Writer Loop", JSON_STACK_SIZE, nullptr, JSONWRITER_PRIORITY, &_taskJSONWriter, JSONWRITER_CORE);
-    CheckHeap();
-}
-
-void NightDriverTaskManager::NotifyJSONWriterThread()
-{
-    if (_taskJSONWriter == nullptr)
-        return;
-
-    debugW(">> Notifying JSON Writer Thread");
-    // Wake up the writer invoker task if it's sleeping, or request another write cycle if it isn't
-    xTaskNotifyGive(_taskJSONWriter);
-}
-
-void NightDriverTaskManager::NotifyNetworkThread()
-{
-    if (_taskNetwork == nullptr)
-        return;
-
-    debugW(">> Notifying Network Thread");
-    // Wake up the network task if it's sleeping, or request another read cycle if it isn't
-    xTaskNotifyGive(_taskNetwork);
-}
-
 // Effect threads run with NET priority and on the NET core by default. It seems a sensible choice
 //   because effect threads tend to pull things from the Internet that they want to show
 
-TaskHandle_t NightDriverTaskManager::StartEffectThread(EffectTaskFunction function, LEDStripEffect* pEffect, const char* name, UBaseType_t priority, BaseType_t core)
+TaskHandle_t TaskManager::StartEffectThread(EffectTaskFunction function, LEDStripEffect* pEffect, const char* name, UBaseType_t priority, BaseType_t core)
 {
     // We use a raw pointer here just to cross the thread/task boundary. The EffectTaskEntry method
     //   deletes the object as soon as it can.

--- a/src/telnetserver.cpp
+++ b/src/telnetserver.cpp
@@ -49,9 +49,10 @@
 #include <unistd.h>
 
 #include "console.h"
+#include "debugconsole.h"
 #include "logger.h"
 #include "nd_network.h"
-
+#include "taskmgr.h"   // DEBUG_STACK_SIZE / DEBUG_PRIORITY / DEBUG_CORE
 
 
 #if ENABLE_WIFI
@@ -132,14 +133,30 @@ static void NegotiateTelnetOptions(int fd)
     SendTelnetOption(fd, TELNET_DO,   OPT_SGA);
 }
 
-void DebugLoopTaskEntry(void* pvParameters)
+// DebugConsole ITaskService hooks
+//
+// Start/Stop/IsRunning are inherited final from ITaskService; this class
+// only supplies the task config and the telnet accept/process loop body.
+
+ITaskService::TaskConfig DebugConsole::GetTaskConfig() const
+{
+    return TaskConfig {
+        "Debug Loop",
+        DEBUG_STACK_SIZE,
+        DEBUG_PRIORITY,
+        DEBUG_CORE,
+        2000   // Stop timeout: outer accept() polls non-blocking with delay(100).
+    };
+}
+
+void DebugConsole::Run()
 {
     int listen_fd = socket(AF_INET, SOCK_STREAM, 0);
     if (listen_fd < 0) {
         debugE("Failed to create telnet socket");
-        vTaskDelete(NULL);
         return;
     }
+    _listenFd.store(listen_fd);
 
     struct sockaddr_in serv_addr;
     memset(&serv_addr, 0, sizeof(serv_addr));
@@ -149,15 +166,21 @@ void DebugLoopTaskEntry(void* pvParameters)
 
     if (bind(listen_fd, (struct sockaddr*)&serv_addr, sizeof(serv_addr)) < 0) {
         debugE("Failed to bind telnet socket");
-        close(listen_fd);
-        vTaskDelete(NULL);
+        const int fd = _listenFd.exchange(-1);
+        if (fd >= 0) close(fd);
         return;
     }
 
     nd_network::SetSocketBlockingEnabled(listen_fd, false);
-    listen(listen_fd, 1);
+    if (listen(listen_fd, 1) < 0)
+    {
+        debugE("Failed to listen on telnet socket");
+        const int fd = _listenFd.exchange(-1);
+        if (fd >= 0) close(fd);
+        return;
+    }
 
-    while (true)
+    while (!ShouldShutdown())
     {
         struct sockaddr_in cli_addr;
         socklen_t cli_len = sizeof(cli_addr);
@@ -168,11 +191,21 @@ void DebugLoopTaskEntry(void* pvParameters)
                 delay(100);
                 continue;
             }
+            // If our listening fd was closed under us by OnBeforeWaitForStop,
+            // accept() will return EBADF — fall through to the shutdown check.
+            if (ShouldShutdown())
+                break;
             delay(100);
             continue;
         }
 
         debugI("Telnet client connected from %s", inet_ntoa(cli_addr.sin_addr));
+
+        // Non-blocking client so recv() can also observe ShouldShutdown()
+        // without sitting in a blocking syscall that only OnBeforeWaitForStop
+        // could rescue. We poll with a short delay between empty reads.
+        nd_network::SetSocketBlockingEnabled(client_fd, false);
+        _clientFd.store(client_fd);
 
         // Negotiate character-at-a-time mode and server-side echo before
         // registering the sink, so the client is in the right mode before
@@ -196,7 +229,7 @@ void DebugLoopTaskEntry(void* pvParameters)
         RecvState state = RecvState::Normal;
 
         uint8_t buf[128];
-        while (true)
+        while (!ShouldShutdown())
         {
             int n = recv(client_fd, buf, sizeof(buf), 0);
             if (n == 0)
@@ -206,8 +239,17 @@ void DebugLoopTaskEntry(void* pvParameters)
             }
             if (n < 0)
             {
+                if (errno == EAGAIN || errno == EWOULDBLOCK)
+                {
+                    // No data available right now; sleep briefly and re-check
+                    // ShouldShutdown() at the top of the loop.
+                    delay(50);
+                    continue;
+                }
                 if (errno == EINTR)
                     continue;   // Signal interrupted syscall, retry
+                if (errno == EBADF)
+                    break;      // OnBeforeWaitForStop closed us; exit cleanly
                 // Use Serial directly to avoid any risk of recursion through
                 // the Telnet sink that may itself be in a broken state.
                 Serial.printf("[TelnetServer] recv error: %s\n", strerror(errno));
@@ -300,8 +342,39 @@ void DebugLoopTaskEntry(void* pvParameters)
         }
 
         ConsoleManager::Instance().ClearTelnetSink();
-        close(client_fd);
+        {
+            const int fd = _clientFd.exchange(-1);
+            if (fd >= 0)
+                close(fd);
+        }
         debugI("Telnet client disconnected");
+    }
+
+    {
+        const int fd = _listenFd.exchange(-1);
+        if (fd >= 0)
+            close(fd);
+    }
+}
+
+void DebugConsole::OnBeforeWaitForStop()
+{
+    // Close the listening socket and any active client connection from the
+    // Stop() thread so the task's accept()/recv() return promptly with EBADF
+    // and the loop can observe ShouldShutdown(). Both fds are atomic<int>
+    // so the exchange is the only point at which they're consumed.
+
+    const int listen_fd = _listenFd.exchange(-1);
+    if (listen_fd >= 0)
+    {
+        shutdown(listen_fd, SHUT_RDWR);
+        close(listen_fd);
+    }
+    const int client_fd = _clientFd.exchange(-1);
+    if (client_fd >= 0)
+    {
+        shutdown(client_fd, SHUT_RDWR);
+        close(client_fd);
     }
 }
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -40,6 +40,7 @@
 #include <limits>
 #include <utility>
 
+#include "audioservice.h"
 #include "deviceconfig.h"
 #include "effectmanager.h"
 #include "gfxbase.h"
@@ -49,6 +50,7 @@
 #include "systemcontainer.h"
 #include "taskmgr.h"
 #include "values.h"
+#include "websocketserver.h"   // Stop() tears down our websocket clients first
 
 namespace
 {
@@ -193,7 +195,7 @@ namespace
     // The API currently accepts both the legacy flat device.audioInputPin field
     // and the nested device.audio.inputPin field, so validation/apply can consume
     // one resolved value instead of duplicating that lookup logic.
-    
+
     std::optional<int> GetRequestedUnifiedAudioInputPin(JsonObjectConst device)
     {
         std::optional<int> requestedAudioInputPin;
@@ -315,6 +317,82 @@ void CWebServer::AddCORSHeaderAndSendResponse<AsyncJsonResponse>(AsyncWebServerR
 }
 
 // Member function implementations
+
+// IService::Start - delegates to begin(). begin() does the heavy lifting of
+// registering route handlers and calling AsyncWebServer::begin(); Start just
+// sets the running flag and reports the result.
+bool CWebServer::Start()
+{
+    if (_running.load())
+        return true;
+
+    if (_everStarted.load())
+    {
+        debugW("WebServer: Start() after Stop() - AsyncWebServer/AsyncTCP "
+               "may not have fully released its listening socket on this "
+               "platform; if subsequent requests fail, a reboot is the "
+               "documented workaround.");
+    }
+
+    debugI("WebServer: starting on port %d", (int)NetworkPort::Webserver);
+    begin();
+    _everStarted.store(true);
+    _running.store(true);
+    return true;
+}
+
+// IService::Stop - shut down the AsyncWebServer. Safe to call before Start().
+void CWebServer::Stop()
+{
+    if (!_running.load())
+        return;
+
+    debugI("WebServer: stop requested");
+    // The WebSocketServer's listening sockets and handler registration are
+    // owned here, so its lifecycle is entirely delegated to ours: tear down
+    // any websocket client connections first so they don't outlast end().
+    #if WEB_SOCKETS_ANY_ENABLED
+        if (g_ptrSystem && g_ptrSystem->HasWebSocketServer())
+            g_ptrSystem->GetWebSocketServer().Stop();
+    #endif
+    _server.end();
+    _running.store(false);
+    debugI("WebServer: stop completed");
+}
+
+// ApplyAudioInputPinChange - factored out of SetSettingsIfPresent /
+// SetUnifiedSettings. Compares the current persisted pin against `oldPin`;
+// if the pin actually changed and the build supports a live reconfigure
+// (and AudioService is present), pushes the new AudioConfig through
+// AudioService::Reconfigure(). Reverts the persisted pin on failure so the
+// caller's serialized response matches the live state. Safe to call when
+// g_ptrSystem is null or AudioService isn't constructed.
+bool CWebServer::ApplyAudioInputPinChange(int oldPin)
+{
+    if (!g_ptrSystem || !g_ptrSystem->HasDeviceConfig())
+        return true;
+
+    auto& deviceConfig = g_ptrSystem->GetDeviceConfig();
+    const int newPin = deviceConfig.GetAudioInputPin();
+
+    if (newPin == oldPin)
+        return true;
+
+    if (!deviceConfig.SupportsLiveAudioInputReconfigure())
+        return true;
+
+    if (!g_ptrSystem->HasAudioService())
+        return true;
+
+    auto& audioService = g_ptrSystem->GetAudioService();
+    if (!audioService.Reconfigure(AudioConfig::FromCurrentSettings()))
+    {
+        debugW("Audio: live reconfigure failed; reverting persisted pin to %d", oldPin);
+        deviceConfig.SetAudioInputPin(oldPin);
+        return false;
+    }
+    return true;
+}
 
 // begin - register page load handlers and start serving pages
 void CWebServer::begin()
@@ -777,7 +855,7 @@ bool CWebServer::ValidateLegacyDeviceSettings(AsyncWebServerRequest * pRequest, 
     // Validate the constrained settings first so the legacy POST path behaves like the unified JSON API:
     // either the nontrivial request is coherent as a whole, or we reject it before any setters persist a
     // partially applied config.
-    
+
     if (pRequest->hasParam(DeviceConfig::OpenWeatherApiKeyTag, true, false))
     {
         auto [isValid, validationMessage] =
@@ -974,7 +1052,20 @@ bool CWebServer::SetSettingsIfPresent(AsyncWebServerRequest * pRequest, String* 
     PushPostParamIfPresent<bool>(pRequest, DeviceConfig::RememberCurrentEffectTag, SET_VALUE(deviceConfig.SetRememberCurrentEffect(value)));
     PushPostParamIfPresent<int>(pRequest, DeviceConfig::PowerLimitTag, SET_VALUE(deviceConfig.SetPowerLimit(value)));
     PushPostParamIfPresent<int>(pRequest, DeviceConfig::BrightnessTag, SET_VALUE(deviceConfig.SetBrightness(value)));
-    PushPostParamIfPresent<int>(pRequest, DeviceConfig::AudioInputPinTag, SET_VALUE(deviceConfig.SetAudioInputPin(value)));
+
+    // Audio input pin: persist the new pin and, when supported, ask AudioService
+    // to apply it live so the user doesn't need to reboot.
+    {
+        const int oldPin = deviceConfig.GetAudioInputPin();
+        const bool audioInputPinChanged =
+            PushPostParamIfPresent<int>(pRequest, DeviceConfig::AudioInputPinTag, SET_VALUE(deviceConfig.SetAudioInputPin(value)));
+        if (audioInputPinChanged && !ApplyAudioInputPinChange(oldPin))
+        {
+            if (errorMessage)
+                *errorMessage = "Audio input pin live apply failed";
+            return false;
+        }
+    }
 
     #if SHOW_VU_METER
     PushPostParamIfPresent<bool>(pRequest, DeviceConfig::ShowVUMeterTag, SET_VALUE(effectManager.ShowVU(value)));
@@ -1119,7 +1210,15 @@ void CWebServer::SetUnifiedSettings(AsyncWebServerRequest * pRequest, JsonVarian
         if (device[DeviceConfig::PowerLimitTag].is<int>()) deviceConfig.SetPowerLimit(device[DeviceConfig::PowerLimitTag].as<int>());
         if (device[DeviceConfig::BrightnessTag].is<int>()) deviceConfig.SetBrightness(device[DeviceConfig::BrightnessTag].as<int>());
         if (const auto requestedAudioInputPin = GetRequestedUnifiedAudioInputPin(device); requestedAudioInputPin.has_value())
+        {
+            const int oldPin = deviceConfig.GetAudioInputPin();
             deviceConfig.SetAudioInputPin(requestedAudioInputPin.value());
+            if (!ApplyAudioInputPinChange(oldPin))
+            {
+                AddCORSHeaderAndSendBadRequest(pRequest, "Audio input pin live apply failed");
+                return;
+            }
+        }
 
         std::optional<CRGB> globalColor = {};
         std::optional<CRGB> secondColor = {};


### PR DESCRIPTION
NightDriverStrip service lifecycle and audio/input cleanup
This check-in moves several long-running background loops behind explicit service lifecycles, tightens shutdown/restart behavior, and finishes the recent audio-input reconfiguration work. It also updates the RGB Music Blend Stars effect to use beat events directly, improves the web settings UI so edited interval values are not overwritten by refreshes, and adds validation/cleanup around the settings paths that can now apply changes live.

The biggest change here is that I removed the TaskManager-owned task startup path because it had become a loose collection of global task entry points with inconsistent ownership and shutdown behavior. Moving those loops into IService / ITaskService puts each task’s lifecycle next to the state it owns: construction, start, shutdown signaling, socket or hardware teardown, and destructor cleanup all live on the service object. That makes stop/restart paths much safer, avoids friend/global entry-point plumbing, gives every task a common Start() / Stop() contract, and lets services break out of blocking calls cleanly before the object or its resources are destroyed.

Some of the service migrations were straightforward, but others (notably the network service) required a bit of refactoring to break circular dependencies and move state around. The web server was a special case because of the AsyncTCP listener that is registered inside LWIP and cannot be fully reset from this fork; I added an _everStarted flag to warn if we try to start the web server more than once, which would leak or double-bind the listening socket.

Changes:

Added IService / ITaskService and migrated task-owned loops onto service objects with consistent Start(), Stop(), IsRunning(), shutdown signaling, and destructor discipline.
Moved audio sampling into AudioService, with runtime reconfigure support for the persisted audio input pin and safe silent fallback behavior when audio is stopped or unavailable.
Updated web settings handling so audio input pin changes use the shared live-apply helper and report failure instead of silently accepting a reverted setting.
Hardened socket/telnet/network service shutdown by closing descriptors from the stop path, avoiding double-close races, and cleaning up mDNS on network task exit.
Made RemoteControl::end() stop the IR polling task, so OTA/start-stop hooks actually shut down the service.
Converted color preview streaming into ColorStreamerService, including frame listener cleanup and socket cleanup on shutdown.
Converted render, JSON writer, debug console, websocket, socket server, network reader, screen, and audio serial work to the new service model where applicable.
Updated RGB Music Blend Stars to use OnBeat / OnNearBeat instead of VU ratio, with blue stars for near beats, green for beats, and red for strong beats.
Fixed the effect interval editor so background refreshes no longer immediately overwrite a value while it is being edited or saved.
Added web UI validation/error handling improvements for settings and topology changes.
Removed stale task-entry declarations and cleaned up includes after the service migration.
Added documentation around service destructor discipline and cleaned up small housekeeping items such as header comments, trailing whitespace, and the minimal drawing.h placeholder.

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).