### PR TITLE
Add RGBWW support, SK6812 support, warm glow test effect

### DIFF
--- a/include/crgbw.h
+++ b/include/crgbw.h
@@ -1,0 +1,94 @@
+#pragma once
+
+//+--------------------------------------------------------------------------
+//
+// File:        crgbw.h
+//
+// NightDriverStrip - (c) 2026 Plummer's Software LLC.  All Rights Reserved.
+//
+// Description:
+//
+//   CRGBW: a two-byte "whites plane" pixel type used alongside the existing
+//   FastLED CRGB array for 4- and 5-channel addressable LED strips.
+//
+//   - cw  = cool-white channel intent (0..255)
+//   - ww  = warm-white channel intent (0..255)
+//
+//   The internal representation always carries both channels regardless of
+//   what the physical strip can render. The PixelFormat for each chip
+//   (Ws2812Format / Sk6812Format / Sm16825Format) decides how to map
+//   (cw, ww) to that chip's actual channel count:
+//
+//     - 3-channel WS2812:  whites are ignored (or folded back into RGB by
+//                          the format's policy; default is "discard").
+//     - 4-channel SK6812:  the strip has one physical white at a fixed
+//                          color temperature; the format combines cw + ww
+//                          into a single W output value. Kelvin is intent
+//                          metadata on that path, not independently rendered.
+//     - 5-channel SM16825: cw and ww are emitted directly as separate
+//                          channels.
+//
+//   Effects that don't care about CCT continue to write only to leds[];
+//   the per-pixel shared-portion synthesis in the PixelFormat fills in
+//   the white channels automatically. Effects that want explicit control
+//   call setPixelWhite() or setPixelCCT() on GFXBase to write the whites
+//   plane directly.
+//
+//---------------------------------------------------------------------------
+
+#include <cstdint>
+#include <algorithm>
+
+struct CRGBW
+{
+    uint8_t cw;     // cool-white channel intent (0..255)
+    uint8_t ww;     // warm-white channel intent (0..255)
+
+    constexpr CRGBW() noexcept : cw(0), ww(0) {}
+    constexpr CRGBW(uint8_t cool, uint8_t warm) noexcept : cw(cool), ww(warm) {}
+
+    constexpr bool isZero() const noexcept { return cw == 0 && ww == 0; }
+
+    static constexpr CRGBW Black() noexcept { return CRGBW(0, 0); }
+};
+
+static_assert(sizeof(CRGBW) == 2, "CRGBW must be 2 bytes for compact whites-plane storage");
+
+// SplitByCct
+//
+// Maps a desired (kelvin, brightness) pair to a (cw, ww) intensity pair.
+// Linear interpolation between 2700K (pure warm) and 6500K (pure cool):
+//
+//   kelvin = 2700K -> (cw=0,   ww=brightness)
+//   kelvin = 4600K -> (cw=brightness/2, ww=brightness/2)
+//   kelvin = 6500K -> (cw=brightness, ww=0)
+//
+// Below 2700K clamps to pure WW; above 6500K clamps to pure CW.
+//
+// This linear curve is a first cut. Real LED CW/WW phosphors don't have a
+// clean blackbody curve and the perceived neutral point depends on the
+// strip vendor. Once we have a 5-channel strip in hand we'll replace this
+// with a tunable LUT (or per-strip calibration) and ship that as a
+// separate change.
+//
+// We deliberately keep the helper inline + header-only so the PixelFormat
+// implementations can call it from per-frame hot paths without a function
+// call hop.
+
+inline CRGBW SplitByCct(uint16_t kelvin, uint8_t brightness) noexcept
+{
+    constexpr uint16_t kKelvinWarm = 2700;
+    constexpr uint16_t kKelvinCool = 6500;
+    constexpr uint16_t kKelvinSpan = kKelvinCool - kKelvinWarm; // 3800
+
+    if (brightness == 0)
+        return CRGBW::Black();
+
+    const uint16_t clamped = std::min<uint16_t>(std::max<uint16_t>(kelvin, kKelvinWarm), kKelvinCool);
+    const uint16_t coolPart = static_cast<uint16_t>(clamped - kKelvinWarm); // 0 .. 3800
+    // cw fraction = (kelvin - 2700) / (6500 - 2700)
+    // ww fraction = 1 - cw fraction
+    const uint16_t cw16 = static_cast<uint16_t>((coolPart * brightness + (kKelvinSpan / 2)) / kKelvinSpan);
+    const uint16_t ww16 = static_cast<uint16_t>(brightness - cw16);
+    return CRGBW(static_cast<uint8_t>(cw16), static_cast<uint8_t>(ww16));
+}

--- a/include/effects/strip/cct_effects.h
+++ b/include/effects/strip/cct_effects.h
@@ -31,43 +31,31 @@
 // unless RGB fallback is being used. Future 5-channel formats can render the
 // CW/WW split directly.
 //
-// On builds without a whites plane, falls back to filling RGB with a coarse
-// Kelvin approximation so warm and cool presets are visibly distinct.
+// This effect is intended as a maximum-output white scene. It fills RGB with
+// the brightest RGB approximation of the requested CCT and, when a whites
+// plane exists, adds the brightest CCT-correct CW/WW mix the hardware can
+// represent.
+//
+// Check your power supplies and power limits!  Monitor temperatures and 
+// current draw when running this effect, especially at high brightness levels.  
+// It can easily draw more current than the strip or power supply can handle, 
+// which can cause damage.  Start with low brightness and work your way up 
+// while monitoring the strip's behavior and temperature.
 
 class WarmGlowEffect : public EffectWithId<WarmGlowEffect>
 {
 protected:
 
     uint16_t _kelvin     = 4000;     // default: neutral-ish single-white intent
-    uint8_t  _brightness = 200;      // 0..255 white intensity
+    uint8_t  _brightness = 255;      // 0..255 scene intensity
 
     static String NameForKelvin(uint16_t kelvin)
     {
         if (kelvin <= 3000)
             return "Warm White Glow";
-        if (kelvin >= 6000)
+        if (kelvin >= 5000)
             return "Cool White Glow";
         return "White Glow";
-    }
-
-    static CRGB ApproximateRgbForKelvin(uint16_t kelvin, uint8_t brightness)
-    {
-        constexpr uint16_t kKelvinWarm = 2700;
-        constexpr uint16_t kKelvinCool = 6500;
-        constexpr uint16_t kKelvinSpan = kKelvinCool - kKelvinWarm;
-
-        const uint16_t clamped = std::min<uint16_t>(std::max<uint16_t>(kelvin, kKelvinWarm), kKelvinCool);
-        const uint16_t coolPart = static_cast<uint16_t>(clamped - kKelvinWarm);
-        const uint16_t warmPart = static_cast<uint16_t>(kKelvinSpan - coolPart);
-
-        const auto mix = [&](uint8_t warm, uint8_t cool) -> uint8_t {
-            const uint32_t channel = (static_cast<uint32_t>(warm) * warmPart)
-                                   + (static_cast<uint32_t>(cool) * coolPart)
-                                   + (kKelvinSpan / 2);
-            return static_cast<uint8_t>((channel / kKelvinSpan) * brightness / 255);
-        };
-
-        return CRGB(mix(255, 205), mix(180, 225), mix(100, 255));
     }
 
 public:
@@ -83,7 +71,7 @@ public:
     WarmGlowEffect(const JsonObjectConst& jsonObject)
         : EffectWithId<WarmGlowEffect>(jsonObject),
           _kelvin    (jsonObject["kelvin"]     | 4000),
-          _brightness(jsonObject["brightness"] |  200)
+          _brightness(jsonObject["brightness"] |  255)
     {
     }
 
@@ -99,29 +87,16 @@ public:
 
     void Draw() override
     {
-        // We hit each device's whites plane directly because the existing
-        // setPixelOnAllChannels helpers only know about CRGB. Effects that
-        // want CCT just iterate _GFX themselves; this is a deliberately
-        // small surface for the first cut.
+        const CRGB rgb = GFXBase::MaximumRgbForKelvin(_kelvin, _brightness);
+        const CRGBW white = GFXBase::MaximumWhiteForKelvin(_kelvin, _brightness);
+
         for (auto& device : _GFX)
         {
+            fill_solid(device->leds, _cLEDs, rgb);
             if (device->whites)
             {
-                // Whites plane available: drive the dedicated white LED(s).
                 for (size_t i = 0; i < _cLEDs; ++i)
-                    device->setPixelCCT(static_cast<int>(i), _kelvin, _brightness);
-
-                // Make sure RGB stays dark so the white doesn't get tinted
-                // by leftover color from a previous effect.
-                fill_solid(device->leds, _cLEDs, CRGB::Black);
-            }
-            else
-            {
-                // No whites plane (plain WS2812 build): fall back to a
-                // coarse Kelvin approximation so the strip still shows
-                // something visible and warm/cool presets remain distinct.
-                const CRGB approx = ApproximateRgbForKelvin(_kelvin, _brightness);
-                fill_solid(device->leds, _cLEDs, approx);
+                    device->whites[i] = white;
             }
         }
     }

--- a/include/effects/strip/cct_effects.h
+++ b/include/effects/strip/cct_effects.h
@@ -51,11 +51,15 @@ protected:
 
     static String NameForKelvin(uint16_t kelvin)
     {
+        // Return a string of the format "Warm White: 3000K" based on the temp
+
+        String result("White");
         if (kelvin <= 3000)
-            return "Warm White Glow";
-        if (kelvin >= 5000)
-            return "Cool White Glow";
-        return "White Glow";
+            result = "Warm White";
+        if (kelvin >= 4500)
+            result = "Cool White";
+        
+        return result + ": " + String(kelvin) + "K";
     }
 
 public:

--- a/include/effects/strip/cct_effects.h
+++ b/include/effects/strip/cct_effects.h
@@ -1,0 +1,130 @@
+#pragma once
+
+//+--------------------------------------------------------------------------
+//
+// File:        cct_effects.h
+//
+// NightDriverStrip - (c) 2026 Plummer's Software LLC.  All Rights Reserved.
+//
+// Description:
+//
+//   Reference effects that drive the CCT whites plane (cool-white /
+//   warm-white) directly via GFXBase::setPixelCCT(). Useful as a known-
+//   good test on 4-channel SK6812 strips and future 5-channel SM16825/WS2805
+//   strips. On plain 3-channel WS2812 builds setPixelCCT() is a no-op
+//   (whites plane isn't allocated), so the effect falls back to drawing
+//   a Kelvin-tinted CRGB approximation through the RGB channels - the strip
+//   stays useful even where the dedicated white LED isn't present.
+//
+//---------------------------------------------------------------------------
+
+#include "effectsupport.h"
+
+#include <algorithm>
+
+// WarmGlowEffect
+//
+// Lights every pixel with a configurable color temperature and brightness.
+// The default 4000K is neutral-ish white. On 4-channel SK6812 RGBW hardware
+// Kelvin only expresses intent: both CW and WW components collapse into the
+// one physical W channel in PixelFormat, so 2700K and 6500K are not distinct
+// unless RGB fallback is being used. Future 5-channel formats can render the
+// CW/WW split directly.
+//
+// On builds without a whites plane, falls back to filling RGB with a coarse
+// Kelvin approximation so warm and cool presets are visibly distinct.
+
+class WarmGlowEffect : public EffectWithId<WarmGlowEffect>
+{
+protected:
+
+    uint16_t _kelvin     = 4000;     // default: neutral-ish single-white intent
+    uint8_t  _brightness = 200;      // 0..255 white intensity
+
+    static String NameForKelvin(uint16_t kelvin)
+    {
+        if (kelvin <= 3000)
+            return "Warm White Glow";
+        if (kelvin >= 6000)
+            return "Cool White Glow";
+        return "White Glow";
+    }
+
+    static CRGB ApproximateRgbForKelvin(uint16_t kelvin, uint8_t brightness)
+    {
+        constexpr uint16_t kKelvinWarm = 2700;
+        constexpr uint16_t kKelvinCool = 6500;
+        constexpr uint16_t kKelvinSpan = kKelvinCool - kKelvinWarm;
+
+        const uint16_t clamped = std::min<uint16_t>(std::max<uint16_t>(kelvin, kKelvinWarm), kKelvinCool);
+        const uint16_t coolPart = static_cast<uint16_t>(clamped - kKelvinWarm);
+        const uint16_t warmPart = static_cast<uint16_t>(kKelvinSpan - coolPart);
+
+        const auto mix = [&](uint8_t warm, uint8_t cool) -> uint8_t {
+            const uint32_t channel = (static_cast<uint32_t>(warm) * warmPart)
+                                   + (static_cast<uint32_t>(cool) * coolPart)
+                                   + (kKelvinSpan / 2);
+            return static_cast<uint8_t>((channel / kKelvinSpan) * brightness / 255);
+        };
+
+        return CRGB(mix(255, 205), mix(180, 225), mix(100, 255));
+    }
+
+public:
+
+    WarmGlowEffect()
+        : EffectWithId<WarmGlowEffect>(NameForKelvin(_kelvin)) {}
+
+    WarmGlowEffect(uint16_t kelvin, uint8_t brightness)
+        : EffectWithId<WarmGlowEffect>(NameForKelvin(kelvin)),
+          _kelvin(kelvin),
+          _brightness(brightness) {}
+
+    WarmGlowEffect(const JsonObjectConst& jsonObject)
+        : EffectWithId<WarmGlowEffect>(jsonObject),
+          _kelvin    (jsonObject["kelvin"]     | 4000),
+          _brightness(jsonObject["brightness"] |  200)
+    {
+    }
+
+    bool SerializeToJSON(JsonObject& jsonObject) override
+    {
+        auto jsonDoc = CreateJsonDocument();
+        JsonObject root = jsonDoc.to<JsonObject>();
+        LEDStripEffect::SerializeToJSON(root);
+        jsonDoc["kelvin"]     = _kelvin;
+        jsonDoc["brightness"] = _brightness;
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
+    }
+
+    void Draw() override
+    {
+        // We hit each device's whites plane directly because the existing
+        // setPixelOnAllChannels helpers only know about CRGB. Effects that
+        // want CCT just iterate _GFX themselves; this is a deliberately
+        // small surface for the first cut.
+        for (auto& device : _GFX)
+        {
+            if (device->whites)
+            {
+                // Whites plane available: drive the dedicated white LED(s).
+                for (size_t i = 0; i < _cLEDs; ++i)
+                    device->setPixelCCT(static_cast<int>(i), _kelvin, _brightness);
+
+                // Make sure RGB stays dark so the white doesn't get tinted
+                // by leftover color from a previous effect.
+                fill_solid(device->leds, _cLEDs, CRGB::Black);
+            }
+            else
+            {
+                // No whites plane (plain WS2812 build): fall back to a
+                // coarse Kelvin approximation so the strip still shows
+                // something visible and warm/cool presets remain distinct.
+                const CRGB approx = ApproximateRgbForKelvin(_kelvin, _brightness);
+                fill_solid(device->leds, _cLEDs, approx);
+            }
+        }
+    }
+
+    size_t DesiredFramesPerSecond() const override { return 5; }   // static scene; no need to redraw fast
+};

--- a/include/effects/strip/fireworkseffect.h
+++ b/include/effects/strip/fireworkseffect.h
@@ -77,7 +77,25 @@ class FireworksEffect : public EffectWithId<FireworksEffect>
             return color;
         }
 
