### PR TITLE
Complete fix for #871

### DIFF
--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -202,7 +202,9 @@ public:
     virtual ~GFXBase() override;
 
     #if USE_NOISE
-    // Returns true if noise was just initialized, false if it was already initialized.
+    // Ensures noise is initialized.
+    // Returns true only if this call performed the initialization; returns false for all
+    // other calls, including concurrent callers that observe initialization complete.
     bool EnsureNoise() const;
 
     Noise &GetNoise()
@@ -520,7 +522,7 @@ public:
 
     private:
         // Called only from within EnsureNoise() (already inside call_once), and therefore
-        // must NOT call EnsureNoise() itself — doing so would deadlock std::call_once.
+        // must NOT call EnsureNoise() itself — doing so would result in undefined behavior.
         void FillGetNoiseImpl() const;
 
     public:

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -517,6 +517,13 @@ public:
 
         void FillGetNoise() const;
 
+    private:
+        // Called only from within EnsureNoise() (already inside call_once), and therefore
+        // must NOT call EnsureNoise() itself — doing so would deadlock std::call_once.
+        void FillGetNoiseImpl() const;
+
+    public:
+
         // The next couple of two-liners define function templates for the different noise approaches
         // that are implemented in the project. The desired noise approach for a particular use case
         // can be chosen by passing one of the NoiseApproach enum's values as a template parameter.

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -202,7 +202,8 @@ public:
     virtual ~GFXBase() override;
 
     #if USE_NOISE
-    void EnsureNoise() const;
+    // Returns true if noise was just initialized, false if it was already initialized.
+    bool EnsureNoise() const;
 
     Noise &GetNoise()
     {

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -512,8 +512,6 @@ public:
         // the oscillators: linear ramps 0-255
         // osci[0-3] are used for noise animation
         // osci[4-5] are used for palette rotation
-        void NoiseVariablesSetup() const;
-
         void SetNoise(uint32_t nx, uint32_t ny, uint32_t nz, uint32_t sx, uint32_t sy);
 
         void FillGetNoise() const;

--- a/src/gfxbase.cpp
+++ b/src/gfxbase.cpp
@@ -1125,8 +1125,8 @@ CRGB GFXBase::HsvToRgb(uint8_t h, uint8_t s, uint8_t v)
 
     void GFXBase::FillGetNoise() const
     {
-        EnsureNoise();
-        FillGetNoiseImpl();
+        if (!EnsureNoise())
+            FillGetNoiseImpl();
     }
 
     template<>
@@ -1420,9 +1420,10 @@ void GFXBase::ConfigureTopology(size_t width, size_t height, bool serpentine)
 }
 
 #if USE_NOISE
-void GFXBase::EnsureNoise() const
+bool GFXBase::EnsureNoise() const
 {
-    std::call_once(_noiseInitOnce, [this]()
+    bool justInitialized = false;
+    std::call_once(_noiseInitOnce, [&]()
     {
         // Noise is large and only used by a subset of effects. Lazy allocation keeps the boot path leaner
         // and still allows runtime topology to stay within the build-time maximum noise backing store.
@@ -1430,7 +1431,10 @@ void GFXBase::EnsureNoise() const
         assert(_ptrNoise);
         NoiseVariablesSetup();
         FillGetNoiseImpl();
+        justInitialized = true;
     });
+
+    return justInitialized;
 }
 #endif
 

--- a/src/gfxbase.cpp
+++ b/src/gfxbase.cpp
@@ -1096,7 +1096,10 @@ CRGB GFXBase::HsvToRgb(uint8_t h, uint8_t s, uint8_t v)
         _ptrNoise->noise_scale_y = sy;
     }
 
-    void GFXBase::FillGetNoise() const
+    // Internal implementation: assumes _ptrNoise is already initialized.
+    // Must NOT call EnsureNoise() — this is invoked from within EnsureNoise()'s
+    // call_once lambda, and a recursive call_once on the same flag deadlocks.
+    void GFXBase::FillGetNoiseImpl() const
     {
         EnsureNoise();
         // Subtracting the center offset before scaling ensures the noise pattern radiates
@@ -1118,6 +1121,12 @@ CRGB GFXBase::HsvToRgb(uint8_t h, uint8_t s, uint8_t v)
                 _ptrNoise->noise[i][j] = newdata;
             }
         }
