### PR TITLE
Actually use custom_merged_image variable

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -398,7 +398,7 @@ build_type      = debug
 build_unflags   = -std=gnu++11
 lib_extra_dirs  = ${PROJECT_DIR}/lib
 monitor_filters = esp32_exception_decoder
-custom_merged_image = ${PROJECT_BUILD_DIR}/${PIOENV}/merged_image.bin
+custom_merged_image = merged_image.bin
 extra_scripts   = pre:tools/install_intelhex.py
                   pre:tools/bake_site.py
                   post:tools/merge_image.py

--- a/tools/merge_image.py
+++ b/tools/merge_image.py
@@ -76,7 +76,7 @@ build_dir = env.subst("$BUILD_DIR")
 progname = env.subst("$PROGNAME")
 
 app_bin = os.path.join(build_dir, f"{progname}.bin")
-merged_image = os.path.join(build_dir, "merged_image.bin")
+merged_image = os.path.join(build_dir, env.GetProjectOption("custom_merged_image", "merged_image.bin"))
 
 merged_target = env.Command(
     target=merged_image,


### PR DESCRIPTION
## Description

This fixes a slip-up in #875, where a custom_merged_image variable was introduced in platformio.ini that was actually not used while putting the merged image together.

merge_image.py now uses it, defaulting to merged_image.bin if unset.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).