+        // I want to opportunistically pull the ignition phase towards pure white, so that if the beat is 
+        // strong and the particle ignites fully, it has a bright white core.  This is a defining 
+        // characteristic of fireworks and makes them pop visually, but it also means that at lower 
+        // brightness levels, the colors can be very dim until the particle is well into its ignition phase.  
+        // This method allows effects that want to maintain a more colorful look at low brightness to 
+        // check whether the particle is still in that very-white ignition phase.
+
+        bool IsPureWhiteIgnition() const
+        {
+            if (age >= preignitionTime + ignitionTime)
+                return false;
+
+            const float ignitionAge = std::max(0.0f, age - preignitionTime);
+            const float ignitionBlend = ignitionTime > 0.0f ? std::clamp(ignitionAge / ignitionTime, 0.0f, 1.0f) : 1.0f;
+            return ignitionBlend < 0.60f;
+        }
+
       private:
+
         static CRGB BlendColor(const CRGB& a, const CRGB& b, uint8_t amountOfB)
         {
             CRGB mixed = a;
@@ -192,6 +210,7 @@ class FireworksEffect : public EffectWithId<FireworksEffect>
     void Draw() override
     {
         fadeAllChannelsToBlackBy(_frameFade);
+        clearWhitesOnAllChannels();
 
         const float deltaSeconds = static_cast<float>(g_Values.AppTime.LastFrameTime());
         if (deltaSeconds <= 0.0f)
@@ -207,7 +226,10 @@ class FireworksEffect : public EffectWithId<FireworksEffect>
                 continue;
             }
 
-            setPixelsFOnAllChannels(it->position - it->size * 0.5f, it->size, it->CurrentColor(), true);
+            const float start = it->position - it->size * 0.5f;
+            setPixelsFOnAllChannels(start, it->size, it->CurrentColor(), true);
+            if (it->IsPureWhiteIgnition())
+                setWhiteOnAllChannels(start, it->size, CRGBW(255, 255), true);
             ++it;
         }
     }

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -461,6 +461,7 @@ public:
     // headroom they have when approximating CCT on RGB strips.
 
     static CRGB MaximumRgbForKelvin(uint16_t kelvin, uint8_t brightness);
+
     static CRGBW MaximumWhiteForKelvin(uint16_t kelvin, uint8_t brightness);
 
     void blurRows(CRGB *leds, uint16_t width, uint16_t height, uint16_t first, fract8 blur_amount);

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -432,6 +432,37 @@ public:
     //   We fill pixel with .75 worth of color
     void setPixelsF(float fPos, float count, CRGB c, bool bMerge = false) const;
 
+    // setWhitePixelsF - Floating point variant for the whites plane.
+    //
+    // This mirrors setPixelsF() for CRGBW. If the device has no whites plane,
+    // it is a no-op. When bMerge is true, CW/WW are saturating-added to the
+    // existing white pixel data instead of replacing it.
+
+    void setWhitePixelsF(float fPos, float count, CRGBW white, bool bMerge = false) const;
+    
+    // ScaleWhtieCoverage - Helper for setWhitePixelsF() to convert a fractional 
+    // coverage (0.0..1.0) into a linear scale factor (0..255) for the white channels.
+
+    static uint8_t ScaleWhiteCoverage(float coverage);
+    
+    // ApproximateRgbForKelvin - Helper to convert a color temperature in Kelvin to an RGB 
+    // approximation of that color, at a given brightness. Useful for effects that want to 
+    // approximate CCT on RGB-only strips.
+
+    static CRGB ApproximateRgbForKelvin(uint16_t kelvin, uint8_t brightness);
+    
+    // ScaleRgbToMax - Helper to scale an RGB color so that its brightest channel is at the specified brightness.
+
+    static CRGB ScaleRgbToMax(CRGB color, uint8_t brightness);
+    
+    // MaximumRgbForKelvin / MaximumWhiteForKelvin - Helpers to calculate the maximum RGB or 
+    // white values for a given CCT and brightness, based on the SK6812's white extraction behavior. 
+    // Useful for effects that want to use the whites plane on RGBW strips, or want to know how much 
+    // headroom they have when approximating CCT on RGB strips.
+
+    static CRGB MaximumRgbForKelvin(uint16_t kelvin, uint8_t brightness);
+    static CRGBW MaximumWhiteForKelvin(uint16_t kelvin, uint8_t brightness);
+
     void blurRows(CRGB *leds, uint16_t width, uint16_t height, uint16_t first, fract8 blur_amount);
 
     // blurColumns: perform a blur1d on each column of a rectangular matrix

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -73,6 +73,7 @@
 
 #include "Adafruit_GFX.h"
 #include "pixeltypes.h"
+#include "crgbw.h"
 
 // Calculates a weight for anti-aliasing in Wu's algorithm.
 constexpr static inline uint8_t WU_WEIGHT(uint8_t a, uint8_t b)
@@ -188,6 +189,22 @@ public:
     // Many of the Aurora effects need direct access to these from external classes
 
     CRGB *leds = nullptr;
+
+    // Optional "whites plane" used by 4-/5-channel addressable strips
+    // (SK6812 RGBW, SM16825 RGBCCW, WS2805, etc). Allocated parallel to
+    // `leds` by GFX subclasses that target white strips; left nullptr by
+    // default so existing CRGB-only effects keep working unchanged.
+    //
+    // Effects that want explicit cool-white / warm-white control call
+    // setPixelWhite() or setPixelCCT(); both are no-ops when this is
+    // nullptr, so the same effect source compiles and runs on plain
+    // WS2812 builds without conditional branches.
+    //
+    // The PixelFormat for each chip reads (leds[i], whites[i]) together
+    // at output time and decides how to map both planes onto the chip's
+    // actual channel count.
+
+    CRGBW *whites = nullptr;
     #if MATRIX_HEIGHT > 1
         std::unique_ptr<Boid[]> _boids;
     #endif