+    }
+
+    void GFXBase::FillGetNoise() const
+    {
+        EnsureNoise();
+        FillGetNoiseImpl();
     }
 
     template<>
@@ -1420,7 +1429,7 @@ void GFXBase::EnsureNoise() const
         _ptrNoise = std::make_unique<Noise>();
         assert(_ptrNoise);
         NoiseVariablesSetup();
-        FillGetNoise();
+        FillGetNoiseImpl();
     });
 }
 #endif

--- a/src/gfxbase.cpp
+++ b/src/gfxbase.cpp
@@ -1074,18 +1074,6 @@ CRGB GFXBase::HsvToRgb(uint8_t h, uint8_t s, uint8_t v)
     // The following functions are specializations of noise-related member function
     // templates declared in gfxbase.h.
 
-    void GFXBase::NoiseVariablesSetup() const
-    {
-        EnsureNoise();
-        _ptrNoise->noisesmoothing = 200;
-
-        _ptrNoise->noise_x = random16();
-        _ptrNoise->noise_y = random16();
-        _ptrNoise->noise_z = random16();
-        _ptrNoise->noise_scale_x = 6000;
-        _ptrNoise->noise_scale_y = 6000;
-    }
-
     void GFXBase::SetNoise(uint32_t nx, uint32_t ny, uint32_t nz, uint32_t sx, uint32_t sy)
     {
         EnsureNoise();
@@ -1428,7 +1416,13 @@ bool GFXBase::EnsureNoise() const
         // and still allows runtime topology to stay within the build-time maximum noise backing store.
         _ptrNoise = std::make_unique<Noise>();
         assert(_ptrNoise);
-        NoiseVariablesSetup();
+        _ptrNoise->noisesmoothing = 200;
+
+        _ptrNoise->noise_x = random16();
+        _ptrNoise->noise_y = random16();
+        _ptrNoise->noise_z = random16();
+        _ptrNoise->noise_scale_x = 6000;
+        _ptrNoise->noise_scale_y = 6000;
         FillGetNoiseImpl();
         justInitialized = true;
     });

--- a/src/gfxbase.cpp
+++ b/src/gfxbase.cpp
@@ -1101,7 +1101,6 @@ CRGB GFXBase::HsvToRgb(uint8_t h, uint8_t s, uint8_t v)
     // call_once lambda, and a recursive call_once on the same flag deadlocks.
     void GFXBase::FillGetNoiseImpl() const
     {
-        EnsureNoise();
         // Subtracting the center offset before scaling ensures the noise pattern radiates
         // outwards from the center of the display (exactly as #803 intended).
         //

--- a/src/gfxbase.cpp
+++ b/src/gfxbase.cpp
@@ -1098,7 +1098,7 @@ CRGB GFXBase::HsvToRgb(uint8_t h, uint8_t s, uint8_t v)
 
     // Internal implementation: assumes _ptrNoise is already initialized.
     // Must NOT call EnsureNoise() — this is invoked from within EnsureNoise()'s
-    // call_once lambda, and a recursive call_once on the same flag deadlocks.
+    // call_once lambda, and a recursive call_once on the same flag is UB.
     void GFXBase::FillGetNoiseImpl() const
     {
         // Subtracting the center offset before scaling ensures the noise pattern radiates


### PR DESCRIPTION
## Description

Extends the fix embedded in #869 for crashes due to uninitialized noise like reported in #871, to prevent a mutual invocation of FillGetNoise() and EnsureNoise() causing two re-entrant hits on the same once_flag in EnsureNoise(). This is an uncovered scenario in the documentation of call_once, and as such effectively undefined behavior. The fact that this works in our case instead of causing a deadlock, is a lucky implementation detail we shouldn't rely on.

It solves this by extracting the actual FillGetNoise logic into a private Impl version of that function that does not call EnsureNoise(), which is called by EnsureNoise() and FillGetNoise() if EnsureNoise() hasn't already.

Fixes #871.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).