### PR TITLE
Bugfixes - Concurrency and Memory Safety

### DIFF
--- a/UISpec.md
+++ b/UISpec.md
@@ -1,0 +1,1361 @@
+# NightDriverStrip Web UI Specification
+
+This document is the regeneration spec for the current on-device web UI. It is intended to be detailed enough to recreate the UI from scratch without treating the current `site/` files as the only source of truth.
+
+The current implementation is a static, dependency-free browser application served by the ESP32 firmware. It lives in:
+
+- `site/index.html`
+- `site/styles.css`
+- `site/app.js`
+- `tools/bake_site.py`
+- `src/webserver.cpp`
+
+## Goals
+
+- Provide a compact control surface for a NightDriverStrip device.
+- Run directly from the firmware without Node, React, Vite, CDNs, web fonts, or external assets.
+- Prefer firmware-driven metadata for settings so the UI does not hardcode every setting.
+- Keep the app usable on desktop and mobile browsers.
+- Support regeneration at any time by preserving the contracts described here.
+
+## Non-Goals
+
+- Do not create a marketing page, setup wizard, or multi-page site.
+- Do not depend on internet access or third-party frontend packages.
+- Do not require a frontend build step beyond gzip embedding.
+- Do not store device configuration in the browser except for UI preferences.
+
+## Runtime And Build Model
+
+The UI consists of three static assets:
+
+- `/index.html`
+- `/styles.css`
+- `/app.js`
+
+`tools/bake_site.py` gzips these into:
+
+- `site/dist/index.html.gz`
+- `site/dist/styles.css.gz`
+- `site/dist/app.js.gz`
+
+PlatformIO embeds these files through `board_build.embed_files`. The firmware serves them from `src/webserver.cpp` when `ENABLE_WEB_UI` is enabled:
+
+- `/`
+- `/index.html`
+- `/styles.css`
+- `/app.js`
+
+The firmware also embeds `config/timezones.json` and serves it at `/timezones.json`.
+
+The generated UI must be plain HTML, CSS, and JavaScript. It should run as a single immediately invoked script with `"use strict"`. It may use modern browser APIs already used by the current UI: `fetch`, `Promise.allSettled`, `URLSearchParams`, `localStorage`, `dialog`, `WebSocket`, `requestAnimationFrame`, `Intl.DisplayNames`, and `CanvasRenderingContext2D`.
+
+## Information Architecture
+
+The application has one screen with these regions, in order:
+
+1. Fixed visual background layers.
+2. Main shell.
+3. Top status bar.
+4. Toolbar.
+5. Summary card grid.
+6. Tabbed main panel.
+7. Effect settings modal dialog.
+8. Toast stack.
+
+There are three tabs:
+
+- Effects
+- Settings
+- Statistics
+
+Only one tab pane is visible at a time. The selected tab persists in `localStorage` under `nd.activeTab`.
+
+## Static DOM Structure
+
+The static HTML must include these elements and IDs because the controller binds by ID.
+
+### Background
+
+- `div.backdrop`
+- `div.grid-overlay`
+
+Both are fixed, non-interactive, and cover the viewport.
+
+### Main Shell
+
+`main.shell` wraps all primary content.
+
+### Topbar
+
+`header.topbar.panel.card-blue` contains:
+
+- `div.title-block`
+  - `p.eyebrow`: text `ESP32 Control Surface`
+  - `h1`: text `NightDriverStrip`
+- `div.status-cluster`
+  - `div#connectionStatus.status-pill`
+    - `span.status-dot`
+    - `span#connectionStatusText`: initial text `Starting`
+  - host pill:
+    - label `Host`
+    - `strong#hostValue`: initial `--`
+  - port pill:
+    - label `Web Port`
+    - `strong#webPortValue`: initial `--`
+
+The controller sets host and port from `window.location`.
+
+### Toolbar
+
+`section.toolbar.panel.card-orange` contains four groups:
+
+- Effects group:
+  - `button#prevEffectButton`: previous effect
+  - `button#nextEffectButton`: next effect
+  - `button#refreshEffectsButton`: reload effects
+- Interval group:
+  - `input#effectIntervalInput[type=number][min=0][step=1]`
+  - `button#saveIntervalButton`: apply interval
+- Statistics group:
+  - `input#statsRefreshInput[type=number][min=1][max=60][step=1]`
+  - `input#autoRefreshToggle[type=checkbox]`
+- Device group:
+  - `button#rebootButton`
+  - `button#resetDeviceConfigButton`
+  - `button#resetEffectsConfigButton`
+
+The device group is pushed to the right on wide layouts.
+
+### Summary Cards
+
+`section.summary-grid` contains six `article.summary-card.panel` cards:
+
+1. Current Effect, `card-red`
+   - `#summaryCurrentEffect`
+   - `#summaryEffectStatus`
+2. Interval, `card-yellow`
+   - `#summaryInterval`
+   - `#summaryIntervalRemaining`
+3. Topology, `card-green`
+   - `#summaryTopology`
+   - `#summaryDriver`
+4. LED FPS, `card-cyan`
+   - `#summaryLedFps`
+   - `#summaryAudioFps`
+5. CPU Used, `card-purple`
+   - `#summaryCpu`
+   - `#summaryCpuCores`
+6. Heap Free, `card-pink`
+   - `#summaryHeap`
+   - `#summaryPsram`
+
+### Tabbed Main Panel
+
+`section.main-grid.tabs-grid` contains `div.tab-shell`.
+
+The tab strip is:
+
+- `div.tab-strip[role=tablist][aria-label="Main sections"]`
+  - `button#tabEffectsButton.tab-button.tab-effects`
+  - `button#tabSettingsButton.tab-button.tab-settings`
+  - `button#tabStatisticsButton.tab-button.tab-statistics`
+
+Each tab button has `role=tab`, `aria-selected`, and `aria-controls`.
+
+The tab body is:
+
+- `article#tabBodyPanel.panel.tab-body-panel`
+
+Its color theme changes by active tab:
+
+- Effects: `card-green`
+- Settings: `card-blue`
+- Statistics: `card-purple`
+
+Each tab pane has `role=tabpanel`. Hidden panes must have the `hidden` attribute and lack `.active`.
+
+#### Effects Pane
+
+`section#tabEffectsPane.tab-pane.active` contains:
+
+- panel header:
+  - eyebrow `Runtime Effects`
+  - heading `Effects`
+  - `#effectsMeta`
+- `div.table-wrap`
+  - `table.canvas-table`
+    - columns: grip, On, Name, Status, Core, Actions
+    - `tbody#effectsTableBody`
+
+Initial tbody should show one full-width loading row.
+
+#### Settings Pane
+
+`section#tabSettingsPane.tab-pane[hidden]` contains:
+
+- panel header:
+  - eyebrow `Device`
+  - heading `Settings`
+  - `button#reloadSettingsButton`
+  - `button#applySettingsButton`
+  - `button#applySettingsRebootButton`
+- `form#deviceSettingsForm.settings-grid`
+
+The form is rendered dynamically from `/settings/specs` plus `/api/v1/settings/schema`.
+
+#### Statistics Pane
+
+`section#tabStatisticsPane.tab-pane[hidden]` contains:
+
+- panel header:
+  - eyebrow `Runtime`
+  - heading `Statistics`
+  - `#statsTimestamp`
+- `div#statsGrid.stats-grid`
+- preview header:
+  - eyebrow `Websocket`
+  - heading `Frame Preview`
+  - `button#previewConnectButton`
+  - `button#previewDisconnectButton`
+- `div.preview-meta`
+  - `span#previewStatus`
+- `div#previewWrap.preview-wrap.is-empty`
+  - `canvas#previewCanvas[width=640][height=320]`
+
+The preview wrapper is hidden while empty.
+
+### Effect Settings Dialog
+
+Use a native `dialog#effectSettingsDialog.editor-dialog`.
+
+Inside it:
+
+- `form.dialog-shell.panel.card-red[method=dialog]`
+  - `header.dialog-header`
+    - eyebrow `Effect`
+    - `h2#effectDialogTitle`
+    - `button#closeEffectDialogButton`
+  - `div#effectSettingsForm.settings-grid`
+  - `footer.dialog-actions`
+    - `button#cancelEffectDialogButton`
+    - `button#applyEffectDialogButton`
+
+The dialog is opened with `showModal()` and closed with `close()`.
+
+### Toasts
+
+Use `div#toastStack.toast-stack[aria-live=polite]`. Toasts are transient child `div.toast` nodes with optional `.success` or `.error`.
+
+## Visual Design
+
+The UI is a dark, neon, monospace control surface.
+
+### Typography
+
+- Body font stack: `"SFMono-Regular", "Menlo", "Consolas", monospace`.
+- Buttons, inputs, selects, and textareas inherit the body font.
+- Main title is uppercase, wide tracked, and responsive.
+- Eyebrows, summary labels, summary notes, panel metadata, toolbar labels, field labels, toggle labels, and inline suffixes are small uppercase text with wide letter spacing.
+
+### Core CSS Variables
+
+The root palette must include:
+
+- `--bg: #030712`
+- `--bg-soft: #081122`
+- `--panel: rgba(7, 14, 29, 0.84)`
+- `--panel-strong: rgba(10, 18, 38, 0.94)`
+- `--line: rgba(74, 222, 255, 0.24)`
+- `--line-strong: rgba(74, 222, 255, 0.54)`
+- `--ink: #eff8ff`
+- `--muted: #8ea7c8`
+- `--accent: #4adeff`
+- `--accent-warm: #ffcf40`
+- `--accent-hot: #ff5b88`
+- `--accent-good: #39ff88`
+- `--danger: #ff5b88`
+- `--warning: #ffcf40`
+- `--good: #39ff88`
+- `--shadow: rgba(0, 0, 0, 0.35)`
+
+### Panel Themes
+
+Panels use a custom `--card-rgb` variable to create borders, highlights, radial glow, and shadows.
+
+Theme classes:
+
+- `.card-red`: `255, 40, 40`
+- `.card-yellow`: `255, 214, 10`
+- `.card-green`: `57, 255, 136`
+- `.card-cyan`: `0, 224, 255`
+- `.card-blue`: `64, 140, 255`
+- `.card-purple`: `191, 90, 242`
+- `.card-orange`: `255, 149, 0`
+- `.card-pink`: `255, 62, 131`
+
+`.panel` has:
+
+- `position: relative`
+- `overflow: hidden`
+- 1px themed border
+- 18px border radius
+- layered radial and linear backgrounds
+- inner highlight, drop shadow, outer glow
+- `backdrop-filter: blur(10px)`
+- a pseudo-element border sheen
+
+### Background
+
+The page background is dark. `.backdrop` uses layered radial gradients and a dark linear gradient. `.grid-overlay` adds a 48px grid, low opacity, and a vertical fade mask.
+
+### Layout Dimensions
+
+- `.shell`: `width: min(1680px, calc(100vw - 24px))`, centered, top/bottom padding.
+- Major regions have 16px bottom margin.
+- Summary grid is six equal columns on wide screens.
+- Statistics grid is two equal columns on wide screens.
+- Settings grid is one column of section containers.
+
+Responsive breakpoints:
+
+- At max-width 1220px:
+  - summary grid becomes three columns.
+  - any old `.main-grid.nds-main-grid` layout collapses to one column if present.
+- At max-width 760px:
+  - shell uses `calc(100vw - 16px)`.
+  - topbar and toolbar padding shrink.
+  - summary, stats, and settings grids become one column.
+  - setting rows become one column.
+  - main title becomes about 1.8rem.
+
+### Controls
+
+Buttons:
+
+- `.action-button` and `.icon-button` have a translucent border, dark gradient background, 12px radius, 10px x 14px padding, pointer cursor, and hover lift.
+- `.action-button.accent` uses green border emphasis.
+- `.action-button.warning` uses hot pink border emphasis.
+- Disabled buttons reduce opacity and remove hover effects.
+
+Inputs/selects/textareas:
+
+- Minimum height 44px.
+- 12px radius.
+- 1px cyan translucent border.
+- dark translucent background.
+- `padding: 10px 12px`.
+- Checkboxes keep intrinsic dimensions.
+- Range inputs have no padding.
+
+Boolean switches use a custom mac-style switch:
+
+- `label.mac-switch`
+- hidden checkbox
+- `.mac-switch-track` 52px by 32px rounded track
+- `.mac-switch-thumb` 24px circular thumb
+- checked state is green, thumb translates 20px.
+
+### Effects Table
+
+Use `table.canvas-table`, full width, collapsed borders. Cells have compact vertical padding and cyan separator lines. Headers are uppercase muted text. Drag state:
+
+- `tr.dragging`: opacity 0.4
+- `tr.drop-target`: inset top line highlight
+- `.drag-grip` is a 24px square grab handle with a list/hamburger glyph via CSS content.
+
+Action cells use `.row-actions`, `.mini-button`, and `.mini-icon-button`. Current action labels are icon-like glyphs:
+
+- Trigger effect: U+25B6 play triangle
+- Effect settings: U+2699 gear
+- Delete effect: U+1F5D1 wastebasket
+
+A regenerating implementation may use text or SVG/icon equivalents, but the button titles and behavior must remain.
+
+### Settings Form
+
+Settings are grouped into `.settings-section` blocks:
+
+- section border and dark translucent background.
+- header with title and optional description.
+- rows use `.setting-row`.
+- normal row grid: label/meta column and control column.
+- palette rows use `.setting-row.stacked`.
+- control width is capped at 360px on wide screens.
+- help text is muted and supports HTML from firmware descriptions.
+- validation errors use `.field-error`.
+
+### Stats Cards
+
+`.stat-card` is a bordered dark card. It has an `h3`, optional `.meter`, and a `.stat-list` of `.stat-row` pairs. Meter fills are linear cyan-to-green.
+
+### Preview Canvas
+
+The preview canvas:
+
+- has pixelated rendering.
+- has dark background, cyan border, 14px radius.
+- toggles `.preview-canvas-thin` when rendered height is <= 12px to remove border/background for one-row strips.
+
+### Toasts
+
+Toast stack is fixed bottom-right. Toasts have dark background, 12px radius, cyan border. `.toast.error` uses danger border; `.toast.success` uses good border. Toasts auto-remove after 4200ms.
+
+## Client State
+
+The client keeps all mutable UI state in one object equivalent to:
+
+- `staticStats`: result of `/statistics/static`
+- `dynamicStats`: result of `/statistics/dynamic`
+- `settings`: result of `/settings`
+- `settingsSpecs`: result of `/settings/specs`
+- `timezones`: parsed external timezone document, initially null
+- `timezonesLoading`: guard flag
+- `unifiedSettings`: result of `/api/v1/settings`
+- `unifiedSchema`: result of `/api/v1/settings/schema`
+- `effects`: result of `/effects`
+- `effectIntervalInputDirty`: protects user edits in toolbar interval input
+- `effectIntervalPendingMs`: interval value posted but not yet reflected by server, or null
+- `deviceDraft`: unsaved device settings keyed by setting spec name
+- `deviceErrors`: `Map<settingName, message>`
+- `effectDialog`: object with `open`, `effectIndex`, `effectName`, `specs`, `values`, `draft`, and `errors`
+- `autoRefresh`: boolean
+- `statsRefreshSeconds`: loaded from `localStorage["nd.statsRefreshSeconds"]`, default 3
+- `timers`: `stats`, `effects`, `countdown`
+- `preview`: websocket/render-loop state
+- `drag`: effect drag state
+- `activeTab`: loaded from `localStorage["nd.activeTab"]`, default `effects`
+
+Persist these browser-only preferences:
+
+- `nd.activeTab`
+- `nd.statsRefreshSeconds`
+
+Do not persist drafts in localStorage.
+
+## Initialization Flow
+
+On `DOMContentLoaded`:
+
+1. Bind all required DOM elements by ID.
+2. Attach event handlers.
+3. Initialize static shell:
+   - Host and web port from `window.location`.
+   - Stats refresh input from `state.statsRefreshSeconds`.
+   - Auto refresh checkbox from `state.autoRefresh`.
+   - Restore active tab.
+   - Set connection state to `Starting`.
+4. `loadAll()`.
+5. Start timezone loading if needed.
+6. Start polling.
+
+`loadAll()` fetches these endpoints concurrently with `Promise.allSettled`:
+
+- `/statistics/static`
+- `/statistics/dynamic`
+- `/settings`
+- `/settings/specs`
+- `/api/v1/settings`
+- `/api/v1/settings/schema`
+- `/effects`
+
+Any successful response is accepted. Failures are collected and shown as a toast. After load:
+
+- clear `deviceDraft`
+- clear `deviceErrors`
+- render settings, effects, summaries, stats, and preview independently so one renderer failure does not block the others
+- set connection status to `Connected` if any request succeeded, otherwise `Offline`
+
+## Polling
+
+`restartPolling()` clears all timers, then:
+
+- If auto-refresh is on:
+  - fetch `/statistics/dynamic` every `state.statsRefreshSeconds` seconds
+  - fetch `/effects` every 3000ms
+- Always update the countdown/summary display every 250ms.
+
+Changing `#statsRefreshInput` clamps to 1..60 seconds, writes `nd.statsRefreshSeconds`, and restarts polling.
+
+Changing `#autoRefreshToggle` updates `state.autoRefresh` and restarts polling.
+
+## HTTP Helpers
+
+All fetch failures throw an Error built from HTTP status, JSON `message`, or response text.
+
+`fetchJson(path, options)`:
+
+- performs `fetch`
+- requires `response.ok`
+- reads text, trims trailing NUL bytes and whitespace, parses JSON
+
+`postJson(path, payload)`:
+
+- method POST
+- header `Content-Type: application/json`
+- body `JSON.stringify(payload || {})`
+- returns parsed JSON when response content type contains `application/json` or `text/json`, otherwise null
+
+`postForm(path, payload)`:
+
+- method POST
+- header `Content-Type: application/x-www-form-urlencoded;charset=UTF-8`
+- serializes primitives with `String(value)`
+- serializes arrays/objects with `JSON.stringify(value)`
+- skips null/undefined values
+- returns parsed JSON when response content type is JSON, otherwise null
+
+## API Contract
+
+### Static Assets
+
+- `GET /`
+- `GET /index.html`
+- `GET /styles.css`
+- `GET /app.js`
+- `GET /timezones.json`
+
+The first three app assets may be gzip encoded by firmware. The timezone document is JSON/text JSON.
+
+### Statistics
+
+`GET /statistics/static` returns static/config fields used by the UI:
+
+- `MATRIX_WIDTH`
+- `MATRIX_HEIGHT`
+- `CONFIGURED_MATRIX_WIDTH`
+- `CONFIGURED_MATRIX_HEIGHT`
+- `CONFIGURED_NUM_LEDS`
+- `ACTIVE_MATRIX_WIDTH`
+- `ACTIVE_MATRIX_HEIGHT`
+- `ACTIVE_NUM_LEDS`
+- `COMPILED_NUM_LEDS`
+- `COMPILED_NUM_CHANNELS`
+- `ACTIVE_NUM_CHANNELS`
+- `COMPILED_OUTPUT_DRIVER`
+- `ACTIVE_OUTPUT_DRIVER`
+- `COMPILED_WS281X_COLOR_ORDER`
+- `CONFIGURED_WS281X_COLOR_ORDER`
+- `COMPILED_AUDIO_INPUT_PIN`
+- `CONFIGURED_AUDIO_INPUT_PIN`
+- `AUDIO_INPUT_MODE`
+- `FRAMES_SOCKET`
+- `EFFECTS_SOCKET`
+- `CHIP_MODEL`
+- `CHIP_CORES`
+- `CHIP_SPEED`
+- `PROG_SIZE`
+- `CODE_SIZE`
+- `FLASH_SIZE`
+- `HEAP_SIZE`
+- `DMA_SIZE`
+- `PSRAM_SIZE`
+- `CODE_FREE`
+
+`GET /statistics/dynamic` returns:
+
+- `LED_FPS`
+- `SERIAL_FPS`
+- `AUDIO_FPS`
+- `HEAP_FREE`
+- `HEAP_MIN`
+- `DMA_FREE`
+- `DMA_MIN`
+- `PSRAM_FREE`
+- `PSRAM_MIN`
+- `CPU_USED`
+- `CPU_USED_CORE0`
+- `CPU_USED_CORE1`
+
+`GET /statistics` and `GET /getStatistics` return both static and dynamic fields.
+
+### Effects
+
+`GET /effects` and `GET /getEffectList` return:
+
+```json
+{
+  "currentEffect": 0,
+  "millisecondsRemaining": 12345,
+  "eternalInterval": false,
+  "effectInterval": 60000,
+  "Effects": [
+    {
+      "name": "Effect name",
+      "enabled": true,
+      "core": false
+    }
+  ]
+}
+```
+
+Effect actions are form POSTs:
+
+- `POST /nextEffect`
+- `POST /previousEffect`
+- `POST /currentEffect` with `currentEffectIndex`
+- `POST /setCurrentEffectIndex` with `currentEffectIndex`
+- `POST /enableEffect` with `effectIndex`
+- `POST /disableEffect` with `effectIndex`
+- `POST /moveEffect` with `effectIndex`, `newIndex`
+- `POST /copyEffect` with `effectIndex`
+- `POST /deleteEffect` with `effectIndex`
+
+The current UI uses all except copy.
+
+### Device Settings
+
+`GET /settings` returns a flat, legacy settings object. It includes device config fields such as:
+
+- `hostname`
+- `location`
+- `locationIsZip`
+- `countryCode`
+- `timeZone`
+- `use24HourClock`
+- `useCelsius`
+- `ntpServer`
+- `rememberCurrentEffect`
+- `powerLimit`
+- `brightness`
+- `globalColor`
+- `applyGlobalColors`
+- `secondColor`
+- `audioInputPin`
+- `matrixWidth`
+- `matrixHeight`
+- `matrixSerpentine`
+- `outputDriver`
+- `ws281xChannelCount`
+- `ws281xColorOrder`
+- `ws281xPins`
+- `effectInterval`
+
+Sensitive fields such as the weather API key are omitted from this read response.
+
+`POST /settings` accepts form-encoded legacy fields by name. The current UI only uses this for settings without an `apiPath` and for the toolbar effect interval shortcut.
+
+`GET /settings/specs` returns an array of setting spec objects. Each spec has:
+
+- `name`: stable setting key used in draft maps and legacy posts
+- `friendlyName`: label
+- `description`: HTML-capable help text
+- `type`: numeric setting type
+- `typeName`: textual type
+- `hasValidation`: optional boolean
+- `minimumValue`: optional number
+- `maximumValue`: optional number
+- `emptyAllowed`: optional boolean
+- `readOnly`: optional boolean
+- `writeOnly`: optional boolean
+- `section`: optional section ID
+- `priority`: optional number; lower sorts first
+- `requiresReboot`: optional boolean
+- `apiPath`: optional dotted path into `/api/v1/settings`
+- `widget`: optional widget metadata
+
+Setting type numbers:
+
+- `0`: Integer
+- `1`: PositiveBigInteger
+- `2`: Float
+- `3`: Boolean
+- `4`: String
+- `5`: Palette
+- `6`: Color
+- `7`: Slider
+
+Widget kinds:
+
+- omitted or `default`
+- `intervalToggle`
+- `select`
+- `slider`
+- `color`
+
+Select option sources:
+
+- `inline`: use `widget.options.values` and optional parallel `labels`
+- `schemaPath`: read an array from `/api/v1/settings/schema` at `widget.options.schemaPath`
+- `intlCountryCodes`: generate ISO country options in-browser via `Intl.DisplayNames`
+- `externalTimeZones`: fetch `widget.options.url` and normalize timezone identifiers
+
+`GET /api/v1/settings` returns structured settings:
+
+```json
+{
+  "device": {
+    "hostname": "name",
+    "location": "",
+    "locationIsZip": false,
+    "countryCode": "US",
+    "timeZone": "America/Los_Angeles",
+    "use24HourClock": false,
+    "useCelsius": false,
+    "ntpServer": "",
+    "rememberCurrentEffect": true,
+    "powerLimit": 0,
+    "brightness": 255,
+    "globalColor": 16711680,
+    "secondColor": 16711680,
+    "applyGlobalColors": false,
+    "remote": {
+      "enabled": false,
+      "pin": -1
+    },
+    "audio": {
+      "enabled": true,
+      "audioInputPin": 0,
+      "compiledDefaultPin": 0,
+      "mode": "mode",
+      "liveApply": false,
+      "requiresReboot": true,
+      "supportsPinOverride": true
+    }
+  },
+  "topology": {
+    "width": 32,
+    "height": 8,
+    "serpentine": true,
+    "ledCount": 256,
+    "liveApply": true
+  },
+  "outputs": {
+    "driver": "ws281x",
+    "compiledDriver": "ws281x",
+    "liveApply": true,
+    "ws281x": {
+      "channelCount": 1,
+      "compiledMaxChannels": 1,
+      "colorOrder": "GRB",
+      "compiledColorOrder": "GRB",
+      "pins": [5]
+    }
+  },
+  "effects": {
+    "effectInterval": 60000
+  }
+}
+```
+
+`POST /api/v1/settings` accepts a partial structured JSON document. The UI sends only changed fields whose specs have `apiPath`. Supported paths include:
+
+- `device.hostname`
+- `device.powerLimit`
+- `device.location`
+- `device.locationIsZip`
+- `device.countryCode`
+- `device.timeZone`
+- `device.use24HourClock`
+- `device.useCelsius`
+- `device.ntpServer`
+- `device.openWeatherApiKey`
+- `device.audioInputPin`
+- `device.brightness`
+- `device.globalColor`
+- `device.secondColor`
+- `device.applyGlobalColors`
+- `device.clearGlobalColor`
+- `device.rememberCurrentEffect`
+- `topology.width`
+- `topology.height`
+- `topology.serpentine`
+- `outputs.driver`
+- `outputs.ws281x.channelCount`
+- `outputs.ws281x.colorOrder`
+- `outputs.ws281x.pins[N]`
+- `effects.effectInterval`
+
+When posting array element paths like `outputs.ws281x.pins[2]`, the UI must seed the outgoing array with the current full array from `state.unifiedSettings` before changing the indexed element. This prevents sparse arrays from clearing other pins.
+
+`GET /api/v1/settings/schema` returns schema/support metadata:
+
+```json
+{
+  "topology": {
+    "compiledMaxWidth": 256,
+    "compiledMaxHeight": 256,
+    "compiledNominalWidth": 32,
+    "compiledNominalHeight": 8,
+    "compiledMaxLEDs": 256,
+    "liveApply": true,
+    "rejectMessage": "recompile needed"
+  },
+  "outputs": {
+    "compiledDriver": "ws281x",
+    "liveApply": true,
+    "rejectMessage": "recompile needed",
+    "allowedDrivers": ["ws281x"],
+    "ws281x": {
+      "compiledMaxChannels": 1,
+      "compiledMaxLEDs": 256,
+      "compiledColorOrder": "GRB",
+      "allowedChannelCounts": [1],
+      "allowedColorOrders": ["RGB", "RBG", "GRB", "GBR", "BRG", "BGR"],
+      "compiledPins": [5]
+    }
+  },
+  "device": {
+    "remote": {
+      "enabled": false,
+      "pin": -1
+    },
+    "audio": {
+      "enabled": true,
+      "compiledDefaultPin": 0,
+      "mode": "mode",
+      "liveApply": false,
+      "requiresReboot": true,
+      "supportsPinOverride": true,
+      "rejectMessage": "recompile needed"
+    }
+  },
+  "sections": [
+    {
+      "id": "system",
+      "title": "System",
+      "description": "..."
+    }
+  ]
+}
+```
+
+The UI must use `sections` to group settings. Unknown sections may be skipped if empty. Specs with no section fall back to `system`.
+
+### Effect Settings
+
+`GET /settings/effect/specs?effectIndex=N` returns setting specs for one effect.
+
+`GET /settings/effect?effectIndex=N` returns current effect setting values. Base effect settings include:
+
+- `_friendlyName`
+- `_maximumEffectTime`
+- `hasMaximumEffectTime`
+
+Individual effect subclasses may add more fields.
+
+`POST /settings/effect` accepts form fields:
+
+- required `effectIndex`
+- changed effect setting fields by spec name
+
+### Reset
+
+`POST /reset` accepts form fields:
+
+- `board=1`: reboot board
+- `deviceConfig=1`: reset persisted device config
+- `effectsConfig=1`: reset persisted effects config
+
+The current UI sends:
+
+- Reboot: `{ board: 1 }`
+- Reset Device Config: `{ board: 1, deviceConfig: 1 }`
+- Reset Effect Config: `{ board: 1, effectsConfig: 1 }`
+
+### Frame Preview WebSocket
+
+Connect to `/ws/frames` using `ws://` or `wss://` matching the current page protocol.
+
+The socket sends binary frames. Interpret each message as a `Uint8Array` of packed RGB bytes:
+
+- byte 0: red for pixel 0
+- byte 1: green for pixel 0
+- byte 2: blue for pixel 0
+- then repeat
+
+Pixels are row-major with dimensions from:
+
+- `ACTIVE_MATRIX_WIDTH` or `CONFIGURED_MATRIX_WIDTH`
+- `ACTIVE_MATRIX_HEIGHT` or `CONFIGURED_MATRIX_HEIGHT`
+
+The UI throttles canvas rendering to 30 FPS. If more frames arrive, keep the latest and render it on the next eligible animation frame.
+
+If the socket closes while `shouldReconnect` is true, reconnect after 1000ms.
+
+If `FRAMES_SOCKET` is false in static stats, clicking Connect should show an error toast instead of opening the socket.
+
+## Rendering Rules
+
+### Connection Status
+
+`setConnectionState(text, stateClass)`:
+
+- writes `#connectionStatusText`
+- removes `.online` and `.offline`
+- adds `.online` or `.offline` only for those states
+
+Visual states:
+
+- pending/no class: yellow dot
+- `.online`: green dot
+- `.offline`: pink/red dot
+
+### Summary Cards
+
+Render summaries only when `effects`, `staticStats`, and `dynamicStats` are all available.
+
+Current effect:
+
+- name from `effects.Effects[effects.currentEffect].name`
+- note is `Enabled`, `Disabled`, or `No effect`
+
+Interval:
+
+- pinned when `effects.eternalInterval` is true or `effectInterval` is 0
+- use `effectInterval` spec's `intervalToggle` widget metadata when available
+- displayed interval is raw milliseconds divided by `unitDivisor`
+- remaining time is `ceil(millisecondsRemaining / unitDivisor)`
+
+Topology:
+
+- value: `ACTIVE_MATRIX_WIDTHxACTIVE_MATRIX_HEIGHT / ACTIVE_NUM_LEDS leds`
+- note: `ACTIVE_OUTPUT_DRIVER / ACTIVE_NUM_CHANNELS ch`
+
+FPS:
+
+- value: integer `LED_FPS`
+- note: `Audio <AUDIO_FPS> / Serial <SERIAL_FPS>`
+
+CPU:
+
+- value: `CPU_USED` with one decimal and `%`
+- note: `C0 <CPU_USED_CORE0>% / C1 <CPU_USED_CORE1>%`
+
+Memory:
+
+- value: formatted `HEAP_FREE`
+- note: `PSRAM <PSRAM_FREE>`
+
+Formatting:
+
+- `formatNumber`: fixed 0 decimals
+- `formatPercent`: fixed 1 decimal
+- `formatBytes`: bytes, KB, or MB with one decimal above thresholds
+
+### Toolbar Effect Interval
+
+The toolbar interval input is in seconds. On apply:
+
+1. Clamp seconds to 0..2147483.
+2. Convert to milliseconds.
+3. Set `effectIntervalPendingMs`.
+4. POST `/settings` with `{ effectInterval: intervalMs }`.
+5. On success, show toast and reload effects and settings.
+6. On failure, clear pending state, mark input dirty, show error.
+
+Periodic refresh must not overwrite a user edit while the input is focused or dirty. If a pending value is later reflected by the server, clear dirty/pending state.
+
+### Effects Table
+
+If effects are unavailable, show `No effects loaded.`
+
+For each effect:
+
+- Add `tr[data-effect-index]`.
+- First cell: drag grip.
+- Second cell: checkbox bound to enabled state.
+- Third cell: escaped effect name in `.effect-name`.
+- Fourth cell:
+  - current effect: text `Active`, class `.effect-active`
+  - enabled non-current: text `Queued`, class `.effect-disabled`
+  - disabled: text `Disabled`, class `.effect-disabled`
+- Fifth cell: `Core` when `effect.core`, otherwise `User`.
+- Sixth cell: row actions.
+
+Toggling enabled:
+
+- If currently enabled, POST `/disableEffect`.
+- If disabled, POST `/enableEffect`.
+- Payload: `{ effectIndex }`.
+- Reload effects on success.
+- Revert checkbox and show error on failure.
+
+Trigger:
+
+- POST `/currentEffect` with `{ currentEffectIndex: index }`.
+- Disabled when effect is not enabled.
+
+Settings:
+
+- Open effect dialog.
+
+Delete:
+
+- Confirm with `window.confirm("Delete this effect?")`.
+- POST `/deleteEffect` with `{ effectIndex }`.
+- Disabled for core effects.
+
+Drag reorder:
+
+- Drag starts from grip.
+- Store source index in state.
+- Drag over a row sets drop target styling.
+- Drop calls `POST /moveEffect` with `{ effectIndex: fromIndex, newIndex: targetIndex }`.
+- Clear all drag styles after drag end/drop.
+
+### Settings Form
+
+Settings render from specs and current values.
+
+Current value resolution:
+
+1. If spec has `apiPath`, read that path from `state.unifiedSettings`.
+2. Otherwise read `state.settings[spec.name]`.
+3. Otherwise use `defaultValueForSpec`.
+
+Spec ordering:
+
+- Filter out specs where `writeOnly && !hasValidation`.
+- Sort by `priority` ascending, default priority 100.
+- Tie break by `friendlyName || name`.
+
+Grouping:
+
+- Use `state.unifiedSchema.sections` as ordered section catalog.
+- Each section object has `id`, `title`, `description`.
+- Assign specs by `spec.section || "system"`.
+- Do not render sections with no specs.
+
+Each setting row:
+
+- `.setting-row`; add `.stacked` for palette settings.
+- Meta column:
+  - `.setting-name`: `friendlyName || name`
+  - `.field-help`: `description || ""`
+- Value column:
+  - `.setting-value`
+  - one widget rendered from `spec.type` and `spec.widget.kind`
+
+Draft behavior:
+
+- Draft map key is always `spec.name`.
+- A changed value goes into `deviceDraft` or `effectDialog.draft`.
+- If the new value JSON-equals the original value, remove it from the draft.
+- Values are compared with `JSON.stringify`.
+
+Validation:
+
+- Strings: if `emptyAllowed` is false and raw value is empty, error.
+- Numeric types: value is required, must parse to a number, and must respect `minimumValue` and `maximumValue`.
+- Error text goes into `.field-help` and adds `.field-error`.
+- Clearing error restores original description HTML.
+
+Topology cross-field validation:
+
+- Determine max LEDs from `unifiedSchema.topology.compiledMaxLEDs` or `staticStats.COMPILED_NUM_LEDS`.
+- Read drafted or current `matrixWidth` and `matrixHeight`.
+- If width * height exceeds max LEDs, add same error to both fields unless they already have errors.
+
+Apply flow:
+
+1. Collect validation errors.
+2. If errors exist, re-render form and show error toast.
+3. Split draft:
+   - specs with `apiPath` -> structured JSON payload for `/api/v1/settings`
+   - specs without `apiPath` -> legacy form payload for `/settings`
+4. If no changes, show success toast `No device setting changes to apply.`
+5. If not applying with reboot and any drafted spec has `requiresReboot`, show a confirm dialog explaining it will not take effect until reboot.
+6. POST unified payload first, then legacy payload.
+7. Show `Device settings applied.`
+8. Reload settings.
+9. If Apply + Reboot was used, POST `/reset` with `{ board: 1 }`.
+
+### Setting Widgets
+
+#### Default Input
+
+Used for String, Integer, PositiveBigInteger, and Float unless another widget applies.
+
+- Numeric types render `input[type=number]`.
+- String renders `input[type=text]`.
+- Set `min`, `max`, and `step=1` where applicable.
+- Use `readOnly` when `spec.readOnly`.
+- On both `input` and `change`, validate, coerce, and update draft.
+- Integer, PositiveBigInteger, and Slider coerce with `Math.trunc(Number(value))`.
+- Float coerces with `Number(value)`.
+- String remains raw.
+
+#### Boolean
+
+- Render the custom `.mac-switch`.
+- Checkbox checked state is Boolean current value.
+- Disable when read-only.
+- On change, draft Boolean value.
+
+#### Select
+
+- Render `select`.
+- Populate from `getWidgetSelectOptions`.
+- For numeric setting types, store `Number(control.value)`.
+- Otherwise store string.
+- Disable when read-only.
+
+#### Slider
+
+Used when `widget.kind == "slider"` or type is Slider.
+
+- Render a range input and number output in `.slider-row`.
+- If `widget.displayScale` exists:
+  - map raw to display linearly using `rawMin`, `rawMax`, `displayMin`, `displayMax`
+  - clamp display to scale range
+  - map display back to raw on changes
+  - append suffix when `displayScale.suffix` exists
+- Without display scale, range min/max come from spec min/max or 0/255.
+- Range updates on `input`.
+- Number updates on `change`.
+
+#### Interval Toggle
+
+Used when `widget.kind == "intervalToggle"`.
+
+- Render `.interval-row`.
+- Contains custom switch, verb label, numeric input, optional unit suffix.
+- Raw value 0 means off.
+- Switch checked when raw draft is greater than 0.
+- Numeric value displays raw / `unitDivisor`.
+- When switched off, numeric input is disabled and draft value is 0.
+- Fallback display is at least 1, based on current value or 60 units.
+- Clamp display to 1..2147483.
+
+#### Color
+
+Used for type Color or `widget.kind == "color"`.
+
+- Render color input plus numeric input in `.color-row`.
+- Store colors as integer RGB values from 0 to 16777215.
+- Convert integer to hex with six digits for color input.
+- Numeric input clamps to 0..16777215.
+
+#### Palette
+
+Used for type Palette.
+
+- Render `.palette-row`.
+- Each palette entry is `.palette-entry` with color input and numeric input.
+- Store an array of integer RGB values.
+- Current UI supports editing existing entries; it does not add/remove palette entries.
+
+### Effect Settings Dialog
+
+Opening:
+
+1. Fetch specs and values concurrently:
+   - `/settings/effect/specs?effectIndex=N`
+   - `/settings/effect?effectIndex=N`
+2. Set dialog state.
+3. Render using the same setting field renderer as device settings.
+4. Call `showModal()`.
+
+Applying:
+
+- If errors exist, show error toast.
+- If no draft changes, close dialog.
+- POST `/settings/effect` as form with `effectIndex` plus draft values.
+- On success, show `Effect settings applied.`, close dialog, reload effects.
+
+Closing:
+
+- Clear dialog draft and errors.
+- Close native dialog if open.
+
+### Statistics Tab
+
+Render only when static and dynamic stats exist. Otherwise show `Statistics data is unavailable.`
+
+Cards:
+
+1. Output
+   - Compiled driver
+   - Active driver
+   - Compiled order
+   - Active order
+   - Configured dimensions
+   - Active dimensions
+   - LEDs active / compiled
+   - Channels active / compiled
+2. Audio
+   - Mode
+   - Configured pin
+   - Compiled pin
+   - Audio FPS
+   - Frames socket
+   - Effects socket
+3. CPU, with meter percentage `CPU_USED`
+   - Total
+   - Core 0
+   - Core 1
+   - LED FPS
+   - Serial FPS
+4. Memory, with meter equal to used heap percentage
+   - Heap free
+   - Heap size
+   - DMA free
+   - DMA size
+   - PSRAM free
+   - PSRAM size
+5. Package
+   - Chip
+   - Cores
+   - Clock
+   - Program
+   - Flash
+   - Code free
+6. Schema, only when `unifiedSettings` has topology, outputs, device.audio, and device.remote
+   - Topology live
+   - Output live
+   - Audio live
+   - Audio reboot
+   - Remote enabled
+   - Remote pin
+
+After rendering, set `#statsTimestamp` to `Updated <local time>`.
+
+### Frame Preview
+
+Connect button calls `connectPreviewSocket`.
+
+Disconnect button:
+
+- disables reconnect
+- closes socket if present
+- clears frame buffers
+- stops render loop
+- sets status to `Preview offline`
+- hides preview wrapper
+
+On socket open:
+
+- mark connected
+- reset last render time
+- clear reconnect timer
+- status `Preview connected`
+- toast success
+
+On socket close:
+
+- mark disconnected
+- clear socket and frames
+- stop render loop
+- status `Preview reconnecting...` if reconnecting, else `Preview offline`
+- hide preview wrapper
+- schedule reconnect if needed
+
+On message:
+
+- convert `event.data` to `Uint8Array`
+- store as latest frame
+- mark dirty
+- show preview wrapper
+- ensure render loop
+
+Display metrics:
+
+- width = active or configured matrix width, fallback 1
+- height = active or configured matrix height, fallback 1
+- available display width = parent content width or width
+- pixel width = available width / width
+- pixel height = max(pixel width, 10)
+- display height = height * pixel height
+
+Rendering:
+
+- set canvas CSS dimensions to display width/height
+- set canvas backing dimensions multiplied by device pixel ratio
+- disable image smoothing
+- fill one rectangle per pixel from row-major RGB bytes
+
+## Settings Metadata Produced By Firmware
+
+The current firmware emits these major device setting sections:
+
+- `system`
+- `location`
+- `clock`
+- `audio`
+- `appearance`
+- `topology`
+- `output`
+
+Notable settings:
+
+- Hostname: string, reboot required, path `device.hostname`.
+- Power limit: integer, validated, path `device.powerLimit`.
+- Location: string, path `device.location`.
+- Location is postal code: boolean, path `device.locationIsZip`.
+- Country code: string select, generated ISO country options, path `device.countryCode`.
+- Time zone: string select, options from `/timezones.json`, path `device.timeZone`.
+- 24-hour clock: boolean, path `device.use24HourClock`.
+- Celsius: boolean, path `device.useCelsius`.
+- NTP server: string, path `device.ntpServer`.
+- Open Weather API key: write-only string with validation, path `device.openWeatherApiKey`.
+- Audio input pin: integer, min -1, max 48, may require reboot, path `device.audioInputPin`.
+- Brightness: integer slider, raw brightness range displayed as 5..100%, path `device.brightness`.
+- Global color: color integer, path `device.globalColor`.
+- Second color: color integer, path `device.secondColor`.
+- Apply global color: write-only boolean, path `device.applyGlobalColors`.
+- Clear global color: write-only boolean, path `device.clearGlobalColor`.
+- Remember current effect: boolean, path `device.rememberCurrentEffect`.
+- Matrix width: positive integer, priority 0, path `topology.width`.
+- Matrix height: positive integer, priority 1, path `topology.height`.
+- Serpentine layout: boolean, priority 2, path `topology.serpentine`.
+- Output driver: select from schema path `outputs.allowedDrivers`, path `outputs.driver`.
+- WS281x channel count: select from `outputs.ws281x.allowedChannelCounts`, path `outputs.ws281x.channelCount`.
+- WS281x color order: select from `outputs.ws281x.allowedColorOrders`, path `outputs.ws281x.colorOrder`.
+- WS281x pin N: integer min -1 max 48, path `outputs.ws281x.pins[N]`.
+
+The current webserver-owned `effectInterval` spec is in the `appearance` section:
+
+- PositiveBigInteger.
+- Path `effects.effectInterval`.
+- Widget `intervalToggle`.
+- Unit divisor 1000.
+- On label `Rotate effects`.
+- Off label `Off`.
+- Unit label `seconds`.
+
+## Accessibility And Semantics
+
+- Tabs use `role=tablist`, `role=tab`, `role=tabpanel`, `aria-selected`, and `aria-controls`.
+- Toast stack uses `aria-live=polite`.
+- Icon-like buttons must set `title` and `aria-label`.
+- Form controls must be wrapped in labels where practical or clearly associated with visible text.
+- The native dialog provides modal semantics.
+- Hidden tab panes must use the `hidden` attribute.
+
+## Error Handling
+
+- Any failed operation should call a shared error handler that logs to console and shows a toast.
+- HTTP error messages should prefer a JSON `message` field when available.
+- Partial initial load is acceptable; render what succeeded and toast failures.
+- Settings validation failures must not post to firmware.
+- Effect setting validation failures must not post to firmware.
+- If effect enable/disable fails, restore the checkbox to its previous state.
+
+## Regeneration Checklist
+
+A regenerated UI is compatible when all of the following are true:
+
+- `tools/bake_site.py` can gzip `site/index.html`, `site/styles.css`, and `site/app.js`.
+- PlatformIO can embed the gzipped files without new frontend dependencies.
+- The static DOM provides every ID consumed by the script.
+- Initial load fetches all current endpoints and tolerates partial failure.
+- Effects table can enable/disable, trigger, configure, delete, and reorder effects.
+- Device settings render from firmware specs and schema, including all current widget kinds.
+- Settings with `apiPath` post through `/api/v1/settings`; settings without it post through `/settings`.
+- Array-element api paths seed existing arrays before writing.
+- Matrix width/height are cross-validated against compiled LED capacity.
+- Reboot-required setting changes warn on normal Apply.
+- Apply + Reboot posts settings first, then `/reset`.
+- Statistics cards use the same static/dynamic fields.
+- Preview WebSocket renders packed RGB frames against active matrix dimensions.
+- Auto-refresh and selected tab persist in localStorage under the existing keys.
+- The app remains usable below 760px width.
+
+## Implementation Notes
+
+- The current code intentionally keeps all frontend behavior in one `site/app.js` file. Regeneration may reorganize internally, but the delivered asset must remain a static script or be bundled into one static script before embedding.
+- Avoid hardcoding specific setting lists into the UI renderer. The firmware setting spec and schema are the contract.
+- Preserve old endpoint aliases where currently used by firmware, but the UI should prefer `/effects`, `/statistics/static`, `/statistics/dynamic`, `/settings`, `/settings/specs`, `/api/v1/settings`, and `/api/v1/settings/schema`.
+- The UI should never require CORS special handling when served from the device, but the firmware currently adds CORS headers to API responses.
+- The app should not assume the device is online forever; polling and WebSocket failure paths must remain graceful.