@@ -352,6 +369,46 @@ public:
             leds[x] = color;
         else
             debugE("Invalid setPixel request: x=%d, NUM_LEDS=%d", x, NUM_LEDS);
+    }
+
+    // ---- Whites plane (CCT) API -----------------------------------------
+    //
+    // setPixelWhite / setPixelCCT write to the whites[] plane parallel to
+    // leds[]. They are no-ops if the GFX subclass didn't allocate a whites
+    // plane (i.e. on plain WS2812 RGB-only builds), so calling them is
+    // always safe and effects don't need to branch on chip type.
+    //
+    // On 4-channel SK6812 strips both cw and ww route to the same physical
+    // white LED at output time; on 5-channel SM16825/WS2805 strips they
+    // drive the cool-white and warm-white channels independently. Effects
+    // can therefore code against the dual-white intent and the PixelFormat
+    // will collapse to single-white where the hardware only has one.
+
+    __attribute__((always_inline)) void setPixelWhite(int16_t x, int16_t y, uint8_t cw, uint8_t ww) noexcept
+    {
+        if (whites && isValidPixel(static_cast<uint>(x), static_cast<uint>(y)))
+            whites[XY(x, y)] = CRGBW(cw, ww);
+    }
+
+    __attribute__((always_inline)) void setPixelWhite(int x, uint8_t cw, uint8_t ww) noexcept
+    {
+        if (whites && isValidPixel(static_cast<uint>(x)))
+            whites[x] = CRGBW(cw, ww);
+    }
+
+    // Set a pixel's whites by color temperature and brightness. kelvin is
+    // clamped to [2700, 6500]; outside that range the helper saturates to
+    // pure WW or pure CW respectively.
+    __attribute__((always_inline)) void setPixelCCT(int16_t x, int16_t y, uint16_t kelvin, uint8_t brightness) noexcept
+    {
+        if (whites && isValidPixel(static_cast<uint>(x), static_cast<uint>(y)))
+            whites[XY(x, y)] = SplitByCct(kelvin, brightness);
+    }
+
+    __attribute__((always_inline)) void setPixelCCT(int x, uint16_t kelvin, uint8_t brightness) noexcept
+    {
+        if (whites && isValidPixel(static_cast<uint>(x)))
+            whites[x] = SplitByCct(kelvin, brightness);
     }
 
     // DrawSafeCircle

--- a/include/ledstripeffect.h
+++ b/include/ledstripeffect.h
@@ -34,6 +34,7 @@
 #include "effects.h"
 #include "hashing.h"
 #include "jsonserializer.h"
+#include "crgbw.h"
 
 #include <functional>
 #include <memory>
@@ -225,6 +226,9 @@ class LEDStripEffect : public IJSONSerializable
     // Smooth drawing on fractional pixels on all channels in the given color; if merge is specified,
 
     void setPixelsFOnAllChannels(float fPos, float count, CRGB c, bool bMerge = false);
+    void setWhitePixelsFOnAllChannels(float fPos, float count, CRGBW white, bool bMerge = false);
+    void setWhiteOnAllChannels(float fPos, float count, CRGBW white, bool bMerge = false);
+    void clearWhitesOnAllChannels();
 
     // ClearFrameOnAllChannels
     //

--- a/include/pixelformat.h
+++ b/include/pixelformat.h
@@ -253,21 +253,23 @@ public:
             // of 128 strikes a workable middle ground on the strips we've
             // tested so far. The right value is strip-dependent; expose
             // through DeviceConfig + SetupUI once we wire that through.
-            const uint8_t shared = std::min(color.r, std::min(color.g, color.b));
-            // pull = round(shared * ratio / 255)
-            const uint8_t pull = static_cast<uint8_t>((static_cast<uint16_t>(shared) * ratio + 127) / 255);
-            color.r -= pull;
-            color.g -= pull;
-            color.b -= pull;
-
-            // Explicit effect-set whites (if the whites plane is allocated
-            // and the effect wrote to it). On a single-white strip both
-            // CW and WW intent route to the same W channel. The extract
-            // ratio does NOT apply here - effects that explicitly drove
-            // the white plane meant it.
             uint8_t effectWhite = 0;
             if (whites)
                 effectWhite = PixelFormatHelpers::SaturatingAdd(whites[i].cw, whites[i].ww);
+
+            // Explicit effect-set whites are additive on top of RGB. When an
+            // effect wrote a white value, do not pull shared white out of RGB:
+            // the effect is intentionally asking for both RGB and W output.
+            uint8_t pull = 0;
+            if (effectWhite == 0)
+            {
+                const uint8_t shared = std::min(color.r, std::min(color.g, color.b));
+                // pull = round(shared * ratio / 255)
+                pull = static_cast<uint8_t>((static_cast<uint16_t>(shared) * ratio + 127) / 255);
+                color.r -= pull;
+                color.g -= pull;
+                color.b -= pull;
+            }
 
             uint8_t w = PixelFormatHelpers::SaturatingAdd(pull, effectWhite);
             w        = std::max(w, ambientWhite);

