### PR TITLE
Refactor SettingSpec construction; add ApiPath-aware dispatch; update…

### DIFF
--- a/REST_API.md
+++ b/REST_API.md
@@ -18,6 +18,7 @@
   - [Get device setting specifications](#get-device-setting-specifications)
   - [Device settings](#device-settings)
   - [Set setting with validation](#set-setting-with-validation)
+  - [Unified device settings](#unified-device-settings)
   - [Get effect setting specifications](#get-effect-setting-specifications)
   - [Effect settings](#effect-settings)
   - [Reset configuration and/or device](#reset-configuration-andor-device)
@@ -245,9 +246,73 @@ Note that validation is not implemented for all settings; the validation step is
 |-|-|-|
 | URL | `/settings/validated` | |
 | Method | POST | |
-| Parameters | | Exactly one setting that has been returned by the [Get dvice setting specifications endpoint](#get-device-setting-specifications). |
+| Parameters | | Exactly one setting that has been returned by the [Get device setting specifications endpoint](#get-device-setting-specifications). |
 | Response | 200 (OK) | Validation succeeded and the provided value has been set. |
 | | 400 (Bad Request) | More than one known setting was provided, or validation failed. The applicable message is returned in a JSON blob. |
+
+### Unified device settings
+
+This set of endpoints provides a structured, grouped interface for retrieving and changing device configuration settings. Unlike the [Device settings](#device-settings) endpoint, which uses a flat key/value format, the unified settings endpoints organize values into logical groups (`device`, `topology`, `outputs`, `effects`). They also expose runtime applicability information alongside each group, indicating whether a change can be applied live or requires a reboot.
+
+#### Get unified device settings schema
+
+This endpoint returns compile-time constraints and metadata for the unified settings. It can be used to understand what values and options are valid for the current firmware build before constructing a change request.
+
+| Property| Value | Explanation |
+|-|-|-|
+| URL | `/api/v1/settings/schema` | |
+| Method | GET | |
+| Parameters | | |
+| Response | 200 (OK) | A JSON blob with compile-time constraints and schema information for the unified settings. Includes topology limits, allowed output drivers, WS281x options (allowed channel counts, color orders, and compiled pin assignments), audio configuration, remote control availability, and a section catalog that can be used by a UI to group settings into labeled categories. |
+
+#### Retrieve unified device settings
+
+| Property| Value | Explanation |
+|-|-|-|
+| URL | `/api/v1/settings` | |
+| Method | GET | |
+| Parameters | | |
+| Response | 200 (OK) | A JSON blob with the current unified device settings, organized into `device`, `topology`, `outputs`, and `effects` groups. Read-only informational fields (such as compiled defaults and live-apply flags) are included alongside the mutable values. |
+
+#### Change unified device settings
+
+All fields in the request body are optional. Only the values that are included are changed; everything else stays as-is.
+
+Changes to `topology` and `outputs` are applied as a transaction: the new configuration is validated, applied live if the device supports it, and only persisted once live application succeeds. If live application fails, the previous configuration is restored and an error is returned.
+
+For groups where the response (or schema) reports `liveApply: false`, changes to that group require a reboot before they take effect.
+
+| Property| Value | Explanation |
+|-|-|-|
+| URL | `/api/v1/settings` | |
+| Method | POST | |
+| Body | JSON object | |
+| Parameters | `topology.width` | Matrix width. |
+| | `topology.height` | Matrix height. |
+| | `topology.serpentine` | Whether the LED matrix is wired in serpentine order. |
+| | `outputs.driver` | Output driver name. Must be one of the values from `allowedDrivers` in the schema response. |
+| | `outputs.ws281x.channelCount` | Number of active WS281x channels. |
+| | `outputs.ws281x.colorOrder` | WS281x color component order. Must be one of the values from `allowedColorOrders` in the schema response. |
+| | `outputs.ws281x.pins` | Array of GPIO pin numbers, one per WS281x channel. |
+| | `device.hostname` | Device hostname. |
+| | `device.location` | Device location (city name or ZIP code). |
+| | `device.locationIsZip` | Whether `location` is a ZIP code (`true`/`false`). |
+| | `device.countryCode` | ISO country code for the device's location. |
+| | `device.timeZone` | IANA time zone name. |
+| | `device.use24HourClock` | Whether to display time using a 24-hour clock (`true`/`false`). |
+| | `device.useCelsius` | Whether to display temperatures in Celsius (`true`/`false`). |
+| | `device.ntpServer` | NTP server hostname. |
+| | `device.rememberCurrentEffect` | Whether to resume the last-active effect on reboot (`true`/`false`). |
+| | `device.powerLimit` | Power consumption limit in milliwatts. |
+| | `device.brightness` | LED brightness (0–255). |
+| | `device.audioInputPin` or `device.audio.inputPin` | GPIO pin number for the audio input. Both fields are accepted; providing conflicting values in the same request is an error. |
+| | `device.globalColor` | Global LED color override, as a 24-bit integer. |
+| | `device.secondColor` | Secondary LED color, as a 24-bit integer. |
+| | `device.applyGlobalColors` | Whether the global/secondary color override is active (`true`/`false`). |
+| | `device.clearGlobalColor` | Set to `true` to clear the current global color override. |
+| | `effects.effectInterval` | Duration in milliseconds that each effect runs before the next is activated. |
+| Response | 200 (OK) | A JSON blob with the current unified device settings after applying the changes in the request, in the same format as the GET response. |
+| | 400 (Bad Request) | Validation failed for one or more of the provided values. The applicable message is returned in a JSON blob. |
 
 ### Get effect setting specifications
 

--- a/REST_API.md
+++ b/REST_API.md
@@ -55,8 +55,8 @@ Besides a REST-like API with endpoints that are to be called by the client, the 
 
 This endpoint returns a JSON document with basic information about the effects on the device.
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/effects` | |
 | Method | GET | |
 | Parameters | | |
@@ -66,8 +66,8 @@ This endpoint returns a JSON document with basic information about the effects o
 
 This endpoint can be used to set the effect that the device is currently showing.
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/currentEffect` | |
 | Method | POST | |
 | Parameters | `currentEffectIndex` | The (zero-based) integer index of the effect to activate in the device's effect list. |
@@ -77,8 +77,8 @@ This endpoint can be used to set the effect that the device is currently showing
 
 This endpoint can be used to activate the next effect.
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/nextEffect` | |
 | Method | POST | |
 | Parameters | | |
@@ -88,8 +88,8 @@ This endpoint can be used to activate the next effect.
 
 This endpoint can be used to activate the previous effect.
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/previousEffect` | |
 | Method | POST | |
 | Parameters | | |
@@ -99,8 +99,8 @@ This endpoint can be used to activate the previous effect.
 
 With this endpoint an effect can be disabled. This means it will no longer be activated, and skipped when it's its turn to be shown.
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/disableEffect` | |
 | Method | POST | |
 | Parameters | `effectIndex` | The (zero-based) integer index of the effect to disable in the device's effect list. |
@@ -110,8 +110,8 @@ With this endpoint an effect can be disabled. This means it will no longer be ac
 
 With this endpoint a previously disabled effect can be enabled. From that moment on, it will once again be shown.
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/enableEffect` | |
 | Method | POST | |
 | Parameters | `effectIndex` | The (zero-based) integer index of the effect to enable in the device's effect list. |
@@ -121,8 +121,8 @@ With this endpoint a previously disabled effect can be enabled. From that moment
 
 With this endpoint an effect can be moved within the effect list, changing its place in the effect visualisation cycle.
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/moveEffect` | |
 | Method | POST | |
 | Parameters | `effectIndex` | The (zero-based) integer index of the effect to move in the device's effect list. |
@@ -133,8 +133,8 @@ With this endpoint an effect can be moved within the effect list, changing its p
 
 With this endpoint an effect in the effect list can be copied. The created copy will be added to the end of the effect list. While copying the effect, supported effect settings on the copy can be set within the same call.
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/copyEffect` | |
 | Method | POST | |
 | Parameters | `effectIndex` | The (zero-based) integer index of the effect of which a copy should be made. |
@@ -145,8 +145,8 @@ With this endpoint an effect in the effect list can be copied. The created copy 
 
 With this endpoint an effect from the effect list can be deleted. Only effects that are copies of the default set (see [Copy effect](#copy-effect)) can be deleted.
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/deleteEffect` | |
 | Method | POST | |
 | Parameters | `effectIndex` | The (zero-based) integer index of the effect that should be deleted from the effect list. |
@@ -157,8 +157,8 @@ With this endpoint an effect from the effect list can be deleted. Only effects t
 
 This endpoint returns a JSON document with information about the detailed configuration of the effects on the device. Note that this document currently has an internal purpose, and is as such not optimized for human inspection.
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/effectsConfig` | |
 | Method | GET | |
 | Parameters | | |
@@ -170,8 +170,8 @@ This set of endpoints can be used to retrieve device statistics from the device.
 
 #### Static values
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/statistics/static` | |
 | Method | GET | |
 | Parameters | | |
@@ -179,8 +179,8 @@ This set of endpoints can be used to retrieve device statistics from the device.
 
 #### Dynamic values
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/statistics/dynamic` | |
 | Method | GET | |
 | Parameters | | |
@@ -188,8 +188,8 @@ This set of endpoints can be used to retrieve device statistics from the device.
 
 #### All values
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/statistics` | |
 | Method | GET | |
 | Parameters | | |
@@ -199,8 +199,8 @@ This set of endpoints can be used to retrieve device statistics from the device.
 
 This endpoint can be used to retrieve the list of known device configuration settings.
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/settings/specs` | |
 | Method | GET | |
 | Parameters | | |
@@ -220,8 +220,8 @@ When changing settings:
 
 #### Retrieve device settings
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/settings` | |
 | Method | GET | |
 | Parameters | | |
@@ -229,8 +229,8 @@ When changing settings:
 
 #### Change device settings
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/settings` | |
 | Method | POST | |
 | Parameters | | One or more settings that have been returned by the [Get device setting specifications endpoint](#get-device-setting-specifications). |
@@ -242,8 +242,8 @@ This endpoint can be used to validate the value for one device configuration set
 
 Note that validation is not implemented for all settings; the validation step is skipped for settings for which validation is not available.
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/settings/validated` | |
 | Method | POST | |
 | Parameters | | Exactly one setting that has been returned by the [Get device setting specifications endpoint](#get-device-setting-specifications). |
@@ -258,8 +258,8 @@ This set of endpoints provides a structured, grouped interface for retrieving an
 
 This endpoint returns compile-time constraints and metadata for the unified settings. It can be used to understand what values and options are valid for the current firmware build before constructing a change request.
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/api/v1/settings/schema` | |
 | Method | GET | |
 | Parameters | | |
@@ -267,8 +267,8 @@ This endpoint returns compile-time constraints and metadata for the unified sett
 
 #### Retrieve unified device settings
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/api/v1/settings` | |
 | Method | GET | |
 | Parameters | | |
@@ -282,8 +282,8 @@ Changes to `topology` and `outputs` are applied as a transaction: the new config
 
 For groups where the response (or schema) reports `liveApply: false`, changes to that group require a reboot before they take effect.
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/api/v1/settings` | |
 | Method | POST | |
 | Body | JSON object | |
@@ -318,8 +318,8 @@ For groups where the response (or schema) reports `liveApply: false`, changes to
 
 This endpoint can be used to retrieve the list of known effect-specific configuration settings for an individual effect.
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/settings/effect/specs` | |
 | Method | GET | |
 | Parameters | `effectIndex` | The (zero-based) integer index in the device's effect list of the effect to retrieve the setting specifications for. |
@@ -339,8 +339,8 @@ When changing settings:
 
 #### Retrieve effect settings
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/settings/effect` | |
 | Method | GET | |
 | Parameters | `effectIndex` | The (zero-based) integer index in the device's effect list of the effect to retrieve the settings for. |
@@ -348,8 +348,8 @@ When changing settings:
 
 #### Change effect settings
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/settings/effect` | |
 | Method | POST | |
 | Parameters | `effectIndex` | The (zero-based) integer index in the device's effect list of the effect to change settings for. |
@@ -362,8 +362,8 @@ This endpoint can be used to reset effect configuration (see [Get effect configu
 
 Any parameters that are not provided are considered to be `false`.
 
-| Property| Value | Explanation |
-|-|-|-|
+| Property | Value | Explanation |
+| - | - | - |
 | URL | `/reset` | |
 | Method | POST | |
 | Parameters | `deviceConfig` | A boolean value indicating if device settings should be reset to defaults (`true`/1) or not (`false`/0). |

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -96,7 +96,7 @@
 #define DEVICE_CONFIG_FILE          "/device.cfg"
 #define NTP_SERVER_DEFAULT          "0.pool.ntp.org"
 #ifndef BRIGHTNESS_MIN
-    #define BRIGHTNESS_MIN          uint8_t(10)
+    #define BRIGHTNESS_MIN          uint8_t(13)
 #endif
 #ifndef BRIGHTNESS_MAX
     #define BRIGHTNESS_MAX          uint8_t(255)
@@ -192,6 +192,7 @@ class DeviceConfig : public IJSONSerializable
 
     std::vector<SettingSpec, psram_allocator<SettingSpec>> settingSpecs;
     std::vector<std::reference_wrapper<SettingSpec>> settingSpecReferences;
+    std::vector<String> pinSpecStrings;
     size_t writerIndex;
 
     void SaveToJSON() const;
@@ -249,7 +250,7 @@ class DeviceConfig : public IJSONSerializable
     static constexpr const char * WS281xChannelCountTag = "ws281xChannelCount";
     static constexpr const char * WS281xPinsTag = "ws281xPins";
     static constexpr const char * WS281xColorOrderTag = "ws281xColorOrder";
-    static constexpr const char * AudioInputPinTag = "audioInputPin";
+    static constexpr const char * AudioInputPinTag = NAME_OF(audioInputPin);
 
     DeviceConfig();
 

--- a/include/effects/matrix/PatternStocks.h
+++ b/include/effects/matrix/PatternStocks.h
@@ -338,12 +338,18 @@ private:
         // Lazily load this class' SettingSpec instances if they haven't been already
         if (mySettingSpecs.size() == 0)
         {
-            mySettingSpecs.emplace_back(NAME_OF(stockServer), "Stock server location",
-                                        "The host and port of the service that provides stock data.",
-                                        SettingSpec::SettingType::String);
-            mySettingSpecs.emplace_back(NAME_OF(tickerSymbols), "Ticker symbols",
-                                        "Comma-separated list of ticker symbols to show stock data for.",
-                                        SettingSpec::SettingType::String);
+            mySettingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+                .Name         = NAME_OF(stockServer),
+                .FriendlyName = "Stock server location",
+                .Description  = "The host and port of the service that provides stock data.",
+                .Type         = SettingSpec::SettingType::String
+            }));
+            mySettingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+                .Name         = NAME_OF(tickerSymbols),
+                .FriendlyName = "Ticker symbols",
+                .Description  = "Comma-separated list of ticker symbols to show stock data for.",
+                .Type         = SettingSpec::SettingType::String
+            }));
         }
 
         return &mySettingSpecs;

--- a/include/effects/matrix/PatternStocks.h
+++ b/include/effects/matrix/PatternStocks.h
@@ -347,7 +347,7 @@ private:
             mySettingSpecs.push_back(SettingSpec::Validate(SettingSpec{
                 .Name         = NAME_OF(tickerSymbols),
                 .FriendlyName = "Ticker symbols",
-                .Description  = "Comma-separated list of ticker symbols to show stock data for.",
+                .Description  = "Comma-separated list of ticker symbols for which to retrieve and display stock data.",
                 .Type         = SettingSpec::SettingType::String
             }));
         }

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -147,30 +147,32 @@ class PatternSubscribers : public EffectWithId<PatternSubscribers>
         // Lazily load this class' SettingSpec instances if they haven't been already
         if (mySettingSpecs.size() == 0)
         {
-            mySettingSpecs.emplace_back(
-                NAME_OF(youtubeChannelGuid),
-                "YouTube channel GUID",
-                "The <a href=\"http://tools.tastethecode.com/youtube-sight\">YouTube Sight</a> GUID of the channel for which "
-                "the effect should show subscriber information.",
-                SettingSpec::SettingType::String
-            );
-            mySettingSpecs.emplace_back(NAME_OF(backgroundColor), "Background Color",
-                                        "Color for the background",
-                                        SettingSpec::SettingType::Color);
-            mySettingSpecs.emplace_back(NAME_OF(borderColor), "Border Color",
-                                        "Color for the border around the edge", SettingSpec::SettingType::Color);
-            {
-                SettingSpec::FinishGuard spec(mySettingSpecs.emplace_back(NAME_OF(youtubeChannelName), "YouTube channel name",
-                                             "The name of the channel for which the effect should show subscriber information.",
-                                             SettingSpec::SettingType::String));
-                spec->EmptyAllowed = true;
-            }
-            {
-                SettingSpec::FinishGuard spec(mySettingSpecs.emplace_back(NAME_OF(youtubeChannelName), "YouTube channel name",
-                                             "The name of the channel for which the effect should show subscriber information.",
-                                             SettingSpec::SettingType::String));
-                spec->EmptyAllowed = true;
-            }
+            mySettingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+                .Name         = NAME_OF(youtubeChannelGuid),
+                .FriendlyName = "YouTube channel GUID",
+                .Description  = "The <a href=\"http://tools.tastethecode.com/youtube-sight\">YouTube Sight</a> GUID of the channel for which "
+                                "the effect should show subscriber information.",
+                .Type         = SettingSpec::SettingType::String
+            }));
+            mySettingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+                .Name         = NAME_OF(backgroundColor),
+                .FriendlyName = "Background Color",
+                .Description  = "Color for the background",
+                .Type         = SettingSpec::SettingType::Color
+            }));
+            mySettingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+                .Name         = NAME_OF(borderColor),
+                .FriendlyName = "Border Color",
+                .Description  = "Color for the border around the edge",
+                .Type         = SettingSpec::SettingType::Color
+            }));
+            mySettingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+                .Name         = NAME_OF(youtubeChannelName),
+                .FriendlyName = "YouTube channel name",
+                .Description  = "The name of the channel for which the effect should show subscriber information.",
+                .Type         = SettingSpec::SettingType::String,
+                .EmptyAllowed = true
+            }));
         }
 
         return &mySettingSpecs;

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -159,10 +159,18 @@ class PatternSubscribers : public EffectWithId<PatternSubscribers>
                                         SettingSpec::SettingType::Color);
             mySettingSpecs.emplace_back(NAME_OF(borderColor), "Border Color",
                                         "Color for the border around the edge", SettingSpec::SettingType::Color);
-            mySettingSpecs.emplace_back(NAME_OF(youtubeChannelName), "YouTube channel name",
-                                         "The name of the channel for which the effect should show subscriber information.",
-                                         SettingSpec::SettingType::String)
-                                         .EmptyAllowed = true;
+            {
+                SettingSpec::FinishGuard spec(mySettingSpecs.emplace_back(NAME_OF(youtubeChannelName), "YouTube channel name",
+                                             "The name of the channel for which the effect should show subscriber information.",
+                                             SettingSpec::SettingType::String));
+                spec->EmptyAllowed = true;
+            }
+            {
+                SettingSpec::FinishGuard spec(mySettingSpecs.emplace_back(NAME_OF(youtubeChannelName), "YouTube channel name",
+                                             "The name of the channel for which the effect should show subscriber information.",
+                                             SettingSpec::SettingType::String));
+                spec->EmptyAllowed = true;
+            }
         }
 
         return &mySettingSpecs;

--- a/include/interfaces.h
+++ b/include/interfaces.h
@@ -336,87 +336,27 @@ struct SettingSpec
     // spec keeps the UI from having to bake a path like "/timezones.json".
     const char* OptionsExternalUrl = nullptr;
 
-    // Finishes the initialization of the spec, and then validates the consistency of its overall contents.
-    // Note that it does the latter quite rudely: it uses assert() on things it feels should be in order.
-    // All call sites must call this after all fields have been assigned. The FinishGuard RAII helper
-    // below is the preferred way to ensure that: construction happens inside the guard, all post-
-    // constructor field assignments are made in the enclosing block body, and the destructor fires
-    // FinishAndValidateInitialization() automatically when the block ends.
+    // Validates the consistency of the spec's contents. Called by Construct(); can also be
+    // called directly when constructing specs without using Construct().
     void FinishAndValidateInitialization();
 
-    // RAII wrapper that calls FinishAndValidateInitialization() when the enclosing scope exits.
-    // Usage:
-    //   {
-    //       SettingSpec::FinishGuard spec(mySpecs.emplace_back(name, friendlyName, type));
-    //       spec->Widget = WidgetKind::Select;
-    //       spec->OptionsSchemaPath = "some.path";
-    //   } // ← FinishAndValidateInitialization() fires here, after all fields are set
-    struct FinishGuard
-    {
-        SettingSpec& ref;
-        explicit FinishGuard(SettingSpec& s) : ref(s) {}
-        ~FinishGuard() { ref.FinishAndValidateInitialization(); }
-        SettingSpec* operator->() const { return &ref; }
-        SettingSpec& operator*()  const { return ref; }
-        FinishGuard(const FinishGuard&)            = delete;
-        FinishGuard& operator=(const FinishGuard&) = delete;
-    };
+    // Factory method: construct a SettingSpec via C++20 designated initializers, then call
+    // FinishAndValidateInitialization() and return the validated spec. Use this for specs
+    // that need no post-construction field assignments:
+    //
+    //   settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+    //       .Name         = "myName",
+    //       .FriendlyName = "My Name",
+    //       .Type         = SettingType::String,
+    //       .Section      = "section",
+    //       .ApiPath      = "path.to.setting"
+    //   }));
+    //
+    // Fields not listed receive their in-class defaults. Designated initializers must appear
+    // in the same order as the members are declared in this struct (C++20 requirement).
+    static SettingSpec Validate(SettingSpec spec);
 
-    // ---- Base constructors (type only) ----
-    SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type);
-    SettingSpec(const char* name, const char* friendlyName, SettingType type);
-
-    // Base constructors with min/max range
-    SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type, double min, double max);
-    SettingSpec(const char* name, const char* friendlyName, SettingType type, double min, double max);
-
-    // ---- Constructors for UI-positioned specs (type + section + apiPath) ----
-    // Constructor A: basic positioned spec (Boolean, Color, String, etc.)
-    SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
-                const char* section, const char* apiPath, std::optional<int> priority = {});
-    SettingSpec(const char* name, const char* friendlyName, SettingType type,
-                const char* section, const char* apiPath, std::optional<int> priority = {});
-
-    // Constructor B: positioned spec with non-default access (ReadOnly or WriteOnly)
-    SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
-                const char* section, const char* apiPath, SettingAccess access, bool hasValidation = false);
-    SettingSpec(const char* name, const char* friendlyName, SettingType type,
-                const char* section, const char* apiPath, SettingAccess access, bool hasValidation = false);
-
-    // Constructor C: positioned spec with range (min/max)
-    SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
-                double min, double max, const char* section, const char* apiPath, std::optional<int> priority = {});
-    SettingSpec(const char* name, const char* friendlyName, SettingType type,
-                double min, double max, const char* section, const char* apiPath, std::optional<int> priority = {});
-
-    // Constructor D: positioned SchemaPath Select widget
-    SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
-                const char* section, const char* apiPath, const char* optionsSchemaPath, std::optional<int> priority = {});
-    SettingSpec(const char* name, const char* friendlyName, SettingType type,
-                const char* section, const char* apiPath, const char* optionsSchemaPath, std::optional<int> priority = {});
-
-    // Constructor E: positioned Select widget with non-Inline source (IntlCountryCodes or ExternalTimeZones)
-    SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
-                const char* section, const char* apiPath, OptionsSource optionsSource,
-                const char* optionsExternalUrl = nullptr);
-    SettingSpec(const char* name, const char* friendlyName, SettingType type,
-                const char* section, const char* apiPath, OptionsSource optionsSource,
-                const char* optionsExternalUrl = nullptr);
-
-    // Constructor F: positioned Slider widget with display scale
-    SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
-                const char* section, const char* apiPath,
-                double displayRawMin, double displayRawMax, double displayMin, double displayMax,
-                const char* displaySuffix = nullptr, bool hasValidation = false);
-    SettingSpec(const char* name, const char* friendlyName, SettingType type,
-                const char* section, const char* apiPath,
-                double displayRawMin, double displayRawMax, double displayMin, double displayMax,
-                const char* displaySuffix = nullptr, bool hasValidation = false);
-
-    SettingSpec() = default;
-    virtual ~SettingSpec() = default;
-
-    virtual String TypeName() const;
+    String TypeName() const;
 
     // String form of WidgetKind, suitable for emission in the spec response.
     const char* WidgetName() const;

--- a/include/interfaces.h
+++ b/include/interfaces.h
@@ -200,8 +200,7 @@ struct SettingSpec
         Boolean,
         String,
         Palette,
-        Color,
-        Slider
+        Color
     };
 
     enum class SettingAccess : char
@@ -220,8 +219,7 @@ struct SettingSpec
         Default,           // type-driven default (Integer -> number input, Boolean -> checkbox, etc.)
         Slider,            // numeric slider; honors DisplayScale and DisplaySuffix
         Select,            // dropdown sourced from inline Options or via OptionsSource
-        IntervalToggle,    // boolean-on + numeric value composite (effectInterval-style)
-        Color              // color picker; raw value is an integer 0xRRGGBB
+        IntervalToggle     // boolean-on + numeric value composite (effectInterval-style)
     };
 
     // Where the widget gets its option list from when WidgetKind::Select is used.
@@ -318,10 +316,16 @@ struct SettingSpec
     // For WidgetKind::Select: how to populate the options list.
     OptionsSource Options = OptionsSource::Inline;
 
-    // For Options == OptionsSource::Inline: parallel arrays of values and
-    // friendly labels. If OptionLabels is empty, values double as labels.
-    std::vector<const char*> InlineOptionValues = {};
-    std::vector<const char*> InlineOptionLabels = {};
+    // Parallel arrays of raw values and friendly labels for Select options.
+    // For OptionsSource::Inline: the full option list. OptionLabels may be
+    //   empty, in which case values double as labels.
+    // For OptionsSource::SchemaPath: optional label overrides for schema-
+    //   derived values (e.g. "ws281x" -> "WS281x"). Either both arrays are
+    //   empty (no overrides) or both are non-empty and the same length.
+    // For OptionsSource::ExternalTimeZones: optional label overrides for
+    //   specific time zone identifiers. Same empty-or-matched-length rule.
+    std::vector<const char*> OptionValues = {};
+    std::vector<const char*> OptionLabels = {};
 
     // For Options == OptionsSource::SchemaPath: the dotted path within
     // /api/v1/settings/schema where the option array lives.
@@ -332,27 +336,82 @@ struct SettingSpec
     // spec keeps the UI from having to bake a path like "/timezones.json".
     const char* OptionsExternalUrl = nullptr;
 
-    // Optional JSON-object (as a literal string) of value -> friendly-label
-    // overrides for Select options that come from a schema list. For example,
-    // mapping "ws281x" -> "WS281x" and "hub75" -> "HUB75" when the schema
-    // exposes raw driver identifiers. Parsed verbatim by the UI.
-    const char* OptionLabelMapJson = nullptr;
-
     // Finishes the initialization of the spec, and then validates the consistency of its overall contents.
     // Note that it does the latter quite rudely: it uses assert() on things it feels should be in order.
-    // This function is called by this struct's constructors that initialize values, but this being a struct
-    // allows itself to be called from the outside as well.
+    // All call sites must call this after all fields have been assigned. The FinishGuard RAII helper
+    // below is the preferred way to ensure that: construction happens inside the guard, all post-
+    // constructor field assignments are made in the enclosing block body, and the destructor fires
+    // FinishAndValidateInitialization() automatically when the block ends.
     void FinishAndValidateInitialization();
 
-    SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type);
+    // RAII wrapper that calls FinishAndValidateInitialization() when the enclosing scope exits.
+    // Usage:
+    //   {
+    //       SettingSpec::FinishGuard spec(mySpecs.emplace_back(name, friendlyName, type));
+    //       spec->Widget = WidgetKind::Select;
+    //       spec->OptionsSchemaPath = "some.path";
+    //   } // ← FinishAndValidateInitialization() fires here, after all fields are set
+    struct FinishGuard
+    {
+        SettingSpec& ref;
+        explicit FinishGuard(SettingSpec& s) : ref(s) {}
+        ~FinishGuard() { ref.FinishAndValidateInitialization(); }
+        SettingSpec* operator->() const { return &ref; }
+        SettingSpec& operator*()  const { return ref; }
+        FinishGuard(const FinishGuard&)            = delete;
+        FinishGuard& operator=(const FinishGuard&) = delete;
+    };
 
+    // ---- Base constructors (type only) ----
+    SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type);
     SettingSpec(const char* name, const char* friendlyName, SettingType type);
 
-    // Constructor that sets both minimum and maximum values
+    // Base constructors with min/max range
     SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type, double min, double max);
-
-    // Constructor that sets both minimum and maximum values
     SettingSpec(const char* name, const char* friendlyName, SettingType type, double min, double max);
+
+    // ---- Constructors for UI-positioned specs (type + section + apiPath) ----
+    // Constructor A: basic positioned spec (Boolean, Color, String, etc.)
+    SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
+                const char* section, const char* apiPath, std::optional<int> priority = {});
+    SettingSpec(const char* name, const char* friendlyName, SettingType type,
+                const char* section, const char* apiPath, std::optional<int> priority = {});
+
+    // Constructor B: positioned spec with non-default access (ReadOnly or WriteOnly)
+    SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
+                const char* section, const char* apiPath, SettingAccess access, bool hasValidation = false);
+    SettingSpec(const char* name, const char* friendlyName, SettingType type,
+                const char* section, const char* apiPath, SettingAccess access, bool hasValidation = false);
+
+    // Constructor C: positioned spec with range (min/max)
+    SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
+                double min, double max, const char* section, const char* apiPath, std::optional<int> priority = {});
+    SettingSpec(const char* name, const char* friendlyName, SettingType type,
+                double min, double max, const char* section, const char* apiPath, std::optional<int> priority = {});
+
+    // Constructor D: positioned SchemaPath Select widget
+    SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
+                const char* section, const char* apiPath, const char* optionsSchemaPath, std::optional<int> priority = {});
+    SettingSpec(const char* name, const char* friendlyName, SettingType type,
+                const char* section, const char* apiPath, const char* optionsSchemaPath, std::optional<int> priority = {});
+
+    // Constructor E: positioned Select widget with non-Inline source (IntlCountryCodes or ExternalTimeZones)
+    SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
+                const char* section, const char* apiPath, OptionsSource optionsSource,
+                const char* optionsExternalUrl = nullptr);
+    SettingSpec(const char* name, const char* friendlyName, SettingType type,
+                const char* section, const char* apiPath, OptionsSource optionsSource,
+                const char* optionsExternalUrl = nullptr);
+
+    // Constructor F: positioned Slider widget with display scale
+    SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
+                const char* section, const char* apiPath,
+                double displayRawMin, double displayRawMax, double displayMin, double displayMax,
+                const char* displaySuffix = nullptr, bool hasValidation = false);
+    SettingSpec(const char* name, const char* friendlyName, SettingType type,
+                const char* section, const char* apiPath,
+                double displayRawMin, double displayRawMax, double displayMin, double displayMax,
+                const char* displaySuffix = nullptr, bool hasValidation = false);
 
     SettingSpec() = default;
     virtual ~SettingSpec() = default;

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -113,8 +113,7 @@ class CWebServer
     // Per-channel pin specs synthesized at first /settings/specs request from
     // the compiled channel maximum, with stable backing storage for the
     // const char* fields they hold.
-    static std::vector<SettingSpec, psram_allocator<SettingSpec>> synthesizedPinSpecs;
-    static std::vector<String> synthesizedPinSpecStrings;
+
     static const std::map<String, ValueValidator> settingValidators;
 
     AsyncWebServer _server;

--- a/site/app.js
+++ b/site/app.js
@@ -1045,17 +1045,27 @@ $$$$$$$b   *u    ^$L            $$  $$$$$$$$$$$$u@       $$  d$$$$$$
   //   "schemaPath"         - resolve a path against state.unifiedSchema. If the
   //                          target is an array, use it directly. If it's a
   //                          number, generate 1..N (used for compiledMaxChannels).
+  //                          Optional widget.options.values/labels provide label
+  //                          overrides for specific raw values.
   //   "intlCountryCodes"   - the prebuilt COUNTRY_OPTIONS list
   //   "externalTimeZones"  - the lazily-fetched time zone list
-  // labelOverrides maps raw values to friendly labels (e.g. ws281x -> WS281x).
   function getWidgetSelectOptions(spec, widget) {
     const source = (widget.options && widget.options.source) || "inline";
     const options = widget.options || {};
-    const overrides = options.labelOverrides || {};
-    const decorate = (rawValue) => ({
-      value: String(rawValue),
-      label: Object.prototype.hasOwnProperty.call(overrides, String(rawValue)) ? overrides[String(rawValue)] : String(rawValue)
-    });
+    const values = Array.isArray(options.values) ? options.values : [];
+    const labels = Array.isArray(options.labels) ? options.labels : [];
+
+    // Build a value->label map from the parallel values/labels arrays.
+    const labelMap = {};
+    values.forEach((v, i) => { if (i < labels.length) labelMap[String(v)] = labels[i]; });
+
+    // Apply the label map to a raw array, falling back to the raw value as label.
+    function applyLabelMap(rawValues) {
+      return rawValues.map((value) => ({
+        value: String(value),
+        label: Object.prototype.hasOwnProperty.call(labelMap, String(value)) ? labelMap[String(value)] : String(value)
+      }));
+    }
 
     if (source === "intlCountryCodes") {
       return COUNTRY_OPTIONS.map((option) => ({ value: option.value, label: option.label }));
@@ -1063,22 +1073,17 @@ $$$$$$$b   *u    ^$L            $$  $$$$$$$$$$$$u@       $$  d$$$$$$
     if (source === "externalTimeZones") {
       // The URL is carried on the spec's widget metadata so the UI doesn't
       // bake the document path. ensureTimezonesLoaded() reads the same field.
-      return getTimeZoneOptions().map((value) => decorate(value));
+      return applyLabelMap(getTimeZoneOptions());
     }
     if (source === "schemaPath") {
       const target = readJsonPath(state.unifiedSchema, options.schemaPath);
       if (Array.isArray(target)) {
-        return target.map((value) => decorate(value));
+        return applyLabelMap(target);
       }
       return [];
     }
     // Inline (default)
-    const values = Array.isArray(options.values) ? options.values : [];
-    const labels = Array.isArray(options.labels) ? options.labels : [];
-    return values.map((value, index) => ({
-      value: String(value),
-      label: index < labels.length ? labels[index] : (Object.prototype.hasOwnProperty.call(overrides, String(value)) ? overrides[String(value)] : String(value))
-    }));
+    return applyLabelMap(values);
   }
 
   // Linearly remap a raw value into the displayed range, then clamp.
@@ -1204,7 +1209,7 @@ $$$$$$$b   *u    ^$L            $$  $$$$$$$$$$$$u@       $$  d$$$$$$
     }
   }
 
-  
+
   async function moveEffect(effectIndex, newIndex) {
     try {
       await postForm("/moveEffect", { effectIndex, newIndex });

--- a/src/deviceconfig.cpp
+++ b/src/deviceconfig.cpp
@@ -383,236 +383,272 @@ const std::vector<std::reference_wrapper<SettingSpec>>& DeviceConfig::GetSetting
         constexpr const char* kSectionOutput     = "output";
 
         // ---- system section ------------------------------------------------
-        {
-            SettingSpec::FinishGuard spec(settingSpecs.emplace_back(
-                HostnameTag,
-                "Hostname",
-                "The hostname of the device. A reboot is required after changing this.",
-                SettingSpec::SettingType::String
-            ));
-            spec->EmptyAllowed = true;
-            spec->Section = kSectionSystem;
-            spec->RequiresReboot = true;
-            spec->ApiPath = "device.hostname";
-        }
-        {
-            SettingSpec::FinishGuard spec(settingSpecs.emplace_back(
-                PowerLimitTag,
-                "Power limit",
-                "The maximum power in mW that the matrix attached to the board is allowed to use. As the previous sentence implies, this "
-                "setting only applies if a matrix is used.",
-                SettingSpec::SettingType::Integer,
-                kSectionSystem, "device.powerLimit"
-            ));
-            spec->MinimumValue = POWER_LIMIT_MIN;
-            spec->HasValidation = true;
-        }
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name           = HostnameTag,
+            .FriendlyName   = "Hostname",
+            .Description    = "The hostname of the device. A reboot is required after changing this.",
+            .Type           = SettingSpec::SettingType::String,
+            .EmptyAllowed   = true,
+            .Section        = kSectionSystem,
+            .RequiresReboot = true,
+            .ApiPath        = "device.hostname"
+        }));
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name          = PowerLimitTag,
+            .FriendlyName  = "Power limit",
+            .Description   = "The maximum power in mW that the matrix attached to the board is allowed to use. As the previous sentence implies, this "
+                             "setting only applies if a matrix is used.",
+            .Type          = SettingSpec::SettingType::Integer,
+            .HasValidation = true,
+            .MinimumValue  = (double)POWER_LIMIT_MIN,
+            .Section       = kSectionSystem,
+            .ApiPath       = "device.powerLimit"
+        }));
 
         // ---- location section ----------------------------------------------
-        settingSpecs.emplace_back(
-            LocationTag,
-            "Location",
-            "The location (city or postal code) where the device is located.",
-            SettingSpec::SettingType::String,
-            kSectionLocation, "device.location"
-        );
-        settingSpecs.emplace_back(
-            LocationIsZipTag,
-            "Location is postal code",
-            "Indicates if the value for the \"Location\" setting is a postal code (yes if checked) or not.",
-            SettingSpec::SettingType::Boolean,
-            kSectionLocation, "device.locationIsZip"
-        );
-        settingSpecs.emplace_back(
-            CountryCodeTag,
-            "Country code",
-            "The <a href=\"https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2\">ISO 3166-1 alpha-2</a> country "
-            "code for the country that the device is located in.",
-            SettingSpec::SettingType::String,
-            kSectionLocation, "device.countryCode",
-            SettingSpec::OptionsSource::IntlCountryCodes
-        );
-        settingSpecs.emplace_back(
-            TimeZoneTag,
-            "Time zone",
-            "The timezone the device resides in, in <a href=\"https://en.wikipedia.org/wiki/Tz_database\">tz database</a> format. "
-            "The list of available timezone identifiers can be found in the <a href=\"/timezones.json\">timezones.json</a> file.",
-            SettingSpec::SettingType::String,
-            kSectionLocation, "device.timeZone",
-            SettingSpec::OptionsSource::ExternalTimeZones, "/timezones.json"
-        );
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name         = LocationTag,
+            .FriendlyName = "Location",
+            .Description  = "The location (city or postal code) where the device is located.",
+            .Type         = SettingSpec::SettingType::String,
+            .Section      = kSectionLocation,
+            .ApiPath      = "device.location"
+        }));
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name         = LocationIsZipTag,
+            .FriendlyName = "Location is postal code",
+            .Description  = "Indicates if the value for the \"Location\" setting is a postal code (yes if checked) or not.",
+            .Type         = SettingSpec::SettingType::Boolean,
+            .Section      = kSectionLocation,
+            .ApiPath      = "device.locationIsZip"
+        }));
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name         = CountryCodeTag,
+            .FriendlyName = "Country code",
+            .Description  = "The <a href=\"https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2\">ISO 3166-1 alpha-2</a> country "
+                            "code for the country that the device is located in.",
+            .Type         = SettingSpec::SettingType::String,
+            .Section      = kSectionLocation,
+            .ApiPath      = "device.countryCode",
+            .Widget       = SettingSpec::WidgetKind::Select,
+            .Options      = SettingSpec::OptionsSource::IntlCountryCodes
+        }));
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name               = TimeZoneTag,
+            .FriendlyName       = "Time zone",
+            .Description        = "The timezone the device resides in, in <a href=\"https://en.wikipedia.org/wiki/Tz_database\">tz database</a> format. "
+                                  "The list of available timezone identifiers can be found in the <a href=\"/timezones.json\">timezones.json</a> file.",
+            .Type               = SettingSpec::SettingType::String,
+            .Section            = kSectionLocation,
+            .ApiPath            = "device.timeZone",
+            .Widget             = SettingSpec::WidgetKind::Select,
+            .Options            = SettingSpec::OptionsSource::ExternalTimeZones,
+            .OptionsExternalUrl = "/timezones.json"
+        }));
 
         // ---- clock section -------------------------------------------------
-        settingSpecs.emplace_back(
-            Use24HourClockTag,
-            "Use 24 hour clock",
-            "Indicates if time should be shown in 24-hour format (yes if checked) or 12-hour AM/PM format.",
-            SettingSpec::SettingType::Boolean,
-            kSectionClock, "device.use24HourClock"
-        );
-        settingSpecs.emplace_back(
-            UseCelsiusTag,
-            "Use degrees Celsius",
-            "Indicates if temperatures should be shown in degrees Celsius (yes if checked) or degrees Fahrenheit.",
-            SettingSpec::SettingType::Boolean,
-            kSectionClock, "device.useCelsius"
-        );
-        settingSpecs.emplace_back(
-            NTPServerTag,
-            "NTP server address",
-            "The hostname or IP address of the NTP server to be used for time synchronization.",
-            SettingSpec::SettingType::String,
-            kSectionClock, "device.ntpServer"
-        );
-        settingSpecs.emplace_back(
-            OpenWeatherApiKeyTag,
-            "Open Weather API key",
-            "The API key for the <a href=\"https://openweathermap.org/api\">Weather API provided by Open Weather Map</a>.",
-            SettingSpec::SettingType::String,
-            kSectionClock, "device.openWeatherApiKey",
-            SettingSpec::SettingAccess::WriteOnly, /*hasValidation=*/true
-        );
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name         = Use24HourClockTag,
+            .FriendlyName = "Use 24 hour clock",
+            .Description  = "Indicates if time should be shown in 24-hour format (yes if checked) or 12-hour AM/PM format.",
+            .Type         = SettingSpec::SettingType::Boolean,
+            .Section      = kSectionClock,
+            .ApiPath      = "device.use24HourClock"
+        }));
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name         = UseCelsiusTag,
+            .FriendlyName = "Use degrees Celsius",
+            .Description  = "Indicates if temperatures should be shown in degrees Celsius (yes if checked) or degrees Fahrenheit.",
+            .Type         = SettingSpec::SettingType::Boolean,
+            .Section      = kSectionClock,
+            .ApiPath      = "device.useCelsius"
+        }));
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name         = NTPServerTag,
+            .FriendlyName = "NTP server address",
+            .Description  = "The hostname or IP address of the NTP server to be used for time synchronization.",
+            .Type         = SettingSpec::SettingType::String,
+            .Section      = kSectionClock,
+            .ApiPath      = "device.ntpServer"
+        }));
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name          = OpenWeatherApiKeyTag,
+            .FriendlyName  = "Open Weather API key",
+            .Description   = "The API key for the <a href=\"https://openweathermap.org/api\">Weather API provided by Open Weather Map</a>.",
+            .Type          = SettingSpec::SettingType::String,
+            .HasValidation = true,
+            .Access        = SettingSpec::SettingAccess::WriteOnly,
+            .Section       = kSectionClock,
+            .ApiPath       = "device.openWeatherApiKey"
+        }));
 
         // ---- audio section -------------------------------------------------
-        {
-            SettingSpec::FinishGuard spec(settingSpecs.emplace_back(
-                AudioInputPinTag,
-                "Audio input pin",
-                "External microphone input pin. This is boot-applied today because the audio task still owns the active DMA/I2S handles once sampling starts.",
-                SettingSpec::SettingType::Integer,
-                -1, 48,
-                kSectionAudio, "device.audioInputPin"
-            ));
-            spec->HasValidation = true;
-            spec->RequiresReboot = !SupportsLiveAudioInputReconfigure();
-        }
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name           = AudioInputPinTag,
+            .FriendlyName   = "Audio input pin",
+            .Description    = "External microphone input pin. This is boot-applied today because the audio task still owns the active DMA/I2S handles once sampling starts.",
+            .Type           = SettingSpec::SettingType::Integer,
+            .HasValidation  = true,
+            .MinimumValue   = -1.0,
+            .MaximumValue   = 48.0,
+            .Section        = kSectionAudio,
+            .RequiresReboot = !SupportsLiveAudioInputReconfigure(),
+            .ApiPath        = "device.audioInputPin"
+        }));
 
         // ---- appearance section --------------------------------------------
-        settingSpecs.emplace_back(
-            BrightnessTag,
-            "Brightness",
-            "Overall brightness the connected LEDs or matrix should be run at.",
-            SettingSpec::SettingType::Integer,
-            kSectionAppearance, "device.brightness",
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name          = BrightnessTag,
+            .FriendlyName  = "Brightness",
+            .Description   = "Overall brightness the connected LEDs or matrix should be run at.",
+            .Type          = SettingSpec::SettingType::Integer,
+            .HasValidation = true,
+            .Section       = kSectionAppearance,
+            .ApiPath       = "device.brightness",
+            .Widget        = SettingSpec::WidgetKind::Slider,
             // Display as 5..100 percent over the raw 13..255 range. The endpoints
             // mirror what the legacy UI did: clamp at 5% on the low side, 100% at
             // raw max, with linear remapping in between. The UI does the math.
-            (double)BRIGHTNESS_MIN, (double)BRIGHTNESS_MAX, 5.0, 100.0, "%", /*hasValidation=*/true
-        );
-        settingSpecs.emplace_back(
-            GlobalColorTag,
-            "Global color",
-            "Main color that is applied to all those effects that support using it.",
-            SettingSpec::SettingType::Color,
-            kSectionAppearance, "device.globalColor"
-        );
-        settingSpecs.emplace_back(
-            SecondColorTag,
-            "Second color",
-            "Second color that is used to create a global palette in combination with the current global color. That palette is used "
-            "by some effects. Defaults to the <em>previous</em> global color if not explicitly set.",
-            SettingSpec::SettingType::Color,
-            kSectionAppearance, "device.secondColor"
-        );
-        settingSpecs.emplace_back(
-            ApplyGlobalColorsTag,
-            "(Re)apply global color",
-            "You can use this to \"reselect\" and apply the current global color, to force the composition of the derived "
-            "global palette. This checkbox is ignored if the \"Clear global color\" checkbox is selected.",
-            SettingSpec::SettingType::Boolean,
-            kSectionAppearance, "device.applyGlobalColors",
-            SettingSpec::SettingAccess::WriteOnly
-        );
-        settingSpecs.emplace_back(
-            ClearGlobalColorTag,
-            "Clear global color",
-            "Stop applying the global color/derived palette. This takes precedence over the \"(Re)apply global color\" checkbox.",
-            SettingSpec::SettingType::Boolean,
-            kSectionAppearance, "device.clearGlobalColor",
-            SettingSpec::SettingAccess::WriteOnly
-        );
+            .DisplayRawMin = (double)BRIGHTNESS_MIN,
+            .DisplayRawMax = (double)BRIGHTNESS_MAX,
+            .DisplayMin    = 5.0,
+            .DisplayMax    = 100.0,
+            .DisplaySuffix = "%"
+        }));
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name         = GlobalColorTag,
+            .FriendlyName = "Global color",
+            .Description  = "Main color that is applied to all those effects that support using it.",
+            .Type         = SettingSpec::SettingType::Color,
+            .Section      = kSectionAppearance,
+            .ApiPath      = "device.globalColor"
+        }));
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name         = SecondColorTag,
+            .FriendlyName = "Second color",
+            .Description  = "Second color that is used to create a global palette in combination with the current global color. That palette is used "
+                            "by some effects. Defaults to the <em>previous</em> global color if not explicitly set.",
+            .Type         = SettingSpec::SettingType::Color,
+            .Section      = kSectionAppearance,
+            .ApiPath      = "device.secondColor"
+        }));
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name         = ApplyGlobalColorsTag,
+            .FriendlyName = "(Re)apply global color",
+            .Description  = "You can use this to \"reselect\" and apply the current global color, to force the composition of the derived "
+                            "global palette. This checkbox is ignored if the \"Clear global color\" checkbox is selected.",
+            .Type         = SettingSpec::SettingType::Boolean,
+            .Access       = SettingSpec::SettingAccess::WriteOnly,
+            .Section      = kSectionAppearance,
+            .ApiPath      = "device.applyGlobalColors"
+        }));
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name         = ClearGlobalColorTag,
+            .FriendlyName = "Clear global color",
+            .Description  = "Stop applying the global color/derived palette. This takes precedence over the \"(Re)apply global color\" checkbox.",
+            .Type         = SettingSpec::SettingType::Boolean,
+            .Access       = SettingSpec::SettingAccess::WriteOnly,
+            .Section      = kSectionAppearance,
+            .ApiPath      = "device.clearGlobalColor"
+        }));
 
         #if SHOW_VU_METER
-        settingSpecs.emplace_back(
-            ShowVUMeterTag,
-            "Show VU meter",
-            "Used to show (checked) or hide the VU meter at the top of the matrix.",
-            SettingSpec::SettingType::Boolean,
-            kSectionAppearance, nullptr
-        );
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name         = ShowVUMeterTag,
+            .FriendlyName = "Show VU meter",
+            .Description  = "Used to show (checked) or hide the VU meter at the top of the matrix.",
+            .Type         = SettingSpec::SettingType::Boolean,
+            .Section      = kSectionAppearance
+        }));
         #endif
 
-        settingSpecs.emplace_back(
-            RememberCurrentEffectTag,
-            "Remember current effect",
-            "Indicates if the current effect index should be saved after an effect transition, so the device resumes "
-            "from the same effect when restarted. Enabling this will lead to more wear on the flash chip of your device.",
-            SettingSpec::SettingType::Boolean,
-            kSectionAppearance, "device.rememberCurrentEffect"
-        );
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name         = RememberCurrentEffectTag,
+            .FriendlyName = "Remember current effect",
+            .Description  = "Indicates if the current effect index should be saved after an effect transition, so the device resumes "
+                            "from the same effect when restarted. Enabling this will lead to more wear on the flash chip of your device.",
+            .Type         = SettingSpec::SettingType::Boolean,
+            .Section      = kSectionAppearance,
+            .ApiPath      = "device.rememberCurrentEffect"
+        }));
 
         // ---- topology section ----------------------------------------------
-        settingSpecs.emplace_back(
-            MatrixWidthTag,
-            "Matrix width",
-            "Active matrix width. WS281x builds validate this by total LED capacity, so width * height must stay within the compiled LED budget.",
-            SettingSpec::SettingType::PositiveBigInteger,
-            1.0, (double)GetCompiledLEDCount(),
-            kSectionTopology, "topology.width", /*priority=*/0
-        );
-        settingSpecs.emplace_back(
-            MatrixHeightTag,
-            "Matrix height",
-            "Active matrix height. WS281x builds validate this by total LED capacity, so width * height must stay within the compiled LED budget.",
-            SettingSpec::SettingType::PositiveBigInteger,
-            1.0, (double)GetCompiledLEDCount(),
-            kSectionTopology, "topology.height", /*priority=*/1
-        );
-        settingSpecs.emplace_back(
-            MatrixSerpentineTag,
-            "Serpentine layout",
-            "Controls the logical XY mapping for strip-based matrices. HUB75 ignores this because its panel mapping is build-defined.",
-            SettingSpec::SettingType::Boolean,
-            kSectionTopology, "topology.serpentine", /*priority=*/2
-        );
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name         = MatrixWidthTag,
+            .FriendlyName = "Matrix width",
+            .Description  = "Active matrix width. WS281x builds validate this by total LED capacity, so width * height must stay within the compiled LED budget.",
+            .Type         = SettingSpec::SettingType::PositiveBigInteger,
+            .MinimumValue = 1.0,
+            .MaximumValue = (double)GetCompiledLEDCount(),
+            .Section      = kSectionTopology,
+            .Priority     = 0,
+            .ApiPath      = "topology.width"
+        }));
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name         = MatrixHeightTag,
+            .FriendlyName = "Matrix height",
+            .Description  = "Active matrix height. WS281x builds validate this by total LED capacity, so width * height must stay within the compiled LED budget.",
+            .Type         = SettingSpec::SettingType::PositiveBigInteger,
+            .MinimumValue = 1.0,
+            .MaximumValue = (double)GetCompiledLEDCount(),
+            .Section      = kSectionTopology,
+            .Priority     = 1,
+            .ApiPath      = "topology.height"
+        }));
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name         = MatrixSerpentineTag,
+            .FriendlyName = "Serpentine layout",
+            .Description  = "Controls the logical XY mapping for strip-based matrices. HUB75 ignores this because its panel mapping is build-defined.",
+            .Type         = SettingSpec::SettingType::Boolean,
+            .Section      = kSectionTopology,
+            .Priority     = 2,
+            .ApiPath      = "topology.serpentine"
+        }));
 
         // ---- output section -------------------------------------------------
-        {
-            SettingSpec::FinishGuard spec(settingSpecs.emplace_back(
-                OutputDriverTag,
-                "Output driver",
-                "Runtime-selected driver. If this differs from the firmware's compiled driver, the API reports recompile required.",
-                SettingSpec::SettingType::String,
-                kSectionOutput, "outputs.driver",
-                "outputs.allowedDrivers", /*priority=*/10
-            ));
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name              = OutputDriverTag,
+            .FriendlyName      = "Output driver",
+            .Description       = "Runtime-selected driver. If this differs from the firmware's compiled driver, the API reports recompile required.",
+            .Type              = SettingSpec::SettingType::String,
+            .Section           = kSectionOutput,
+            .Priority          = 10,
+            .ApiPath           = "outputs.driver",
+            .Widget            = SettingSpec::WidgetKind::Select,
             // Friendly labels for the raw driver identifiers the schema exposes.
-            spec->OptionValues = {"ws281x", "hub75"};
-            spec->OptionLabels = {"WS281x", "HUB75"};
-        }
-        {
-            SettingSpec::FinishGuard spec(settingSpecs.emplace_back(
-                WS281xChannelCountTag,
-                "WS281x channel count",
-                "Number of active strip channels within the compiled maximum. Live updates are limited to WS281x builds.",
-                SettingSpec::SettingType::PositiveBigInteger,
-                1.0, (double)GetCompiledChannelCount(),
-                kSectionOutput, "outputs.ws281x.channelCount", /*priority=*/11
-            ));
-            spec->Widget = SettingSpec::WidgetKind::Select;
-            spec->Options = SettingSpec::OptionsSource::SchemaPath;
+            .Options           = SettingSpec::OptionsSource::SchemaPath,
+            .OptionValues      = {"ws281x", "hub75"},
+            .OptionLabels      = {"WS281x", "HUB75"},
+            .OptionsSchemaPath = "outputs.allowedDrivers"
+        }));
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name              = WS281xChannelCountTag,
+            .FriendlyName      = "WS281x channel count",
+            .Description       = "Number of active strip channels within the compiled maximum. Live updates are limited to WS281x builds.",
+            .Type              = SettingSpec::SettingType::PositiveBigInteger,
+            .MinimumValue      = 1.0,
+            .MaximumValue      = (double)GetCompiledChannelCount(),
+            .Section           = kSectionOutput,
+            .Priority          = 11,
+            .ApiPath           = "outputs.ws281x.channelCount",
+            .Widget            = SettingSpec::WidgetKind::Select,
             // Concrete list at outputs.ws281x.allowedChannelCounts in the
             // schema, so the UI doesn't have to derive a range itself.
-            spec->OptionsSchemaPath = "outputs.ws281x.allowedChannelCounts";
-        }
-        settingSpecs.emplace_back(
-            WS281xColorOrderTag,
-            "WS281x color order",
-            "Byte order used when streaming RGB values to WS281x LEDs. This applies live on strip builds and is ignored on HUB75 builds.",
-            SettingSpec::SettingType::String,
-            kSectionOutput, "outputs.ws281x.colorOrder",
-            "outputs.ws281x.allowedColorOrders", /*priority=*/12
-        );
+            .Options           = SettingSpec::OptionsSource::SchemaPath,
+            .OptionsSchemaPath = "outputs.ws281x.allowedChannelCounts"
+        }));
+        settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name              = WS281xColorOrderTag,
+            .FriendlyName      = "WS281x color order",
+            .Description       = "Byte order used when streaming RGB values to WS281x LEDs. This applies live on strip builds and is ignored on HUB75 builds.",
+            .Type              = SettingSpec::SettingType::String,
+            .Section           = kSectionOutput,
+            .Priority          = 12,
+            .ApiPath           = "outputs.ws281x.colorOrder",
+            .Widget            = SettingSpec::WidgetKind::Select,
+            .Options           = SettingSpec::OptionsSource::SchemaPath,
+            .OptionsSchemaPath = "outputs.ws281x.allowedColorOrders"
+        }));
 
         // ---- per-channel pin specs ------------------------------------------
         // ws281xPin{N} specs are synthesized here because all the relevant
@@ -633,16 +669,17 @@ const std::vector<std::reference_wrapper<SettingSpec>>& DeviceConfig::GetSetting
             const auto& descriptionStr = pinSpecStrings.emplace_back(str_sprintf("GPIO assigned to WS281x channel %zu.", i + 1));
             const auto& apiPathStr     = pinSpecStrings.emplace_back(str_sprintf("outputs.ws281x.pins[%zu]", i));
 
-            SettingSpec::FinishGuard guard(settingSpecs.emplace_back());
-            guard->Name         = stableCStr(nameStr);
-            guard->FriendlyName = stableCStr(friendlyStr);
-            guard->Description  = stableCStr(descriptionStr);
-            guard->Type         = SettingSpec::SettingType::Integer;
-            guard->MinimumValue = -1;
-            guard->MaximumValue = 48;
-            guard->Section      = kSectionOutput;
-            guard->Priority     = 3 + static_cast<int>(i);
-            guard->ApiPath      = stableCStr(apiPathStr);
+            settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+                .Name         = stableCStr(nameStr),
+                .FriendlyName = stableCStr(friendlyStr),
+                .Description  = stableCStr(descriptionStr),
+                .Type         = SettingSpec::SettingType::Integer,
+                .MinimumValue = -1.0,
+                .MaximumValue = 48.0,
+                .Section      = kSectionOutput,
+                .Priority     = 3 + static_cast<int>(i),
+                .ApiPath      = stableCStr(apiPathStr)
+            }));
         }
 
         settingSpecReferences.insert(settingSpecReferences.end(), settingSpecs.begin(), settingSpecs.end());

--- a/src/deviceconfig.cpp
+++ b/src/deviceconfig.cpp
@@ -49,7 +49,7 @@ namespace
 {
     constexpr const char* kRecompileNeededMessage = "recompile needed";
 
-    // It's annoying to have to map from the compile-time COLOR_ORDER macro to the 
+    // It's annoying to have to map from the compile-time COLOR_ORDER macro to the
     // runtime enum, but it is what it is.  It's better than tying to a FastLED type.
 
     constexpr DeviceConfig::WS281xColorOrder ToRuntimeColorOrder(EOrder order)
@@ -384,324 +384,265 @@ const std::vector<std::reference_wrapper<SettingSpec>>& DeviceConfig::GetSetting
 
         // ---- system section ------------------------------------------------
         {
-            auto& spec = settingSpecs.emplace_back(
+            SettingSpec::FinishGuard spec(settingSpecs.emplace_back(
                 HostnameTag,
                 "Hostname",
                 "The hostname of the device. A reboot is required after changing this.",
                 SettingSpec::SettingType::String
-            );
-            spec.EmptyAllowed = true;
-            spec.Section = kSectionSystem;
-            spec.RequiresReboot = true;
-            spec.ApiPath = "device.hostname";
+            ));
+            spec->EmptyAllowed = true;
+            spec->Section = kSectionSystem;
+            spec->RequiresReboot = true;
+            spec->ApiPath = "device.hostname";
         }
         {
-            auto& spec = settingSpecs.emplace_back(
+            SettingSpec::FinishGuard spec(settingSpecs.emplace_back(
                 PowerLimitTag,
                 "Power limit",
                 "The maximum power in mW that the matrix attached to the board is allowed to use. As the previous sentence implies, this "
                 "setting only applies if a matrix is used.",
-                SettingSpec::SettingType::Integer
-            );
-            spec.MinimumValue = POWER_LIMIT_MIN;
-            spec.HasValidation = true;
-            spec.Section = kSectionSystem;
-            spec.ApiPath = "device.powerLimit";
+                SettingSpec::SettingType::Integer,
+                kSectionSystem, "device.powerLimit"
+            ));
+            spec->MinimumValue = POWER_LIMIT_MIN;
+            spec->HasValidation = true;
         }
 
         // ---- location section ----------------------------------------------
-        {
-            auto& spec = settingSpecs.emplace_back(
-                LocationTag,
-                "Location",
-                "The location (city or postal code) where the device is located.",
-                SettingSpec::SettingType::String
-            );
-            spec.Section = kSectionLocation;
-            spec.ApiPath = "device.location";
-        }
-        {
-            auto& spec = settingSpecs.emplace_back(
-                LocationIsZipTag,
-                "Location is postal code",
-                "Indicates if the value for the \"Location\" setting is a postal code (yes if checked) or not.",
-                SettingSpec::SettingType::Boolean
-            );
-            spec.Section = kSectionLocation;
-            spec.ApiPath = "device.locationIsZip";
-        }
-        {
-            auto& spec = settingSpecs.emplace_back(
-                CountryCodeTag,
-                "Country code",
-                "The <a href=\"https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2\">ISO 3166-1 alpha-2</a> country "
-                "code for the country that the device is located in.",
-                SettingSpec::SettingType::String
-            );
-            spec.Section = kSectionLocation;
-            spec.ApiPath = "device.countryCode";
-            spec.Widget = SettingSpec::WidgetKind::Select;
-            spec.Options = SettingSpec::OptionsSource::IntlCountryCodes;
-        }
-        {
-            auto& spec = settingSpecs.emplace_back(
-                TimeZoneTag,
-                "Time zone",
-                "The timezone the device resides in, in <a href=\"https://en.wikipedia.org/wiki/Tz_database\">tz database</a> format. "
-                "The list of available timezone identifiers can be found in the <a href=\"/timezones.json\">timezones.json</a> file.",
-                SettingSpec::SettingType::String
-            );
-            spec.Section = kSectionLocation;
-            spec.ApiPath = "device.timeZone";
-            spec.Widget = SettingSpec::WidgetKind::Select;
-            spec.Options = SettingSpec::OptionsSource::ExternalTimeZones;
-            spec.OptionsExternalUrl = "/timezones.json";
-        }
+        settingSpecs.emplace_back(
+            LocationTag,
+            "Location",
+            "The location (city or postal code) where the device is located.",
+            SettingSpec::SettingType::String,
+            kSectionLocation, "device.location"
+        );
+        settingSpecs.emplace_back(
+            LocationIsZipTag,
+            "Location is postal code",
+            "Indicates if the value for the \"Location\" setting is a postal code (yes if checked) or not.",
+            SettingSpec::SettingType::Boolean,
+            kSectionLocation, "device.locationIsZip"
+        );
+        settingSpecs.emplace_back(
+            CountryCodeTag,
+            "Country code",
+            "The <a href=\"https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2\">ISO 3166-1 alpha-2</a> country "
+            "code for the country that the device is located in.",
+            SettingSpec::SettingType::String,
+            kSectionLocation, "device.countryCode",
+            SettingSpec::OptionsSource::IntlCountryCodes
+        );
+        settingSpecs.emplace_back(
+            TimeZoneTag,
+            "Time zone",
+            "The timezone the device resides in, in <a href=\"https://en.wikipedia.org/wiki/Tz_database\">tz database</a> format. "
+            "The list of available timezone identifiers can be found in the <a href=\"/timezones.json\">timezones.json</a> file.",
+            SettingSpec::SettingType::String,
+            kSectionLocation, "device.timeZone",
+            SettingSpec::OptionsSource::ExternalTimeZones, "/timezones.json"
+        );
 
         // ---- clock section -------------------------------------------------
-        {
-            auto& spec = settingSpecs.emplace_back(
-                Use24HourClockTag,
-                "Use 24 hour clock",
-                "Indicates if time should be shown in 24-hour format (yes if checked) or 12-hour AM/PM format.",
-                SettingSpec::SettingType::Boolean
-            );
-            spec.Section = kSectionClock;
-            spec.ApiPath = "device.use24HourClock";
-        }
-        {
-            auto& spec = settingSpecs.emplace_back(
-                UseCelsiusTag,
-                "Use degrees Celsius",
-                "Indicates if temperatures should be shown in degrees Celsius (yes if checked) or degrees Fahrenheit.",
-                SettingSpec::SettingType::Boolean
-            );
-            spec.Section = kSectionClock;
-            spec.ApiPath = "device.useCelsius";
-        }
-        {
-            auto& spec = settingSpecs.emplace_back(
-                NTPServerTag,
-                "NTP server address",
-                "The hostname or IP address of the NTP server to be used for time synchronization.",
-                SettingSpec::SettingType::String
-            );
-            spec.Section = kSectionClock;
-            spec.ApiPath = "device.ntpServer";
-        }
-        {
-            auto& spec = settingSpecs.emplace_back(
-                OpenWeatherApiKeyTag,
-                "Open Weather API key",
-                "The API key for the <a href=\"https://openweathermap.org/api\">Weather API provided by Open Weather Map</a>.",
-                SettingSpec::SettingType::String
-            );
-            spec.HasValidation = true;
-            spec.Access = SettingSpec::SettingAccess::WriteOnly;
-            spec.EmptyAllowed.reset();              // Silently ignore empty value at the front-end
-            spec.Section = kSectionClock;
-            spec.ApiPath = "device.openWeatherApiKey";
-        }
+        settingSpecs.emplace_back(
+            Use24HourClockTag,
+            "Use 24 hour clock",
+            "Indicates if time should be shown in 24-hour format (yes if checked) or 12-hour AM/PM format.",
+            SettingSpec::SettingType::Boolean,
+            kSectionClock, "device.use24HourClock"
+        );
+        settingSpecs.emplace_back(
+            UseCelsiusTag,
+            "Use degrees Celsius",
+            "Indicates if temperatures should be shown in degrees Celsius (yes if checked) or degrees Fahrenheit.",
+            SettingSpec::SettingType::Boolean,
+            kSectionClock, "device.useCelsius"
+        );
+        settingSpecs.emplace_back(
+            NTPServerTag,
+            "NTP server address",
+            "The hostname or IP address of the NTP server to be used for time synchronization.",
+            SettingSpec::SettingType::String,
+            kSectionClock, "device.ntpServer"
+        );
+        settingSpecs.emplace_back(
+            OpenWeatherApiKeyTag,
+            "Open Weather API key",
+            "The API key for the <a href=\"https://openweathermap.org/api\">Weather API provided by Open Weather Map</a>.",
+            SettingSpec::SettingType::String,
+            kSectionClock, "device.openWeatherApiKey",
+            SettingSpec::SettingAccess::WriteOnly, /*hasValidation=*/true
+        );
 
         // ---- audio section -------------------------------------------------
         {
-            auto& spec = settingSpecs.emplace_back(
+            SettingSpec::FinishGuard spec(settingSpecs.emplace_back(
                 AudioInputPinTag,
                 "Audio input pin",
                 "External microphone input pin. This is boot-applied today because the audio task still owns the active DMA/I2S handles once sampling starts.",
                 SettingSpec::SettingType::Integer,
-                -1,
-                48
-            );
-            spec.HasValidation = true;
-            spec.Section = kSectionAudio;
-            spec.RequiresReboot = !SupportsLiveAudioInputReconfigure();
-            spec.ApiPath = "device.audioInputPin";
+                -1, 48,
+                kSectionAudio, "device.audioInputPin"
+            ));
+            spec->HasValidation = true;
+            spec->RequiresReboot = !SupportsLiveAudioInputReconfigure();
         }
 
         // ---- appearance section --------------------------------------------
-        {
-            auto& spec = settingSpecs.emplace_back(
-                BrightnessTag,
-                "Brightness",
-                "Overall brightness the connected LEDs or matrix should be run at.",
-                SettingSpec::SettingType::Slider,
-                BRIGHTNESS_MIN,
-                BRIGHTNESS_MAX
-            );
-            spec.HasValidation = true;
-            spec.Section = kSectionAppearance;
-            spec.ApiPath = "device.brightness";
-            spec.Widget = SettingSpec::WidgetKind::Slider;
+        settingSpecs.emplace_back(
+            BrightnessTag,
+            "Brightness",
+            "Overall brightness the connected LEDs or matrix should be run at.",
+            SettingSpec::SettingType::Integer,
+            kSectionAppearance, "device.brightness",
             // Display as 5..100 percent over the raw 13..255 range. The endpoints
             // mirror what the legacy UI did: clamp at 5% on the low side, 100% at
             // raw max, with linear remapping in between. The UI does the math.
-            spec.DisplayRawMin = 13;
-            spec.DisplayRawMax = BRIGHTNESS_MAX;
-            spec.DisplayMin = 5;
-            spec.DisplayMax = 100;
-            spec.DisplaySuffix = "%";
-        }
-        {
-            auto& spec = settingSpecs.emplace_back(
-                GlobalColorTag,
-                "Global color",
-                "Main color that is applied to all those effects that support using it.",
-                SettingSpec::SettingType::Color
-            );
-            spec.Section = kSectionAppearance;
-            spec.ApiPath = "device.globalColor";
-        }
-        {
-            auto& spec = settingSpecs.emplace_back(
-                SecondColorTag,
-                "Second color",
-                "Second color that is used to create a global palette in combination with the current global color. That palette is used "
-                "by some effects. Defaults to the <em>previous</em> global color if not explicitly set.",
-                SettingSpec::SettingType::Color
-            );
-            spec.Section = kSectionAppearance;
-            spec.ApiPath = "device.secondColor";
-        }
-        {
-            auto& spec = settingSpecs.emplace_back(
-                ApplyGlobalColorsTag,
-                "(Re)apply global color",
-                "You can use this to \"reselect\" and apply the current global color, to force the composition of the derived "
-                "global palette. This checkbox is ignored if the \"Clear global color\" checkbox is selected.",
-                SettingSpec::SettingType::Boolean
-            );
-            spec.Access = SettingSpec::SettingAccess::WriteOnly;
-            spec.Section = kSectionAppearance;
-            spec.ApiPath = "device.applyGlobalColors";
-        }
-        {
-            auto& spec = settingSpecs.emplace_back(
-                ClearGlobalColorTag,
-                "Clear global color",
-                "Stop applying the global color/derived palette. This takes precedence over the \"(Re)apply global color\" checkbox.",
-                SettingSpec::SettingType::Boolean
-            );
-            spec.Access = SettingSpec::SettingAccess::WriteOnly;
-            spec.Section = kSectionAppearance;
-            spec.ApiPath = "device.clearGlobalColor";
-        }
+            (double)BRIGHTNESS_MIN, (double)BRIGHTNESS_MAX, 5.0, 100.0, "%", /*hasValidation=*/true
+        );
+        settingSpecs.emplace_back(
+            GlobalColorTag,
+            "Global color",
+            "Main color that is applied to all those effects that support using it.",
+            SettingSpec::SettingType::Color,
+            kSectionAppearance, "device.globalColor"
+        );
+        settingSpecs.emplace_back(
+            SecondColorTag,
+            "Second color",
+            "Second color that is used to create a global palette in combination with the current global color. That palette is used "
+            "by some effects. Defaults to the <em>previous</em> global color if not explicitly set.",
+            SettingSpec::SettingType::Color,
+            kSectionAppearance, "device.secondColor"
+        );
+        settingSpecs.emplace_back(
+            ApplyGlobalColorsTag,
+            "(Re)apply global color",
+            "You can use this to \"reselect\" and apply the current global color, to force the composition of the derived "
+            "global palette. This checkbox is ignored if the \"Clear global color\" checkbox is selected.",
+            SettingSpec::SettingType::Boolean,
+            kSectionAppearance, "device.applyGlobalColors",
+            SettingSpec::SettingAccess::WriteOnly
+        );
+        settingSpecs.emplace_back(
+            ClearGlobalColorTag,
+            "Clear global color",
+            "Stop applying the global color/derived palette. This takes precedence over the \"(Re)apply global color\" checkbox.",
+            SettingSpec::SettingType::Boolean,
+            kSectionAppearance, "device.clearGlobalColor",
+            SettingSpec::SettingAccess::WriteOnly
+        );
 
         #if SHOW_VU_METER
-        {
-            auto& spec = settingSpecs.emplace_back(
-                ShowVUMeterTag,
-                "Show VU meter",
-                "Used to show (checked) or hide the VU meter at the top of the matrix.",
-                SettingSpec::SettingType::Boolean
-            );
-            spec.Section = kSectionAppearance;
-        }
+        settingSpecs.emplace_back(
+            ShowVUMeterTag,
+            "Show VU meter",
+            "Used to show (checked) or hide the VU meter at the top of the matrix.",
+            SettingSpec::SettingType::Boolean,
+            kSectionAppearance, nullptr
+        );
         #endif
 
-        {
-            auto& spec = settingSpecs.emplace_back(
-                RememberCurrentEffectTag,
-                "Remember current effect",
-                "Indicates if the current effect index should be saved after an effect transition, so the device resumes "
-                "from the same effect when restarted. Enabling this will lead to more wear on the flash chip of your device.",
-                SettingSpec::SettingType::Boolean
-            );
-            spec.Section = kSectionAppearance;
-            spec.ApiPath = "device.rememberCurrentEffect";
-        }
+        settingSpecs.emplace_back(
+            RememberCurrentEffectTag,
+            "Remember current effect",
+            "Indicates if the current effect index should be saved after an effect transition, so the device resumes "
+            "from the same effect when restarted. Enabling this will lead to more wear on the flash chip of your device.",
+            SettingSpec::SettingType::Boolean,
+            kSectionAppearance, "device.rememberCurrentEffect"
+        );
 
         // ---- topology section ----------------------------------------------
-        {
-            auto& spec = settingSpecs.emplace_back(
-                MatrixWidthTag,
-                "Matrix width",
-                "Active matrix width. WS281x builds validate this by total LED capacity, so width * height must stay within the compiled LED budget.",
-                SettingSpec::SettingType::PositiveBigInteger,
-                1,
-                GetCompiledLEDCount()
-            );
-            spec.Section = kSectionTopology;
-            spec.Priority = 0;
-            spec.ApiPath = "topology.width";
-        }
-        {
-            auto& spec = settingSpecs.emplace_back(
-                MatrixHeightTag,
-                "Matrix height",
-                "Active matrix height. WS281x builds validate this by total LED capacity, so width * height must stay within the compiled LED budget.",
-                SettingSpec::SettingType::PositiveBigInteger,
-                1,
-                GetCompiledLEDCount()
-            );
-            spec.Section = kSectionTopology;
-            spec.Priority = 1;
-            spec.ApiPath = "topology.height";
-        }
-        {
-            auto& spec = settingSpecs.emplace_back(
-                MatrixSerpentineTag,
-                "Serpentine layout",
-                "Controls the logical XY mapping for strip-based matrices. HUB75 ignores this because its panel mapping is build-defined.",
-                SettingSpec::SettingType::Boolean
-            );
-            spec.Section = kSectionTopology;
-            spec.Priority = 2;
-            spec.ApiPath = "topology.serpentine";
-        }
+        settingSpecs.emplace_back(
+            MatrixWidthTag,
+            "Matrix width",
+            "Active matrix width. WS281x builds validate this by total LED capacity, so width * height must stay within the compiled LED budget.",
+            SettingSpec::SettingType::PositiveBigInteger,
+            1.0, (double)GetCompiledLEDCount(),
+            kSectionTopology, "topology.width", /*priority=*/0
+        );
+        settingSpecs.emplace_back(
+            MatrixHeightTag,
+            "Matrix height",
+            "Active matrix height. WS281x builds validate this by total LED capacity, so width * height must stay within the compiled LED budget.",
+            SettingSpec::SettingType::PositiveBigInteger,
+            1.0, (double)GetCompiledLEDCount(),
+            kSectionTopology, "topology.height", /*priority=*/1
+        );
+        settingSpecs.emplace_back(
+            MatrixSerpentineTag,
+            "Serpentine layout",
+            "Controls the logical XY mapping for strip-based matrices. HUB75 ignores this because its panel mapping is build-defined.",
+            SettingSpec::SettingType::Boolean,
+            kSectionTopology, "topology.serpentine", /*priority=*/2
+        );
 
         // ---- output section -------------------------------------------------
-        // ws281xPin{N} synthetic specs are emitted at HTTP-response time by
-        // CWebServer::SendSettingSpecsResponse() because their count depends
-        // on the compiled channel maximum and they're not stored individually
-        // in DeviceConfig. They get section "output" and Priority 3 + index.
         {
-            auto& spec = settingSpecs.emplace_back(
+            SettingSpec::FinishGuard spec(settingSpecs.emplace_back(
                 OutputDriverTag,
                 "Output driver",
                 "Runtime-selected driver. If this differs from the firmware's compiled driver, the API reports recompile required.",
-                SettingSpec::SettingType::String
-            );
-            spec.Section = kSectionOutput;
-            spec.Priority = 10;
-            spec.ApiPath = "outputs.driver";
-            spec.Widget = SettingSpec::WidgetKind::Select;
-            spec.Options = SettingSpec::OptionsSource::SchemaPath;
-            spec.OptionsSchemaPath = "outputs.allowedDrivers";
+                SettingSpec::SettingType::String,
+                kSectionOutput, "outputs.driver",
+                "outputs.allowedDrivers", /*priority=*/10
+            ));
             // Friendly labels for the raw driver identifiers the schema exposes.
-            spec.OptionLabelMapJson = R"({"ws281x":"WS281x","hub75":"HUB75"})";
+            spec->OptionValues = {"ws281x", "hub75"};
+            spec->OptionLabels = {"WS281x", "HUB75"};
         }
         {
-            auto& spec = settingSpecs.emplace_back(
+            SettingSpec::FinishGuard spec(settingSpecs.emplace_back(
                 WS281xChannelCountTag,
                 "WS281x channel count",
                 "Number of active strip channels within the compiled maximum. Live updates are limited to WS281x builds.",
                 SettingSpec::SettingType::PositiveBigInteger,
-                1,
-                GetCompiledChannelCount()
-            );
-            spec.Section = kSectionOutput;
-            spec.Priority = 11;
-            spec.ApiPath = "outputs.ws281x.channelCount";
-            spec.Widget = SettingSpec::WidgetKind::Select;
-            spec.Options = SettingSpec::OptionsSource::SchemaPath;
+                1.0, (double)GetCompiledChannelCount(),
+                kSectionOutput, "outputs.ws281x.channelCount", /*priority=*/11
+            ));
+            spec->Widget = SettingSpec::WidgetKind::Select;
+            spec->Options = SettingSpec::OptionsSource::SchemaPath;
             // Concrete list at outputs.ws281x.allowedChannelCounts in the
             // schema, so the UI doesn't have to derive a range itself.
-            spec.OptionsSchemaPath = "outputs.ws281x.allowedChannelCounts";
+            spec->OptionsSchemaPath = "outputs.ws281x.allowedChannelCounts";
         }
+        settingSpecs.emplace_back(
+            WS281xColorOrderTag,
+            "WS281x color order",
+            "Byte order used when streaming RGB values to WS281x LEDs. This applies live on strip builds and is ignored on HUB75 builds.",
+            SettingSpec::SettingType::String,
+            kSectionOutput, "outputs.ws281x.colorOrder",
+            "outputs.ws281x.allowedColorOrders", /*priority=*/12
+        );
+
+        // ---- per-channel pin specs ------------------------------------------
+        // ws281xPin{N} specs are synthesized here because all the relevant
+        // details (channel count, naming convention, apiPath format, priority
+        // range) are DeviceConfig internals.
+        // pinSpecStrings holds the String backing; settingSpecs owns the specs.
+        // Both are sized up front so no reallocation can invalidate pointers.
+        constexpr size_t kPinStringsPerChannel = 4; // name, friendly, description, apiPath
+        const auto compiledChannelCount = GetCompiledChannelCount();
+        settingSpecs.reserve(settingSpecs.size() + compiledChannelCount);
+        pinSpecStrings.reserve(compiledChannelCount * kPinStringsPerChannel);
+        const auto stableCStr = [](const String& s) { return s.c_str(); };
+
+        for (size_t i = 0; i < compiledChannelCount; ++i)
         {
-            auto& spec = settingSpecs.emplace_back(
-                WS281xColorOrderTag,
-                "WS281x color order",
-                "Byte order used when streaming RGB values to WS281x LEDs. This applies live on strip builds and is ignored on HUB75 builds.",
-                SettingSpec::SettingType::String
-            );
-            spec.Section = kSectionOutput;
-            spec.Priority = 12;
-            spec.ApiPath = "outputs.ws281x.colorOrder";
-            spec.Widget = SettingSpec::WidgetKind::Select;
-            spec.Options = SettingSpec::OptionsSource::SchemaPath;
-            spec.OptionsSchemaPath = "outputs.ws281x.allowedColorOrders";
+            const auto& nameStr        = pinSpecStrings.emplace_back(str_sprintf("ws281xPin%zu", i));
+            const auto& friendlyStr    = pinSpecStrings.emplace_back(str_sprintf("WS281x pin %zu", i + 1));
+            const auto& descriptionStr = pinSpecStrings.emplace_back(str_sprintf("GPIO assigned to WS281x channel %zu.", i + 1));
+            const auto& apiPathStr     = pinSpecStrings.emplace_back(str_sprintf("outputs.ws281x.pins[%zu]", i));
+
+            SettingSpec::FinishGuard guard(settingSpecs.emplace_back());
+            guard->Name         = stableCStr(nameStr);
+            guard->FriendlyName = stableCStr(friendlyStr);
+            guard->Description  = stableCStr(descriptionStr);
+            guard->Type         = SettingSpec::SettingType::Integer;
+            guard->MinimumValue = -1;
+            guard->MaximumValue = 48;
+            guard->Section      = kSectionOutput;
+            guard->Priority     = 3 + static_cast<int>(i);
+            guard->ApiPath      = stableCStr(apiPathStr);
         }
 
         settingSpecReferences.insert(settingSpecReferences.end(), settingSpecs.begin(), settingSpecs.end());

--- a/src/ledstripeffect.cpp
+++ b/src/ledstripeffect.cpp
@@ -59,35 +59,33 @@ void LEDStripEffect::FillBaseSettingSpecs()
 
     // ...otherwise, create and add them
 
-    _baseSettingSpecs.emplace_back(
-        ACTUAL_NAME_OF(_friendlyName),
-        "Friendly name",
-        "The friendly name of the effect, as shown in the web UI and/or on the matrix.",
-        SettingSpec::SettingType::String
-    );
-    _baseSettingSpecs.emplace_back(
-        ACTUAL_NAME_OF(_maximumEffectTime),
-        "Maximum effect time",
-        "The maximum time in ms that the effect is shown per effect rotation. This duration is only applied if it's "
-        "shorter than the default effect interval. A value of 0 means no maximum effect time is set.",
-        SettingSpec::SettingType::PositiveBigInteger
-    );
-    _baseSettingSpecs.emplace_back(
-        "hasMaximumEffectTime",
-        "Has maximum effect time set",
-        "Indicates if the effect has a maximum effect time set.",
-        SettingSpec::SettingType::Boolean,
-        /*section=*/nullptr, /*apiPath=*/nullptr,
-        SettingSpec::SettingAccess::ReadOnly
-    );
-    _baseSettingSpecs.emplace_back(
-        "clearMaximumEffectTime",
-        "Clear maximum effect time",
-        "Clear maximum effect time. Set to true to reset the maximum effect time to the default value.",
-        SettingSpec::SettingType::Boolean,
-        /*section=*/nullptr, /*apiPath=*/nullptr,
-        SettingSpec::SettingAccess::WriteOnly
-    );
+    _baseSettingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+        .Name         = ACTUAL_NAME_OF(_friendlyName),
+        .FriendlyName = "Friendly name",
+        .Description  = "The friendly name of the effect, as shown in the web UI and/or on the matrix.",
+        .Type         = SettingSpec::SettingType::String
+    }));
+    _baseSettingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+        .Name         = ACTUAL_NAME_OF(_maximumEffectTime),
+        .FriendlyName = "Maximum effect time",
+        .Description  = "The maximum time in ms that the effect is shown per effect rotation. This duration is only applied if it's "
+                        "shorter than the default effect interval. A value of 0 means no maximum effect time is set.",
+        .Type         = SettingSpec::SettingType::PositiveBigInteger
+    }));
+    _baseSettingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+        .Name         = "hasMaximumEffectTime",
+        .FriendlyName = "Has maximum effect time set",
+        .Description  = "Indicates if the effect has a maximum effect time set.",
+        .Type         = SettingSpec::SettingType::Boolean,
+        .Access       = SettingSpec::SettingAccess::ReadOnly
+    }));
+    _baseSettingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+        .Name         = "clearMaximumEffectTime",
+        .FriendlyName = "Clear maximum effect time",
+        .Description  = "Clear maximum effect time. Set to true to reset the maximum effect time to the default value.",
+        .Type         = SettingSpec::SettingType::Boolean,
+        .Access       = SettingSpec::SettingAccess::WriteOnly
+    }));
 }
 
 // LEDStripEffect

--- a/src/ledstripeffect.cpp
+++ b/src/ledstripeffect.cpp
@@ -76,14 +76,18 @@ void LEDStripEffect::FillBaseSettingSpecs()
         "hasMaximumEffectTime",
         "Has maximum effect time set",
         "Indicates if the effect has a maximum effect time set.",
-        SettingSpec::SettingType::Boolean
-    ).Access = SettingSpec::SettingAccess::ReadOnly;
+        SettingSpec::SettingType::Boolean,
+        /*section=*/nullptr, /*apiPath=*/nullptr,
+        SettingSpec::SettingAccess::ReadOnly
+    );
     _baseSettingSpecs.emplace_back(
         "clearMaximumEffectTime",
         "Clear maximum effect time",
         "Clear maximum effect time. Set to true to reset the maximum effect time to the default value.",
-        SettingSpec::SettingType::Boolean
-    ).Access = SettingSpec::SettingAccess::WriteOnly;
+        SettingSpec::SettingType::Boolean,
+        /*section=*/nullptr, /*apiPath=*/nullptr,
+        SettingSpec::SettingAccess::WriteOnly
+    );
 }
 
 // LEDStripEffect

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -102,15 +102,40 @@ double CAppTime::LastFrameTime() const
 // allows itself to be called from the outside as well.
 void SettingSpec::FinishAndValidateInitialization()
 {
-    // Default to front-end rejection of empty Strings
-    if (Type == SettingType::String)
+    // Default to front-end rejection of empty Strings, but only if the caller hasn't already
+    // set EmptyAllowed explicitly (so FinishGuard re-runs don't clobber an intentional override)
+    if (Type == SettingType::String && !EmptyAllowed.has_value())
         EmptyAllowed = false;
-    else
-        // Check that both min and max value are set for Slider
-        assert(Type != SettingType::Slider || (MinimumValue.has_value() && MaximumValue.has_value()));
 
     // If min and max value are both set, min must be less or equal than max
     assert(!(MinimumValue.has_value() && MaximumValue.has_value()) || MinimumValue.value() <= MaximumValue.value());
+
+    // For Slider widgets, display scale members must all be set or all be unset
+    assert(Widget != WidgetKind::Slider || (DisplayRawMin.has_value() == DisplayRawMax.has_value() &&
+           DisplayRawMin.has_value() == DisplayMin.has_value() &&
+           DisplayRawMin.has_value() == DisplayMax.has_value()));
+
+    // For Select widgets, validate options source-specific requirements
+    if (Widget == WidgetKind::Select)
+    {
+        // For Inline select options, labels must be empty or match the number of values
+        assert(Options != OptionsSource::Inline ||
+               OptionLabels.empty() || OptionLabels.size() == OptionValues.size());
+
+        // For SchemaPath select options, OptionsSchemaPath must be set, and
+        // any label overrides must be provided as matched pairs (both non-empty, same length)
+        assert(Options != OptionsSource::SchemaPath || OptionsSchemaPath != nullptr);
+        assert(Options != OptionsSource::SchemaPath ||
+               (OptionValues.empty() == OptionLabels.empty() &&
+                (OptionValues.empty() || OptionValues.size() == OptionLabels.size())));
+
+        // For ExternalTimeZones select options, OptionsExternalUrl must be set, and
+        // any label overrides must be provided as matched pairs (both non-empty, same length)
+        assert(Options != OptionsSource::ExternalTimeZones || OptionsExternalUrl != nullptr);
+        assert(Options != OptionsSource::ExternalTimeZones ||
+               (OptionValues.empty() == OptionLabels.empty() &&
+                (OptionValues.empty() || OptionValues.size() == OptionLabels.size())));
+    }
 }
 
 SettingSpec::SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type)
@@ -142,6 +167,141 @@ SettingSpec::SettingSpec(const char* name, const char* friendlyName, SettingType
     : SettingSpec(name, friendlyName, nullptr, type, min, max)
 {}
 
+// Constructor A: basic positioned spec (section + apiPath, optional priority)
+SettingSpec::SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
+                         const char* section, const char* apiPath, std::optional<int> priority)
+    : Name(name),
+    FriendlyName(friendlyName),
+    Description(description),
+    Type(type),
+    Section(section),
+    Priority(priority),
+    ApiPath(apiPath)
+{
+    FinishAndValidateInitialization();
+}
+
+SettingSpec::SettingSpec(const char* name, const char* friendlyName, SettingType type,
+                         const char* section, const char* apiPath, std::optional<int> priority)
+    : SettingSpec(name, friendlyName, nullptr, type, section, apiPath, priority)
+{}
+
+// Constructor B: positioned spec with non-default access and optional hasValidation
+SettingSpec::SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
+                         const char* section, const char* apiPath, SettingAccess access, bool hasValidation)
+    : Name(name),
+    FriendlyName(friendlyName),
+    Description(description),
+    Type(type),
+    HasValidation(hasValidation),
+    Access(access),
+    Section(section),
+    ApiPath(apiPath)
+{
+    FinishAndValidateInitialization();
+}
+
+SettingSpec::SettingSpec(const char* name, const char* friendlyName, SettingType type,
+                         const char* section, const char* apiPath, SettingAccess access, bool hasValidation)
+    : SettingSpec(name, friendlyName, nullptr, type, section, apiPath, access, hasValidation)
+{}
+
+// Constructor C: positioned spec with min/max range
+SettingSpec::SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
+                         double min, double max, const char* section, const char* apiPath, std::optional<int> priority)
+    : Name(name),
+    FriendlyName(friendlyName),
+    Description(description),
+    Type(type),
+    MinimumValue(min),
+    MaximumValue(max),
+    Section(section),
+    Priority(priority),
+    ApiPath(apiPath)
+{
+    FinishAndValidateInitialization();
+}
+
+SettingSpec::SettingSpec(const char* name, const char* friendlyName, SettingType type,
+                         double min, double max, const char* section, const char* apiPath, std::optional<int> priority)
+    : SettingSpec(name, friendlyName, nullptr, type, min, max, section, apiPath, priority)
+{}
+
+// Constructor D: positioned SchemaPath Select widget
+SettingSpec::SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
+                         const char* section, const char* apiPath, const char* optionsSchemaPath, std::optional<int> priority)
+    : Name(name),
+    FriendlyName(friendlyName),
+    Description(description),
+    Type(type),
+    Section(section),
+    Priority(priority),
+    ApiPath(apiPath),
+    Widget(WidgetKind::Select),
+    Options(OptionsSource::SchemaPath),
+    OptionsSchemaPath(optionsSchemaPath)
+{
+    FinishAndValidateInitialization();
+}
+
+SettingSpec::SettingSpec(const char* name, const char* friendlyName, SettingType type,
+                         const char* section, const char* apiPath, const char* optionsSchemaPath, std::optional<int> priority)
+    : SettingSpec(name, friendlyName, nullptr, type, section, apiPath, optionsSchemaPath, priority)
+{}
+
+// Constructor E: positioned Select widget with non-Inline source
+SettingSpec::SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
+                         const char* section, const char* apiPath, OptionsSource optionsSource,
+                         const char* optionsExternalUrl)
+    : Name(name),
+    FriendlyName(friendlyName),
+    Description(description),
+    Type(type),
+    Section(section),
+    ApiPath(apiPath),
+    Widget(WidgetKind::Select),
+    Options(optionsSource),
+    OptionsExternalUrl(optionsExternalUrl)
+{
+    FinishAndValidateInitialization();
+}
+
+SettingSpec::SettingSpec(const char* name, const char* friendlyName, SettingType type,
+                         const char* section, const char* apiPath, OptionsSource optionsSource,
+                         const char* optionsExternalUrl)
+    : SettingSpec(name, friendlyName, nullptr, type, section, apiPath, optionsSource, optionsExternalUrl)
+{}
+
+// Constructor F: positioned Slider widget with display scale
+SettingSpec::SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
+                         const char* section, const char* apiPath,
+                         double displayRawMin, double displayRawMax, double displayMin, double displayMax,
+                         const char* displaySuffix, bool hasValidation)
+    : Name(name),
+    FriendlyName(friendlyName),
+    Description(description),
+    Type(type),
+    HasValidation(hasValidation),
+    Section(section),
+    ApiPath(apiPath),
+    Widget(WidgetKind::Slider),
+    DisplayRawMin(displayRawMin),
+    DisplayRawMax(displayRawMax),
+    DisplayMin(displayMin),
+    DisplayMax(displayMax),
+    DisplaySuffix(displaySuffix)
+{
+    FinishAndValidateInitialization();
+}
+
+SettingSpec::SettingSpec(const char* name, const char* friendlyName, SettingType type,
+                         const char* section, const char* apiPath,
+                         double displayRawMin, double displayRawMax, double displayMin, double displayMax,
+                         const char* displaySuffix, bool hasValidation)
+    : SettingSpec(name, friendlyName, nullptr, type, section, apiPath,
+                  displayRawMin, displayRawMax, displayMin, displayMax, displaySuffix, hasValidation)
+{}
+
 String SettingSpec::TypeName() const
 {
     switch (Type)
@@ -153,7 +313,6 @@ String SettingSpec::TypeName() const
         case SettingType::String:               return "String";
         case SettingType::Palette:              return "Palette";
         case SettingType::Color:                return "Color";
-        case SettingType::Slider:               return "Slider";
         default:                                return "Unknown";
     }
 }
@@ -165,8 +324,6 @@ const char* SettingSpec::WidgetName() const
         case WidgetKind::Slider:           return "slider";
         case WidgetKind::Select:           return "select";
         case WidgetKind::IntervalToggle:   return "intervalToggle";
-        case WidgetKind::Color:            return "color";
-        case WidgetKind::Default:          return "default";
         default:                           return "default";
     }
 }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -96,14 +96,12 @@ double CAppTime::LastFrameTime() const
     return _deltaTime;
 }
 
-// Finishes the initialization of the spec, and then validates the consistency of its overall contents.
-// Note that it does the latter quite rudely: it uses assert() on things it feels should be in order.
-// This function is called by this struct's constructors that initialize values, but this being a struct
-// allows itself to be called from the outside as well.
+// Validates the consistency of the spec's contents after all fields have been assigned.
+// Called by Construct(); can also be called directly if needed.
 void SettingSpec::FinishAndValidateInitialization()
 {
     // Default to front-end rejection of empty Strings, but only if the caller hasn't already
-    // set EmptyAllowed explicitly (so FinishGuard re-runs don't clobber an intentional override)
+    // set EmptyAllowed explicitly.
     if (Type == SettingType::String && !EmptyAllowed.has_value())
         EmptyAllowed = false;
 
@@ -138,169 +136,11 @@ void SettingSpec::FinishAndValidateInitialization()
     }
 }
 
-SettingSpec::SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type)
-    : Name(name),
-    FriendlyName(friendlyName),
-    Description(description),
-    Type(type)
+SettingSpec SettingSpec::Validate(SettingSpec spec)
 {
-    FinishAndValidateInitialization();
+    spec.FinishAndValidateInitialization();
+    return spec;
 }
-
-SettingSpec::SettingSpec(const char* name, const char* friendlyName, SettingType type) : SettingSpec(name, friendlyName, nullptr, type)
-{}
-
-// Constructor that sets both minimum and maximum values
-SettingSpec::SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type, double min, double max)
-    : Name(name),
-    FriendlyName(friendlyName),
-    Description(description),
-    Type(type),
-    MinimumValue(min),
-    MaximumValue(max)
-{
-    FinishAndValidateInitialization();
-}
-
-// Constructor that sets both minimum and maximum values
-SettingSpec::SettingSpec(const char* name, const char* friendlyName, SettingType type, double min, double max)
-    : SettingSpec(name, friendlyName, nullptr, type, min, max)
-{}
-
-// Constructor A: basic positioned spec (section + apiPath, optional priority)
-SettingSpec::SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
-                         const char* section, const char* apiPath, std::optional<int> priority)
-    : Name(name),
-    FriendlyName(friendlyName),
-    Description(description),
-    Type(type),
-    Section(section),
-    Priority(priority),
-    ApiPath(apiPath)
-{
-    FinishAndValidateInitialization();
-}
-
-SettingSpec::SettingSpec(const char* name, const char* friendlyName, SettingType type,
-                         const char* section, const char* apiPath, std::optional<int> priority)
-    : SettingSpec(name, friendlyName, nullptr, type, section, apiPath, priority)
-{}
-
-// Constructor B: positioned spec with non-default access and optional hasValidation
-SettingSpec::SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
-                         const char* section, const char* apiPath, SettingAccess access, bool hasValidation)
-    : Name(name),
-    FriendlyName(friendlyName),
-    Description(description),
-    Type(type),
-    HasValidation(hasValidation),
-    Access(access),
-    Section(section),
-    ApiPath(apiPath)
-{
-    FinishAndValidateInitialization();
-}
-
-SettingSpec::SettingSpec(const char* name, const char* friendlyName, SettingType type,
-                         const char* section, const char* apiPath, SettingAccess access, bool hasValidation)
-    : SettingSpec(name, friendlyName, nullptr, type, section, apiPath, access, hasValidation)
-{}
-
-// Constructor C: positioned spec with min/max range
-SettingSpec::SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
-                         double min, double max, const char* section, const char* apiPath, std::optional<int> priority)
-    : Name(name),
-    FriendlyName(friendlyName),
-    Description(description),
-    Type(type),
-    MinimumValue(min),
-    MaximumValue(max),
-    Section(section),
-    Priority(priority),
-    ApiPath(apiPath)
-{
-    FinishAndValidateInitialization();
-}
-
-SettingSpec::SettingSpec(const char* name, const char* friendlyName, SettingType type,
-                         double min, double max, const char* section, const char* apiPath, std::optional<int> priority)
-    : SettingSpec(name, friendlyName, nullptr, type, min, max, section, apiPath, priority)
-{}
-
-// Constructor D: positioned SchemaPath Select widget
-SettingSpec::SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
-                         const char* section, const char* apiPath, const char* optionsSchemaPath, std::optional<int> priority)
-    : Name(name),
-    FriendlyName(friendlyName),
-    Description(description),
-    Type(type),
-    Section(section),
-    Priority(priority),
-    ApiPath(apiPath),
-    Widget(WidgetKind::Select),
-    Options(OptionsSource::SchemaPath),
-    OptionsSchemaPath(optionsSchemaPath)
-{
-    FinishAndValidateInitialization();
-}
-
-SettingSpec::SettingSpec(const char* name, const char* friendlyName, SettingType type,
-                         const char* section, const char* apiPath, const char* optionsSchemaPath, std::optional<int> priority)
-    : SettingSpec(name, friendlyName, nullptr, type, section, apiPath, optionsSchemaPath, priority)
-{}
-
-// Constructor E: positioned Select widget with non-Inline source
-SettingSpec::SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
-                         const char* section, const char* apiPath, OptionsSource optionsSource,
-                         const char* optionsExternalUrl)
-    : Name(name),
-    FriendlyName(friendlyName),
-    Description(description),
-    Type(type),
-    Section(section),
-    ApiPath(apiPath),
-    Widget(WidgetKind::Select),
-    Options(optionsSource),
-    OptionsExternalUrl(optionsExternalUrl)
-{
-    FinishAndValidateInitialization();
-}
-
-SettingSpec::SettingSpec(const char* name, const char* friendlyName, SettingType type,
-                         const char* section, const char* apiPath, OptionsSource optionsSource,
-                         const char* optionsExternalUrl)
-    : SettingSpec(name, friendlyName, nullptr, type, section, apiPath, optionsSource, optionsExternalUrl)
-{}
-
-// Constructor F: positioned Slider widget with display scale
-SettingSpec::SettingSpec(const char* name, const char* friendlyName, const char* description, SettingType type,
-                         const char* section, const char* apiPath,
-                         double displayRawMin, double displayRawMax, double displayMin, double displayMax,
-                         const char* displaySuffix, bool hasValidation)
-    : Name(name),
-    FriendlyName(friendlyName),
-    Description(description),
-    Type(type),
-    HasValidation(hasValidation),
-    Section(section),
-    ApiPath(apiPath),
-    Widget(WidgetKind::Slider),
-    DisplayRawMin(displayRawMin),
-    DisplayRawMax(displayRawMax),
-    DisplayMin(displayMin),
-    DisplayMax(displayMax),
-    DisplaySuffix(displaySuffix)
-{
-    FinishAndValidateInitialization();
-}
-
-SettingSpec::SettingSpec(const char* name, const char* friendlyName, SettingType type,
-                         const char* section, const char* apiPath,
-                         double displayRawMin, double displayRawMax, double displayMin, double displayMax,
-                         const char* displaySuffix, bool hasValidation)
-    : SettingSpec(name, friendlyName, nullptr, type, section, apiPath,
-                  displayRawMin, displayRawMax, displayMin, displayMax, displaySuffix, hasValidation)
-{}
 
 String SettingSpec::TypeName() const
 {

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -824,22 +824,20 @@ const std::vector<std::reference_wrapper<SettingSpec>> & CWebServer::LoadDeviceS
         // so its spec is owned here. The Widget metadata mirrors the legacy
         // composite "Rotate effects toggle + seconds input" UX in a way the
         // front-end can render generically.
-        {
-            SettingSpec::FinishGuard spec(mySettingSpecs.emplace_back(
-                "effectInterval",
-                "Effect interval",
-                "The duration in milliseconds that an individual effect runs, before the next effect is activated. "
-                "Disable rotation to keep the current effect active indefinitely.",
-                SettingSpec::SettingType::PositiveBigInteger
-            ));
-            spec->Section = "appearance";
-            spec->ApiPath = "effects.effectInterval";
-            spec->Widget = SettingSpec::WidgetKind::IntervalToggle;
-            spec->IntervalUnitDivisor = 1000;
-            spec->IntervalUnitLabel = "seconds";
-            spec->IntervalOnLabel  = "Rotate effects";
-            spec->IntervalOffLabel = "Off";
-        }
+        mySettingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+            .Name                = "effectInterval",
+            .FriendlyName        = "Effect interval",
+            .Description         = "The duration in milliseconds that an individual effect runs, before the next effect is activated. "
+                                   "Disable rotation to keep the current effect active indefinitely.",
+            .Type                = SettingSpec::SettingType::PositiveBigInteger,
+            .Section             = "appearance",
+            .ApiPath             = "effects.effectInterval",
+            .Widget              = SettingSpec::WidgetKind::IntervalToggle,
+            .IntervalUnitDivisor = 1000,
+            .IntervalOnLabel     = "Rotate effects",
+            .IntervalOffLabel    = "Off",
+            .IntervalUnitLabel   = "seconds"
+        }));
 
         deviceSettingSpecs.insert(deviceSettingSpecs.end(), mySettingSpecs.begin(), mySettingSpecs.end());
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -227,7 +227,7 @@ namespace
     // The API currently accepts both the legacy flat device.audioInputPin field
     // and the nested device.audio.inputPin field, so validation/apply can consume
     // one resolved value instead of duplicating that lookup logic.
-    
+
     std::optional<int> GetRequestedUnifiedAudioInputPin(JsonObjectConst device)
     {
         std::optional<int> requestedAudioInputPin;
@@ -297,8 +297,6 @@ const std::map<String, CWebServer::ValueValidator> CWebServer::settingValidators
 
 std::vector<SettingSpec, psram_allocator<SettingSpec>> CWebServer::mySettingSpecs = {};
 std::vector<std::reference_wrapper<SettingSpec>> CWebServer::deviceSettingSpecs{};
-std::vector<SettingSpec, psram_allocator<SettingSpec>> CWebServer::synthesizedPinSpecs{};
-std::vector<String> CWebServer::synthesizedPinSpecStrings{};
 
 // Member function template specializations
 
@@ -755,8 +753,7 @@ void CWebServer::SendSettingSpecsResponse(AsyncWebServerRequest * pRequest, cons
             widget["kind"] = spec.WidgetName();
 
             if (spec.Widget == SettingSpec::WidgetKind::Slider
-                && spec.DisplayRawMin.has_value() && spec.DisplayRawMax.has_value()
-                && spec.DisplayMin.has_value()    && spec.DisplayMax.has_value())
+                && spec.DisplayRawMin.has_value()) // Presence of other Display members is validated at SettingSpec construction
             {
                 auto scale = widget["displayScale"].to<JsonObject>();
                 scale["rawMin"]     = spec.DisplayRawMin.value();
@@ -782,36 +779,29 @@ void CWebServer::SendSettingSpecsResponse(AsyncWebServerRequest * pRequest, cons
                 auto options = widget["options"].to<JsonObject>();
                 options["source"] = spec.OptionsSourceName();
 
+                auto addOptionArrays = [&]()
+                {
+                    auto valuesArr = options["values"].to<JsonArray>();
+                    for (auto entry : spec.OptionValues)
+                        valuesArr.add(entry ? entry : "");
+                    auto labelsArr = options["labels"].to<JsonArray>();
+                    for (auto entry : spec.OptionLabels)
+                        labelsArr.add(entry ? entry : "");
+                };
+
                 if (spec.Options == SettingSpec::OptionsSource::Inline)
                 {
-                    auto values = options["values"].to<JsonArray>();
-                    auto labels = options["labels"].to<JsonArray>();
-                    for (size_t i = 0; i < spec.InlineOptionValues.size(); ++i)
-                    {
-                        if (spec.InlineOptionValues[i])
-                            values.add(spec.InlineOptionValues[i]);
-                    }
-                    for (size_t i = 0; i < spec.InlineOptionLabels.size(); ++i)
-                    {
-                        if (spec.InlineOptionLabels[i])
-                            labels.add(spec.InlineOptionLabels[i]);
-                    }
+                    addOptionArrays();
                 }
                 else if (spec.OptionsSchemaPath)
                 {
                     options["schemaPath"] = spec.OptionsSchemaPath;
+                    if (!spec.OptionValues.empty())
+                        addOptionArrays();
                 }
 
                 if (spec.OptionsExternalUrl)
                     options["url"] = spec.OptionsExternalUrl;
-
-                if (spec.OptionLabelMapJson)
-                {
-                    JsonDocument labelMap;
-                    auto err = deserializeJson(labelMap, spec.OptionLabelMapJson);
-                    if (!err)
-                        options["labelOverrides"] = labelMap.as<JsonObjectConst>();
-                }
             }
         }
 
@@ -835,58 +825,26 @@ const std::vector<std::reference_wrapper<SettingSpec>> & CWebServer::LoadDeviceS
         // composite "Rotate effects toggle + seconds input" UX in a way the
         // front-end can render generically.
         {
-            auto& spec = mySettingSpecs.emplace_back(
+            SettingSpec::FinishGuard spec(mySettingSpecs.emplace_back(
                 "effectInterval",
                 "Effect interval",
                 "The duration in milliseconds that an individual effect runs, before the next effect is activated. "
                 "Disable rotation to keep the current effect active indefinitely.",
                 SettingSpec::SettingType::PositiveBigInteger
-            );
-            spec.Section = "appearance";
-            spec.ApiPath = "effects.effectInterval";
-            spec.Widget = SettingSpec::WidgetKind::IntervalToggle;
-            spec.IntervalUnitDivisor = 1000;
-            spec.IntervalUnitLabel = "seconds";
-            spec.IntervalOnLabel  = "Rotate effects";
-            spec.IntervalOffLabel = "Off";
+            ));
+            spec->Section = "appearance";
+            spec->ApiPath = "effects.effectInterval";
+            spec->Widget = SettingSpec::WidgetKind::IntervalToggle;
+            spec->IntervalUnitDivisor = 1000;
+            spec->IntervalUnitLabel = "seconds";
+            spec->IntervalOnLabel  = "Rotate effects";
+            spec->IntervalOffLabel = "Off";
         }
 
         deviceSettingSpecs.insert(deviceSettingSpecs.end(), mySettingSpecs.begin(), mySettingSpecs.end());
 
         auto deviceConfigSpecs = g_ptrSystem->GetDeviceConfig().GetSettingSpecs();
         deviceSettingSpecs.insert(deviceSettingSpecs.end(), deviceConfigSpecs.begin(), deviceConfigSpecs.end());
-
-        // Synthesize one ws281xPin{N} spec per compiled channel. These are not
-        // individually persisted in DeviceConfig (they are stored as an array
-        // inside RuntimeConfig.outputs.outputPins), but the UI needs per-channel
-        // editable entries with stable names and apiPaths. We reserve up front
-        // so vector growth never reallocates and invalidates the references
-        // that deviceSettingSpecs holds and the c_str() pointers the spec uses.
-        const auto compiledChannelCount = DeviceConfig::GetCompiledChannelCount();
-        constexpr size_t kStringsPerPin = 4;        // name, friendly, description, apiPath
-        synthesizedPinSpecs.reserve(compiledChannelCount);
-        synthesizedPinSpecStrings.reserve(compiledChannelCount * kStringsPerPin);
-        const auto stableCStr = [](const String& s) { return s.c_str(); };
-
-        for (size_t pinIndex = 0; pinIndex < compiledChannelCount; ++pinIndex)
-        {
-            const auto& nameStr        = synthesizedPinSpecStrings.emplace_back(str_sprintf("ws281xPin%zu", pinIndex));
-            const auto& friendlyStr    = synthesizedPinSpecStrings.emplace_back(str_sprintf("WS281x pin %zu", pinIndex + 1));
-            const auto& descriptionStr = synthesizedPinSpecStrings.emplace_back(str_sprintf("GPIO assigned to WS281x channel %zu.", pinIndex + 1));
-            const auto& apiPathStr     = synthesizedPinSpecStrings.emplace_back(str_sprintf("outputs.ws281x.pins[%zu]", pinIndex));
-
-            auto& spec = synthesizedPinSpecs.emplace_back();
-            spec.Name         = stableCStr(nameStr);
-            spec.FriendlyName = stableCStr(friendlyStr);
-            spec.Description  = stableCStr(descriptionStr);
-            spec.Type         = SettingSpec::SettingType::Integer;
-            spec.MinimumValue = -1;
-            spec.MaximumValue = 48;
-            spec.Section      = "output";
-            spec.Priority     = 3 + static_cast<int>(pinIndex);
-            spec.ApiPath      = stableCStr(apiPathStr);
-            deviceSettingSpecs.emplace_back(spec);
-        }
     }
 
     return deviceSettingSpecs;
@@ -937,7 +895,7 @@ bool CWebServer::ValidateLegacyDeviceSettings(AsyncWebServerRequest * pRequest, 
     // Validate the constrained settings first so the legacy POST path behaves like the unified JSON API:
     // either the nontrivial request is coherent as a whole, or we reject it before any setters persist a
     // partially applied config.
-    
+
     if (pRequest->hasParam(DeviceConfig::OpenWeatherApiKeyTag, true, false))
     {
         auto [isValid, validationMessage] =
@@ -1362,7 +1320,11 @@ bool CWebServer::ApplyEffectSettings(AsyncWebServerRequest * pRequest, std::shar
 
     for (auto& settingSpecWrapper : effect->GetSettingSpecs())
     {
-        const String& settingName = settingSpecWrapper.get().Name;
+        const auto& spec = settingSpecWrapper.get();
+        // Settings with an ApiPath are addressed via a structured path, not by name — skip them here.
+        if (spec.ApiPath)
+            continue;
+        const String& settingName = spec.Name;
         settingChanged = PushPostParamIfPresent<String>(pRequest, settingName, [&](auto value) { return effect->SetSetting(settingName, value); })
             || settingChanged;
     }
@@ -1394,6 +1356,10 @@ void CWebServer::ValidateAndSetSetting(AsyncWebServerRequest * pRequest)
     for (auto& settingSpecWrapper : LoadDeviceSettingSpecs())
     {
         auto& settingSpec = settingSpecWrapper.get();
+
+        // Settings with an ApiPath are addressed via a structured path, not by name — skip them here.
+        if (settingSpec.ApiPath)
+            continue;
 
         if (pRequest->hasParam(settingSpec.Name, true))
         {


### PR DESCRIPTION
## Note

This PR aims to update the head branch of #859 (localui), _not_ main. The reason for this is that this allows my proposed changes to the local UI to be reviewed separately before the mentioned PR is merged into the main tree. This means that after this PR has been merged, #859 still needs to be merged into main for the local UI to end up in the main tree

## Description

This PR refactors `SettingSpec` construction, corrects the webserver's setting dispatch logic, moves pin spec generation to `DeviceConfig`, aligns the web UI's select-option handling with the firmware's serialization format, and documents the unified settings API endpoints.

## Changes

### `SettingSpec` constructor families (`include/interfaces.h`, `src/types.cpp`)

Adds typed constructor families (A–F) that call `FinishAndValidateInitialization()` directly, so most call sites no longer need a `FinishGuard` scope. `FinishGuard` is retained only where post-construction mutation is genuinely necessary: runtime-determined `RequiresReboot`, `EmptyAllowed` overrides, `OptionValues`/`OptionLabels` overrides, and the synthesized per-channel pin specs.

### Call-site conversions (`src/deviceconfig.cpp`, `src/ledstripeffect.cpp`, `include/effects/matrix/PatternSubscribers.h`)

All `SettingSpec` construction sites are converted to the new constructors where possible, replacing the previous pattern of constructing a bare spec and then assigning UI metadata fields one by one in a `FinishGuard` block.

### Pin spec generation moved to `DeviceConfig` (`src/deviceconfig.cpp`, `include/deviceconfig.h`, `src/webserver.cpp`, `include/webserver.h`)

The per-channel `ws281xPin{N}` setting specs were previously synthesized in `CWebServer`. They are now generated in `DeviceConfig::GetSettingSpecs()`, where the channel count, naming convention, `apiPath` format, and priority range are already available. A `pinSpecStrings` member is added to `DeviceConfig` to provide stable `const char*` backing. `CWebServer::LoadDeviceSettingSpecs()` is simplified accordingly and the `synthesizedPinSpecs`/`synthesizedPinSpecStrings` static members are removed from `CWebServer`.

### ApiPath-aware dispatch (`src/webserver.cpp`)

Both name-based dispatch loops — `ApplyEffectSettings` and `ValidateAndSetSetting` — now skip specs that carry an `ApiPath`. Settings with an `ApiPath` are addressed through the structured unified-settings path and cannot be matched by POST parameter name; previously the code would silently do nothing for them.

### Web UI select-option handling (`site/app.js`)

`getWidgetSelectOptions()` is refactored to replace the `labelOverrides` map (a client-side concept) with a unified `applyLabelMap()` helper that reads from the parallel `values`/`labels` arrays already serialized by the firmware. This aligns the UI with the wire format used by `SendSettingSpecsResponse` for all three option sources (`schemaPath`, `externalTimeZones`, and inline), removing a layer of client-side knowledge about how individual values should be labelled.

### REST API documentation (`REST_API.md`)

Documents the previously undocumented `GET /api/v1/settings/schema`, `GET /api/v1/settings`, and `POST /api/v1/settings` endpoints, including the full set of accepted fields and the transactional apply semantics for topology and output changes. Also fixes a pre-existing typo in the validated-setting endpoint description.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).