--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -42,6 +42,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 class GFXBase;
@@ -126,6 +127,7 @@ class  EffectManager : public IJSONSerializable
     std::shared_ptr<LEDStripEffect> _tempEffect;
     std::vector<std::reference_wrapper<IFrameEventListener>> _frameEventListeners;
     std::vector<std::reference_wrapper<IEffectEventListener>> _effectEventListeners;
+    mutable std::mutex _listenerMutex;
 
     void construct(bool clearTempEffect);
     void DispatchBeatIfNeeded();
@@ -262,12 +264,14 @@ public:
 
     void PlayAll(bool bPlayAll);
     void SetInterval(uint interval, bool skipSave = false);
-    const std::vector<std::shared_ptr<LEDStripEffect>> & EffectsList() const;
+    std::vector<std::shared_ptr<LEDStripEffect>> EffectsList() const;
+    std::shared_ptr<LEDStripEffect> EffectAt(size_t index) const;
+    bool IsCoreEffect(size_t index) const;
     size_t EffectCount() const;
     bool AreEffectsEnabled() const;
     size_t GetCurrentEffectIndex() const;
     LEDStripEffect& GetCurrentEffect() const;
-    const String & GetCurrentEffectName() const;
+    String GetCurrentEffectName() const;
     void SetCurrentEffectIndex(size_t i);
     uint GetTimeUsedByCurrentEffect() const;
     uint GetTimeRemainingForCurrentEffect() const;