--- a/include/pixelformat.h
+++ b/include/pixelformat.h
@@ -1,0 +1,287 @@
+#pragma once
+
+//+--------------------------------------------------------------------------
+//
+// File:        pixelformat.h
+//
+// NightDriverStrip - (c) 2026 Plummer's Software LLC.  All Rights Reserved.
+//
+// Description:
+//
+//   PixelFormat is the chip-specific policy that converts the framebuffer
+//   pair (CRGB leds[], CRGBW whites[]) into the byte stream the addressable
+//   LED chip on the wire actually expects.
+//
+//   The Transport class in ws281xoutputmanager.cpp owns the RMT plumbing
+//   (legacy driver/rmt.h or IDF5 driver_ng) and is identical across chips
+//   in the WS281x family. PixelFormat is the *orthogonal* axis: how many
+//   bytes per pixel, and how (R, G, B, optional CW, optional WW) map onto
+//   those bytes.
+//
+//   Concrete subclasses:
+//
+//     Ws2812Format   - 3 bytes/pixel.  Whites plane is ignored. Existing
+//                      behavior; reproduces what PackChannelPixelsForColorOrder
+//                      did before this strategy class existed.
+//
+//     Sk6812Format   - 4 bytes/pixel.  Strip has one physical white LED at
+//                      a fixed color temperature (RGBW / RGBNW / RGBWW SKUs).
+//                      W is synthesized from RGB shared-portion + summed
+//                      with effect-explicit (cw, ww) from the whites plane.
+//
+//     [future] Sm16825Format / Ws2805Format - 5 bytes/pixel. CW and WW
+//                      emitted directly as separate channels.
+//
+//   All formats currently use the same WS281x family bit timings (800 kHz
+//   NRZ). Future 5-channel formats will need different timings; when that
+//   happens we'll add T0H/T0L/T1H/T1L virtuals here and have the Transport
+//   read them at channel-configure time. Not needed yet for SK6812.
+//
+//---------------------------------------------------------------------------
+
+#include <cstdint>
+#include <cstddef>
+#include <algorithm>
+
+#include "pixeltypes.h"     // FastLED CRGB
+#include "crgbw.h"          // CRGBW + SplitByCct helper
+#include "deviceconfig.h"   // DeviceConfig::WS281xColorOrder
+
+// ---------------------------------------------------------------------
+// Abstract base
+// ---------------------------------------------------------------------
+
+class PixelFormat
+{
+public:
+    virtual ~PixelFormat() = default;
+
+    // How many bytes does one packed pixel occupy on the wire? 3 for plain
+    // RGB chips, 4 for RGBW, 5 for RGBCCW.
+    virtual size_t BytesPerPixel() const = 0;
+
+    // Pack `activeLedCount` pixels into `output`. Pixels at index >=
+    // pixelsToShow are written as black. `whites` may be nullptr (which
+    // is the normal case for plain CRGB effects) - in that case the
+    // format's default synthesis policy is used to derive any white
+    // channels from RGB content.
+    //
+    // brightness and fader are applied uniformly to every channel.
+    //
+    // cctKelvin is the global color-temperature target used to split a
+    // synthesized white between cool-white and warm-white outputs.
+    // ambientCw and ambientWw are per-pixel floors added under whatever
+    // effects produce. Both are no-ops on a 3-channel format.
+    //
+    // whiteExtractRatio (0..255) controls how aggressively the shared-
+    // portion white is *pulled out* of RGB into the dedicated white
+    // channel(s) by the format's auto-synthesis path:
+    //   - 0   = don't extract; the W LED stays off and RGB does all the
+    //           additive white the way a WS2812 does
+    //   - 255 = full extraction; the entire min(R,G,B) shared portion
+    //           routes to W and RGB drops to (saturation-only) on the
+    //           white-share region. This is what looks washed out on
+    //           strips with bright W LEDs.
+    //   - 128 = half-and-half (current default). Half the shared white
+    //           routes to W (where the brighter dedicated LED carries
+    //           it efficiently), half stays in RGB (preserves color
+    //           character on warm/cool-tinted content).
+    // Per-pixel explicit whites (effects calling setPixelWhite /
+    // setPixelCCT) are NOT scaled by this - they're additive on top.
+    virtual void Pack(uint8_t* output,
+                      const CRGB* leds,
+                      const CRGBW* whites,                       // may be nullptr
+                      size_t activeLedCount,
+                      size_t pixelsToShow,
+                      uint8_t brightness,
+                      uint8_t fader,
+                      DeviceConfig::WS281xColorOrder colorOrder,
+                      uint16_t cctKelvin,
+                      uint8_t ambientCw,
+                      uint8_t ambientWw,
+                      uint8_t whiteExtractRatio) const = 0;
+};
+
+// ---------------------------------------------------------------------
+// Helpers shared by concrete formats
+// ---------------------------------------------------------------------
+
+namespace PixelFormatHelpers
+{
+    // Apply brightness + fader video-scale to a single channel byte.
+    inline uint8_t Scale(uint8_t value, uint8_t brightness, uint8_t fader)
+    {
+        // Mirrors nscale8_video twice; kept inline so the per-pixel inner
+        // loop avoids function call overhead. Same math as FastLED's
+        // nscale8x3_video applied per-channel.
+        const uint16_t a = (static_cast<uint16_t>(value) * (static_cast<uint16_t>(brightness) + 1)) >> 8;
+        const uint16_t b = (a * (static_cast<uint16_t>(fader) + 1)) >> 8;
+        return static_cast<uint8_t>(b);
+    }
+
+    inline uint8_t SaturatingAdd(uint8_t a, uint8_t b)
+    {
+        const uint16_t s = static_cast<uint16_t>(a) + static_cast<uint16_t>(b);
+        return s > 255 ? 255 : static_cast<uint8_t>(s);
+    }
+
+    // The three RGB output byte indices for a wire-side color order.
+    struct ColorOrderIndices
+    {
+        uint8_t rIdx;
+        uint8_t gIdx;
+        uint8_t bIdx;
+    };
+
+    inline ColorOrderIndices IndicesFor(DeviceConfig::WS281xColorOrder order)
+    {
+        switch (order)
+        {
+            case DeviceConfig::WS281xColorOrder::RGB: return { 0, 1, 2 };
+            case DeviceConfig::WS281xColorOrder::RBG: return { 0, 2, 1 };
+            case DeviceConfig::WS281xColorOrder::GRB: return { 1, 0, 2 };
+            case DeviceConfig::WS281xColorOrder::GBR: return { 2, 0, 1 };
+            case DeviceConfig::WS281xColorOrder::BRG: return { 1, 2, 0 };
+            case DeviceConfig::WS281xColorOrder::BGR: return { 2, 1, 0 };
+            default:                                  return { 1, 0, 2 }; // GRB default
+        }
+    }
+}
+
+// ---------------------------------------------------------------------
+// Ws2812Format - 3 bytes per pixel, whites ignored
+// ---------------------------------------------------------------------
+//
+// Reproduces the pre-strategy behavior exactly. Picked as the format when
+// the build doesn't set a whiteys flag.
+
+class Ws2812Format final : public PixelFormat
+{
+public:
+    size_t BytesPerPixel() const override { return 3; }
+
+    void Pack(uint8_t* output,
+              const CRGB* leds,
+              const CRGBW* /*whites*/,
+              size_t activeLedCount,
+              size_t pixelsToShow,
+              uint8_t brightness,
+              uint8_t fader,
+              DeviceConfig::WS281xColorOrder colorOrder,
+              uint16_t /*cctKelvin*/,
+              uint8_t /*ambientCw*/,
+              uint8_t /*ambientWw*/,
+              uint8_t /*whiteExtractRatio*/) const override
+    {
+        // No W channel - shared-portion extraction has nowhere to route, so
+        // the ratio knob is a no-op here. Plain RGB pack only.
+        const auto idx = PixelFormatHelpers::IndicesFor(colorOrder);
+        for (size_t i = 0; i < activeLedCount; ++i)
+        {
+            CRGB color = (i < pixelsToShow) ? leds[i] : CRGB::Black;
+
+            uint8_t r = PixelFormatHelpers::Scale(color.r, brightness, fader);
+            uint8_t g = PixelFormatHelpers::Scale(color.g, brightness, fader);
+            uint8_t b = PixelFormatHelpers::Scale(color.b, brightness, fader);
+
+            const size_t off = i * 3;
+            output[off + idx.rIdx] = r;
+            output[off + idx.gIdx] = g;
+            output[off + idx.bIdx] = b;
+        }
+    }
+};
+
+// ---------------------------------------------------------------------
+// Sk6812Format - 4 bytes per pixel (RGB + single white)
+// ---------------------------------------------------------------------
+//
+// SK6812 strips have one physical white LED per pixel at a fixed color
+// temperature (RGBW / RGBNW typically ~4000K; RGBWW ~3000K; RGBCW ~6500K).
+// We collapse the project's internal (cw, ww) dual-white intent down to a
+// single W byte by simply summing the two with saturating add. That treats
+// "cool intent" and "warm intent" as equivalent calls for "light up the
+// strip's white LED."
+//
+// For full CCT control we need a 5-channel chip (SM16825 / WS2805). The
+// single-white case is the obvious degenerate.
+//
+// Wire byte order is the same color-order config as WS2812 for the RGB
+// triple, plus W tacked on as byte 3. (BTF / Adafruit SK6812 RGBW strips
+// ship with GRBW on the wire — DeviceConfig::WS281xColorOrder == GRB plus
+// W in byte 3 reproduces that.)
+
+class Sk6812Format final : public PixelFormat
+{
+public:
+    size_t BytesPerPixel() const override { return 4; }
+
+    void Pack(uint8_t* output,
+              const CRGB* leds,
+              const CRGBW* whites,
+              size_t activeLedCount,
+              size_t pixelsToShow,
+              uint8_t brightness,
+              uint8_t fader,
+              DeviceConfig::WS281xColorOrder colorOrder,
+              uint16_t /*cctKelvin*/,
+              uint8_t ambientCw,
+              uint8_t ambientWw,
+              uint8_t whiteExtractRatio) const override
+    {
+        const auto idx = PixelFormatHelpers::IndicesFor(colorOrder);
+        // Saturating-sum the ambient floor once outside the loop. Single
+        // white LED can't reproduce CW/WW separately so we collapse here.
+        const uint8_t ambientWhite = PixelFormatHelpers::SaturatingAdd(ambientCw, ambientWw);
+        const uint16_t ratio = static_cast<uint16_t>(whiteExtractRatio); // 0..255
+
+        for (size_t i = 0; i < activeLedCount; ++i)
+        {
+            CRGB color = (i < pixelsToShow) ? leds[i] : CRGB::Black;
+
+            // Partial-extraction shared-portion subtract.
+            //
+            // The W LED on most SK6812 RGBW SKUs is noticeably brighter per
+            // digital count than the RGB sum, so pulling the full shared
+            // intensity into W and dropping RGB to (saturation-only) makes
+            // any near-white content look washed out and pastel.
+            //
+            // Instead we pull `ratio/255` of the shared white into W and
+            // leave the rest in the RGB triple. At ratio=0 the W LED stays
+            // off and the pixel renders exactly like a WS2812 would; at
+            // ratio=255 we fully transfer to W (old behavior); the default
+            // of 128 strikes a workable middle ground on the strips we've
+            // tested so far. The right value is strip-dependent; expose
+            // through DeviceConfig + SetupUI once we wire that through.
+            const uint8_t shared = std::min(color.r, std::min(color.g, color.b));
+            // pull = round(shared * ratio / 255)
+            const uint8_t pull = static_cast<uint8_t>((static_cast<uint16_t>(shared) * ratio + 127) / 255);
+            color.r -= pull;
+            color.g -= pull;
+            color.b -= pull;
+
+            // Explicit effect-set whites (if the whites plane is allocated
+            // and the effect wrote to it). On a single-white strip both
+            // CW and WW intent route to the same W channel. The extract
+            // ratio does NOT apply here - effects that explicitly drove
+            // the white plane meant it.
+            uint8_t effectWhite = 0;
+            if (whites)
+                effectWhite = PixelFormatHelpers::SaturatingAdd(whites[i].cw, whites[i].ww);
+
+            uint8_t w = PixelFormatHelpers::SaturatingAdd(pull, effectWhite);
+            w        = std::max(w, ambientWhite);
+
+            uint8_t r = PixelFormatHelpers::Scale(color.r, brightness, fader);
+            uint8_t g = PixelFormatHelpers::Scale(color.g, brightness, fader);
+            uint8_t b = PixelFormatHelpers::Scale(color.b, brightness, fader);
+            uint8_t wOut = PixelFormatHelpers::Scale(w,     brightness, fader);
+
+            const size_t off = i * 4;
+            output[off + idx.rIdx] = r;
+            output[off + idx.gIdx] = g;
+            output[off + idx.bIdx] = b;
+            output[off + 3]        = wOut;        // W always last byte
+        }
+    }
+};

--- a/include/pixelformat.h
+++ b/include/pixelformat.h
@@ -153,7 +153,7 @@ namespace PixelFormatHelpers
 // ---------------------------------------------------------------------
 //
 // Reproduces the pre-strategy behavior exactly. Picked as the format when
-// the build doesn't set a whiteys flag.
+// the build doesn't enable white channels.
 
 class Ws2812Format final : public PixelFormat
 {

--- a/include/ws281xoutputmanager.h
+++ b/include/ws281xoutputmanager.h
@@ -24,6 +24,7 @@
 
 class GFXBase;
 class Transport;
+class PixelFormat;
 
 class WS281xOutputManager
 {
@@ -41,7 +42,8 @@ class WS281xOutputManager
     size_t _activeChannelCount = 0;
     size_t _activeLEDCount = 0;
     DeviceConfig::WS281xColorOrder _colorOrder = DeviceConfig::GetCompiledWS281xColorOrder();
-    std::unique_ptr<Transport> _transport;
+    std::unique_ptr<Transport>    _transport;
+    std::unique_ptr<PixelFormat>  _format;          // picked at construction by chip-type flag
 
     bool RecreateChannel(size_t channelIndex, int8_t pin, size_t ledCount, String* errorMessage);
     void ReleaseChannel(size_t channelIndex);

--- a/platformio.ini
+++ b/platformio.ini
@@ -645,6 +645,24 @@ build_flags     = ${dev_m5stick_c_plus2.build_flags}
 build_src_flags = ${dev_m5stick_c_plus2.build_src_flags}
                   ${env:m5demo.build_src_flags}
 
+; M5StickC Plus2 driving an SK6812 RGBW strip on the grove connector.
+; Same hardware setup as m5plusdemo but USE_SK6812=1 makes the output
+; manager pack 4 bytes/pixel through Sk6812Format and allocates the
+; whites plane parallel to leds. Bit timings are identical to WS2812
+; (800kHz NRZ) so the existing Transport classes don't need any changes.
+;
+; LED_PIN0 / MATRIX_WIDTH inherited from env:m5demo. If your test strip
+; has a different LED count or color order, override here. Most BTF /
+; Adafruit SK6812 RGBW strips ship as GRBW on the wire which matches
+; the WS281xColorOrder::GRB default plus W in byte 3.
+
+[env:m5plusdemo_sk6812]
+extends         = env:m5plusdemo
+build_flags     = ${env:m5plusdemo.build_flags}
+build_src_flags = ${env:m5plusdemo.build_src_flags}
+                  -DUSE_SK6812=1
+                  -DPROJECT_NAME="\"M5SK6812Demo\""
+
 ; The _v2 and _v3 envs are intended for on-going development efforts by the project maintainers.
 ; Use them at your own risk.
 [env:m5plusdemo_v2]
@@ -1515,6 +1533,61 @@ build_src_flags = ${dev_m5stick_c_plus.build_src_flags}
                   -DLED_PIN1=33
                   -DDEFAULT_EFFECT_INTERVAL=300000
                   -DEFFECTS_MINIMAL=1
+
+; SK6812 RGBW variant of spirallamp.
+;
+; Targets the M5StickC Plus 2 (note the Plus 2, not the original Plus). Two
+; SK6812 RGBW strips of 144 LEDs each, one per channel, wired to GPIO 32
+; and GPIO 33 on the bottom grove connector. Each pixel is 4 bytes on the
+; wire (R, G, B, W) and the white LED is driven by:
+;   - Auto-synthesis from RGB's shared-portion at output time. Old CRGB
+;     effects look cleaner because near-whites route to the dedicated
+;     white LED instead of approximating with R+G+B.
+;   - Explicit CCT control from WarmGlowEffect, which writes the whites
+;     plane via setPixelCCT() and ignores leds[].
+;
+; Bit timings are the same 800 kHz NRZ that WS2812 uses, so no Transport
+; change is needed - the existing RMT/driver_ng plumbing drives SK6812
+; out of the box once USE_SK6812 is defined.
+;
+; Uses EFFECTS_DEMO instead of EFFECTS_SPIRALLAMP because some of the
+; older spirallamp effects (notably FireFanEffect) write through FastLED's
+; global controller registry (`FastLED[i][x] = color`) which is empty in
+; the NightDriver runtime-managed strip path, causing a null-deref at
+; first draw. The DEMO effect set is the one m5plusdemo ships with and
+; is proven on the runtime path; WarmGlowEffect is registered there too.
+; Fix the FireFanEffect path-of-drawing separately and switch back to
+; EFFECTS_SPIRALLAMP once that lands.
+
+[env:spirallamp_rgbw]
+extends         = dev_m5stick_c_plus2
+build_flags     = ${dev_m5stick_c_plus2.build_flags}
+build_src_flags = ${dev_m5stick_c_plus2.build_src_flags}
+                  -DUSE_SK6812=1
+                  -DSPIRALLAMP=1
+                  -DPROJECT_NAME='"Spiral Light RGBW"'
+                  -DENABLE_WIFI=1
+                  -DINCOMING_WIFI_ENABLED=1
+                  -DWAIT_FOR_WIFI=0
+                  -DTIME_BEFORE_LOCAL=3
+                  -DENABLE_OTA=0
+                  -DNUM_CHANNELS=2
+                  -DMATRIX_WIDTH=144
+                  -DMATRIX_HEIGHT=1
+                  -DNUM_LEDS=144
+                  -DENABLE_REMOTE=1
+                  -DIR_REMOTE_PIN=26
+                  -DENABLE_AUDIO=1
+                  -DUSE_SCREEN=1
+                  -DFAN_SIZE=144
+                  -DNUM_FANS=1
+                  -DNUM_RINGS=1
+                  -DFULL_COLOR_REMOTE_FILL=1
+                  -DBRIGHTNESS_MIN=0
+                  -DLED_PIN0=32
+                  -DLED_PIN1=33
+                  -DDEFAULT_EFFECT_INTERVAL=300000
+                  -DEFFECTS_DEMO=1
 
 [env:platecover]
 extends         = dev_m5stick_c_plus

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -143,6 +143,28 @@ void EffectManager::StartEffect()
         matrix.SetCaption(effect->FriendlyName(), CAPTION_TIME);
     #endif
 
+    // Zero the whites plane on every graphics device at effect-switch.
+    //
+    // CCT-aware effects (WarmGlowEffect and friends) write to whites[]
+    // every frame; effects that don't know about whites write only to
+    // leds[]. Without this reset, the previous effect's W-LED state
+    // persists through the transition and gets re-rendered by the
+    // PixelFormat under the new effect's colors - the strip ends up
+    // showing the old warm-white tint behind whatever colors the new
+    // effect draws. (leds[] doesn't need to be reset here for the same
+    // reason: every well-behaved effect overwrites the pixels it draws
+    // each frame, and effects that deliberately persist state across
+    // frames - like FireEffect's heat decay - want that persistence.
+    // The whites plane has no equivalent persisting-effect right now,
+    // so blanket-zeroing it on switch is the right semantic.)
+    
+    for (auto& device : _gfx)
+    {
+        if (device && device->whites)
+            memset(device->whites, 0,
+                   device->GetLEDCount() * sizeof(CRGBW));
+    }
+
     effect->Start();
     _lastBeatSequence = g_Analyzer.LastBeat().sequence;
     _lastNearBeatSequence = g_Analyzer.LastNearBeat().sequence;

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -47,6 +47,7 @@
 
 #include "effects/matrix/PatternClock.h"        // No matrix dependencies
 #include "effects/strip/bouncingballeffect.h"   // bouncing ball effects
+#include "effects/strip/cct_effects.h"          // WarmGlowEffect (whites/CCT plane)
 #include "effects/strip/doublepaletteeffect.h"  // double palette effect
 #include "effects/strip/fireeffect.h"           // fire effects
 #include "effects/strip/fireworkseffect.h"
@@ -228,7 +229,17 @@ void LoadEffectFactories()
             Effect<StarEffect<QuietStar>>("Rainbow Twinkle Stars", RainbowColors_p, kStarEffectProbability, 1, LINEARBLEND, 2.0, 0.0, kStarEffectMusicFactor),
             Effect<TwinkleEffect>(NUM_LEDS / 2, 20, 50),
             Effect<PaletteEffect>(RainbowColors_p, .25, 1, 0, 1.0, 0.0, LINEARBLEND, true, 1.0),
-            Effect<PaletteEffect>(RainbowColors_p)
+            Effect<PaletteEffect>(RainbowColors_p),
+            // CCT-aware reference effect. A single-white SK6812 strip cannot
+            // render warm/cool Kelvin endpoints distinctly, so expose one
+            // neutral white there. RGB-only builds use the fallback tinting
+            // path, where warm and cool presets are visibly different.
+            #if defined(USE_SK6812) && USE_SK6812
+                Effect<WarmGlowEffect>(4000, 200)
+            #else
+                Effect<WarmGlowEffect>(2700, 200),
+                Effect<WarmGlowEffect>(6500, 200)
+            #endif
         );
 
     #endif
@@ -553,7 +564,17 @@ void LoadEffectFactories()
             Effect<StarEffect<MusicStar>>("Green Stars", GreenColors_p, kStarEffectProbability, 1, LINEARBLEND, 2.0, 0.0, kStarEffectMusicFactor),
             Effect<TwinkleEffect>(NUM_LEDS / 2, 20, 50),
             Effect<PaletteEffect>(RainbowColors_p, .25, 1, 0, 1.0, 0.0, LINEARBLEND, true, 1.0),
-            Effect<PaletteEffect>(RainbowColors_p)
+            Effect<PaletteEffect>(RainbowColors_p),
+            // CCT-aware reference effect. A single-white SK6812 strip cannot
+            // render warm/cool Kelvin endpoints distinctly, so expose one
+            // neutral white there. RGB-only builds use the fallback tinting
+            // path, where warm and cool presets are visibly different.
+            #if defined(USE_SK6812) && USE_SK6812
+                Effect<WarmGlowEffect>(4000, 200)
+            #else
+                Effect<WarmGlowEffect>(2700, 200),
+                Effect<WarmGlowEffect>(6500, 200)
+            #endif
         );
     #endif
 

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -235,10 +235,10 @@ void LoadEffectFactories()
             // neutral white there. RGB-only builds use the fallback tinting
             // path, where warm and cool presets are visibly different.
             #if defined(USE_SK6812) && USE_SK6812
-                Effect<WarmGlowEffect>(4000, 200)
+                Effect<WarmGlowEffect>(4000, 255)
             #else
-                Effect<WarmGlowEffect>(2700, 200),
-                Effect<WarmGlowEffect>(6500, 200)
+                Effect<WarmGlowEffect>(2700, 255),
+                Effect<WarmGlowEffect>(6500, 255)
             #endif
         );
 
@@ -570,10 +570,10 @@ void LoadEffectFactories()
             // neutral white there. RGB-only builds use the fallback tinting
             // path, where warm and cool presets are visibly different.
             #if defined(USE_SK6812) && USE_SK6812
-                Effect<WarmGlowEffect>(4000, 200)
+                Effect<WarmGlowEffect>(4000, 255)
             #else
-                Effect<WarmGlowEffect>(2700, 200),
-                Effect<WarmGlowEffect>(6500, 200)
+                Effect<WarmGlowEffect>(2700, 255),
+                Effect<WarmGlowEffect>(6500, 255)
             #endif
         );
     #endif

--- a/src/gfxbase.cpp
+++ b/src/gfxbase.cpp
@@ -32,6 +32,7 @@
 
 #include "globals.h"
 
+#include <cmath>
 #include <gfxfont.h>
 #include <memory>
 #include <stdexcept>
@@ -376,6 +377,96 @@ void GFXBase::setPixelsF(float fPos, float count, CRGB c, bool bMerge) const
     if (count > 0)
         if (p >= 0 && isValidPixel(p))
             leds[(int)p] = bMerge ? leds[(int)p] + c2 : c2;
+}
+
+uint8_t GFXBase::ScaleWhiteCoverage(float coverage)
+{
+    return static_cast<uint8_t>(std::clamp(coverage, 0.0f, 1.0f) * 255.0f);
+}
+
+void GFXBase::setWhitePixelsF(float fPos, float count, CRGBW white, bool bMerge) const
+{
+    if (!whites || count <= 0.0f)
+        return;
+
+    const float start = fPos;
+    const float end = fPos + count;
+    const int firstPixel = static_cast<int>(floorf(start));
+    const int lastPixel = static_cast<int>(floorf(end));
+
+    for (int pixel = firstPixel; pixel <= lastPixel; ++pixel)
+    {
+        const float pixelStart = static_cast<float>(pixel);
+        const float pixelEnd = pixelStart + 1.0f;
+        const float coverage = std::min(end, pixelEnd) - std::max(start, pixelStart);
+        if (coverage <= 0.0f || !isValidPixel(pixel))
+            continue;
+
+        const uint8_t scale = ScaleWhiteCoverage(coverage);
+        CRGBW scaled(
+            scale8_video(white.cw, scale),
+            scale8_video(white.ww, scale));
+
+        if (bMerge)
+        {
+            whites[pixel].cw = qadd8(whites[pixel].cw, scaled.cw);
+            whites[pixel].ww = qadd8(whites[pixel].ww, scaled.ww);
+        }
+        else
+        {
+            whites[pixel] = scaled;
+        }
+    }
+}
+
+CRGB GFXBase::ApproximateRgbForKelvin(uint16_t kelvin, uint8_t brightness)
+{
+    constexpr uint16_t kKelvinWarm = 2700;
+    constexpr uint16_t kKelvinCool = 6500;
+    constexpr uint16_t kKelvinSpan = kKelvinCool - kKelvinWarm;
+
+    const uint16_t clamped = std::min<uint16_t>(std::max<uint16_t>(kelvin, kKelvinWarm), kKelvinCool);
+    const uint16_t coolPart = static_cast<uint16_t>(clamped - kKelvinWarm);
+    const uint16_t warmPart = static_cast<uint16_t>(kKelvinSpan - coolPart);
+
+    const auto mix = [&](uint8_t warm, uint8_t cool) -> uint8_t {
+        const uint32_t channel = (static_cast<uint32_t>(warm) * warmPart)
+                               + (static_cast<uint32_t>(cool) * coolPart)
+                               + (kKelvinSpan / 2);
+        return static_cast<uint8_t>((channel / kKelvinSpan) * brightness / 255);
+    };
+
+    return CRGB(mix(255, 205), mix(180, 225), mix(100, 255));
+}
+
+CRGB GFXBase::ScaleRgbToMax(CRGB color, uint8_t brightness)
+{
+    const uint8_t maxChannel = std::max(color.r, std::max(color.g, color.b));
+    if (maxChannel == 0)
+        return CRGB::Black;
+
+    color.r = static_cast<uint8_t>((static_cast<uint16_t>(color.r) * 255U) / maxChannel);
+    color.g = static_cast<uint8_t>((static_cast<uint16_t>(color.g) * 255U) / maxChannel);
+    color.b = static_cast<uint8_t>((static_cast<uint16_t>(color.b) * 255U) / maxChannel);
+    color.nscale8_video(brightness);
+    return color;
+}
+
+CRGB GFXBase::MaximumRgbForKelvin(uint16_t kelvin, uint8_t brightness)
+{
+    return ScaleRgbToMax(ApproximateRgbForKelvin(kelvin, 255), brightness);
+}
+
+CRGBW GFXBase::MaximumWhiteForKelvin(uint16_t kelvin, uint8_t brightness)
+{
+    CRGBW split = SplitByCct(kelvin, 255);
+    const uint8_t maxChannel = std::max(split.cw, split.ww);
+    if (maxChannel == 0 || brightness == 0)
+        return CRGBW::Black();
+
+    split.cw = static_cast<uint8_t>((static_cast<uint32_t>(split.cw) * 255U * brightness) / (maxChannel * 255U));
+    split.ww = static_cast<uint8_t>((static_cast<uint32_t>(split.ww) * 255U * brightness) / (maxChannel * 255U));
+    return split;
 }
 
 void GFXBase::blurRows(CRGB *leds, uint16_t width, uint16_t height, uint16_t first, fract8 blur_amount)