--- a/include/itaskservice.h
+++ b/include/itaskservice.h
@@ -75,6 +75,7 @@
 #include <atomic>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
+#include <mutex>
 
 #include "iservice.h"
 
@@ -148,6 +149,7 @@ class ITaskService : public IService
 
     void WakeTask() const
     {
+        std::lock_guard<std::mutex> guard(_taskHandleMutex);
         if (_taskHandle != nullptr)
             xTaskNotifyGive(_taskHandle);
     }
@@ -160,7 +162,13 @@ class ITaskService : public IService
 
     static void TaskEntryThunk(void* p);
 
+    void SetTaskHandle(TaskHandle_t taskHandle);
+    TaskHandle_t ClearTaskHandle();
+    bool HasTaskHandle() const;
+
     TaskHandle_t       _taskHandle = nullptr;
+    mutable std::mutex _lifecycleMutex;
+    mutable std::mutex _taskHandleMutex;
     std::atomic<bool>  _running{false};
     std::atomic<bool>  _shutdownRequested{false};
     std::atomic<bool>  _taskExited{false};

--- a/include/ledbuffer.h
+++ b/include/ledbuffer.h
@@ -69,6 +69,11 @@ class LEDBuffer
 
     bool IsBufferOlderThan(const timeval & tv) const;
 
+    static bool ValidateWirePayload(const std::unique_ptr<uint8_t []>& payloadData,
+                                    size_t payloadLength,
+                                    size_t ledCount,
+                                    size_t* payloadBytes = nullptr);
+
     // UpdateFromWire
     //
     // Parse and deposit a WiFi packet into a buffer
@@ -91,6 +96,7 @@ class LEDBufferManager
     std::shared_ptr<LEDBuffer> _pLastBufferAdded;   // Keeps track of the MRU buffer
     size_t                                               _iNextBuffer;        // Head pointer index
     size_t                                               _iLastBuffer;        // Tail pointer index
+    size_t                                               _cQueuedBuffers;     // Active frames in the circular queue
     uint32_t                                             _cBuffers;           // Number of buffers
 
   public:
@@ -106,6 +112,8 @@ class LEDBufferManager
     // The fixed, maximum size of the whole thing if it were full
 
     size_t BufferCount() const;
+
+    size_t LEDCount() const;
 
     // Depth
     //

--- a/include/webserver.h
+++ b/include/webserver.h
@@ -112,6 +112,7 @@ class CWebServer : public IService
 
     static std::vector<SettingSpec> mySettingSpecs;
     static std::vector<std::reference_wrapper<SettingSpec>> deviceSettingSpecs;
+    static String deviceSettingSpecsJson;
     // Per-channel pin specs synthesized at first /settings/specs request from
     // the compiled channel maximum, with stable backing storage for the
     // const char* fields they hold.
@@ -182,6 +183,8 @@ class CWebServer : public IService
     static void SendBufferOverflowResponse(AsyncWebServerRequest * pRequest);
     static bool IsPostParamTrue(AsyncWebServerRequest * pRequest, const String & paramName);
     static const std::vector<std::reference_wrapper<SettingSpec>> & LoadDeviceSettingSpecs();
+    static bool EnsureDeviceSettingSpecsJson();
+    static bool BuildSettingSpecsJson(String& json, const std::vector<std::reference_wrapper<SettingSpec>> & settingSpecs);
     static void SendSettingSpecsResponse(AsyncWebServerRequest * pRequest, const std::vector<std::reference_wrapper<SettingSpec>> & settingSpecs);
     static bool ValidateLegacyDeviceSettings(AsyncWebServerRequest * pRequest, String* errorMessage = nullptr);
     static bool ValidateUnifiedDeviceSettings(JsonObjectConst device, String* errorMessage = nullptr);