--- a/src/gfxbase.cpp
+++ b/src/gfxbase.cpp
@@ -122,10 +122,22 @@ uint16_t GFXBase::to16bit(CRGB::HTMLColorCode code)
 
 void GFXBase::Clear(CRGB color)
 {
+    const size_t count = _width * _height;
     if (color == CRGB::Black)
-        memset(leds, 0, sizeof(CRGB) * _width * _height);
+        memset(leds, 0, sizeof(CRGB) * count);
     else
-        fill_solid(leds, _width * _height, color);
+        fill_solid(leds, count, color);
+
+    // Also zero the whites plane (if allocated). Without this, a previous
+    // effect that lit the dedicated W LEDs (e.g. WarmGlowEffect or any
+    // setPixelWhite/setPixelCCT caller) leaves them lit across the
+    // effect-switch boundary - the next effect writes only leds[] and the
+    // stale W content washes its colors out. Effects that want to preserve
+    // whites can rewrite them after the Clear() call; that's how the leds
+    // plane already behaves.
+    
+    if (whites)
+        memset(whites, 0, sizeof(CRGBW) * count);
 }
 
 // getPixel

--- a/src/ledstripeffect.cpp
+++ b/src/ledstripeffect.cpp
@@ -238,11 +238,21 @@ void LEDStripEffect::fillSolidOnAllChannels(CRGB color, int iStart, int numToFil
         if (everyN == 1)
         {
             fill_solid(device->leds + iStart, numToFill, color);
+            // Zero the matching whites range so a prior CCT-aware effect's
+            // residual W intensity doesn't bleed under the new solid color.
+            // Mirrors the leds[] semantics: "fill with X" means "this region
+            // now displays X and nothing else."
+            if (device->whites)
+                memset(device->whites + iStart, 0, numToFill * sizeof(CRGBW));
             continue;
         }
 
         for (int i = iStart; i < iStart + numToFill; i += everyN)
+        {
             device->leds[i] = color;
+            if (device->whites)
+                device->whites[i] = CRGBW(0, 0);
+        }
     }
 }
 
@@ -327,7 +337,13 @@ void LEDStripEffect::setAllOnAllChannels(uint8_t r, uint8_t g, uint8_t b) const
 {
     const CRGB color(r, g, b);
     for (auto& device : _GFX)
+    {
         fill_solid(device->leds, _cLEDs, color);
+        // Same rationale as fillSolidOnAllChannels: "set everything to X"
+        // implies "no residual whites from a previous effect."
+        if (device->whites)
+            memset(device->whites, 0, _cLEDs * sizeof(CRGBW));
+    }
 }
 
 // setPixelOnAllChannels

--- a/src/ledstripeffect.cpp
+++ b/src/ledstripeffect.cpp
@@ -32,6 +32,7 @@
 #include "ledstripeffect.h"
 
 #include <algorithm>
+#include <cstring>
 #include <cstdlib>
 #include <iterator>
 #include <stdexcept>
@@ -264,6 +265,24 @@ void LEDStripEffect::setPixelsFOnAllChannels(float fPos, float count, CRGB c, bo
 {
     for (auto& device : _GFX)
         device->setPixelsF(fPos, count, c, bMerge);
+}
+
+void LEDStripEffect::setWhitePixelsFOnAllChannels(float fPos, float count, CRGBW white, bool bMerge)
+{
+    for (auto& device : _GFX)
+        device->setWhitePixelsF(fPos, count, white, bMerge);
+}
+
+void LEDStripEffect::setWhiteOnAllChannels(float fPos, float count, CRGBW white, bool bMerge)
+{
+    setWhitePixelsFOnAllChannels(fPos, count, white, bMerge);
+}
+
+void LEDStripEffect::clearWhitesOnAllChannels()
+{
+    for (auto& device : _GFX)
+        if (device->whites)
+            memset(device->whites, 0, _cLEDs * sizeof(CRGBW));
 }
 
 // ClearFrameOnAllChannels

--- a/src/ws281xgfx.cpp
+++ b/src/ws281xgfx.cpp
@@ -108,15 +108,19 @@ namespace
             for (size_t i = 0; i < ledCount; ++i)
             {
                 CRGB color = graphics.leds[i];
-                const uint8_t shared = std::min(color.r, std::min(color.g, color.b));
-                const uint8_t pull = static_cast<uint8_t>((static_cast<uint16_t>(shared) * ratio + 127) / 255);
-                color.r -= pull;
-                color.g -= pull;
-                color.b -= pull;
-
                 uint8_t effectWhite = 0;
                 if (graphics.whites)
                     effectWhite = SaturatingAdd(graphics.whites[i].cw, graphics.whites[i].ww);
+
+                uint8_t pull = 0;
+                if (effectWhite == 0)
+                {
+                    const uint8_t shared = std::min(color.r, std::min(color.g, color.b));
+                    pull = static_cast<uint8_t>((static_cast<uint16_t>(shared) * ratio + 127) / 255);
+                    color.r -= pull;
+                    color.g -= pull;
+                    color.b -= pull;
+                }
 
                 red += color.r;
                 green += color.g;

--- a/src/ws281xgfx.cpp
+++ b/src/ws281xgfx.cpp
@@ -46,6 +46,112 @@
 namespace
 {
     DRAM_ATTR std::mutex g_ws281xTransportMutex;
+
+    constexpr uint8_t kPowerRedMw = 16 * 5;      // FastLED default: 16 mA at 5 V
+    constexpr uint8_t kPowerGreenMw = 11 * 5;    // FastLED default: 11 mA at 5 V
+    constexpr uint8_t kPowerBlueMw = 15 * 5;     // FastLED default: 15 mA at 5 V
+    constexpr uint8_t kPowerDarkMw = 1 * 5;      // FastLED default: 1 mA at 5 V
+
+    #ifndef SK6812_WHITE_MW
+        #define SK6812_WHITE_MW (15 * 5)
+    #endif
+    #ifndef NIGHTDRIVER_DEFAULT_AMBIENT_CW
+        #define NIGHTDRIVER_DEFAULT_AMBIENT_CW 0
+    #endif
+    #ifndef NIGHTDRIVER_DEFAULT_AMBIENT_WW
+        #define NIGHTDRIVER_DEFAULT_AMBIENT_WW 0
+    #endif
+    #ifndef SK6812_WHITE_EXTRACT_RATIO
+        #define SK6812_WHITE_EXTRACT_RATIO 128
+    #endif
+
+    constexpr uint8_t kPowerWhiteMw = SK6812_WHITE_MW;
+    constexpr uint8_t kDefaultAmbientCw = NIGHTDRIVER_DEFAULT_AMBIENT_CW;
+    constexpr uint8_t kDefaultAmbientWw = NIGHTDRIVER_DEFAULT_AMBIENT_WW;
+    constexpr uint8_t kDefaultWhiteExtractRatio = SK6812_WHITE_EXTRACT_RATIO;
+
+    uint32_t EstimateRGBUnscaledPowerMw(const CRGB* leds, size_t ledCount)
+    {
+        uint32_t red = 0;
+        uint32_t green = 0;
+        uint32_t blue = 0;
+
+        for (size_t i = 0; i < ledCount; ++i)
+        {
+            red += leds[i].r;
+            green += leds[i].g;
+            blue += leds[i].b;
+        }
+
+        return ((red * kPowerRedMw) >> 8)
+             + ((green * kPowerGreenMw) >> 8)
+             + ((blue * kPowerBlueMw) >> 8)
+             + (kPowerDarkMw * ledCount);
+    }
+
+    uint8_t SaturatingAdd(uint8_t a, uint8_t b)
+    {
+        const uint16_t sum = static_cast<uint16_t>(a) + static_cast<uint16_t>(b);
+        return sum > 255 ? 255 : static_cast<uint8_t>(sum);
+    }
+
+    uint32_t EstimateWS281xUnscaledPowerMw(const GFXBase& graphics, size_t ledCount)
+    {
+        #if defined(USE_SK6812) && USE_SK6812
+            uint32_t red = 0;
+            uint32_t green = 0;
+            uint32_t blue = 0;
+            uint32_t white = 0;
+            const uint16_t ratio = static_cast<uint16_t>(kDefaultWhiteExtractRatio);
+            const uint8_t ambientWhite = SaturatingAdd(kDefaultAmbientCw, kDefaultAmbientWw);
+
+            for (size_t i = 0; i < ledCount; ++i)
+            {
+                CRGB color = graphics.leds[i];
+                const uint8_t shared = std::min(color.r, std::min(color.g, color.b));
+                const uint8_t pull = static_cast<uint8_t>((static_cast<uint16_t>(shared) * ratio + 127) / 255);
+                color.r -= pull;
+                color.g -= pull;
+                color.b -= pull;
+
+                uint8_t effectWhite = 0;
+                if (graphics.whites)
+                    effectWhite = SaturatingAdd(graphics.whites[i].cw, graphics.whites[i].ww);
+
+                red += color.r;
+                green += color.g;
+                blue += color.b;
+                white += std::max(SaturatingAdd(pull, effectWhite), ambientWhite);
+            }
+
+            return ((red * kPowerRedMw) >> 8)
+                 + ((green * kPowerGreenMw) >> 8)
+                 + ((blue * kPowerBlueMw) >> 8)
+                 + ((white * kPowerWhiteMw) >> 8)
+                 + (kPowerDarkMw * ledCount);
+        #else
+            return EstimateRGBUnscaledPowerMw(graphics.leds, ledCount);
+        #endif
+    }
+
+    uint8_t LimitBrightnessForPower(uint32_t unscaledPowerMw, uint8_t targetBrightness, uint8_t fader, uint32_t maxPowerMw)
+    {
+        if (unscaledPowerMw == 0 || targetBrightness == 0 || fader == 0)
+            return targetBrightness;
+
+        const uint64_t requestedMw =
+            (static_cast<uint64_t>(unscaledPowerMw) * targetBrightness * fader) / (256ULL * 256ULL);
+        if (requestedMw <= maxPowerMw)
+            return targetBrightness;
+
+        return static_cast<uint8_t>((static_cast<uint64_t>(targetBrightness) * maxPowerMw) / requestedMw);
+    }
+
+    uint32_t ScalePowerMw(uint32_t unscaledPowerMw, uint8_t brightness, uint8_t fader)
+    {
+        return static_cast<uint32_t>(
+            (static_cast<uint64_t>(unscaledPowerMw) * brightness * fader) / (256ULL * 256ULL));
+    }
 }
 
 std::mutex& WS281xGFX::TransportMutex()
@@ -72,16 +178,42 @@ static CRGB* AllocLedBuffer(size_t count)
     return static_cast<CRGB*>(mem);
 }
 
+#if defined(USE_SK6812) && USE_SK6812
+// The whites plane is consumed by PixelFormat::Pack at frame-build time
+// but never DMA'd directly, so we don't need DMA-capable memory. Pinning
+// it to internal RAM still keeps the per-frame access path off PSRAM,
+// which matters under the project's PSRAM-default allocator policy.
+static CRGBW* AllocWhitesBuffer(size_t count)
+{
+    void* mem = heap_caps_malloc(count * sizeof(CRGBW),
+                                 MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    if (!mem)
+        throw std::runtime_error("Unable to allocate whites plane in WS281xGFX");
+    memset(mem, 0, count * sizeof(CRGBW));
+    return static_cast<CRGBW*>(mem);
+}
+#endif
+
 WS281xGFX::WS281xGFX(size_t w, size_t h) : GFXBase(w, h)
 {
     debugV("Creating Device of size %zu x %zu", w, h);
     leds = AllocLedBuffer(w * h);
+    #if defined(USE_SK6812) && USE_SK6812
+        whites = AllocWhitesBuffer(w * h);
+    #endif
 }
 
 WS281xGFX::~WS281xGFX()
 {
     heap_caps_free(leds);
     leds = nullptr;
+    #if defined(USE_SK6812) && USE_SK6812
+        if (whites)
+        {
+            heap_caps_free(whites);
+            whites = nullptr;
+        }
+    #endif
 }
 
 void WS281xGFX::ConfigureTopology(size_t width, size_t height, bool serpentine)
@@ -98,6 +230,17 @@ void WS281xGFX::ConfigureTopology(size_t width, size_t height, bool serpentine)
         }
 
         leds = newPixels;
+
+        #if defined(USE_SK6812) && USE_SK6812
+            CRGBW* newWhites = AllocWhitesBuffer(newLEDCount);
+            if (whites)
+            {
+                memcpy(newWhites, whites,
+                       std::min(GetLEDCount(), newLEDCount) * sizeof(CRGBW));
+                heap_caps_free(whites);
+            }
+            whites = newWhites;
+        #endif
     }
 
     GFXBase::ConfigureTopology(width, height, serpentine);