@@ -230,12 +233,13 @@ class CWebServer : public IService
     {
         _server.on(strUri, HTTP_GET, [strUri, file](AsyncWebServerRequest *request)
         {
-            Serial.printf("GET for: %s\n", strUri);
             AsyncWebServerResponse *response = request->beginResponse(200, file.type, file.contents, file.length);
             if (file.encoding)
             {
                 response->addHeader("Content-Encoding", file.encoding);
             }
+            response->addHeader("Cache-Control", "no-store, max-age=0");
+            response->addHeader("Pragma", "no-cache");
 
             AddCORSHeaderAndSendResponse(request, response);
         });

--- a/platformio.ini
+++ b/platformio.ini
@@ -458,6 +458,8 @@ board_build.embed_files = assets/bmp/brokenclouds.jpg
 
 [mesmerizer_config]
 build_flags     = ${psram_lx6_flags.build_flags}
+                  -DCONFIG_ASYNC_TCP_STACK_SIZE=8192
+                  -DCONFIG_ASYNC_TCP_PRIORITY=3
 build_src_flags = -DPROJECT_NAME="\"Mesmerizer\""
                   -DMESMERIZER=1
                   -DSHOW_FPS_ON_MATRIX=0
@@ -472,6 +474,8 @@ build_src_flags = -DPROJECT_NAME="\"Mesmerizer\""
                   -DENABLE_WEBSERVER=1
                   -DENABLE_NTP=1
                   -DENABLE_OTA=1
+                  -DCOLORDATA_SERVER_ENABLED=0
+                  -DCOLORDATA_WEB_SOCKET_ENABLED=0
                   -DENABLE_REMOTE=1
                   -DENABLE_AUDIO=1
                   -DMILLIS_PER_FRAME=0

--- a/src/debug_cli.cpp
+++ b/src/debug_cli.cpp
@@ -309,6 +309,7 @@ std::string_view TabComplete(std::string_view partial, std::string_view full_lin
     else if (full_line.substr(0, 6) == "effect")
     {
         auto& effectManager = g_ptrSystem->GetEffectManager();
+        auto effects = effectManager.EffectsList();
         std::string_view firstMatch = "";
         int matches = 0;
         size_t common_len = 0;

--- a/src/debug_cli.cpp
+++ b/src/debug_cli.cpp
@@ -314,9 +314,9 @@ std::string_view TabComplete(std::string_view partial, std::string_view full_lin
         int matches = 0;
         size_t common_len = 0;
 
-        for (size_t i = 0; i < effectManager.EffectCount(); ++i)
+        for (const auto& effect : effects)
         {
-            const String& name = effectManager.EffectsList()[i]->FriendlyName();
+            const String& name = effect->FriendlyName();
             if (StringStartsWithInsensitive(name.c_str(), partial))
             {
                 if (matches == 0)
@@ -350,6 +350,7 @@ std::string_view TabComplete(std::string_view partial, std::string_view full_lin
 static std::optional<size_t> ResolveEffect(std::string_view arg)
 {
     auto& effectManager = g_ptrSystem->GetEffectManager();
+    auto effects = effectManager.EffectsList();
 
     // Try as index first
     // Try as index first
@@ -357,13 +358,13 @@ static std::optional<size_t> ResolveEffect(std::string_view arg)
     auto [ptr, ec] = std::from_chars(arg.begin(), arg.end(), val);
     if (ec == std::errc() && ptr == arg.end())
     {
-        if (val < effectManager.EffectCount())
+        if (val < effects.size())
         {
             return val;
         }
         else
         {
-            cli_printf("Error: Effect index %zu out of range (0-%u)\n", val, effectManager.EffectCount() - 1);
+            cli_printf("Error: Effect index %zu out of range (0-%zu)\n", val, effects.empty() ? 0 : effects.size() - 1);
             return std::nullopt;
         }
     }
@@ -373,9 +374,9 @@ static std::optional<size_t> ResolveEffect(std::string_view arg)
     int matches = 0;
     std::vector<std::string> candidates;
 
-    for (size_t i = 0; i < effectManager.EffectCount(); ++i)
+    for (size_t i = 0; i < effects.size(); ++i)
     {
-        const String& name = effectManager.EffectsList()[i]->FriendlyName();
+        const String& name = effects[i]->FriendlyName();
         if (ContainsInsensitive(name.c_str(), arg))
         {
             match_index = i;

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -174,7 +174,11 @@ int CalcDelayUntilNextFrame(double frameStartTime, uint16_t localPixelsDrawn, ui
 
     if (localPixelsDrawn > 0)
     {
-        const double fpsRaw = static_cast<double>(g_ptrSystem->GetEffectManager().GetCurrentEffect().DesiredFramesPerSecond());
+        double fpsRaw = 0.0;
+        {
+            std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+            fpsRaw = static_cast<double>(g_ptrSystem->GetEffectManager().GetCurrentEffect().DesiredFramesPerSecond());
+        }
         // If FPS is invalid (<= 0 or non-finite), treat as unlimited (0s minimum frame time).
         const double minimumFrameTime = (!std::isfinite(fpsRaw) || fpsRaw <= 0.0) ? 0.0 : (1.0 / fpsRaw);
         // Use a monotonic-like elapsed (never negative) in case wall clock adjustments go backward.
@@ -190,15 +194,23 @@ int CalcDelayUntilNextFrame(double frameStartTime, uint16_t localPixelsDrawn, ui
         double t = std::numeric_limits<double>::max();
         bool bFoundFrame = false;
 
-        for (auto& bufferManager : g_ptrSystem->GetBufferManagers())
         {
-            auto pOldest = bufferManager.PeekOldestBuffer();
-            if (pOldest)
+            // The socket task can add frames while the render task is
+            // calculating its next sleep. Protect this read-only peek with the
+            // same mutex used by enqueue/dequeue so the ring indices and
+            // timestamps are sampled consistently.
+            
+            std::lock_guard<std::mutex> guard(g_buffer_mutex);
+            for (auto& bufferManager : g_ptrSystem->GetBufferManagers())
             {
-                // TimeTillDue() should be non-negative for future-due frames; if negative (stale), treat as now.
-                // Note I'm not using clamp since clamp can return nan if TimeTillDue does, whereas this guards against that.
-                t = std::min(t, std::max(0.0, pOldest->TimeTillDue()));
-                bFoundFrame = true;
+                auto pOldest = bufferManager.PeekOldestBuffer();
+                if (pOldest)
+                {
+                    // TimeTillDue() should be non-negative for future-due frames; if negative (stale), treat as now.
+                    // Note I'm not using clamp since clamp can return nan if TimeTillDue does, whereas this guards against that.
+                    t = std::min(t, std::max(0.0, pOldest->TimeTillDue()));
+                    bFoundFrame = true;
+                }
             }
         }
         // Bound the delay to at most 1 second to avoid pathological multi-second sleeps.

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -57,6 +57,7 @@ extern std::map<int, JSONEffectFactory> g_JsonStarryNightEffectFactories;
 DRAM_ATTR size_t g_EffectsManagerJSONBufferSize = 0;
 static DRAM_ATTR size_t l_EffectsManagerJSONWriterIndex = SIZE_MAX;
 static DRAM_ATTR size_t l_CurrentEffectWriterIndex = SIZE_MAX;
+static DRAM_ATTR bool l_EffectManagerInitializing = false;
 
 //
 // EffectManager initialization functions
@@ -85,6 +86,7 @@ void WriteCurrentEffectIndexFile();
 void InitEffectsManager()
 {
     debugW("InitEffectsManager...");
+    l_EffectManagerInitializing = true;
 
     LoadEffectFactories();
 
@@ -126,6 +128,8 @@ void InitEffectsManager()
     #if EFFECTS_WEB_SOCKET_ENABLED
         g_ptrSystem->GetEffectManager().AddEffectEventListener(g_ptrSystem->GetWebSocketServer());
     #endif
+
+    l_EffectManagerInitializing = false;
 }
 
 void EffectManager::StartEffect()
@@ -468,6 +472,9 @@ void EffectManager::LoadDefaultEffects()
 //   for execution in the background.
 void EffectManager::SaveCurrentEffectIndex()
 {
+    if (l_EffectManagerInitializing)
+        return;
+
     if (g_ptrSystem->GetDeviceConfig().RememberCurrentEffect())
         // Default value for writer index is max value for size_t, so nothing will happen if writer has not yet been registered
         g_ptrSystem->GetJSONWriter().FlagWriter(l_CurrentEffectWriterIndex);
@@ -570,6 +577,9 @@ std::shared_ptr<LEDStripEffect> EffectManager::CopyEffect(size_t index)
 
 void SaveEffectManagerConfig()
 {
+    if (l_EffectManagerInitializing)
+        return;
+
     debugV("Saving effect manager config...");
     // Default value for writer index is max value for size_t, so nothing will happen if writer has not yet been registered
     g_ptrSystem->GetJSONWriter().FlagWriter(l_EffectsManagerJSONWriterIndex);

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -283,11 +283,17 @@ std::vector<std::shared_ptr<GFXBase>> & EffectManager::GetBaseGraphics()
 
 void EffectManager::ReportNewFrameAvailable()
 {
+    // Listener vectors store references whose owners may deregister on other
+    // tasks. Hold this mutex while iterating so remove/destruction cannot race
+    // a callback dispatch.
+    
+    std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
     INFORM_EVENT_LISTENERS(_frameEventListeners, IFrameEventListener::OnNewFrameAvailable);
 }
 
 void EffectManager::AddFrameEventListener(IFrameEventListener& listener)
 {
+    std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
     _frameEventListeners.emplace_back(listener);
 }
 
@@ -299,6 +305,7 @@ void EffectManager::RemoveFrameEventListener(IFrameEventListener& listener)
     // Robert may have a better or less obtuse way to do this, but it works 
     // and it's not like we have thousands of listeners.  Change at will!
     
+    std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
     _frameEventListeners.erase(
         std::remove_if(_frameEventListeners.begin(), _frameEventListeners.end(),
                        [&](const std::reference_wrapper<IFrameEventListener>& w)
@@ -308,6 +315,7 @@ void EffectManager::RemoveFrameEventListener(IFrameEventListener& listener)
 
 void EffectManager::AddEffectEventListener(IEffectEventListener& listener)
 {
+    std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
     _effectEventListeners.emplace_back(listener);
 }
 
@@ -324,6 +332,7 @@ const GFXBase& EffectManager::g(int iChannel) const
 
 bool EffectManager::IsEffectEnabled(size_t i) const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     if (i >= _vEffects.size())
     {
         debugW("Invalid index for IsEffectEnabled");
@@ -334,11 +343,14 @@ bool EffectManager::IsEffectEnabled(size_t i) const
 
 void EffectManager::PlayAll(bool bPlayAll)
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     _bPlayAll = bPlayAll;
 }
 
 void EffectManager::SetInterval(uint interval, bool skipSave)
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+
     // Reject/ignore intervals smaller than a second, but allow 0 (infinity)
     if (interval > 0 && interval < 1000)
         return;
@@ -348,36 +360,63 @@ void EffectManager::SetInterval(uint interval, bool skipSave)
     if (!skipSave)
         SaveEffectManagerConfig();
 
-    INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnIntervalChanged, interval);
+    {
+        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnIntervalChanged, interval);
+    }
 }
 
-const std::vector<std::shared_ptr<LEDStripEffect>> & EffectManager::EffectsList() const
+std::vector<std::shared_ptr<LEDStripEffect>> EffectManager::EffectsList() const
 {
+    // Return a stable snapshot instead of a reference to the live vector. Web,
+    // debug, and render tasks can otherwise hold an iterator/reference while
+    // another task reorders or deletes effects.
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     return _vEffects;
+}
+
+std::shared_ptr<LEDStripEffect> EffectManager::EffectAt(size_t index) const
+{
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    return index < _vEffects.size() ? _vEffects[index] : nullptr;
+}
+
+bool EffectManager::IsCoreEffect(size_t index) const
+{
+    auto effect = EffectAt(index);
+    return effect && effect->IsCoreEffect();
 }
 
 size_t EffectManager::EffectCount() const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     return _vEffects.size();
 }
 
 bool EffectManager::AreEffectsEnabled() const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     return std::any_of(_vEffects.begin(), _vEffects.end(), [](const auto& pEffect){ return pEffect->IsEnabled(); } );
 }
 
 size_t EffectManager::GetCurrentEffectIndex() const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     return _iCurrentEffect;
 }
 
 LEDStripEffect& EffectManager::GetCurrentEffect() const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     return *(_tempEffect ? _tempEffect : _vEffects[_iCurrentEffect]);
 }
 
-const String & EffectManager::GetCurrentEffectName() const
+String EffectManager::GetCurrentEffectName() const
 {
+    // Return a copy while holding the effect lock. Returning a reference here
+    // was unsafe because another task can switch/delete/reinitialize effects
+    // immediately after the lock is released.
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     if (_tempEffect)
         return _tempEffect->FriendlyName();
 
@@ -400,16 +439,21 @@ void EffectManager::SetCurrentEffectIndex(size_t i)
     StartEffect();
     SaveCurrentEffectIndex();
 
-    INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnCurrentEffectChanged, i);
+    {
+        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnCurrentEffectChanged, i);
+    }
 }
 
 uint EffectManager::GetTimeUsedByCurrentEffect() const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     return millis() - _effectStartTime;
 }
 
 uint EffectManager::GetTimeRemainingForCurrentEffect() const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     // If the Interval is set to zero, we treat that as an infinite interval and don't even look at the time used so far
     uint timeUsedByCurrentEffect = GetTimeUsedByCurrentEffect();
     uint interval = GetEffectiveInterval();
@@ -419,7 +463,8 @@ uint EffectManager::GetTimeRemainingForCurrentEffect() const
 
 uint EffectManager::GetEffectiveInterval() const
 {
-    auto& currentEffect = GetCurrentEffect();
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    auto& currentEffect = *(_tempEffect ? _tempEffect : _vEffects[_iCurrentEffect]);
     // This allows you to return a MaximumEffectTime and your effect won't be shown longer than that
     return min((IsIntervalEternal() ? std::numeric_limits<uint>::max() : _effectInterval),
                (currentEffect.HasMaximumEffectTime() ? currentEffect.MaximumEffectTime() : std::numeric_limits<uint>::max()));
@@ -427,28 +472,34 @@ uint EffectManager::GetEffectiveInterval() const
 
 uint EffectManager::GetInterval() const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     return _effectInterval;
 }
 
 bool EffectManager::IsIntervalEternal() const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     return _effectInterval == 0;
 }
 
 void EffectManager::NextPalette()
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
     debugV("EffectManager::NextPalette");
     g().CyclePalette(1);
 }
 
 void EffectManager::PreviousPalette()
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
     debugV("EffectManager::PreviousPalette");
     g().CyclePalette(-1);
 }
 
 void EffectManager::LoadDefaultEffects()
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     _effectSetHashString = g_ptrEffectFactories->HashString();
 
     for (const auto &numberedFactory : g_ptrEffectFactories->GetDefaultFactories())
@@ -538,6 +589,8 @@ void EffectManager::LoadJSONEffects(const JsonArrayConst& effectsArray)
 //   use the AppendEffect() function for that.
 std::shared_ptr<LEDStripEffect> EffectManager::CopyEffect(size_t index)
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     if (index >= _vEffects.size())
     {
         debugW("Invalid index for CopyEffect");
@@ -665,6 +718,8 @@ bool EffectManager::Init()
 
 bool EffectManager::ReinitializeEffects()
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     if (!Init())
         return false;
 
@@ -684,6 +739,8 @@ bool EffectManager::ReinitializeEffects()
 
 bool EffectManager::ShowVU(bool bShow)
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     auto& deviceConfig = g_ptrSystem->GetDeviceConfig();
     bool bResult = deviceConfig.ShowVUMeter();
     debugI("Setting ShowVU to %d\n", bShow);
@@ -698,12 +755,15 @@ bool EffectManager::ShowVU(bool bShow)
 
 bool EffectManager::IsVUVisible() const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     return g_ptrSystem->GetDeviceConfig().ShowVUMeter() && GetCurrentEffect().CanDisplayVUMeter();
 }
 
 
 void EffectManager::ClearRemoteColor(bool retainRemoteEffect)
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     if (!retainRemoteEffect)
         _tempEffect = nullptr;
 
@@ -721,6 +781,8 @@ void EffectManager::ClearRemoteColor(bool retainRemoteEffect)
 
 void EffectManager::ApplyGlobalColor(CRGB color)
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     debugI("Setting Global Color: %08lX\n", (unsigned long)(uint32_t)color);
 
     auto& deviceConfig = g_ptrSystem->GetDeviceConfig();
@@ -731,6 +793,8 @@ void EffectManager::ApplyGlobalColor(CRGB color)
 
 void EffectManager::ApplyGlobalPaletteColors()
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     #if USE_HUB75
         auto& pMatrix = g();
         auto& deviceConfig = g_ptrSystem->GetDeviceConfig();
@@ -801,6 +865,8 @@ void EffectManager::construct(bool clearTempEffect)
 
 bool EffectManager::DeserializeFromJSON(const JsonObjectConst& jsonObject)
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     ClearEffects();
 
     // "efs" is the array of serialized effect objects
@@ -877,6 +943,8 @@ bool EffectManager::DeserializeFromJSON(const JsonObjectConst& jsonObject)
 
 bool EffectManager::SerializeToJSON(JsonObject& jsonObject)
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+
     // Set JSON format version to be able to detect and manage future incompatible structural updates
     jsonObject[PTY_VERSION] = JSON_FORMAT_VERSION;
     jsonObject["ivl"] = _effectInterval;
@@ -898,6 +966,11 @@ bool EffectManager::SerializeToJSON(JsonObject& jsonObject)
 
 void EffectManager::EnableEffect(size_t i, bool skipSave)
 {
+    // Web, remote, and render tasks all touch the effect list/current effect.
+    // Mutations take both locks so a UI request cannot reorder/delete/settings-
+    // mutate an effect while the draw loop is inside that effect's Draw().
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     if (i >= _vEffects.size())
     {
         debugW("Invalid index for EnableEffect");
@@ -916,12 +989,17 @@ void EffectManager::EnableEffect(size_t i, bool skipSave)
         if (!skipSave)
             SaveEffectManagerConfig();
 
-        INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectEnabledStateChanged, i, true);
+        {
+            std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+            INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectEnabledStateChanged, i, true);
+        }
     }
 }
 
 void EffectManager::DisableEffect(size_t i, bool skipSave)
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     if (i >= _vEffects.size())
     {
         debugW("Invalid index for DisableEffect");
@@ -940,12 +1018,17 @@ void EffectManager::DisableEffect(size_t i, bool skipSave)
         if (!skipSave)
             SaveEffectManagerConfig();
 
-        INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectEnabledStateChanged, i, false);
+        {
+            std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+            INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectEnabledStateChanged, i, false);
+        }
     }
 }
 
 void EffectManager::MoveEffect(size_t from, size_t to)
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     if (from >= _vEffects.size() || to >= _vEffects.size())
     {
         debugW("Invalid index for MoveEffect");
@@ -977,13 +1060,18 @@ void EffectManager::MoveEffect(size_t from, size_t to)
 
     SaveEffectManagerConfig();
 
-    INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectListDirty);
+    {
+        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectListDirty);
+    }
 }
 
 // Adds an effect to the effect list and enables it. If an effect is added that is already in the effect list then the result
 //   is undefined but potentially messy.
 bool EffectManager::AppendEffect(std::shared_ptr<LEDStripEffect>& effect)
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     if (!effect->Init(_gfx))
         return false;
 
@@ -992,7 +1080,10 @@ bool EffectManager::AppendEffect(std::shared_ptr<LEDStripEffect>& effect)
 
     SaveEffectManagerConfig();
 
-    INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectListDirty);
+    {
+        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectListDirty);
+    }
 
     return true;
 }
@@ -1000,6 +1091,8 @@ bool EffectManager::AppendEffect(std::shared_ptr<LEDStripEffect>& effect)
 // Deletes an effect from the effect list. Note that core effects cannot be deleted.
 bool EffectManager::DeleteEffect(size_t index)
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     if (index >= _vEffects.size())
     {
         debugW("Invalid index for DeleteEffect");
@@ -1024,7 +1117,10 @@ bool EffectManager::DeleteEffect(size_t index)
 
     SaveEffectManagerConfig();
 
-    INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectListDirty);
+    {
+        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectListDirty);
+    }
 
     return true;
 }
@@ -1070,7 +1166,10 @@ void EffectManager::NextEffect(bool skipSave)
     StartEffect();
     SaveCurrentEffectIndex();
 
-    INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnCurrentEffectChanged, _iCurrentEffect);
+    {
+        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnCurrentEffectChanged, _iCurrentEffect);
+    }
 }
 
 // Go back to the previous effect and abort the current one.
@@ -1094,7 +1193,10 @@ void EffectManager::PreviousEffect()
     StartEffect();
     SaveCurrentEffectIndex();
 
-    INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnCurrentEffectChanged, _iCurrentEffect);
+    {
+        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnCurrentEffectChanged, _iCurrentEffect);
+    }
 }
 
 // EffectManager::Update

--- a/src/gfxbase.cpp
+++ b/src/gfxbase.cpp
@@ -32,6 +32,7 @@
 
 #include "globals.h"
 
+#include <algorithm>
 #include <cmath>
 #include <gfxfont.h>
 #include <memory>
@@ -1412,25 +1413,45 @@ CRGB GFXBase::HsvToRgb(uint8_t h, uint8_t s, uint8_t v)
 // This can't be in gfxbase.h because it uses the FillGetNoise() function template.
 void GFXBase::MoveInwardX(int startY, int endY)
 {
+    const int width = static_cast<int>(_width);
+    const int height = static_cast<int>(_height);
+    const int halfWidth = width / 2;
+    if (leds == nullptr || halfWidth <= 1 || height <= 0)
+        return;
+
+    startY = std::max(0, startY);
+    endY = std::min(height - 1, endY);
+
     for (int y = startY; y <= endY; y++)
     {
-        for (int x = _width / 2; x > 0; x--)
+        // Keep both halves inside the row. The previous loops read x+1 at
+        // width, which can corrupt unrelated pixels or memory at row edges.
+        for (int x = halfWidth - 1; x > 0; x--)
             leds[XY(x, y)] = leds[XY(x - 1, y)];
 
-        for (int x = _width / 2; x < (int)_width; x++)
+        for (int x = halfWidth; x < width - 1; x++)
             leds[XY(x, y)] = leds[XY(x + 1, y)];
     }
 }
 
 void GFXBase::MoveOutwardsX(int startY, int endY)
 {
+    const int width = static_cast<int>(_width);
+    const int height = static_cast<int>(_height);
+    const int halfWidth = width / 2;
+    if (leds == nullptr || halfWidth <= 1 || height <= 0)
+        return;
+
+    startY = std::max(0, startY);
+    endY = std::min(height - 1, endY);
+
     for (int y = startY; y <= endY; y++)
     {
-        for (int x = 0; x < (int)_width / 2 - 1; x++)
-        {
+        for (int x = 0; x < halfWidth - 1; x++)
             leds[XY(x, y)] = leds[XY(x + 1, y)];
-            leds[XY((int)_width - x - 1, y)] = leds[XY((int)_width - x - 2, y)];
-        }
+
+        for (int x = width - 1; x > halfWidth; x--)
+            leds[XY(x, y)] = leds[XY(x - 1, y)];
     }
 }
 

--- a/src/hub75gfx.cpp
+++ b/src/hub75gfx.cpp
@@ -177,33 +177,40 @@ void HUB75GFX::SetCaption(const String & str, uint32_t duration)
 
 void HUB75GFX::MoveInwardX(int startY, int endY)
 {
-    // Optimized for Smartmatrix matrix - uses knowledge of how the pixels are laid
-    // out in order to do the scroll.  We should technically use memmove instead
-    // of memcpy since the regions are overlapping but this is faster and seems
-    // to work!
+    const int halfWidth = MATRIX_WIDTH / 2;
+    if (leds == nullptr || halfWidth <= 1)
+        return;
+
+    startY = std::max(0, startY);
+    endY = std::min(MATRIX_HEIGHT - 1, endY);
 
     for (int y = startY; y <= endY; y++)
     {
         auto pLinemem = leds + y * MATRIX_WIDTH;
         auto pLinemem2 = pLinemem + (MATRIX_WIDTH / 2);
-        memcpy(pLinemem + 1, pLinemem, sizeof(CRGB) * (MATRIX_WIDTH / 2));
-        memcpy(pLinemem2, pLinemem2 + 1, sizeof(CRGB) * (MATRIX_WIDTH / 2));
+        // These shifts overlap within a row. memcpy was undefined behavior and
+        // the old right-half count read one pixel past the row, which could
+        // corrupt adjacent display memory.
+        memmove(pLinemem + 1, pLinemem, sizeof(CRGB) * (halfWidth - 1));
+        memmove(pLinemem2, pLinemem2 + 1, sizeof(CRGB) * (halfWidth - 1));
     }
 }
 
 void HUB75GFX::MoveOutwardsX(int startY, int endY)
 {
-    // Optimized for Smartmatrix matrix - uses knowledge of how the pixels are laid
-    // out in order to do the scroll.  We should technically use memmove instead
-    // of memcpy since the regions are overlapping but this is faster and seems
-    // to work!
+    const int halfWidth = MATRIX_WIDTH / 2;
+    if (leds == nullptr || halfWidth <= 1)
+        return;
+
+    startY = std::max(0, startY);
+    endY = std::min(MATRIX_HEIGHT - 1, endY);
 
     for (int y = startY; y <= endY; y++)
     {
         auto pLinemem = leds + y * MATRIX_WIDTH;
         auto pLinemem2 = pLinemem + (MATRIX_WIDTH / 2);
-        memcpy(pLinemem, pLinemem + 1, sizeof(CRGB) * (MATRIX_WIDTH / 2));
-        memcpy(pLinemem2 + 1, pLinemem2, sizeof(CRGB) * (MATRIX_WIDTH / 2));
+        memmove(pLinemem, pLinemem + 1, sizeof(CRGB) * (halfWidth - 1));
+        memmove(pLinemem2 + 1, pLinemem2, sizeof(CRGB) * (halfWidth - 1));
     }
 }
 