@@ -161,17 +304,36 @@ void WS281xGFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsD
         const auto ledCount = graphics.GetLEDCount();
         const auto activePixels = std::min<size_t>(pixelsDrawn, ledCount);
         if (activePixels < ledCount)
+        {
             fill_solid(graphics.leds + activePixels, ledCount - activePixels, CRGB::Black);
+            // Zero the tail of the whites plane too (if allocated) so a
+            // previously-CCT-lit pixel that's now beyond pixelsDrawn doesn't
+            // stay lit on the next frame.
+            if (graphics.whites)
+                memset(graphics.whites + activePixels, 0,
+                       (ledCount - activePixels) * sizeof(CRGBW));
+        }
     }
 
     auto& outputManager = g_ptrSystem->GetWS281xOutputManager();
-    outputManager.Show(g_ptrSystem->GetDevices(), pixelsDrawn, deviceConfig.GetBrightness(), g_Values.Fader);
+    uint32_t unscaledPowerMw = 0;
+    const size_t activeChannelCount = std::min<size_t>(outputManager.GetActiveChannelCount(), NUM_CHANNELS);
+    const size_t activeLEDCount = outputManager.GetActiveLEDCount();
+    for (size_t i = 0; i < activeChannelCount; ++i)
+    {
+        auto& graphics = effectManager.g(i);
+        const size_t ledCount = std::min(activeLEDCount, graphics.GetLEDCount());
+        unscaledPowerMw += EstimateWS281xUnscaledPowerMw(graphics, ledCount);
+    }
+
+    uint8_t outputBrightness = deviceConfig.GetBrightness();
     #ifdef POWER_LIMIT_MW
-        g_Values.Brite = 100.0 * calculate_max_brightness_for_power_mW(deviceConfig.GetBrightness(), POWER_LIMIT_MW) / 255;
-    #else
-        g_Values.Brite = 100.0 * deviceConfig.GetBrightness() / 255;
+        outputBrightness = LimitBrightnessForPower(unscaledPowerMw, outputBrightness, g_Values.Fader, POWER_LIMIT_MW);
     #endif
-    g_Values.Watts = calculate_unscaled_power_mW(effectManager.g().leds, pixelsDrawn) / 1000; // 1000 for mw->W
+    outputManager.Show(g_ptrSystem->GetDevices(), pixelsDrawn, outputBrightness, g_Values.Fader);
+
+    g_Values.Brite = 100.0 * outputBrightness / 255;
+    g_Values.Watts = ScalePowerMw(unscaledPowerMw, outputBrightness, g_Values.Fader) / 1000; // 1000 for mW->W
     #endif
 }
 

--- a/src/ws281xoutputmanager.cpp
+++ b/src/ws281xoutputmanager.cpp
@@ -48,6 +48,7 @@
 #endif
 
 #include "gfxbase.h"
+#include "pixelformat.h"
 #include "ws281xgfx.h"
 
 // Transport base class. Concrete subclasses (in the anonymous namespace below)
@@ -149,63 +150,9 @@ namespace
     }
 #endif // ESP_IDF_VERSION_MAJOR < 5
 
-    template <uint8_t RIndex, uint8_t GIndex, uint8_t BIndex>
-    void PackChannelPixels(uint8_t* output,
-                           const CRGB* source,
-                           size_t activeLedCount,
-                           size_t pixelsToShow,
-                           uint8_t brightness,
-                           uint8_t fader)
-    {
-        for (size_t pixelIndex = 0; pixelIndex < activeLedCount; ++pixelIndex)
-        {
-            CRGB color = pixelIndex < pixelsToShow ? source[pixelIndex] : CRGB::Black;
-
-            // Preserve the compiled-path semantics without first mutating the effect buffer:
-            // scale by configured brightness, then apply the global master fader.
-            nscale8x3_video(color.r, color.g, color.b, brightness);
-            nscale8x3_video(color.r, color.g, color.b, fader);
-
-            const size_t offset = pixelIndex * 3;
-            output[offset + RIndex] = color.r;
-            output[offset + GIndex] = color.g;
-            output[offset + BIndex] = color.b;
-        }
-    }
-
-    void PackChannelPixelsForColorOrder(uint8_t* output,
-                                        const CRGB* source,
-                                        size_t activeLedCount,
-                                        size_t pixelsToShow,
-                                        uint8_t brightness,
-                                        uint8_t fader,
-                                        DeviceConfig::WS281xColorOrder colorOrder)
-    {
-        switch (colorOrder)
-        {
-            case DeviceConfig::WS281xColorOrder::RGB:
-                PackChannelPixels<0, 1, 2>(output, source, activeLedCount, pixelsToShow, brightness, fader);
-                return;
-            case DeviceConfig::WS281xColorOrder::RBG:
-                PackChannelPixels<0, 2, 1>(output, source, activeLedCount, pixelsToShow, brightness, fader);
-                return;
-            case DeviceConfig::WS281xColorOrder::GRB:
-                PackChannelPixels<1, 0, 2>(output, source, activeLedCount, pixelsToShow, brightness, fader);
-                return;
-            case DeviceConfig::WS281xColorOrder::GBR:
-                PackChannelPixels<2, 0, 1>(output, source, activeLedCount, pixelsToShow, brightness, fader);
-                return;
-            case DeviceConfig::WS281xColorOrder::BRG:
-                PackChannelPixels<1, 2, 0>(output, source, activeLedCount, pixelsToShow, brightness, fader);
-                return;
-            case DeviceConfig::WS281xColorOrder::BGR:
-                PackChannelPixels<2, 1, 0>(output, source, activeLedCount, pixelsToShow, brightness, fader);
-                return;
-            default:
-                PackChannelPixels<1, 0, 2>(output, source, activeLedCount, pixelsToShow, brightness, fader);
-                return;
-        }
-    }
+    // Per-pixel packing moved into PixelFormat (see include/pixelformat.h).
+    // Ws2812Format reproduces the previous PackChannelPixels behavior; new
+    // chips (SK6812, SM16825, WS2805) add sibling format classes there.
 
     void LogRuntimeWS281xConfiguration(const DeviceConfig& config, const std::vector<std::shared_ptr<GFXBase>>& devices, const char* reason)
     {
@@ -502,9 +449,29 @@ namespace
     }
 }
 
+namespace
+{
+    // Pick the PixelFormat that matches the LED chip on the wire. Currently
+    // selected by compile-time flag - eventually this could become a
+    // DeviceConfig runtime knob. SK6812 (4-channel RGBW) is the second chip
+    // we support; the WS2812 path is the default.
+    std::unique_ptr<PixelFormat> CreatePixelFormat()
+    {
+#if defined(USE_SK6812) && USE_SK6812
+        return std::make_unique<Sk6812Format>();
+#else
+        return std::make_unique<Ws2812Format>();
+#endif
+    }
+}
+
 // Out-of-line so the unique_ptr<Transport> default-deleter sees the full
-// Transport definition above.
-WS281xOutputManager::WS281xOutputManager() : _transport(CreateTransport()) {}
+// Transport definition above, and the unique_ptr<PixelFormat> deleter sees
+// the full PixelFormat hierarchy from pixelformat.h.
+WS281xOutputManager::WS281xOutputManager()
+    : _transport(CreateTransport()), _format(CreatePixelFormat())
+{
+}
 
 WS281xOutputManager::~WS281xOutputManager()
 {
@@ -528,7 +495,9 @@ void WS281xOutputManager::Reset()
 bool WS281xOutputManager::RecreateChannel(size_t channelIndex, int8_t pin, size_t ledCount, String* errorMessage)
 {
     auto& state = _channels[channelIndex];
-    const auto byteCount = ledCount * 3;
+    // BytesPerPixel comes from the chip-specific PixelFormat (3 for WS2812,
+    // 4 for SK6812, 5 for SM16825/WS2805).
+    const auto byteCount = ledCount * _format->BytesPerPixel();
 
     // A channel recreate is the "hard" reconfigure path: tear down any existing
     // RMT binding, resize the packed byte buffer if LED count changed, then
@@ -672,7 +641,47 @@ void WS281xOutputManager::Show(const std::vector<std::shared_ptr<GFXBase>>& devi
 
         const auto& device = devices[channelIndex];
         auto* output = state.outputBytes.get();
-        PackChannelPixelsForColorOrder(output, device->leds, _activeLEDCount, pixelsToShow, brightness, fader, _colorOrder);
+        
+        // Delegate to the chip-specific format. Passes the optional whites
+        // plane (nullptr for plain WS2812 builds; populated by setPixelCCT /
+        // setPixelWhite calls on SK6812+ builds). cctKelvin, ambient white,
+        // and white-extract ratio defaults are baked in here pending the
+        // DeviceConfig knobs landing in a follow-up commit. Each can be
+        // overridden at build time via a -D in the env's build_src_flags.
+
+        #ifndef NIGHTDRIVER_DEFAULT_CCT_KELVIN
+            #define NIGHTDRIVER_DEFAULT_CCT_KELVIN 4000
+        #endif
+        #ifndef NIGHTDRIVER_DEFAULT_AMBIENT_CW
+            #define NIGHTDRIVER_DEFAULT_AMBIENT_CW 0
+        #endif
+        #ifndef NIGHTDRIVER_DEFAULT_AMBIENT_WW
+            #define NIGHTDRIVER_DEFAULT_AMBIENT_WW 0
+        #endif
+        
+        // SK6812_WHITE_EXTRACT_RATIO: 0..255, fraction of shared-portion
+        // white pulled into the dedicated W LED
+        
+        #ifndef SK6812_WHITE_EXTRACT_RATIO
+            #define SK6812_WHITE_EXTRACT_RATIO 96
+        #endif
+        
+        constexpr uint16_t kDefaultCctKelvin   = NIGHTDRIVER_DEFAULT_CCT_KELVIN;
+        constexpr uint8_t  kDefaultAmbientCw   = NIGHTDRIVER_DEFAULT_AMBIENT_CW;
+        constexpr uint8_t  kDefaultAmbientWw   = NIGHTDRIVER_DEFAULT_AMBIENT_WW;
+        constexpr uint8_t  kDefaultExtractRatio = SK6812_WHITE_EXTRACT_RATIO;
+
+        _format->Pack(output,
+                      device->leds,
+                      device->whites,                 // may be nullptr
+                      _activeLEDCount,
+                      pixelsToShow,
+                      brightness, fader,
+                      _colorOrder,
+                      kDefaultCctKelvin,
+                      kDefaultAmbientCw,
+                      kDefaultAmbientWw,
+                      kDefaultExtractRatio);
     }
 
     const auto showStartMicros = micros();

--- a/src/ws281xoutputmanager.cpp
+++ b/src/ws281xoutputmanager.cpp
@@ -663,7 +663,7 @@ void WS281xOutputManager::Show(const std::vector<std::shared_ptr<GFXBase>>& devi
         // white pulled into the dedicated W LED
         
         #ifndef SK6812_WHITE_EXTRACT_RATIO
-            #define SK6812_WHITE_EXTRACT_RATIO 96
+            #define SK6812_WHITE_EXTRACT_RATIO 128
         #endif
         
         constexpr uint16_t kDefaultCctKelvin   = NIGHTDRIVER_DEFAULT_CCT_KELVIN;


### PR DESCRIPTION
Check-in: RGBCCW (4/5-channel addressable LED) support

Summary

Adds support for 4-channel SK6812 RGBW strips (and the framework for future 5-channel SM16825/WS2805 RGBCCW chips) to NightDriverStrip without touching any existing CRGB-based effects. Existing 3-channel WS2812 builds are unchanged at the source level and pay zero runtime or memory cost for the new code paths. New ships as a working spirallamp_rgbw env targeted at an M5StickC Plus 2 driving two 144-LED SK6812 strips on GPIO 32 and 33.
What's new
CRGBW pixel type (include/crgbw.h) — a 2-byte {cw, ww} struct used as a parallel "whites plane" alongside the existing FastLED CRGB leds[] array. Internal representation always carries both cool-white and warm-white intent; the PixelFormat for each chip decides how to map those onto the strip's actual physical channels.
PixelFormat strategy class (include/pixelformat.h) — the chip-specific policy that converts the (leds, whites) framebuffer pair into the byte stream the wire expects. Abstract base with two concrete subclasses:

Ws2812Format — 3 bytes/pixel, whites ignored. Reproduces the previous PackChannelPixelsForColorOrder behavior exactly.
Sk6812Format — 4 bytes/pixel. Auto-synthesizes the W channel from RGB shared-portion (W = min(R,G,B)) with a configurable extraction ratio (see below), plus saturating-adds any effect-explicit whites and ambient white floor.

The white plane lives on GFXBase as a sibling pointer to leds. Allocated by WS281xGFX only when USE_SK6812=1; left null otherwise, so 3-channel builds incur no memory cost. Reallocated in ConfigureTopology and freed in the destructor.

New API on GFXBase:

setPixelWhite(x, y, cw, ww) — explicit dual-white intent
setPixelCCT(x, y, kelvin, brightness) — Kelvin gets split between CW/WW via SplitByCct helper in crgbw.h

Both no-op when whites is null, so the same source compiles and runs on plain WS2812 builds without conditional branches.

WarmGlowEffect (include/effects/strip/cct_effects.h) — reference CCT-aware effect with a CRGB-fallback path. On builds with a whites plane it drives the dedicated W LED(s) via setPixelCCT and zeros RGB. On builds without one it falls back to a Kelvin-tinted CRGB approximation so warm and cool presets are visibly distinct. Registered into both EFFECTS_DEMO and EFFECTS_SPIRALLAMP at 2700K and 6500K.

What changed in existing code

WS281xOutputManager now holds a unique_ptr<PixelFormat> picked at construction by USE_SK6812. Per-channel byteCount is format->BytesPerPixel() * ledCount instead of ledCount * 3. The Show() per-channel pack loop calls format->Pack(device->leds, device->whites, …) instead of PackChannelPixelsForColorOrder directly. The old template'd PackChannelPixels and color-order switch have been deleted; that logic moved into Ws2812Format::Pack.
WS281xGFX::PostProcessFrame now zeros the tail of whites[] beyond pixelsDrawn the same way it already zeroed the tail of leds[].

EffectManager::StartEffect now zeros the whites plane on every graphics device at every effect transition. GFXBase::Clear, LEDStripEffect::fillSolidOnAllChannels, and LEDStripEffect::setAllOnAllChannels similarly zero the matching range of whites when clearing leds. This fixes a cross-effect bleed where a CCT effect (WarmGlow) would leave W LEDs lit underneath subsequent RGB effects that wrote only to leds[]. Leds[] is intentionally not blanket-cleared on effect switch — effects like FireEffect deliberately persist leds[] state across frames for heat-decay loops.

Configurable white-extract ratio

The shared-portion extraction in Sk6812Format is now a whiteExtractRatio parameter (0..255). Default 128 (50%): half the shared white routes to the dedicated W LED, half stays in RGB. The previous "full extraction" (255) behavior reliably washed out near-white content because the W LED on most SK6812 SKUs is 2-3× brighter per digital count than RGB. Effect-explicit whites from setPixelWhite/setPixelCCT are NOT scaled by this ratio — those route through unchanged.
Overrideable at build time via -DSK6812_WHITE_EXTRACT_RATIO=N in any env's build_src_flags, alongside NIGHTDRIVER_DEFAULT_CCT_KELVIN, NIGHTDRIVER_DEFAULT_AMBIENT_CW, NIGHTDRIVER_DEFAULT_AMBIENT_WW. Plumbing the same knobs through DeviceConfig + SetupUI for runtime control is a deliberate follow-up — easier to design those once we have real RGBCCW hardware to compare against.

New env

[env:spirallamp_rgbw] — extends dev_m5stick_c_plus2. 2 channels of SK6812 RGBW @ 144 LEDs each, pins 32 and 33, USE_SK6812=1, EFFECTS_DEMO=1. Uses EFFECTS_DEMO instead of EFFECTS_SPIRALLAMP because FireFanEffect in the spirallamp set writes through FastLED's global controller registry (FastLED[i][x] = color), which is empty on the NightDriver runtime-managed strip path and null-derefs on the first draw. That's a pre-existing bug in FireFanEffect — it was latent until now because the original spirallamp env uses EFFECTS_MINIMAL. Worth fixing as a separate change before switching back.
What it doesn't do (deliberate)

No DeviceConfig / SetupUI plumbing for the CCT/ambient/extract-ratio knobs yet. Compile-time defaults are tuned reasonably; runtime knobs are the next commit's problem once the SetupUI design has real RGBCCW hardware feedback to design against.
No SM16825Format yet. The abstraction's there; the format is a ~50-line add when we have actual 5-channel hardware in hand. WS2805 is similarly straightforward.
No tone-curve or LUT-based CCT split. SplitByCct is linear between 2700K (pure WW) and 6500K (pure CW), clamped at both ends. On 4-channel SK6812 the linearity doesn't matter because both halves route to the single W LED anyway; matters more for 5-channel chips where CW and WW are physically separate phosphors.

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subject to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).