--- a/src/itaskservice.cpp
+++ b/src/itaskservice.cpp
@@ -43,6 +43,8 @@
 
 bool ITaskService::Start()
 {
+    std::lock_guard<std::mutex> lifecycleGuard(_lifecycleMutex);
+
     if (_running.load())
     {
         debugI("%s: Start() ignored, already running", Name());
@@ -65,34 +67,43 @@ bool ITaskService::Start()
         (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(),
         (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
 
+    TaskHandle_t taskHandle = nullptr;
     BaseType_t rc = xTaskCreatePinnedToCore(
         TaskEntryThunk,
         cfg.taskName,
         cfg.stackSize,
         this,                       // ITaskService*; thunk casts back
         cfg.priority,
-        &_taskHandle,
+        &taskHandle,
         cfg.core);
 
     if (rc != pdPASS)
     {
         debugE("%s: xTaskCreatePinnedToCore failed (rc=%d)", Name(), (int)rc);
-        _taskHandle = nullptr;
+        SetTaskHandle(nullptr);
         return false;
     }
 
+    SetTaskHandle(taskHandle);
     _running.store(true);
     return true;
 }
 
 void ITaskService::Stop()
 {
-    if (!_running.load() && _taskHandle == nullptr)
+    // Start/Stop still need serialization, but WakeTask only needs the short
+    // _taskHandleMutex below. Holding the old recursive lifecycle mutex across
+    // the whole stop wait was heavier than necessary and existed only because
+    // some stop hooks wake their task.
+    
+    std::lock_guard<std::mutex> lifecycleGuard(_lifecycleMutex);
+
+    if (!_running.load() && !HasTaskHandle())
         return;
 
     debugI("%s: stop requested", Name());
 
-    if (_taskHandle != nullptr)
+    if (HasTaskHandle())
     {
         _shutdownRequested.store(true);
 
@@ -114,8 +125,8 @@ void ITaskService::Stop()
         // TaskEntryThunk's vTaskDelay) or it never acknowledged. Either
         // way, we delete it from this thread so the FreeRTOS task control
         // block is reclaimed before this object is allowed to be destroyed.
-        vTaskDelete(_taskHandle);
-        _taskHandle = nullptr;
+        if (TaskHandle_t taskHandle = ClearTaskHandle())
+            vTaskDelete(taskHandle);
     }
 
     // Service-specific resource cleanup. Runs whether the task exited
@@ -127,6 +138,26 @@ void ITaskService::Stop()
     _shutdownRequested.store(false);
     _taskExited.store(false);
     debugI("%s: stop completed", Name());
+}
+
+void ITaskService::SetTaskHandle(TaskHandle_t taskHandle)
+{
+    std::lock_guard<std::mutex> guard(_taskHandleMutex);
+    _taskHandle = taskHandle;
+}
+
+TaskHandle_t ITaskService::ClearTaskHandle()
+{
+    std::lock_guard<std::mutex> guard(_taskHandleMutex);
+    TaskHandle_t taskHandle = _taskHandle;
+    _taskHandle = nullptr;
+    return taskHandle;
+}
+
+bool ITaskService::HasTaskHandle() const
+{
+    std::lock_guard<std::mutex> guard(_taskHandleMutex);
+    return _taskHandle != nullptr;
 }
 
 // TaskEntryThunk - static task entry point that casts the void* back to

--- a/src/ledbuffer.cpp
+++ b/src/ledbuffer.cpp
@@ -3,6 +3,8 @@
 #include "ledbuffer.h"
 #include "values.h"
 
+#include <limits>
+
 // LEDBuffer
 //
 // Provides a timestamped buffer of colordata.  The LEDBufferManager keeps
@@ -24,7 +26,7 @@ uint32_t LEDBuffer::Length()       const  { return _pixelCount;            }
 
 double LEDBuffer::TimeTillDue() const
 {
-    return g_Values.AppTime.CurrentTime() - _timeStampSeconds - (_timeStampMicroseconds / (double) MICROS_PER_SECOND);
+    return _timeStampSeconds + (_timeStampMicroseconds / (double) MICROS_PER_SECOND) - g_Values.AppTime.CurrentTime();
 }
 
 bool LEDBuffer::IsBufferOlderThan(const timeval & tv) const
@@ -43,8 +45,20 @@ bool LEDBuffer::IsBufferOlderThan(const timeval & tv) const
 //
 // Parse and deposit a WiFi packet into a buffer
 
-bool LEDBuffer::UpdateFromWire(std::unique_ptr<uint8_t []> & payloadData, size_t payloadLength)
+bool LEDBuffer::ValidateWirePayload(const std::unique_ptr<uint8_t []>& payloadData,
+                                    size_t payloadLength,
+                                    size_t ledCount,
+                                    size_t* payloadByteCount)
 {
+    if (payloadByteCount)
+        *payloadByteCount = 0;
+
+    if (!payloadData)
+    {
+        debugW("No payload data received to process");
+        return false;
+    }
+
     if (payloadLength < 24)                 // Our header size
     {
         debugW("Not enough data received to process");
@@ -59,28 +73,66 @@ bool LEDBuffer::UpdateFromWire(std::unique_ptr<uint8_t []> & payloadData, size_t
 
     const size_t cbHeader = sizeof(command16) + sizeof(channel16) + sizeof(length32) + sizeof(seconds) + sizeof(micros);
 
-    _timeStampSeconds      = seconds;
-    _timeStampMicroseconds = micros;
-    _pixelCount            = length32;
+    if (length32 > (std::numeric_limits<size_t>::max() - cbHeader) / sizeof(CRGB))
+    {
+        debugW("LED payload size overflow");
+        return false;
+    }
 
-    if (payloadLength < length32 * sizeof(CRGB) + cbHeader)
+    const size_t requiredPayloadBytes = length32 * sizeof(CRGB);
+    if (payloadLength < requiredPayloadBytes + cbHeader)
     {
         debugW("command16: %hu   length32: %lu,  payloadLength: %zu\n", command16, (unsigned long)length32, payloadLength);
         debugW("Data size mismatch");
         return false;
     }
-    if (length32 > _pStrand->GetLEDCount())
+    if (length32 > ledCount)
     {
         debugW("More data than we have LEDs\n");
         return false;
     }
+
+    if (payloadByteCount)
+        *payloadByteCount = requiredPayloadBytes;
+
+    return true;
+}
+
+bool LEDBuffer::UpdateFromWire(std::unique_ptr<uint8_t []> & payloadData, size_t payloadLength)
+{
+    if (!_pStrand)
+    {
+        debugW("No strand attached to LED buffer");
+        return false;
+    }
+
+    size_t payloadBytes = 0;
+    if (!ValidateWirePayload(payloadData, payloadLength, _pStrand->GetLEDCount(), &payloadBytes))
+        return false;
+
+    uint16_t command16 = WORDFromMemory(&payloadData[0]);
+    uint16_t channel16 = WORDFromMemory(&payloadData[2]);
+    uint32_t length32  = DWORDFromMemory(&payloadData[4]);
+    uint64_t seconds   = ULONGFromMemory(&payloadData[8]);
+    uint64_t micros    = ULONGFromMemory(&payloadData[16]);
+
+    const size_t cbHeader = sizeof(command16) + sizeof(channel16) + sizeof(length32) + sizeof(seconds) + sizeof(micros);
+
     debugV("PayloadLength: %zu, command16: %hu, Length32: %lu", payloadLength, command16, (unsigned long)length32);
 
     CRGB * pRGB = reinterpret_cast<CRGB *>(&payloadData[cbHeader]);
 
-    memcpy(_leds.get(), pRGB, length32 * sizeof(CRGB));
+    // Keep this commit after the shared validation used by ProcessIncomingData.
+    // New queue slots are now reserved only after that validation passes, and
+    // existing-buffer updates still avoid committing invalid metadata.
+    _timeStampSeconds      = seconds;
+    _timeStampMicroseconds = micros;
+    _pixelCount            = length32;
+
+    memcpy(_leds.get(), pRGB, payloadBytes);
     debugV("seconds, micros: %llu.%llu", seconds, micros);
-    debugV("Color0: %08lx", (unsigned long)(uint32_t) _leds[0]);
+    if (length32 > 0)
+        debugV("Color0: %08lx", (unsigned long)(uint32_t) _leds[0]);
     return true;
 }
 
@@ -118,6 +170,7 @@ LEDBufferManager::LEDBufferManager(uint32_t cBuffers, const std::shared_ptr<GFXB
  : _ppBuffers(std::make_unique<std::vector<std::shared_ptr<LEDBuffer>>>()), // Create the circular array of ptrs
    _iNextBuffer(0),
    _iLastBuffer(0),
+   _cQueuedBuffers(0),
    _cBuffers(cBuffers)
 {
     // The initializer creates a uniquely owned table of shared pointers.
@@ -161,21 +214,29 @@ size_t LEDBufferManager::BufferCount() const
     return _cBuffers;
 }
 
+// LEDCount
+// The number of LEDs in each buffer, which is the same as the number of LEDs in the strand
+// that the buffers are configured for. If there are no buffers or the buffers aren't configured, returns 0.
+
+size_t LEDBufferManager::LEDCount() const
+{
+    return (_cBuffers > 0 && !_ppBuffers->empty() && (*_ppBuffers)[0] && (*_ppBuffers)[0]->_pStrand)
+        ? (*_ppBuffers)[0]->_pStrand->GetLEDCount()
+        : 0;
+}
+
 // Depth
 //
 // The variable, current count of buffers in use
 
 size_t LEDBufferManager::Depth() const
 {
-    if (_iNextBuffer < _iLastBuffer)
-        return (_iNextBuffer + _cBuffers - _iLastBuffer);
-    else
-        return _iNextBuffer - _iLastBuffer;
+    return _cQueuedBuffers;
 }
 
 bool LEDBufferManager::IsEmpty() const
 {
-    return _iNextBuffer == _iLastBuffer;
+    return _cQueuedBuffers == 0;
 }
 
 // PeekNewestBuffer
@@ -196,13 +257,19 @@ std::shared_ptr<LEDBuffer> LEDBufferManager::PeekNewestBuffer() const
 
 std::shared_ptr<LEDBuffer> LEDBufferManager::GetNewBuffer()
 {
-    auto pResult = (*_ppBuffers)[_iNextBuffer++];
+    if (_cBuffers == 0)
+        return nullptr;
 
-    if (IsEmpty())
-        _iLastBuffer++;
+    auto pResult = (*_ppBuffers)[_iNextBuffer];
 
-    _iLastBuffer %= _cBuffers;
-    _iNextBuffer %= _cBuffers;
+    // Full and empty used to be represented by the same head/tail indices, so
+    // an exact fill at the wrap point made the whole queue look empty. Track
+    // depth explicitly and advance the tail only when a real overwrite occurs.
+    _iNextBuffer = (_iNextBuffer + 1) % _cBuffers;
+    if (_cQueuedBuffers == _cBuffers)
+        _iLastBuffer = (_iLastBuffer + 1) % _cBuffers;
+    else
+        ++_cQueuedBuffers;
 
     _pLastBufferAdded = pResult;
 
@@ -219,8 +286,8 @@ std::shared_ptr<LEDBuffer> LEDBufferManager::GetOldestBuffer()
         return nullptr;
 
     auto pResult = (*_ppBuffers)[_iLastBuffer];
-    _iLastBuffer++;
-    _iLastBuffer %= _cBuffers;
+    _iLastBuffer = (_iLastBuffer + 1) % _cBuffers;
+    --_cQueuedBuffers;
 
     return pResult;
 }
@@ -246,6 +313,7 @@ void LEDBufferManager::Reconfigure(const std::shared_ptr<GFXBase>& pGFX)
 
     _iNextBuffer = 0;
     _iLastBuffer = 0;
+    _cQueuedBuffers = 0;
     _pLastBufferAdded.reset();
 }
 
@@ -254,7 +322,7 @@ void LEDBufferManager::Reconfigure(const std::shared_ptr<GFXBase>& pGFX)
 // Returns a pointer to the buffer at the specified logical index, or nullptr if empty
 std::shared_ptr<LEDBuffer> LEDBufferManager::operator[](size_t index) const
 {
-    if (IsEmpty())
+    if (IsEmpty() || index >= _cQueuedBuffers)
         return nullptr;
     size_t i = (_iLastBuffer + index) % _cBuffers;
     return (*_ppBuffers)[i];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -809,7 +809,10 @@ void loop()
 
             #if INCOMING_WIFI_ENABLED
                 auto& bufferManager = g_ptrSystem->GetBufferManagers()[0];
-                strOutput += str_sprintf("Buffer: %zu/%zu, ", (size_t)bufferManager.Depth(), (size_t)bufferManager.BufferCount());
+                {
+                    std::lock_guard<std::mutex> guard(g_buffer_mutex);
+                    strOutput += str_sprintf("Buffer: %zu/%zu, ", (size_t)bufferManager.Depth(), (size_t)bufferManager.BufferCount());
+                }
             #endif
 
             const auto& taskManager = g_ptrSystem->GetTaskManager();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -206,6 +206,9 @@
 #include "soundanalyzer.h"
 #include "systemcontainer.h"
 #include "taskmgr.h"
+#if ENABLE_WEBSERVER
+#include "webserver.h"
+#endif
 
 #if INCOMING_WIFI_ENABLED
 extern "C"
@@ -415,7 +418,6 @@ void setup()
 
     #if ENABLE_ESPNOW
         nd_network::SetWiFiModeSTA();
-
         if (esp_now_init() != ESP_OK)
             throw std::runtime_error("Error initializing ESP-NOW");
         // Register receive callback function
@@ -654,6 +656,38 @@ void setup()
 
     InitEffectsManager();
 
+    #if ENABLE_WIFI
+        debugI("Making initial attempt to connect to WiFi.");
+        auto connectResult = nd_network::ConnectToWiFi(WiFi_ssid, WiFi_password);
+        #if WAIT_FOR_WIFI
+            constexpr unsigned long kInitialWiFiConnectTimeoutMs = 30000;
+            constexpr unsigned long kInitialWiFiConnectPollMs    = 250;
+
+            const unsigned long firstConnectStart = millis();
+            while (connectResult == nd_network::WiFiConnectResult::Disconnected &&
+                   millis() - firstConnectStart < kInitialWiFiConnectTimeoutMs)
+            {
+                delay(kInitialWiFiConnectPollMs);
+                connectResult = nd_network::ConnectToWiFi();
+            }
+        #else
+            (void)connectResult;
+        #endif
+    #endif
+
+    #if ENABLE_WIFI && ENABLE_WEBSERVER
+        // With WAIT_FOR_WIFI=0, the first WiFi attempt is intentionally
+        // non-blocking. Only bind AsyncTCP here if the station already has an
+        // IP; otherwise NetworkReader will start these services after connect.
+        if (nd_network::IsWiFiConnected() && g_ptrSystem->HasWebServer())
+            g_ptrSystem->GetWebServer().Start();
+        
+        #if WEB_SOCKETS_ANY_ENABLED
+            if (nd_network::IsWiFiConnected() && g_ptrSystem->HasWebSocketServer())
+                g_ptrSystem->GetWebSocketServer().Start();
+        #endif
+    #endif
+
     // Start things that do not depend on the network
 
     g_ptrSystem->SetupRenderService().Start();
@@ -676,11 +710,6 @@ void setup()
     #if ENABLE_REMOTE
         if (g_ptrSystem->HasRemoteControl())
             g_ptrSystem->GetRemoteControl().Start();
-    #endif
-
-    #if ENABLE_WIFI
-        debugI("Making initial attempt to connect to WiFi.");
-        nd_network::ConnectToWiFi(WiFi_ssid, WiFi_password);
     #endif
 
     // Start the network-dependent services.  These will be NOPs on a non-wifi build.
@@ -708,7 +737,6 @@ void setup()
     DebugCLI::InitDebugCLI();
     nd_network::InitNetworkCLI();
 
-    SaveEffectManagerConfig();
 #if ENABLE_OTA
     ConfirmUpdate();
 #endif

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -38,6 +38,8 @@
     #include <ESPmDNS.h>
     #include <esp_wifi.h>
     #include <iterator>
+    #include <limits>
+    #include <mutex>
     #include <nvs.h>
     #include <WiFi.h>
 #elif ENABLE_ESPNOW
@@ -89,6 +91,15 @@ namespace nd_network
 
 #if ENABLE_WIFI
     static DRAM_ATTR WiFiUDP l_Udp;
+
+    static bool CheckedStandardPacketSize(uint32_t itemCount, size_t itemSize, size_t& packetSize)
+    {
+        if (itemCount > (std::numeric_limits<size_t>::max() - STANDARD_DATA_HEADER_SIZE) / itemSize)
+            return false;
+
+        packetSize = STANDARD_DATA_HEADER_SIZE + itemCount * itemSize;
+        return true;
+    }
 
     // Writer function and flag combo
     struct NetworkReader::ReaderEntry
@@ -660,11 +671,17 @@ namespace nd_network
             FLASH_VERSION_NAME, g_ptrSystem->GetDevices().size(),
             config.GetActiveLEDCount(), (size_t)(ESP.getFreeHeap()/1024), abs(WiFi.RSSI()),
             IsWiFiConnected() ? WiFi.localIP().toString().c_str() : "None");
-        DebugCLI::cli_printf("BUFR:%02zu/%02zu [%lufps]",
-            (size_t)bufferManager.Depth(), (size_t)bufferManager.BufferCount(),
-            (unsigned long)g_Values.FPS);
-        DebugCLI::cli_printf("DATA:%+04.2f-%+04.2f",
-            (float)bufferManager.AgeOfOldestBuffer(), (float)bufferManager.AgeOfNewestBuffer());
+        {
+            // Buffer indices are mutated by the socket task and consumed by
+            // the render task; status reads need the same mutex or they can
+            // sample a half-updated ring state on the other core.
+            std::lock_guard<std::mutex> guard(g_buffer_mutex);
+            DebugCLI::cli_printf("BUFR:%02zu/%02zu [%lufps]",
+                (size_t)bufferManager.Depth(), (size_t)bufferManager.BufferCount(),
+                (unsigned long)g_Values.FPS);
+            DebugCLI::cli_printf("DATA:%+04.2f-%+04.2f",
+                (float)bufferManager.AgeOfOldestBuffer(), (float)bufferManager.AgeOfNewestBuffer());
+        }
 
         #if ENABLE_AUDIO
         DebugCLI::cli_printf("g_Analyzer._VU: %.2f, g_Analyzer._MinVU: %.2f, g_Analyzer._PeakVU: %.2f, g_Analyzer.gVURatio: %.2f",
@@ -794,6 +811,7 @@ void SetupOTA(const String &strHostname)
             debugI("OTA Progress: %u%%\r", p);
 
             #if USE_HUB75
+                std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
                 auto pMatrix = std::static_pointer_cast<HUB75GFX>(g_ptrSystem->GetEffectManager().GetBaseGraphics()[0]);
                 pMatrix->SetCaption(str_sprintf("Update:%d%%", p), CAPTION_TIME);
             #endif
@@ -835,6 +853,12 @@ bool ProcessIncomingData(std::unique_ptr<uint8_t[]> &payloadData, size_t payload
     #if !INCOMING_WIFI_ENABLED
         return false;
     #else
+        if (!payloadData || payloadLength < STANDARD_DATA_HEADER_SIZE)
+        {
+            debugW("Incoming packet too short: %zu", payloadLength);
+            return false;
+        }
+
         uint16_t command16 = payloadData[1] << 8 | payloadData[0];
 
         debugV("payloadLength: %zu, command16: %d", payloadLength, command16);
@@ -853,6 +877,17 @@ bool ProcessIncomingData(std::unique_ptr<uint8_t[]> &payloadData, size_t payload
 
                     debugV("ProcessIncomingData -- Bands: %u, Length: %lu, Seconds: %llu, Micros: %llu ... ",
                            (unsigned int)numbands, (unsigned long)length32, seconds, micros);
+
+                    size_t expectedLength = 0;
+                    if (numbands != NUM_BANDS ||
+                        length32 != numbands * sizeof(float) ||
+                        !nd_network::CheckedStandardPacketSize(length32, sizeof(uint8_t), expectedLength) ||
+                        payloadLength < expectedLength)
+                    {
+                        debugW("Malformed peak data packet: bands=%u length=%lu payload=%zu",
+                               (unsigned int)numbands, (unsigned long)length32, payloadLength);
+                        return false;
+                    }
 
                     // Data is transmitted as NUM_BANDS floats following the standard header
                     const uint8_t* dataStart = payloadData.get() + STANDARD_DATA_HEADER_SIZE;
@@ -883,6 +918,14 @@ bool ProcessIncomingData(std::unique_ptr<uint8_t[]> &payloadData, size_t payload
                 debugV("ProcessIncomingData -- Channel: %u, Length: %lu, Seconds: %llu, Micros: %llu ... ",
                        (unsigned int)channel16, (unsigned long)length32, seconds, micros);
 
+                size_t expectedLength = 0;
+                if (!nd_network::CheckedStandardPacketSize(length32, sizeof(CRGB), expectedLength) || payloadLength < expectedLength)
+                {
+                    debugW("Malformed pixel data packet: length=%lu payload=%zu",
+                           (unsigned long)length32, payloadLength);
+                    return false;
+                }
+
                 // The very old original implementation used channel numbers, not a mask, and only channel 0 was supported at that time, so if
                 // we see a Channel 0 asked for, it must be very old, and we massage it into the mask for Channel0 instead
                 // Another option here would be to draw on all channels (0xff) instead of just one (0x01) if 0 is specified
@@ -902,6 +945,16 @@ bool ProcessIncomingData(std::unique_ptr<uint8_t[]> &payloadData, size_t payload
                         bool bDone = false;
                         auto &bufferManager = g_ptrSystem->GetBufferManagers()[iChannel];
 
+                        // Validate against the active channel before reserving a
+                        // circular-buffer slot. Reserving first meant a rejected
+                        // packet could leave an old frame queued in the new slot.
+                        if (!LEDBuffer::ValidateWirePayload(payloadData, payloadLength, bufferManager.LEDCount()))
+                        {
+                            debugW("Pixel packet rejected for channel %d: %lu LEDs, channel has %zu",
+                                   (unsigned long)length32, iChannel, bufferManager.LEDCount());
+                            return false;
+                        }
+
                         if (!bufferManager.IsEmpty())
                         {
                             auto pNewestBuffer = bufferManager.PeekNewestBuffer();
@@ -917,7 +970,7 @@ bool ProcessIncomingData(std::unique_ptr<uint8_t[]> &payloadData, size_t payload
                         {
                             debugV("No match so adding new buffer");
                             auto pNewBuffer = bufferManager.GetNewBuffer();
-                            if (!pNewBuffer->UpdateFromWire(payloadData, payloadLength))
+                            if (!pNewBuffer || !pNewBuffer->UpdateFromWire(payloadData, payloadLength))
                                 return false;
                         }
                     }

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -36,6 +36,7 @@
     #include <algorithm>
     #include <ArduinoOTA.h>
     #include <ESPmDNS.h>
+    #include <esp_wifi.h>
     #include <iterator>
     #include <nvs.h>
     #include <WiFi.h>
@@ -78,6 +79,7 @@ namespace nd_network
 {
     // Private State
     static std::atomic<bool> l_bWifiDriverReady{false};
+    static std::atomic<bool> l_HasStaIp{false};
 
     // True while Improv owns WiFi during a provisioning attempt. Gates the
     // background reconnect loop so it doesn't race Improv on WiFi.begin /
@@ -155,12 +157,37 @@ namespace nd_network
 
     // WiFi-Specific Implementations
 
-    bool IsWiFiConnected() { return WiFi.isConnected(); }
+    static bool HasUsableStaIp()
+    {
+        const bool hasIp = WiFi.localIP() != IPAddress(0, 0, 0, 0);
+        return hasIp && (l_HasStaIp.load() || WiFi.status() == WL_CONNECTED);
+    }
+
+    bool IsWiFiConnected() { return WiFi.isConnected() && HasUsableStaIp(); }
     int  GetWiFiStatus()    { return (int)WiFi.status(); }
     int  GetWiFiRSSI()      { return WiFi.RSSI(); }
-    void SetWiFiModeSTA()   { WiFi.mode(WIFI_STA); }
 
-    String GetWiFiLocalIP() { return WiFi.localIP().toString(); }
+    static void DisableWiFiPowerSave(const char *reason)
+    {
+        WiFi.setSleep(false);
+        esp_err_t err = esp_wifi_set_ps(WIFI_PS_NONE);
+        if (err == ESP_OK)
+            debugI("WiFi power save disabled (%s)", reason);
+        else
+            debugW("esp_wifi_set_ps(WIFI_PS_NONE) failed (%s): %d", reason, (int)err);
+    }
+
+    // Apply the standard NightDriver WiFi station-mode configuration.
+    void SetWiFiModeSTA()
+    {
+        WiFi.persistent(false);
+        WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);
+        WiFi.setSortMethod(WIFI_CONNECT_AP_BY_SIGNAL);
+        WiFi.mode(WIFI_STA);
+        DisableWiFiPowerSave("STA mode");
+    }
+
+    String GetWiFiLocalIP() { return HasUsableStaIp() ? WiFi.localIP().toString() : String("0.0.0.0"); }
 
     bool GetWiFiHostByName(const char *hostname, IPAddress &ip)
     {
@@ -172,6 +199,22 @@ namespace nd_network
     #define WIFI_WAIT_MAX       60000   // Maximum gap between retries, in ms
 
     #define WIFI_WAIT_INIT      (WIFI_WAIT_BASE - WIFI_WAIT_INCREASE)
+
+    static void EnsureNetworkServicesStarted()
+    {
+        if (!g_ptrSystem)
+            return;
+
+        #if ENABLE_WEBSERVER
+            if (g_ptrSystem->HasWebServer() && !g_ptrSystem->GetWebServer().IsRunning())
+                g_ptrSystem->GetWebServer().Start();
+        #endif
+
+        #if WEB_SOCKETS_ANY_ENABLED
+            if (g_ptrSystem->HasWebSocketServer() && !g_ptrSystem->GetWebSocketServer().IsRunning())
+                g_ptrSystem->GetWebSocketServer().Start();
+        #endif
+    }
 
     // ConnectToWiFi
     //
@@ -193,14 +236,30 @@ namespace nd_network
             WiFi.onEvent([](arduino_event_id_t event, arduino_event_info_t info) {
                 if (event == ARDUINO_EVENT_WIFI_READY)
                     l_bWifiDriverReady = true;
+                else if (event == ARDUINO_EVENT_WIFI_STA_GOT_IP)
+                {
+                    l_HasStaIp.store(true);
+                    DisableWiFiPowerSave("GOT_IP");
+                    debugI("WiFi GOT_IP: ip=%s gateway=%s subnet=%s dns=%s",
+                           WiFi.localIP().toString().c_str(),
+                           WiFi.gatewayIP().toString().c_str(),
+                           WiFi.subnetMask().toString().c_str(),
+                           WiFi.dnsIP().toString().c_str());
+                }
+                else if (event == ARDUINO_EVENT_WIFI_STA_LOST_IP)
+                {
+                    l_HasStaIp.store(false);
+                    debugW("WiFi LOST_IP");
+                }
                 else if (event == ARDUINO_EVENT_WIFI_STA_DISCONNECTED)
                 {
+                    l_HasStaIp.store(false);
                     l_LastWiFiDisconnectReason.store(info.wifi_sta_disconnected.reason);
                     debugW("WiFi Disconnected. Reason: %d", info.wifi_sta_disconnected.reason);
                 }
             });
-            WiFi.mode(WIFI_STA);
-            WiFi.setSleep(false);
+            SetWiFiModeSTA();
+
             bInitialized = true;
         }
 
@@ -223,7 +282,7 @@ namespace nd_network
             retryDelay = WIFI_WAIT_INIT;
             debugI("WiFi credentials passed for SSID \"%s\"", WiFi_ssid.c_str());
         }
-        else if (bPreviousConnection && WiFi.isConnected())
+        else if (bPreviousConnection && IsWiFiConnected())
         {
             return WiFiConnectResult::Connected;
         }
@@ -251,14 +310,15 @@ namespace nd_network
                 // WiFi.begin cannot short-circuit as "already connected" when
                 // the SSID is unchanged.
                 WiFi.disconnect(false, explicitCredentials);
+                l_HasStaIp.store(false);
                 bPreviousConnection = false;
                 bReportedDisconnected = false;
 
                 const unsigned long disconnectStarted = millis();
-                while (WiFi.isConnected() && millis() - disconnectStarted < 2000)
+                while (IsWiFiConnected() && millis() - disconnectStarted < 2000)
                     delay(20);
 
-                if (WiFi.isConnected())
+                if (IsWiFiConnected())
                     debugW("WiFi remained connected after disconnect request; starting the new attempt anyway.");
             }
 
@@ -270,9 +330,15 @@ namespace nd_network
             debugV("Done Wifi.begin, waiting for connection...");
         }
 
-        if (WiFi.isConnected())
+        if (IsWiFiConnected())
         {
+            DisableWiFiPowerSave("connected");
             debugW("Connected to AP with BSSID: \"%s\", received IP: %s", WiFi.BSSIDstr().c_str(), WiFi.localIP().toString().c_str());
+            debugI("WiFi network: subnet=%s gateway=%s dns=%s rssi=%d",
+                   WiFi.subnetMask().toString().c_str(),
+                   WiFi.gatewayIP().toString().c_str(),
+                   WiFi.dnsIP().toString().c_str(),
+                   WiFi.RSSI());
         }
         else
         // Additional services onwards are reliant on network so return if WiFi is not up (yet)
@@ -304,14 +370,8 @@ namespace nd_network
             }
             NTPTimeClient::UpdateClockFromWeb(&l_Udp);
         #endif
-        #if ENABLE_WEBSERVER
-            g_ptrSystem->GetWebServer().Start();
-        #endif
 
-        #if WEB_SOCKETS_ANY_ENABLED
-            if (g_ptrSystem->HasWebSocketServer())
-                g_ptrSystem->GetWebSocketServer().Start();
-        #endif
+        EnsureNetworkServicesStarted();
 
         return WiFiConnectResult::Connected;
     }
@@ -320,7 +380,7 @@ namespace nd_network
         void UpdateNTPTime()
         {
             static unsigned long lastUpdate = 0;
-            if (WiFi.isConnected())
+            if (IsWiFiConnected())
             {
                 // If we've already retrieved the time successfully, we'll only actually update every NTP_DELAY_SECONDS seconds
                 if (!NTPTimeClient::HasClockBeenSet() || (millis() - lastUpdate) > ((NTP_DELAY_SECONDS) * 1000))
@@ -489,6 +549,8 @@ namespace nd_network
 
     void NetworkReader::Run()
     {
+        constexpr unsigned long kReaderDispatchGapMs = 1000;
+
         unsigned long lastConnected = millis();
         unsigned long lastWebSocketCleanup = 0;
         if (!MDNS.begin("esp32")) Serial.println("Error starting mDNS");
@@ -539,15 +601,18 @@ namespace nd_network
                 }
             }
 
-            if (!WiFi.isConnected())
+            if (!IsWiFiConnected())
             {
                 notifyWait = pdMS_TO_TICKS(1000);
                 continue;
             }
 
+            EnsureNetworkServicesStarted();
+
             unsigned long now = millis();
             unsigned long nextEventMs = 1000;
 
+            bool dispatchedReader = false;
             for (auto &entryPtr : readers)
             {
                 auto &entry = *entryPtr;
@@ -569,8 +634,12 @@ namespace nd_network
                     if (entry.reader)
                         entry.reader();
                     entry.lastReadMs.store(millis());
+                    dispatchedReader = true;
+                    break;
                 }
             }
+            if (dispatchedReader)
+                nextEventMs = std::min<unsigned long>(nextEventMs, kReaderDispatchGapMs);
             notifyWait = pdMS_TO_TICKS(nextEventMs);
         }
 
@@ -590,7 +659,7 @@ namespace nd_network
         DebugCLI::cli_printf("%s:%zux%zu %zuK %ddB:%s",
             FLASH_VERSION_NAME, g_ptrSystem->GetDevices().size(),
             config.GetActiveLEDCount(), (size_t)(ESP.getFreeHeap()/1024), abs(WiFi.RSSI()),
-            WiFi.isConnected() ? WiFi.localIP().toString().c_str() : "None");
+            IsWiFiConnected() ? WiFi.localIP().toString().c_str() : "None");
         DebugCLI::cli_printf("BUFR:%02zu/%02zu [%lufps]",
             (size_t)bufferManager.Depth(), (size_t)bufferManager.BufferCount(),
             (unsigned long)g_Values.FPS);
@@ -917,7 +986,7 @@ void IRAM_ATTR ColorStreamerService::Run()
 
     while (!ShouldShutdown())
     {
-        while (!WiFi.isConnected() && !ShouldShutdown())
+        while (!nd_network::IsWiFiConnected() && !ShouldShutdown())
             delay(250);
 
         if (ShouldShutdown())

--- a/src/remotecontrol.cpp
+++ b/src/remotecontrol.cpp
@@ -38,6 +38,7 @@
 #include <esp_idf_version.h>
 #include <esp_intr_alloc.h>
 #include <freertos/FreeRTOS.h>
+#include <mutex>
 
 // IR RX has two RMT backends, picked at compile time based on IDF version:
 //
@@ -985,6 +986,7 @@ void RemoteControl::handle()
                 effectManager.ApplyGlobalColor(RemoteColorCode.color);
                 #if FULL_COLOR_REMOTE_FILL
                     auto effect = std::make_shared<ColorFillEffect>("Remote Color", RemoteColorCode.color, 1, true);
+                    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
                     if (effect->Init(g_ptrSystem->GetEffectManager().GetBaseGraphics()))
                         g_ptrSystem->GetEffectManager().SetTempEffect(effect);
                     else

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -156,13 +156,27 @@ public:
 
         // Buffer Status Line 3
         auto &bufferManager = g_ptrSystem->GetBufferManagers()[0];
+        size_t bufferDepth = 0;
+        size_t bufferCount = 0;
+        double oldestAge = 0.0;
+        double newestAge = 0.0;
+        {
+            // The display runs on its own task, so even status-only buffer
+            // reads need the producer/consumer mutex to avoid sampling torn
+            // circular-buffer indices.
+            std::lock_guard<std::mutex> guard(g_buffer_mutex);
+            bufferDepth = bufferManager.Depth();
+            bufferCount = bufferManager.BufferCount();
+            oldestAge = bufferManager.AgeOfOldestBuffer();
+            newestAge = bufferManager.AgeOfNewestBuffer();
+        }
         display.setCursor(xMargin + 0, yMargin + lineHeight * 4);
-        display.println(str_sprintf("BUFR:%02lu/%02lu %lufps ", (unsigned long)bufferManager.Depth(), (unsigned long)bufferManager.BufferCount(), (unsigned long)g_Values.FPS));
+        display.println(str_sprintf("BUFR:%02lu/%02lu %lufps ", (unsigned long)bufferDepth, (unsigned long)bufferCount, (unsigned long)g_Values.FPS));
 
         // Data Status Line 4
         display.setCursor(xMargin + 0, yMargin + lineHeight * 2);
-        display.println(str_sprintf("DATA:%+06.2lf-%+06.2lf", std::min(99.99, bufferManager.AgeOfOldestBuffer()),
-                                    std::min(99.99, bufferManager.AgeOfNewestBuffer())));
+        display.println(str_sprintf("DATA:%+06.2lf-%+06.2lf", std::min(99.99, oldestAge),
+                                    std::min(99.99, newestAge)));
 
         // Clock info Line 5
         time_t t;
@@ -195,7 +209,7 @@ public:
             int top = display.height() - lineHeight;
             int height = lineHeight - 3;
             int width = display.width() - xMargin * 2;
-            float ratio = (float)bufferManager.Depth() / (float)bufferManager.BufferCount();
+            float ratio = bufferCount == 0 ? 0.0f : (float)bufferDepth / (float)bufferCount;
             ratio = std::min(1.0f, ratio);
             int filled = (width - 2) * ratio;
 
@@ -334,9 +348,10 @@ public:
                 yh += display.fontHeight();
 
                 display.setTextColor(display.GetTextColor(), backColor);
-                w = display.textWidth(g_ptrSystem->GetEffectManager().GetCurrentEffectName());
+                String effectName = g_ptrSystem->GetEffectManager().GetCurrentEffectName();
+                w = display.textWidth(effectName);
                 display.setCursor(display.width() / 2 - w / 2, yh);
-                display.print(g_ptrSystem->GetEffectManager().GetCurrentEffectName());
+                display.print(effectName);
                 yh += display.fontHeight();
 
                 String sIP = nd_network::IsWiFiConnected() ? currentIP.c_str() : "No Wifi";

--- a/src/socketserver.cpp
+++ b/src/socketserver.cpp
@@ -43,6 +43,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
+#include <mutex>
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/time.h>
@@ -54,6 +56,27 @@ extern "C"
 }
 
 #if INCOMING_WIFI_ENABLED
+
+namespace
+{
+    bool CheckedAdd(size_t left, size_t right, size_t& result)
+    {
+        if (left > std::numeric_limits<size_t>::max() - right)
+            return false;
+
+        result = left + right;
+        return true;
+    }
+
+    bool CheckedStandardPacketSize(uint32_t itemCount, size_t itemSize, size_t& packetSize)
+    {
+        if (itemCount > (std::numeric_limits<size_t>::max() - STANDARD_DATA_HEADER_SIZE) / itemSize)
+            return false;
+
+        packetSize = STANDARD_DATA_HEADER_SIZE + itemCount * itemSize;
+        return true;
+    }
+}
 
 // SocketResponse
 //
@@ -255,6 +278,12 @@ bool SocketServer::ReadUntilNBytesReceived(size_t socket, size_t cbNeeded)
 
 bool SocketServer::DecompressBuffer(const uint8_t * pBuffer, size_t cBuffer, uint8_t * pOutput, size_t expectedOutputSize)
 {
+    if (pBuffer == nullptr || pOutput == nullptr || cBuffer < 4)
+    {
+        debugE("Compressed packet too short to decompress: %zu bytes", cBuffer);
+        return false;
+    }
+
     debugV("Compressed Data: %02X %02X %02X %02X...", pBuffer[0], pBuffer[1], pBuffer[2], pBuffer[3]);
 
     struct uzlib_uncomp d = { 0 };
@@ -395,18 +424,25 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
             uint32_t reserved       = _pBuffer[15] << 24 | _pBuffer[14] << 16 | _pBuffer[13] << 8 | _pBuffer[12];
             debugV("Compressed Header: compressedSize: %lu, expandedSize: %lu, reserved: %lu", (unsigned long)compressedSize, (unsigned long)expandedSize, (unsigned long)reserved);
 
-            if (expandedSize > MAXIMUM_PACKET_SIZE)
+            size_t compressedPacketSize = 0;
+            if (!CheckedAdd(COMPRESSED_HEADER_SIZE, compressedSize, compressedPacketSize) ||
+                compressedPacketSize > MAXIMUM_PACKET_SIZE ||
+                expandedSize > MAXIMUM_PACKET_SIZE)
             {
-                debugE("Expanded packet would be %lu but buffer is only %lu !!!!\n", (unsigned long)expandedSize, (unsigned long)MAXIMUM_PACKET_SIZE);
+                debugE("Compressed packet sizes are invalid: compressed=%lu expanded=%lu max=%lu",
+                       (unsigned long)compressedSize, (unsigned long)expandedSize, (unsigned long)MAXIMUM_PACKET_SIZE);
                 break;
             }
 
-            if (false == ReadUntilNBytesReceived(new_socket, COMPRESSED_HEADER_SIZE + compressedSize))
+            // Check addition before ReadUntilNBytesReceived; an overflowed
+            // header+payload size can wrap back below MAXIMUM_PACKET_SIZE and
+            // make the socket reader under-read a malformed packet.
+            if (false == ReadUntilNBytesReceived(new_socket, compressedPacketSize))
             {
                 debugE("Could not read compressed data from stream\n");
                 break;
             }
-            debugV("Successfully read %zu bytes", (size_t)(COMPRESSED_HEADER_SIZE + compressedSize));
+            debugV("Successfully read %zu bytes", compressedPacketSize);
 
             // If our buffer is in PSRAM it would be expensive to decompress in place, as the SPIRAM doesn't like
             // non-linear access from what I can tell.  I bet it must send addr+len to request each unique read, so
@@ -449,13 +485,16 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
                     uint64_t seconds   = ULONGFromMemory(&_pBuffer.get()[8]);
                     uint64_t micros    = ULONGFromMemory(&_pBuffer.get()[16]);
 
-                    size_t totalExpected = STANDARD_DATA_HEADER_SIZE + length32;
+                    size_t totalExpected = 0;
 
                     debugV("PeakData Header: numbands=%u, length=%lu, seconds=%llu, micro=%llu", numbands, (unsigned long)length32, seconds, micros);
 
-                    if (numbands != NUM_BANDS)
+                    if (!CheckedStandardPacketSize(length32, sizeof(uint8_t), totalExpected) ||
+                        totalExpected > MAXIMUM_PACKET_SIZE ||
+                        numbands != NUM_BANDS)
                     {
-                        debugE("Expecting %d bands but received %d", NUM_BANDS, numbands);
+                        debugE("Invalid peak data packet: bands=%u length=%lu total=%zu",
+                               (unsigned int)numbands, (unsigned long)length32, totalExpected);
                         break;
                     }
 
@@ -480,7 +519,13 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
                 #else
                     // Audio disabled: consume any declared payload to keep stream in sync, then ignore it
                     uint32_t length32  = DWORDFromMemory(&_pBuffer.get()[4]);
-                    size_t totalExpected = STANDARD_DATA_HEADER_SIZE + length32;
+                    size_t totalExpected = 0;
+                    if (!CheckedStandardPacketSize(length32, sizeof(uint8_t), totalExpected) ||
+                        totalExpected > MAXIMUM_PACKET_SIZE)
+                    {
+                        debugE("Audio disabled, invalid PEAKDATA payload length %lu", (unsigned long)length32);
+                        break;
+                    }
                     if (!ReadUntilNBytesReceived(new_socket, totalExpected))
                     {
                         debugE("Audio disabled, failed to skip PEAKDATA payload of %zu bytes", (size_t)totalExpected);
@@ -502,8 +547,9 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
 
                 debugV("Uncompressed Header: channel16=%u, length=%lu, seconds=%llu, micro=%llu", channel16, (unsigned long)length32, seconds, micros);
 
-                size_t totalExpected = STANDARD_DATA_HEADER_SIZE + length32 * LED_DATA_SIZE;
-                if (totalExpected > MAXIMUM_PACKET_SIZE)
+                size_t totalExpected = 0;
+                if (!CheckedStandardPacketSize(length32, LED_DATA_SIZE, totalExpected) ||
+                    totalExpected > MAXIMUM_PACKET_SIZE)
                 {
                     debugE("Too many bytes promised (%zu) - more than we can use for our LEDs at max packet (%lu)\n", (size_t)totalExpected, (unsigned long)MAXIMUM_PACKET_SIZE);
                     break;
@@ -548,6 +594,7 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
             debugV("Sending Response Packet from Socket Server");
             auto& bufferManager = g_ptrSystem->GetBufferManagers()[0];
 
+            std::lock_guard<std::mutex> guard(g_buffer_mutex);
             SocketResponse response = {
                                         .size = sizeof(SocketResponse),
                                         .sequence     = sequence++,

--- a/src/systemcontainer.cpp
+++ b/src/systemcontainer.cpp
@@ -304,7 +304,11 @@ int SystemContainer::GetConfiguredAudioInputPin() const
 
 bool SystemContainer::ApplyRuntimeConfiguration(String* errorMessage)
 {
-    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+    // Runtime topology changes retarget both the graphics objects and the
+    // WiFi frame buffers. Lock all three domains together so the render task
+    // cannot draw while the socket task is filling buffers sized for the old
+    // topology.
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex, g_buffer_mutex);
 
     auto& config = GetDeviceConfig();
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -38,6 +38,7 @@
 #include <FS.h>
 #include <algorithm>
 #include <cstdlib>
+#include <mutex>
 #include <limits>
 #include <utility>
 
@@ -624,26 +625,37 @@ void CWebServer::GetEffectListText(AsyncWebServerRequest * pRequest)
     auto response = new AsyncJsonResponse();
     auto& j = response->getRoot();
     auto& effectManager = g_ptrSystem->GetEffectManager();
+    bool overflow = false;
 
-    j["currentEffect"]         = effectManager.GetCurrentEffectIndex();
-    j["millisecondsRemaining"] = effectManager.GetTimeRemainingForCurrentEffect();
-    j["eternalInterval"]       = effectManager.IsIntervalEternal();
-    j["effectInterval"]        = effectManager.GetInterval();
-
-    for (const auto& effect : effectManager.EffectsList())
     {
-        auto effectDoc = CreateJsonDocument();
+        std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
 
-        effectDoc["name"]    = effect->FriendlyName();
-        effectDoc["enabled"] = effect->IsEnabled();
-        effectDoc["core"]    = effect->IsCoreEffect();
+        j["currentEffect"]         = effectManager.GetCurrentEffectIndex();
+        j["millisecondsRemaining"] = effectManager.GetTimeRemainingForCurrentEffect();
+        j["eternalInterval"]       = effectManager.IsIntervalEternal();
+        j["effectInterval"]        = effectManager.GetInterval();
 
-        if (!j["Effects"].add(effectDoc))
+        for (const auto& effect : effectManager.EffectsList())
         {
-            debugV("JSON response buffer overflow!");
-            SendBufferOverflowResponse(pRequest);
-            return;
+            auto effectDoc = CreateJsonDocument();
+
+            effectDoc["name"]    = effect->FriendlyName();
+            effectDoc["enabled"] = effect->IsEnabled();
+            effectDoc["core"]    = effect->IsCoreEffect();
+
+            if (!j["Effects"].add(effectDoc))
+            {
+                debugV("JSON response buffer overflow!");
+                overflow = true;
+                break;
+            }
         }
+    }
+
+    if (overflow)
+    {
+        SendBufferOverflowResponse(pRequest);
+        return;
     }
 
     AddCORSHeaderAndSendResponse(pRequest, response);
@@ -788,7 +800,7 @@ void CWebServer::DeleteEffect(AsyncWebServerRequest * pRequest)
         return;
     }
 
-    if (index < g_ptrSystem->GetEffectManager().EffectCount() && g_ptrSystem->GetEffectManager().EffectsList()[index]->IsCoreEffect())
+    if (g_ptrSystem->GetEffectManager().IsCoreEffect(index))
     {
         AddCORSHeaderAndSendBadRequest(pRequest, "Can't delete core effect");
         return;
@@ -1456,17 +1468,21 @@ void CWebServer::SetUnifiedSettings(AsyncWebServerRequest * pRequest, JsonVarian
 
 bool CWebServer::CheckAndGetSettingsEffect(AsyncWebServerRequest * pRequest, std::shared_ptr<LEDStripEffect> & effect, bool post)
 {
-    const auto& effectsList = g_ptrSystem->GetEffectManager().EffectsList();
     auto effectIndex = GetEffectIndexFromParam(pRequest, post);
 
-    if (effectIndex < 0 || effectIndex >= effectsList.size())
+    if (effectIndex < 0)
     {
         AddCORSHeaderAndSendOKResponse(pRequest);
 
         return false;
     }
 
-    effect = effectsList[effectIndex];
+    effect = g_ptrSystem->GetEffectManager().EffectAt(effectIndex);
+    if (!effect)
+    {
+        AddCORSHeaderAndSendOKResponse(pRequest);
+        return false;
+    }
 
     return true;
 }
@@ -1478,7 +1494,11 @@ void CWebServer::GetEffectSettingSpecs(AsyncWebServerRequest * pRequest)
     if (!CheckAndGetSettingsEffect(pRequest, effect))
         return;
 
-    auto settingSpecs = effect->GetSettingSpecs();
+    std::vector<std::reference_wrapper<SettingSpec>> settingSpecs;
+    {
+        std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+        settingSpecs = effect->GetSettingSpecs();
+    }
 
     SendSettingSpecsResponse(pRequest, settingSpecs);
 }
@@ -1488,7 +1508,13 @@ void CWebServer::SendEffectSettingsResponse(AsyncWebServerRequest * pRequest, st
     auto response = std::make_unique<AsyncJsonResponse>();
     auto jsonObject = response->getRoot().to<JsonObject>();
 
-    if (effect->SerializeSettingsToJSON(jsonObject))
+    bool serialized = false;
+    {
+        std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+        serialized = effect->SerializeSettingsToJSON(jsonObject);
+    }
+
+    if (serialized)
     {
         AddCORSHeaderAndSendResponse(pRequest, response.release());
         return;
@@ -1514,6 +1540,10 @@ bool CWebServer::ApplyEffectSettings(AsyncWebServerRequest * pRequest, std::shar
 {
     bool settingChanged = false;
 
+    // Effect settings are live data consumed by Draw(). Apply and enumerate
+    // them under the render/effect locks so web requests cannot mutate an
+    // effect while the render task is drawing it.
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
     for (auto& settingSpecWrapper : effect->GetSettingSpecs())
     {
         const auto& spec = settingSpecWrapper.get();

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -37,6 +37,7 @@
 #include <AsyncJson.h>
 #include <FS.h>
 #include <algorithm>
+#include <cstdlib>
 #include <limits>
 #include <utility>
 
@@ -58,6 +59,37 @@ namespace
     {
         for (auto pin : pins)
             target.add(pin);
+    }
+
+    // The "readers hold" is a short period after a reader is registered during which we delay 
+    // checking the reader flags and dispatching to them. This gives a chance for any burst of reader 
+    // registrations/flaggings to settle down before we start dispatching, which is helpful for things 
+    // like REST APIs where a single event can cause a flurry of updates.
+
+    bool TryReadUint16(JsonVariantConst value, uint16_t& target)
+    {
+        if (value.is<uint16_t>())
+        {
+            target = value.as<uint16_t>();
+            return true;
+        }
+
+        if (value.is<const char*>())
+        {
+            const String text = value.as<const char*>();
+            if (text.length() == 0)
+                return false;
+
+            char* end = nullptr;
+            const unsigned long parsed = strtoul(text.c_str(), &end, 10);
+            if (end && *end == '\0' && parsed <= std::numeric_limits<uint16_t>::max())
+            {
+                target = static_cast<uint16_t>(parsed);
+                return true;
+            }
+        }
+
+        return false;
     }
 
     void FillUnifiedSettingsJson(JsonObject root)
@@ -301,6 +333,7 @@ const std::map<String, CWebServer::ValueValidator> CWebServer::settingValidators
 
 std::vector<SettingSpec> CWebServer::mySettingSpecs = {};
 std::vector<std::reference_wrapper<SettingSpec>> CWebServer::deviceSettingSpecs{};
+String CWebServer::deviceSettingSpecsJson{};
 
 // Member function template specializations
 
@@ -466,6 +499,9 @@ void CWebServer::begin()
     _staticStats.FreeSketchSpace = ESP.getFreeSketchSpace();
     _staticStats.FlashChipSize = ESP.getFlashChipSize();
 
+    if (!EnsureDeviceSettingSpecsJson())
+        debugW("WebServer: failed to pre-cache device setting specs JSON.");
+
     debugI("Connecting Web Endpoints");
 
     // SPIFFS file requests
@@ -511,7 +547,7 @@ void CWebServer::begin()
     _server.on("/api/v1/settings/schema",HTTP_GET,  GetUnifiedSettingsSchema);
     _server.on("/api/v1/settings",       HTTP_GET,  GetUnifiedSettings);
 
-    auto settingsHandler = new AsyncCallbackJsonWebHandler("/api/v1/settings",
+    auto* settingsHandler = new AsyncCallbackJsonWebHandler("/api/v1/settings",
         [](AsyncWebServerRequest* pRequest, JsonVariant& json)
         {
             SetUnifiedSettings(pRequest, json.as<JsonVariantConst>());
@@ -523,6 +559,7 @@ void CWebServer::begin()
 
     // Embedded file requests
 
+    _server.on("/healthz", HTTP_GET, [](AsyncWebServerRequest* pRequest) { pRequest->send(CWebServer::HttpOk, "text/plain", "ok"); });
     ServeEmbeddedFile("/timezones.json", timezones_file);
 
     #if ENABLE_WEB_UI
@@ -542,7 +579,7 @@ void CWebServer::begin()
             request->send(CWebServer::HttpOk);                                // Apparently needed for CORS: https://github.com/me-no-dev/ESPAsyncWebServer
         } else {
                 debugW("Failed GET for %s\n", request->url().c_str() );
-            request->send(CWebServer::HttpNotFound);
+            request->send(CWebServer::HttpNotFound, "text/plain", "Not found");
         }
     });
 
@@ -777,38 +814,54 @@ void CWebServer::PreviousEffect(AsyncWebServerRequest * pRequest)
 
 void CWebServer::SendSettingSpecsResponse(AsyncWebServerRequest * pRequest, const std::vector<std::reference_wrapper<SettingSpec>> & settingSpecs)
 {
-    auto response = new AsyncJsonResponse();
-    auto jsonArray = response->getRoot().to<JsonArray>();
+    String json;
+    if (!BuildSettingSpecsJson(json, settingSpecs))
+    {
+        debugW("Unable to build setting specs JSON response.");
+        SendBufferOverflowResponse(pRequest);
+        return;
+    }
+
+    AddCORSHeaderAndSendResponse(pRequest, pRequest->beginResponse(HttpOk, "application/json", json));
+}
+
+bool CWebServer::BuildSettingSpecsJson(String& json, const std::vector<std::reference_wrapper<SettingSpec>> & settingSpecs)
+{
+    auto jsonDoc = CreateJsonDocument();
+    auto jsonArray = jsonDoc.to<JsonArray>();
 
     for (const auto& specWrapper : settingSpecs)
     {
         const auto& spec = specWrapper.get();
         auto specObject = jsonArray.add<JsonObject>();
+        if (specObject.isNull())
+        {
+            debugW("Setting specs JSON object allocation failed.");
+            return false;
+        }
 
-        auto jsonDoc = CreateJsonDocument();
-
-        jsonDoc["name"] = spec.Name;
-        jsonDoc["friendlyName"] = spec.FriendlyName;
+        specObject["name"] = spec.Name;
+        specObject["friendlyName"] = spec.FriendlyName;
         if (spec.Description)
-            jsonDoc["description"] = spec.Description;
-        jsonDoc["type"] = to_value(spec.Type);
-        jsonDoc["typeName"] = spec.TypeName();
+            specObject["description"] = spec.Description;
+        specObject["type"] = to_value(spec.Type);
+        specObject["typeName"] = spec.TypeName();
         if (spec.HasValidation)
-            jsonDoc["hasValidation"] = true;
+            specObject["hasValidation"] = true;
         if (spec.MinimumValue.has_value())
-            jsonDoc["minimumValue"] = spec.MinimumValue.value();
+            specObject["minimumValue"] = spec.MinimumValue.value();
         if (spec.MaximumValue.has_value())
-            jsonDoc["maximumValue"] = spec.MaximumValue.value();
+            specObject["maximumValue"] = spec.MaximumValue.value();
         if (spec.EmptyAllowed.has_value())
-            jsonDoc["emptyAllowed"] = spec.EmptyAllowed.value();
+            specObject["emptyAllowed"] = spec.EmptyAllowed.value();
         switch (spec.Access)
         {
             case SettingSpec::SettingAccess::ReadOnly:
-                jsonDoc["readOnly"] = true;
+                specObject["readOnly"] = true;
                 break;
 
             case SettingSpec::SettingAccess::WriteOnly:
-                jsonDoc["writeOnly"] = true;
+                specObject["writeOnly"] = true;
                 break;
 
             default:
@@ -819,17 +872,17 @@ void CWebServer::SendSettingSpecsResponse(AsyncWebServerRequest * pRequest, cons
         // ---- UI metadata: section, priority, requiresReboot, apiPath, widget ----
 
         if (spec.Section)
-            jsonDoc["section"] = spec.Section;
+            specObject["section"] = spec.Section;
         if (spec.Priority.has_value())
-            jsonDoc["priority"] = spec.Priority.value();
+            specObject["priority"] = spec.Priority.value();
         if (spec.RequiresReboot)
-            jsonDoc["requiresReboot"] = true;
+            specObject["requiresReboot"] = true;
         if (spec.ApiPath)
-            jsonDoc["apiPath"] = spec.ApiPath;
+            specObject["apiPath"] = spec.ApiPath;
 
         if (spec.Widget != SettingSpec::WidgetKind::Default)
         {
-            auto widget = jsonDoc["widget"].to<JsonObject>();
+            auto widget = specObject["widget"].to<JsonObject>();
             widget["kind"] = spec.WidgetName();
 
             if (spec.Widget == SettingSpec::WidgetKind::Slider
@@ -884,16 +937,45 @@ void CWebServer::SendSettingSpecsResponse(AsyncWebServerRequest * pRequest, cons
                     options["url"] = spec.OptionsExternalUrl;
             }
         }
-
-        if (jsonDoc.overflowed() || !specObject.set(jsonDoc.as<JsonObjectConst>()))
-        {
-            debugV("JSON response buffer overflow!");
-            SendBufferOverflowResponse(pRequest);
-            return;
-        }
     }
 
-    AddCORSHeaderAndSendResponse(pRequest, response);
+    if (jsonDoc.overflowed())
+    {
+        debugW("Setting specs JSON document overflowed.");
+        return false;
+    }
+
+    const size_t measuredLength = measureJson(jsonArray);
+    json = String();
+    if (!json.reserve(measuredLength))
+    {
+        debugW("Unable to reserve %zu bytes for setting specs JSON.", measuredLength);
+        return false;
+    }
+
+    const size_t serializedLength = serializeJson(jsonArray, json);
+    if (serializedLength != measuredLength)
+    {
+        debugW("Setting specs JSON length mismatch: measured=%zu serialized=%zu.", measuredLength, serializedLength);
+        return false;
+    }
+
+    return true;
+}
+
+bool CWebServer::EnsureDeviceSettingSpecsJson()
+{
+    if (deviceSettingSpecsJson.length() > 0)
+        return true;
+
+    if (!BuildSettingSpecsJson(deviceSettingSpecsJson, LoadDeviceSettingSpecs()))
+    {
+        deviceSettingSpecsJson = String();
+        return false;
+    }
+
+    debugI("WebServer: cached device setting specs JSON (%zu bytes).", (size_t)deviceSettingSpecsJson.length());
+    return true;
 }
 
 const std::vector<std::reference_wrapper<SettingSpec>> & CWebServer::LoadDeviceSettingSpecs()
@@ -930,7 +1012,22 @@ const std::vector<std::reference_wrapper<SettingSpec>> & CWebServer::LoadDeviceS
 
 void CWebServer::GetSettingSpecs(AsyncWebServerRequest * pRequest)
 {
-    SendSettingSpecsResponse(pRequest, LoadDeviceSettingSpecs());
+    // This is a high-traffic endpoint since the front-end fetches it on every page load 
+    // to dynamically render the settings UI, so we cache the serialized JSON rather than 
+    // re-serializing on every request. If the cache is empty for any reason (e.g. JSON 
+    // document overflow during cache population), we attempt to rebuild it on demand and 
+    // respond with an error if that fails.
+    
+    if (!EnsureDeviceSettingSpecsJson())
+    {
+        SendBufferOverflowResponse(pRequest);
+        return;
+    }
+
+    auto response = pRequest->beginResponse(HttpOk, "application/json",
+        reinterpret_cast<const uint8_t*>(deviceSettingSpecsJson.c_str()),
+        deviceSettingSpecsJson.length());
+    AddCORSHeaderAndSendResponse(pRequest, response);
 }
 
 // Responds with current config, excluding any sensitive values
@@ -1238,8 +1335,8 @@ void CWebServer::SetUnifiedSettings(AsyncWebServerRequest * pRequest, JsonVarian
     if (root["topology"].is<JsonObjectConst>())
     {
         auto topology = root["topology"].as<JsonObjectConst>();
-        if (topology["width"].is<uint16_t>()) runtimeConfig.topology.width = topology["width"].as<uint16_t>();
-        if (topology["height"].is<uint16_t>()) runtimeConfig.topology.height = topology["height"].as<uint16_t>();
+        TryReadUint16(topology["width"], runtimeConfig.topology.width);
+        TryReadUint16(topology["height"], runtimeConfig.topology.height);
         if (topology["serpentine"].is<bool>()) runtimeConfig.topology.serpentine = topology["serpentine"].as<bool>();
     }
 

--- a/src/ws281xgfx.cpp
+++ b/src/ws281xgfx.cpp
@@ -36,6 +36,7 @@
 
 #include "deviceconfig.h"
 #include "effectmanager.h"
+#include "pixelformat.h"
 #include "systemcontainer.h"
 #include "values.h"
 #include "ws281xgfx.h"
@@ -89,12 +90,6 @@ namespace
              + (kPowerDarkMw * ledCount);
     }
 
-    uint8_t SaturatingAdd(uint8_t a, uint8_t b)
-    {
-        const uint16_t sum = static_cast<uint16_t>(a) + static_cast<uint16_t>(b);
-        return sum > 255 ? 255 : static_cast<uint8_t>(sum);
-    }
-
     uint32_t EstimateWS281xUnscaledPowerMw(const GFXBase& graphics, size_t ledCount)
     {
         #if defined(USE_SK6812) && USE_SK6812
@@ -103,14 +98,14 @@ namespace
             uint32_t blue = 0;
             uint32_t white = 0;
             const uint16_t ratio = static_cast<uint16_t>(kDefaultWhiteExtractRatio);
-            const uint8_t ambientWhite = SaturatingAdd(kDefaultAmbientCw, kDefaultAmbientWw);
+            const uint8_t ambientWhite = PixelFormatHelpers::SaturatingAdd(kDefaultAmbientCw, kDefaultAmbientWw);
 
             for (size_t i = 0; i < ledCount; ++i)
             {
                 CRGB color = graphics.leds[i];
                 uint8_t effectWhite = 0;
                 if (graphics.whites)
-                    effectWhite = SaturatingAdd(graphics.whites[i].cw, graphics.whites[i].ww);
+                    effectWhite = PixelFormatHelpers::SaturatingAdd(graphics.whites[i].cw, graphics.whites[i].ww);
 
                 uint8_t pull = 0;
                 if (effectWhite == 0)
@@ -125,7 +120,7 @@ namespace
                 red += color.r;
                 green += color.g;
                 blue += color.b;
-                white += std::max(SaturatingAdd(pull, effectWhite), ambientWhite);
+                white += std::max(PixelFormatHelpers::SaturatingAdd(pull, effectWhite), ambientWhite);
             }
 
             return ((red * kPowerRedMw) >> 8)


### PR DESCRIPTION
Fixed several concurrency and memory-safety issues found in the buffer, drawing, network, and task-management paths:

- Fixed the LED circular buffer full/empty ambiguity by tracking queued depth explicitly.
-Fixed WiFi frame timing by correcting TimeTillDue() to return future time remaining.
-Prevented malformed pixel packets from reserving or poisoning buffer slots.
-Added shared wire-payload validation for LED count, payload length, and overflow checks.
-Added checked packet-size arithmetic in the socket server before reads/decompression.
-Protected cross-task buffer status, peek, draw-delay, and runtime reconfiguration reads with g_buffer_mutex.
-Fixed HUB75 and generic matrix X-scroll routines to avoid overlapping memcpy and row-edge out-of-bounds reads.
-Made effect-list access return safe snapshots instead of live vector references.
-Made current-effect name access return a stable copied String.
-Serialized effect-list mutation, settings changes, and listener dispatch against rendering.
-Protected frame/effect listener registration and dispatch with a listener mutex.
-Split task lifecycle locking into a lifecycle mutex plus short task-handle mutex to avoid Start/Stop/WakeTask races without holding a recursive lock.
-Tightened web/debug/screen callers to use the safer effect and buffer APIs.

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).