### PR TITLE
Bugfixes - Memory and concurrency

### DIFF
--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -42,6 +42,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 class GFXBase;
@@ -126,6 +127,7 @@ class  EffectManager : public IJSONSerializable
     std::shared_ptr<LEDStripEffect> _tempEffect;
     std::vector<std::reference_wrapper<IFrameEventListener>> _frameEventListeners;
     std::vector<std::reference_wrapper<IEffectEventListener>> _effectEventListeners;
+    mutable std::mutex _listenerMutex;
 
     void construct(bool clearTempEffect);
     void DispatchBeatIfNeeded();
@@ -262,12 +264,14 @@ public:
 
     void PlayAll(bool bPlayAll);
     void SetInterval(uint interval, bool skipSave = false);
-    const std::vector<std::shared_ptr<LEDStripEffect>> & EffectsList() const;
+    std::vector<std::shared_ptr<LEDStripEffect>> EffectsList() const;
+    std::shared_ptr<LEDStripEffect> EffectAt(size_t index) const;
+    bool IsCoreEffect(size_t index) const;
     size_t EffectCount() const;
     bool AreEffectsEnabled() const;
     size_t GetCurrentEffectIndex() const;
     LEDStripEffect& GetCurrentEffect() const;
-    const String & GetCurrentEffectName() const;
+    String GetCurrentEffectName() const;
     void SetCurrentEffectIndex(size_t i);
     uint GetTimeUsedByCurrentEffect() const;
     uint GetTimeRemainingForCurrentEffect() const;

--- a/include/itaskservice.h
+++ b/include/itaskservice.h
@@ -75,6 +75,7 @@
 #include <atomic>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
+#include <mutex>
 
 #include "iservice.h"
 
@@ -148,6 +149,7 @@ class ITaskService : public IService
 
     void WakeTask() const
     {
+        std::lock_guard<std::mutex> guard(_taskHandleMutex);
         if (_taskHandle != nullptr)
             xTaskNotifyGive(_taskHandle);
     }
@@ -160,7 +162,13 @@ class ITaskService : public IService
 
     static void TaskEntryThunk(void* p);
 
+    void SetTaskHandle(TaskHandle_t taskHandle);
+    TaskHandle_t ClearTaskHandle();
+    bool HasTaskHandle() const;
+
     TaskHandle_t       _taskHandle = nullptr;
+    mutable std::mutex _lifecycleMutex;
+    mutable std::mutex _taskHandleMutex;
     std::atomic<bool>  _running{false};
     std::atomic<bool>  _shutdownRequested{false};
     std::atomic<bool>  _taskExited{false};

--- a/include/itaskservice.h
+++ b/include/itaskservice.h
@@ -149,7 +149,7 @@ class ITaskService : public IService
 
     void WakeTask() const
     {
-        std::lock_guard<std::mutex> guard(_taskHandleMutex);
+        std::lock_guard guard(_taskHandleMutex);
         if (_taskHandle != nullptr)
             xTaskNotifyGive(_taskHandle);
     }

--- a/include/ledbuffer.h
+++ b/include/ledbuffer.h
@@ -69,6 +69,11 @@ class LEDBuffer
 
     bool IsBufferOlderThan(const timeval & tv) const;
 
+    static bool ValidateWirePayload(const std::unique_ptr<uint8_t []>& payloadData,
+                                    size_t payloadLength,
+                                    size_t ledCount,
+                                    size_t* payloadBytes = nullptr);
+
     // UpdateFromWire
     //
     // Parse and deposit a WiFi packet into a buffer
@@ -91,6 +96,7 @@ class LEDBufferManager
     std::shared_ptr<LEDBuffer> _pLastBufferAdded;   // Keeps track of the MRU buffer
     size_t                                               _iNextBuffer;        // Head pointer index
     size_t                                               _iLastBuffer;        // Tail pointer index
+    size_t                                               _cQueuedBuffers;     // Active frames in the circular queue
     uint32_t                                             _cBuffers;           // Number of buffers
 
   public:
@@ -106,6 +112,8 @@ class LEDBufferManager
     // The fixed, maximum size of the whole thing if it were full
 
     size_t BufferCount() const;
+
+    size_t LEDCount() const;
 
     // Depth
     //

--- a/include/soundanalyzer.h
+++ b/include/soundanalyzer.h
@@ -461,13 +461,13 @@ class SoundAnalyzerBase : public ISoundAnalyzer
 
     BeatInfo LastBeat() const override
     {
-        std::lock_guard<std::mutex> lock(_beatInfoMutex);
+        std::lock_guard guard(_beatInfoMutex);
         return _lastBeatInfo;
     }
 
     BeatInfo LastNearBeat() const override
     {
-        std::lock_guard<std::mutex> lock(_beatInfoMutex);
+        std::lock_guard guard(_beatInfoMutex);
         return _lastNearBeatInfo;
     }
 

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -139,7 +139,7 @@ void ConsoleManager::FeedSerialByte(uint8_t byte)
 {
     std::shared_ptr<ConsoleSession> session;
     {
-        std::lock_guard<std::recursive_mutex> lock(_mutex);
+        std::lock_guard guard(_mutex);
         session = _serialSession;
     }
     if (_byteHandler && session)
@@ -150,7 +150,7 @@ void ConsoleManager::FeedTelnetByte(uint8_t byte)
 {
     std::shared_ptr<ConsoleSession> session;
     {
-        std::lock_guard<std::recursive_mutex> lock(_mutex);
+        std::lock_guard guard(_mutex);
         session = _telnetSession;
     }
     if (_byteHandler && session)
@@ -161,7 +161,7 @@ void ConsoleManager::Broadcast(std::string_view data)
 {
     std::shared_ptr<ConsoleSession> serial, telnet;
     {
-        std::lock_guard<std::recursive_mutex> lock(_mutex);
+        std::lock_guard guard(_mutex);
         serial = _serialSession;
         telnet = _telnetSession;
     }
@@ -179,7 +179,7 @@ void ConsoleManager::Broadcast(LogLevel level, const char* tag, const char* mess
 {
     std::shared_ptr<ConsoleSession> serial, telnet;
     {
-        std::lock_guard<std::recursive_mutex> lock(_mutex);
+        std::lock_guard guard(_mutex);
         serial = _serialSession;
         telnet = _telnetSession;
     }
@@ -195,7 +195,7 @@ void ConsoleManager::SetTelnetSink(IConsoleSink* sink)
 {
     std::shared_ptr<ConsoleSession> session;
     {
-        std::lock_guard<std::recursive_mutex> lock(_mutex);
+        std::lock_guard guard(_mutex);
         _telnetSession = std::make_shared<ConsoleSession>(sink);
         session = _telnetSession;
     }
@@ -208,7 +208,7 @@ void ConsoleManager::SetTelnetSink(IConsoleSink* sink)
 
 void ConsoleManager::ClearTelnetSink()
 {
-    std::lock_guard<std::recursive_mutex> lock(_mutex);
+    std::lock_guard guard(_mutex);
     if (_telnetSession)
     {
         _telnetSession.reset();

--- a/src/debug_cli.cpp
+++ b/src/debug_cli.cpp
@@ -364,7 +364,11 @@ static std::optional<size_t> ResolveEffect(std::string_view arg)
         }
         else
         {
-            cli_printf("Error: Effect index %zu out of range (0-%zu)\n", val, effects.empty() ? 0 : effects.size() - 1);
+            if (effects.empty())
+                cli_printf("Error: No effects available to select.\n");
+            else
+                cli_printf("Error: Effect index %zu out of range (0-%zu)\n", val, effects.size() - 1);
+
             return std::nullopt;
         }
     }

--- a/src/debug_cli.cpp
+++ b/src/debug_cli.cpp
@@ -309,6 +309,7 @@ std::string_view TabComplete(std::string_view partial, std::string_view full_lin
     else if (full_line.substr(0, 6) == "effect")
     {
         auto& effectManager = g_ptrSystem->GetEffectManager();
+        auto effects = effectManager.EffectsList();
         std::string_view firstMatch = "";
         int matches = 0;
         size_t common_len = 0;

--- a/src/debug_cli.cpp
+++ b/src/debug_cli.cpp
@@ -314,9 +314,9 @@ std::string_view TabComplete(std::string_view partial, std::string_view full_lin
         int matches = 0;
         size_t common_len = 0;
 
-        for (size_t i = 0; i < effectManager.EffectCount(); ++i)
+        for (const auto& effect : effects)
         {
-            const String& name = effectManager.EffectsList()[i]->FriendlyName();
+            const String& name = effect->FriendlyName();
             if (StringStartsWithInsensitive(name.c_str(), partial))
             {
                 if (matches == 0)
@@ -350,6 +350,7 @@ std::string_view TabComplete(std::string_view partial, std::string_view full_lin
 static std::optional<size_t> ResolveEffect(std::string_view arg)
 {
     auto& effectManager = g_ptrSystem->GetEffectManager();
+    auto effects = effectManager.EffectsList();
 
     // Try as index first
     // Try as index first
@@ -357,13 +358,13 @@ static std::optional<size_t> ResolveEffect(std::string_view arg)
     auto [ptr, ec] = std::from_chars(arg.begin(), arg.end(), val);
     if (ec == std::errc() && ptr == arg.end())
     {
-        if (val < effectManager.EffectCount())
+        if (val < effects.size())
         {
             return val;
         }
         else
         {
-            cli_printf("Error: Effect index %zu out of range (0-%u)\n", val, effectManager.EffectCount() - 1);
+            cli_printf("Error: Effect index %zu out of range (0-%zu)\n", val, effects.empty() ? 0 : effects.size() - 1);
             return std::nullopt;
         }
     }
@@ -373,9 +374,9 @@ static std::optional<size_t> ResolveEffect(std::string_view arg)
     int matches = 0;
     std::vector<std::string> candidates;
 
-    for (size_t i = 0; i < effectManager.EffectCount(); ++i)
+    for (size_t i = 0; i < effects.size(); ++i)
     {
-        const String& name = effectManager.EffectsList()[i]->FriendlyName();
+        const String& name = effects[i]->FriendlyName();
         if (ContainsInsensitive(name.c_str(), arg))
         {
             match_index = i;

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -174,7 +174,11 @@ int CalcDelayUntilNextFrame(double frameStartTime, uint16_t localPixelsDrawn, ui
 
     if (localPixelsDrawn > 0)
     {
-        const double fpsRaw = static_cast<double>(g_ptrSystem->GetEffectManager().GetCurrentEffect().DesiredFramesPerSecond());
+        double fpsRaw = 0.0;
+        {
+            std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+            fpsRaw = static_cast<double>(g_ptrSystem->GetEffectManager().GetCurrentEffect().DesiredFramesPerSecond());
+        }
         // If FPS is invalid (<= 0 or non-finite), treat as unlimited (0s minimum frame time).
         const double minimumFrameTime = (!std::isfinite(fpsRaw) || fpsRaw <= 0.0) ? 0.0 : (1.0 / fpsRaw);
         // Use a monotonic-like elapsed (never negative) in case wall clock adjustments go backward.
@@ -190,15 +194,23 @@ int CalcDelayUntilNextFrame(double frameStartTime, uint16_t localPixelsDrawn, ui
         double t = std::numeric_limits<double>::max();
         bool bFoundFrame = false;
 
-        for (auto& bufferManager : g_ptrSystem->GetBufferManagers())
         {
-            auto pOldest = bufferManager.PeekOldestBuffer();
-            if (pOldest)
+            // The socket task can add frames while the render task is
+            // calculating its next sleep. Protect this read-only peek with the
+            // same mutex used by enqueue/dequeue so the ring indices and
+            // timestamps are sampled consistently.
+            
+            std::lock_guard<std::mutex> guard(g_buffer_mutex);
+            for (auto& bufferManager : g_ptrSystem->GetBufferManagers())
             {
-                // TimeTillDue() should be non-negative for future-due frames; if negative (stale), treat as now.
-                // Note I'm not using clamp since clamp can return nan if TimeTillDue does, whereas this guards against that.
-                t = std::min(t, std::max(0.0, pOldest->TimeTillDue()));
-                bFoundFrame = true;
+                auto pOldest = bufferManager.PeekOldestBuffer();
+                if (pOldest)
+                {
+                    // TimeTillDue() should be non-negative for future-due frames; if negative (stale), treat as now.
+                    // Note I'm not using clamp since clamp can return nan if TimeTillDue does, whereas this guards against that.
+                    t = std::min(t, std::max(0.0, pOldest->TimeTillDue()));
+                    bFoundFrame = true;
+                }
             }
         }
         // Bound the delay to at most 1 second to avoid pathological multi-second sleeps.

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -63,7 +63,7 @@ std::shared_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color);    // Defined i
 
 uint16_t WiFiDraw()
 {
-    std::lock_guard<std::mutex> guard(g_buffer_mutex);
+    std::lock_guard guard(g_buffer_mutex);
 
     uint16_t pixelsDrawn = 0;
     for (auto& bufferManager : g_ptrSystem->GetBufferManagers())
@@ -176,7 +176,7 @@ int CalcDelayUntilNextFrame(double frameStartTime, uint16_t localPixelsDrawn, ui
     {
         double fpsRaw = 0.0;
         {
-            std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+            std::lock_guard effectGuard(g_effect_manager_mutex);
             fpsRaw = static_cast<double>(g_ptrSystem->GetEffectManager().GetCurrentEffect().DesiredFramesPerSecond());
         }
         // If FPS is invalid (<= 0 or non-finite), treat as unlimited (0s minimum frame time).
@@ -199,8 +199,8 @@ int CalcDelayUntilNextFrame(double frameStartTime, uint16_t localPixelsDrawn, ui
             // calculating its next sleep. Protect this read-only peek with the
             // same mutex used by enqueue/dequeue so the ring indices and
             // timestamps are sampled consistently.
-            
-            std::lock_guard<std::mutex> guard(g_buffer_mutex);
+
+            std::lock_guard guard(g_buffer_mutex);
             for (auto& bufferManager : g_ptrSystem->GetBufferManagers())
             {
                 auto pOldest = bufferManager.PeekOldestBuffer();
@@ -328,7 +328,7 @@ void IRAM_ATTR RenderService::Run()
         {
             // Hold the render mutex for the frame pipeline so runtime topology/output
             // changes cannot reconfigure the active buffers mid-frame.
-            std::lock_guard<std::recursive_mutex> renderGuard(g_render_mutex);
+            std::lock_guard renderGuard(g_render_mutex);
             auto& graphics = *g_ptrSystem->GetDevices()[0];
 
             graphics.PrepareFrame();

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -283,11 +283,17 @@ std::vector<std::shared_ptr<GFXBase>> & EffectManager::GetBaseGraphics()
 
 void EffectManager::ReportNewFrameAvailable()
 {
+    // Listener vectors store references whose owners may deregister on other
+    // tasks. Hold this mutex while iterating so remove/destruction cannot race
+    // a callback dispatch.
+    
+    std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
     INFORM_EVENT_LISTENERS(_frameEventListeners, IFrameEventListener::OnNewFrameAvailable);
 }
 
 void EffectManager::AddFrameEventListener(IFrameEventListener& listener)
 {
+    std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
     _frameEventListeners.emplace_back(listener);
 }
 
@@ -299,6 +305,7 @@ void EffectManager::RemoveFrameEventListener(IFrameEventListener& listener)
     // Robert may have a better or less obtuse way to do this, but it works 
     // and it's not like we have thousands of listeners.  Change at will!
     
+    std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
     _frameEventListeners.erase(
         std::remove_if(_frameEventListeners.begin(), _frameEventListeners.end(),
                        [&](const std::reference_wrapper<IFrameEventListener>& w)
@@ -308,6 +315,7 @@ void EffectManager::RemoveFrameEventListener(IFrameEventListener& listener)
 
 void EffectManager::AddEffectEventListener(IEffectEventListener& listener)
 {
+    std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
     _effectEventListeners.emplace_back(listener);
 }
 
@@ -324,6 +332,7 @@ const GFXBase& EffectManager::g(int iChannel) const
 
 bool EffectManager::IsEffectEnabled(size_t i) const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     if (i >= _vEffects.size())
     {
         debugW("Invalid index for IsEffectEnabled");
@@ -334,11 +343,14 @@ bool EffectManager::IsEffectEnabled(size_t i) const
 
 void EffectManager::PlayAll(bool bPlayAll)
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     _bPlayAll = bPlayAll;
 }
 
 void EffectManager::SetInterval(uint interval, bool skipSave)
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+
     // Reject/ignore intervals smaller than a second, but allow 0 (infinity)
     if (interval > 0 && interval < 1000)
         return;
@@ -348,36 +360,63 @@ void EffectManager::SetInterval(uint interval, bool skipSave)
     if (!skipSave)
         SaveEffectManagerConfig();
 
-    INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnIntervalChanged, interval);
+    {
+        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnIntervalChanged, interval);
+    }
 }
 
-const std::vector<std::shared_ptr<LEDStripEffect>> & EffectManager::EffectsList() const
+std::vector<std::shared_ptr<LEDStripEffect>> EffectManager::EffectsList() const
 {
+    // Return a stable snapshot instead of a reference to the live vector. Web,
+    // debug, and render tasks can otherwise hold an iterator/reference while
+    // another task reorders or deletes effects.
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     return _vEffects;
+}
+
+std::shared_ptr<LEDStripEffect> EffectManager::EffectAt(size_t index) const
+{
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    return index < _vEffects.size() ? _vEffects[index] : nullptr;
+}
+
+bool EffectManager::IsCoreEffect(size_t index) const
+{
+    auto effect = EffectAt(index);
+    return effect && effect->IsCoreEffect();
 }
 
 size_t EffectManager::EffectCount() const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     return _vEffects.size();
 }
 
 bool EffectManager::AreEffectsEnabled() const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     return std::any_of(_vEffects.begin(), _vEffects.end(), [](const auto& pEffect){ return pEffect->IsEnabled(); } );
 }
 
 size_t EffectManager::GetCurrentEffectIndex() const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     return _iCurrentEffect;
 }
 
 LEDStripEffect& EffectManager::GetCurrentEffect() const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     return *(_tempEffect ? _tempEffect : _vEffects[_iCurrentEffect]);
 }
 
-const String & EffectManager::GetCurrentEffectName() const
+String EffectManager::GetCurrentEffectName() const
 {
+    // Return a copy while holding the effect lock. Returning a reference here
+    // was unsafe because another task can switch/delete/reinitialize effects
+    // immediately after the lock is released.
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     if (_tempEffect)
         return _tempEffect->FriendlyName();
 
@@ -400,16 +439,21 @@ void EffectManager::SetCurrentEffectIndex(size_t i)
     StartEffect();
     SaveCurrentEffectIndex();
 
-    INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnCurrentEffectChanged, i);
+    {
+        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnCurrentEffectChanged, i);
+    }
 }
 
 uint EffectManager::GetTimeUsedByCurrentEffect() const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     return millis() - _effectStartTime;
 }
 
 uint EffectManager::GetTimeRemainingForCurrentEffect() const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     // If the Interval is set to zero, we treat that as an infinite interval and don't even look at the time used so far
     uint timeUsedByCurrentEffect = GetTimeUsedByCurrentEffect();
     uint interval = GetEffectiveInterval();
@@ -419,7 +463,8 @@ uint EffectManager::GetTimeRemainingForCurrentEffect() const
 
 uint EffectManager::GetEffectiveInterval() const
 {
-    auto& currentEffect = GetCurrentEffect();
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    auto& currentEffect = *(_tempEffect ? _tempEffect : _vEffects[_iCurrentEffect]);
     // This allows you to return a MaximumEffectTime and your effect won't be shown longer than that
     return min((IsIntervalEternal() ? std::numeric_limits<uint>::max() : _effectInterval),
                (currentEffect.HasMaximumEffectTime() ? currentEffect.MaximumEffectTime() : std::numeric_limits<uint>::max()));
@@ -427,28 +472,34 @@ uint EffectManager::GetEffectiveInterval() const
 
 uint EffectManager::GetInterval() const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     return _effectInterval;
 }
 
 bool EffectManager::IsIntervalEternal() const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     return _effectInterval == 0;
 }
 
 void EffectManager::NextPalette()
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
     debugV("EffectManager::NextPalette");
     g().CyclePalette(1);
 }
 
 void EffectManager::PreviousPalette()
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
     debugV("EffectManager::PreviousPalette");
     g().CyclePalette(-1);
 }
 
 void EffectManager::LoadDefaultEffects()
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     _effectSetHashString = g_ptrEffectFactories->HashString();
 
     for (const auto &numberedFactory : g_ptrEffectFactories->GetDefaultFactories())
@@ -538,6 +589,8 @@ void EffectManager::LoadJSONEffects(const JsonArrayConst& effectsArray)
 //   use the AppendEffect() function for that.
 std::shared_ptr<LEDStripEffect> EffectManager::CopyEffect(size_t index)
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     if (index >= _vEffects.size())
     {
         debugW("Invalid index for CopyEffect");
@@ -665,6 +718,8 @@ bool EffectManager::Init()
 
 bool EffectManager::ReinitializeEffects()
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     if (!Init())
         return false;
 
@@ -684,6 +739,8 @@ bool EffectManager::ReinitializeEffects()
 
 bool EffectManager::ShowVU(bool bShow)
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     auto& deviceConfig = g_ptrSystem->GetDeviceConfig();
     bool bResult = deviceConfig.ShowVUMeter();
     debugI("Setting ShowVU to %d\n", bShow);
@@ -698,12 +755,15 @@ bool EffectManager::ShowVU(bool bShow)
 
 bool EffectManager::IsVUVisible() const
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
     return g_ptrSystem->GetDeviceConfig().ShowVUMeter() && GetCurrentEffect().CanDisplayVUMeter();
 }
 
 
 void EffectManager::ClearRemoteColor(bool retainRemoteEffect)
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     if (!retainRemoteEffect)
         _tempEffect = nullptr;
 
@@ -721,6 +781,8 @@ void EffectManager::ClearRemoteColor(bool retainRemoteEffect)
 
 void EffectManager::ApplyGlobalColor(CRGB color)
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     debugI("Setting Global Color: %08lX\n", (unsigned long)(uint32_t)color);
 
     auto& deviceConfig = g_ptrSystem->GetDeviceConfig();
@@ -731,6 +793,8 @@ void EffectManager::ApplyGlobalColor(CRGB color)
 
 void EffectManager::ApplyGlobalPaletteColors()
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     #if USE_HUB75
         auto& pMatrix = g();
         auto& deviceConfig = g_ptrSystem->GetDeviceConfig();
@@ -801,6 +865,8 @@ void EffectManager::construct(bool clearTempEffect)
 
 bool EffectManager::DeserializeFromJSON(const JsonObjectConst& jsonObject)
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     ClearEffects();
 
     // "efs" is the array of serialized effect objects
@@ -877,6 +943,8 @@ bool EffectManager::DeserializeFromJSON(const JsonObjectConst& jsonObject)
 
 bool EffectManager::SerializeToJSON(JsonObject& jsonObject)
 {
+    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+
     // Set JSON format version to be able to detect and manage future incompatible structural updates
     jsonObject[PTY_VERSION] = JSON_FORMAT_VERSION;
     jsonObject["ivl"] = _effectInterval;
@@ -898,6 +966,11 @@ bool EffectManager::SerializeToJSON(JsonObject& jsonObject)
 
 void EffectManager::EnableEffect(size_t i, bool skipSave)
 {
+    // Web, remote, and render tasks all touch the effect list/current effect.
+    // Mutations take both locks so a UI request cannot reorder/delete/settings-
+    // mutate an effect while the draw loop is inside that effect's Draw().
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     if (i >= _vEffects.size())
     {
         debugW("Invalid index for EnableEffect");
@@ -916,12 +989,17 @@ void EffectManager::EnableEffect(size_t i, bool skipSave)
         if (!skipSave)
             SaveEffectManagerConfig();
 
-        INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectEnabledStateChanged, i, true);
+        {
+            std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+            INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectEnabledStateChanged, i, true);
+        }
     }
 }
 
 void EffectManager::DisableEffect(size_t i, bool skipSave)
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     if (i >= _vEffects.size())
     {
         debugW("Invalid index for DisableEffect");
@@ -940,12 +1018,17 @@ void EffectManager::DisableEffect(size_t i, bool skipSave)
         if (!skipSave)
             SaveEffectManagerConfig();
 
-        INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectEnabledStateChanged, i, false);
+        {
+            std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+            INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectEnabledStateChanged, i, false);
+        }
     }
 }
 
 void EffectManager::MoveEffect(size_t from, size_t to)
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     if (from >= _vEffects.size() || to >= _vEffects.size())
     {
         debugW("Invalid index for MoveEffect");
@@ -977,13 +1060,18 @@ void EffectManager::MoveEffect(size_t from, size_t to)
 
     SaveEffectManagerConfig();
 
-    INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectListDirty);
+    {
+        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectListDirty);
+    }
 }
 
 // Adds an effect to the effect list and enables it. If an effect is added that is already in the effect list then the result
 //   is undefined but potentially messy.
 bool EffectManager::AppendEffect(std::shared_ptr<LEDStripEffect>& effect)
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     if (!effect->Init(_gfx))
         return false;
 
@@ -992,7 +1080,10 @@ bool EffectManager::AppendEffect(std::shared_ptr<LEDStripEffect>& effect)
 
     SaveEffectManagerConfig();
 
-    INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectListDirty);
+    {
+        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectListDirty);
+    }
 
     return true;
 }
@@ -1000,6 +1091,8 @@ bool EffectManager::AppendEffect(std::shared_ptr<LEDStripEffect>& effect)
 // Deletes an effect from the effect list. Note that core effects cannot be deleted.
 bool EffectManager::DeleteEffect(size_t index)
 {
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
     if (index >= _vEffects.size())
     {
         debugW("Invalid index for DeleteEffect");
@@ -1024,7 +1117,10 @@ bool EffectManager::DeleteEffect(size_t index)
 
     SaveEffectManagerConfig();
 
-    INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectListDirty);
+    {
+        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectListDirty);
+    }
 
     return true;
 }
@@ -1070,7 +1166,10 @@ void EffectManager::NextEffect(bool skipSave)
     StartEffect();
     SaveCurrentEffectIndex();
 
-    INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnCurrentEffectChanged, _iCurrentEffect);
+    {
+        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnCurrentEffectChanged, _iCurrentEffect);
+    }
 }
 
 // Go back to the previous effect and abort the current one.
@@ -1094,7 +1193,10 @@ void EffectManager::PreviousEffect()
     StartEffect();
     SaveCurrentEffectIndex();
 
-    INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnCurrentEffectChanged, _iCurrentEffect);
+    {
+        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnCurrentEffectChanged, _iCurrentEffect);
+    }
 }
 
 // EffectManager::Update

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -134,8 +134,8 @@ void InitEffectsManager()
 
 void EffectManager::StartEffect()
 {
-    std::lock_guard<std::recursive_mutex> renderGuard(g_render_mutex);
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard renderGuard(g_render_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
 
     // If there's a temporary effect override from the remote control active, we start that, else
     // we start the current regular effect
@@ -161,7 +161,7 @@ void EffectManager::StartEffect()
     // frames - like FireEffect's heat decay - want that persistence.
     // The whites plane has no equivalent persisting-effect right now,
     // so blanket-zeroing it on switch is the right semantic.)
-    
+
     for (auto& device : _gfx)
     {
         if (device && device->whites)
@@ -178,7 +178,7 @@ void EffectManager::StartEffect()
 void EffectManager::DispatchBeatIfNeeded()
 {
 #if ENABLE_AUDIO
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
 
     // Beat callbacks are sequenced here so every active effect sees the same
     // detector output, including BeatEffectBase-derived effects via OnBeat().
@@ -271,8 +271,8 @@ EffectManager::~EffectManager()
 
 void EffectManager::SetTempEffect(std::shared_ptr<LEDStripEffect> effect)
 {
-    std::lock_guard<std::recursive_mutex> renderGuard(g_render_mutex);
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard renderGuard(g_render_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
     _tempEffect = effect;
 }
 
@@ -286,14 +286,14 @@ void EffectManager::ReportNewFrameAvailable()
     // Listener vectors store references whose owners may deregister on other
     // tasks. Hold this mutex while iterating so remove/destruction cannot race
     // a callback dispatch.
-    
-    std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+
+    std::lock_guard listenerGuard(_listenerMutex);
     INFORM_EVENT_LISTENERS(_frameEventListeners, IFrameEventListener::OnNewFrameAvailable);
 }
 
 void EffectManager::AddFrameEventListener(IFrameEventListener& listener)
 {
-    std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+    std::lock_guard listenerGuard(_listenerMutex);
     _frameEventListeners.emplace_back(listener);
 }
 
@@ -302,10 +302,10 @@ void EffectManager::RemoveFrameEventListener(IFrameEventListener& listener)
     // Match by address — reference_wrapper has no operator== so we compare
     // the underlying object pointers. erase/remove_if so we drop every entry
     // even if the same listener was registered more than once.
-    // Robert may have a better or less obtuse way to do this, but it works 
+    // Robert may have a better or less obtuse way to do this, but it works
     // and it's not like we have thousands of listeners.  Change at will!
-    
-    std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+
+    std::lock_guard listenerGuard(_listenerMutex);
     _frameEventListeners.erase(
         std::remove_if(_frameEventListeners.begin(), _frameEventListeners.end(),
                        [&](const std::reference_wrapper<IFrameEventListener>& w)
@@ -315,7 +315,7 @@ void EffectManager::RemoveFrameEventListener(IFrameEventListener& listener)
 
 void EffectManager::AddEffectEventListener(IEffectEventListener& listener)
 {
-    std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+    std::lock_guard listenerGuard(_listenerMutex);
     _effectEventListeners.emplace_back(listener);
 }
 
@@ -332,7 +332,7 @@ const GFXBase& EffectManager::g(int iChannel) const
 
 bool EffectManager::IsEffectEnabled(size_t i) const
 {
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
     if (i >= _vEffects.size())
     {
         debugW("Invalid index for IsEffectEnabled");
@@ -343,13 +343,13 @@ bool EffectManager::IsEffectEnabled(size_t i) const
 
 void EffectManager::PlayAll(bool bPlayAll)
 {
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
     _bPlayAll = bPlayAll;
 }
 
 void EffectManager::SetInterval(uint interval, bool skipSave)
 {
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
 
     // Reject/ignore intervals smaller than a second, but allow 0 (infinity)
     if (interval > 0 && interval < 1000)
@@ -361,7 +361,7 @@ void EffectManager::SetInterval(uint interval, bool skipSave)
         SaveEffectManagerConfig();
 
     {
-        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        std::lock_guard listenerGuard(_listenerMutex);
         INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnIntervalChanged, interval);
     }
 }
@@ -371,13 +371,13 @@ std::vector<std::shared_ptr<LEDStripEffect>> EffectManager::EffectsList() const
     // Return a stable snapshot instead of a reference to the live vector. Web,
     // debug, and render tasks can otherwise hold an iterator/reference while
     // another task reorders or deletes effects.
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
     return _vEffects;
 }
 
 std::shared_ptr<LEDStripEffect> EffectManager::EffectAt(size_t index) const
 {
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
     return index < _vEffects.size() ? _vEffects[index] : nullptr;
 }
 
@@ -389,25 +389,25 @@ bool EffectManager::IsCoreEffect(size_t index) const
 
 size_t EffectManager::EffectCount() const
 {
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
     return _vEffects.size();
 }
 
 bool EffectManager::AreEffectsEnabled() const
 {
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
     return std::any_of(_vEffects.begin(), _vEffects.end(), [](const auto& pEffect){ return pEffect->IsEnabled(); } );
 }
 
 size_t EffectManager::GetCurrentEffectIndex() const
 {
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
     return _iCurrentEffect;
 }
 
 LEDStripEffect& EffectManager::GetCurrentEffect() const
 {
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
     return *(_tempEffect ? _tempEffect : _vEffects[_iCurrentEffect]);
 }
 
@@ -416,7 +416,7 @@ String EffectManager::GetCurrentEffectName() const
     // Return a copy while holding the effect lock. Returning a reference here
     // was unsafe because another task can switch/delete/reinitialize effects
     // immediately after the lock is released.
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
     if (_tempEffect)
         return _tempEffect->FriendlyName();
 
@@ -425,8 +425,8 @@ String EffectManager::GetCurrentEffectName() const
 
 void EffectManager::SetCurrentEffectIndex(size_t i)
 {
-    std::lock_guard<std::recursive_mutex> renderGuard(g_render_mutex);
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard renderGuard(g_render_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
 
     if (i >= _vEffects.size())
     {
@@ -440,20 +440,20 @@ void EffectManager::SetCurrentEffectIndex(size_t i)
     SaveCurrentEffectIndex();
 
     {
-        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        std::lock_guard listenerGuard(_listenerMutex);
         INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnCurrentEffectChanged, i);
     }
 }
 
 uint EffectManager::GetTimeUsedByCurrentEffect() const
 {
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
     return millis() - _effectStartTime;
 }
 
 uint EffectManager::GetTimeRemainingForCurrentEffect() const
 {
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
     // If the Interval is set to zero, we treat that as an infinite interval and don't even look at the time used so far
     uint timeUsedByCurrentEffect = GetTimeUsedByCurrentEffect();
     uint interval = GetEffectiveInterval();
@@ -463,7 +463,7 @@ uint EffectManager::GetTimeRemainingForCurrentEffect() const
 
 uint EffectManager::GetEffectiveInterval() const
 {
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
     auto& currentEffect = *(_tempEffect ? _tempEffect : _vEffects[_iCurrentEffect]);
     // This allows you to return a MaximumEffectTime and your effect won't be shown longer than that
     return min((IsIntervalEternal() ? std::numeric_limits<uint>::max() : _effectInterval),
@@ -472,13 +472,13 @@ uint EffectManager::GetEffectiveInterval() const
 
 uint EffectManager::GetInterval() const
 {
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
     return _effectInterval;
 }
 
 bool EffectManager::IsIntervalEternal() const
 {
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
     return _effectInterval == 0;
 }
 
@@ -755,7 +755,7 @@ bool EffectManager::ShowVU(bool bShow)
 
 bool EffectManager::IsVUVisible() const
 {
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
     return g_ptrSystem->GetDeviceConfig().ShowVUMeter() && GetCurrentEffect().CanDisplayVUMeter();
 }
 
@@ -943,7 +943,7 @@ bool EffectManager::DeserializeFromJSON(const JsonObjectConst& jsonObject)
 
 bool EffectManager::SerializeToJSON(JsonObject& jsonObject)
 {
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
 
     // Set JSON format version to be able to detect and manage future incompatible structural updates
     jsonObject[PTY_VERSION] = JSON_FORMAT_VERSION;
@@ -990,7 +990,7 @@ void EffectManager::EnableEffect(size_t i, bool skipSave)
             SaveEffectManagerConfig();
 
         {
-            std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+            std::lock_guard listenerGuard(_listenerMutex);
             INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectEnabledStateChanged, i, true);
         }
     }
@@ -1019,7 +1019,7 @@ void EffectManager::DisableEffect(size_t i, bool skipSave)
             SaveEffectManagerConfig();
 
         {
-            std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+            std::lock_guard listenerGuard(_listenerMutex);
             INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectEnabledStateChanged, i, false);
         }
     }
@@ -1061,7 +1061,7 @@ void EffectManager::MoveEffect(size_t from, size_t to)
     SaveEffectManagerConfig();
 
     {
-        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        std::lock_guard listenerGuard(_listenerMutex);
         INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectListDirty);
     }
 }
@@ -1081,7 +1081,7 @@ bool EffectManager::AppendEffect(std::shared_ptr<LEDStripEffect>& effect)
     SaveEffectManagerConfig();
 
     {
-        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        std::lock_guard listenerGuard(_listenerMutex);
         INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectListDirty);
     }
 
@@ -1118,7 +1118,7 @@ bool EffectManager::DeleteEffect(size_t index)
     SaveEffectManagerConfig();
 
     {
-        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        std::lock_guard listenerGuard(_listenerMutex);
         INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnEffectListDirty);
     }
 
@@ -1127,8 +1127,8 @@ bool EffectManager::DeleteEffect(size_t index)
 
 void EffectManager::CheckEffectTimerExpired()
 {
-    std::lock_guard<std::recursive_mutex> renderGuard(g_render_mutex);
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard renderGuard(g_render_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
 
     if (IsIntervalEternal() && !GetCurrentEffect().HasMaximumEffectTime())
         return;
@@ -1151,8 +1151,8 @@ void EffectManager::CheckEffectTimerExpired()
 
 void EffectManager::NextEffect(bool skipSave)
 {
-    std::lock_guard<std::recursive_mutex> renderGuard(g_render_mutex);
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard renderGuard(g_render_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
 
     auto enabled = AreEffectsEnabled();
 
@@ -1167,7 +1167,7 @@ void EffectManager::NextEffect(bool skipSave)
     SaveCurrentEffectIndex();
 
     {
-        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        std::lock_guard listenerGuard(_listenerMutex);
         INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnCurrentEffectChanged, _iCurrentEffect);
     }
 }
@@ -1176,8 +1176,8 @@ void EffectManager::NextEffect(bool skipSave)
 
 void EffectManager::PreviousEffect()
 {
-    std::lock_guard<std::recursive_mutex> renderGuard(g_render_mutex);
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard renderGuard(g_render_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
 
     auto enabled = AreEffectsEnabled();
 
@@ -1194,7 +1194,7 @@ void EffectManager::PreviousEffect()
     SaveCurrentEffectIndex();
 
     {
-        std::lock_guard<std::mutex> listenerGuard(_listenerMutex);
+        std::lock_guard listenerGuard(_listenerMutex);
         INFORM_EVENT_LISTENERS(_effectEventListeners, IEffectEventListener::OnCurrentEffectChanged, _iCurrentEffect);
     }
 }
@@ -1205,8 +1205,8 @@ void EffectManager::PreviousEffect()
 
 void EffectManager::Update()
 {
-    std::lock_guard<std::recursive_mutex> renderGuard(g_render_mutex);
-    std::lock_guard<std::recursive_mutex> effectGuard(g_effect_manager_mutex);
+    std::lock_guard renderGuard(g_render_mutex);
+    std::lock_guard effectGuard(g_effect_manager_mutex);
 
     if ((_gfx[0])->GetLEDCount() == 0)
         return;

--- a/src/gfxbase.cpp
+++ b/src/gfxbase.cpp
@@ -32,6 +32,7 @@
 
 #include "globals.h"
 
+#include <algorithm>
 #include <cmath>
 #include <gfxfont.h>
 #include <memory>
@@ -1408,25 +1409,45 @@ CRGB GFXBase::HsvToRgb(uint8_t h, uint8_t s, uint8_t v)
 // This can't be in gfxbase.h because it uses the FillGetNoise() function template.
 void GFXBase::MoveInwardX(int startY, int endY)
 {
+    const int width = static_cast<int>(_width);
+    const int height = static_cast<int>(_height);
+    const int halfWidth = width / 2;
+    if (leds == nullptr || halfWidth <= 1 || height <= 0)
+        return;
+
+    startY = std::max(0, startY);
+    endY = std::min(height - 1, endY);
+
     for (int y = startY; y <= endY; y++)
     {
-        for (int x = _width / 2; x > 0; x--)
+        // Keep both halves inside the row. The previous loops read x+1 at
+        // width, which can corrupt unrelated pixels or memory at row edges.
+        for (int x = halfWidth - 1; x > 0; x--)
             leds[XY(x, y)] = leds[XY(x - 1, y)];
 
-        for (int x = _width / 2; x < (int)_width; x++)
+        for (int x = halfWidth; x < width - 1; x++)
             leds[XY(x, y)] = leds[XY(x + 1, y)];
     }
 }
 
 void GFXBase::MoveOutwardsX(int startY, int endY)
 {
+    const int width = static_cast<int>(_width);
+    const int height = static_cast<int>(_height);
+    const int halfWidth = width / 2;
+    if (leds == nullptr || halfWidth <= 1 || height <= 0)
+        return;
+
+    startY = std::max(0, startY);
+    endY = std::min(height - 1, endY);
+
     for (int y = startY; y <= endY; y++)
     {
-        for (int x = 0; x < (int)_width / 2 - 1; x++)
-        {
+        for (int x = 0; x < halfWidth - 1; x++)
             leds[XY(x, y)] = leds[XY(x + 1, y)];
-            leds[XY((int)_width - x - 1, y)] = leds[XY((int)_width - x - 2, y)];
-        }
+
+        for (int x = width - 1; x > halfWidth; x--)
+            leds[XY(x, y)] = leds[XY(x - 1, y)];
     }
 }
 

--- a/src/gfxbase.cpp
+++ b/src/gfxbase.cpp
@@ -137,7 +137,7 @@ void GFXBase::Clear(CRGB color)
     // stale W content washes its colors out. Effects that want to preserve
     // whites can rewrite them after the Clear() call; that's how the leds
     // plane already behaves.
-    
+
     if (whites)
         memset(whites, 0, sizeof(CRGBW) * count);
 }
@@ -1572,7 +1572,7 @@ const GFXBase::PolarMapArray& GFXBase::getPolarMap()
     // Double-checked locking for thread-safe, on-demand initialization
     if (!rMap_ptr)
     {
-        std::lock_guard lock(rMap_mutex);
+        std::lock_guard guard(rMap_mutex);
         if (!rMap_ptr)
         {
             // Allocate from PSRAM using the project's helper

--- a/src/hub75gfx.cpp
+++ b/src/hub75gfx.cpp
@@ -177,33 +177,40 @@ void HUB75GFX::SetCaption(const String & str, uint32_t duration)
 
 void HUB75GFX::MoveInwardX(int startY, int endY)
 {
-    // Optimized for Smartmatrix matrix - uses knowledge of how the pixels are laid
-    // out in order to do the scroll.  We should technically use memmove instead
-    // of memcpy since the regions are overlapping but this is faster and seems
-    // to work!
+    const int halfWidth = MATRIX_WIDTH / 2;
+    if (leds == nullptr || halfWidth <= 1)
+        return;
+
+    startY = std::max(0, startY);
+    endY = std::min(MATRIX_HEIGHT - 1, endY);
 
     for (int y = startY; y <= endY; y++)
     {
         auto pLinemem = leds + y * MATRIX_WIDTH;
         auto pLinemem2 = pLinemem + (MATRIX_WIDTH / 2);
-        memcpy(pLinemem + 1, pLinemem, sizeof(CRGB) * (MATRIX_WIDTH / 2));
-        memcpy(pLinemem2, pLinemem2 + 1, sizeof(CRGB) * (MATRIX_WIDTH / 2));
+        // These shifts overlap within a row. memcpy was undefined behavior and
+        // the old right-half count read one pixel past the row, which could
+        // corrupt adjacent display memory.
+        memmove(pLinemem + 1, pLinemem, sizeof(CRGB) * (halfWidth - 1));
+        memmove(pLinemem2, pLinemem2 + 1, sizeof(CRGB) * (halfWidth - 1));
     }
 }
 
 void HUB75GFX::MoveOutwardsX(int startY, int endY)
 {
-    // Optimized for Smartmatrix matrix - uses knowledge of how the pixels are laid
-    // out in order to do the scroll.  We should technically use memmove instead
-    // of memcpy since the regions are overlapping but this is faster and seems
-    // to work!
+    const int halfWidth = MATRIX_WIDTH / 2;
+    if (leds == nullptr || halfWidth <= 1)
+        return;
+
+    startY = std::max(0, startY);
+    endY = std::min(MATRIX_HEIGHT - 1, endY);
 
     for (int y = startY; y <= endY; y++)
     {
         auto pLinemem = leds + y * MATRIX_WIDTH;
         auto pLinemem2 = pLinemem + (MATRIX_WIDTH / 2);
-        memcpy(pLinemem, pLinemem + 1, sizeof(CRGB) * (MATRIX_WIDTH / 2));
-        memcpy(pLinemem2 + 1, pLinemem2, sizeof(CRGB) * (MATRIX_WIDTH / 2));
+        memmove(pLinemem, pLinemem + 1, sizeof(CRGB) * (halfWidth - 1));
+        memmove(pLinemem2 + 1, pLinemem2, sizeof(CRGB) * (halfWidth - 1));
     }
 }
 

--- a/src/itaskservice.cpp
+++ b/src/itaskservice.cpp
@@ -43,7 +43,7 @@
 
 bool ITaskService::Start()
 {
-    std::lock_guard<std::mutex> lifecycleGuard(_lifecycleMutex);
+    std::lock_guard lifecycleGuard(_lifecycleMutex);
 
     if (_running.load())
     {
@@ -95,8 +95,8 @@ void ITaskService::Stop()
     // _taskHandleMutex below. Holding the old recursive lifecycle mutex across
     // the whole stop wait was heavier than necessary and existed only because
     // some stop hooks wake their task.
-    
-    std::lock_guard<std::mutex> lifecycleGuard(_lifecycleMutex);
+
+    std::lock_guard lifecycleGuard(_lifecycleMutex);
 
     if (!_running.load() && !HasTaskHandle())
         return;
@@ -142,13 +142,13 @@ void ITaskService::Stop()
 
 void ITaskService::SetTaskHandle(TaskHandle_t taskHandle)
 {
-    std::lock_guard<std::mutex> guard(_taskHandleMutex);
+    std::lock_guard guard(_taskHandleMutex);
     _taskHandle = taskHandle;
 }
 
 TaskHandle_t ITaskService::ClearTaskHandle()
 {
-    std::lock_guard<std::mutex> guard(_taskHandleMutex);
+    std::lock_guard guard(_taskHandleMutex);
     TaskHandle_t taskHandle = _taskHandle;
     _taskHandle = nullptr;
     return taskHandle;
@@ -156,7 +156,7 @@ TaskHandle_t ITaskService::ClearTaskHandle()
 
 bool ITaskService::HasTaskHandle() const
 {
-    std::lock_guard<std::mutex> guard(_taskHandleMutex);
+    std::lock_guard guard(_taskHandleMutex);
     return _taskHandle != nullptr;
 }
 
@@ -195,7 +195,7 @@ void ITaskService::TaskEntryThunk(void* p)
     // Park until Stop() reaps us. The block delay is long but bounded so
     // the task wakes if FreeRTOS tick wraparound math ever surprises us;
     // either way, control returns to the scheduler immediately.
-    
+
     while (true)
         vTaskDelay(pdMS_TO_TICKS(60 * 1000));
 }

--- a/src/itaskservice.cpp
+++ b/src/itaskservice.cpp
@@ -43,6 +43,8 @@
 
 bool ITaskService::Start()
 {
+    std::lock_guard<std::mutex> lifecycleGuard(_lifecycleMutex);
+
     if (_running.load())
     {
         debugI("%s: Start() ignored, already running", Name());
@@ -65,34 +67,43 @@ bool ITaskService::Start()
         (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(),
         (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize()) );
 
+    TaskHandle_t taskHandle = nullptr;
     BaseType_t rc = xTaskCreatePinnedToCore(
         TaskEntryThunk,
         cfg.taskName,
         cfg.stackSize,
         this,                       // ITaskService*; thunk casts back
         cfg.priority,
-        &_taskHandle,
+        &taskHandle,
         cfg.core);
 
     if (rc != pdPASS)
     {
         debugE("%s: xTaskCreatePinnedToCore failed (rc=%d)", Name(), (int)rc);
-        _taskHandle = nullptr;
+        SetTaskHandle(nullptr);
         return false;
     }
 
+    SetTaskHandle(taskHandle);
     _running.store(true);
     return true;
 }
 
 void ITaskService::Stop()
 {
-    if (!_running.load() && _taskHandle == nullptr)
+    // Start/Stop still need serialization, but WakeTask only needs the short
+    // _taskHandleMutex below. Holding the old recursive lifecycle mutex across
+    // the whole stop wait was heavier than necessary and existed only because
+    // some stop hooks wake their task.
+    
+    std::lock_guard<std::mutex> lifecycleGuard(_lifecycleMutex);
+
+    if (!_running.load() && !HasTaskHandle())
         return;
 
     debugI("%s: stop requested", Name());
 
-    if (_taskHandle != nullptr)
+    if (HasTaskHandle())
     {
         _shutdownRequested.store(true);
 
@@ -114,8 +125,8 @@ void ITaskService::Stop()
         // TaskEntryThunk's vTaskDelay) or it never acknowledged. Either
         // way, we delete it from this thread so the FreeRTOS task control
         // block is reclaimed before this object is allowed to be destroyed.
-        vTaskDelete(_taskHandle);
-        _taskHandle = nullptr;
+        if (TaskHandle_t taskHandle = ClearTaskHandle())
+            vTaskDelete(taskHandle);
     }
 
     // Service-specific resource cleanup. Runs whether the task exited
@@ -127,6 +138,26 @@ void ITaskService::Stop()
     _shutdownRequested.store(false);
     _taskExited.store(false);
     debugI("%s: stop completed", Name());
+}
+
+void ITaskService::SetTaskHandle(TaskHandle_t taskHandle)
+{
+    std::lock_guard<std::mutex> guard(_taskHandleMutex);
+    _taskHandle = taskHandle;
+}
+
+TaskHandle_t ITaskService::ClearTaskHandle()
+{
+    std::lock_guard<std::mutex> guard(_taskHandleMutex);
+    TaskHandle_t taskHandle = _taskHandle;
+    _taskHandle = nullptr;
+    return taskHandle;
+}
+
+bool ITaskService::HasTaskHandle() const
+{
+    std::lock_guard<std::mutex> guard(_taskHandleMutex);
+    return _taskHandle != nullptr;
 }
 
 // TaskEntryThunk - static task entry point that casts the void* back to

--- a/src/jsonserializer.cpp
+++ b/src/jsonserializer.cpp
@@ -276,7 +276,7 @@ size_t JSONWriter::RegisterWriter(const std::function<void()>& writer)
     // Add a writer to the collection. Returns the index of the added writer, for use with FlagWriter()
 
     // Add the writer with its flag unset
-    std::lock_guard<std::mutex> lock(writersMutex);
+    std::lock_guard guard(writersMutex);
     writers.push_back(std::make_shared<WriterEntry>(writer));
     return writers.size() - 1;
 }
@@ -288,7 +288,7 @@ void JSONWriter::FlagWriter(size_t index)
     // Check if we received a valid writer index
     std::shared_ptr<WriterEntry> entry;
     {
-        std::lock_guard<std::mutex> lock(writersMutex);
+        std::lock_guard guard(writersMutex);
         if (index >= writers.size())
             return;
         entry = writers[index];
@@ -354,7 +354,7 @@ void JSONWriter::Run()
 
         std::vector<std::shared_ptr<JSONWriter::WriterEntry>> writersSnapshot;
         {
-            std::lock_guard<std::mutex> lock(writersMutex);
+            std::lock_guard guard(writersMutex);
             writersSnapshot = writers;
         }
 

--- a/src/ledbuffer.cpp
+++ b/src/ledbuffer.cpp
@@ -3,6 +3,8 @@
 #include "ledbuffer.h"
 #include "values.h"
 
+#include <limits>
+
 // LEDBuffer
 //
 // Provides a timestamped buffer of colordata.  The LEDBufferManager keeps
@@ -24,7 +26,7 @@ uint32_t LEDBuffer::Length()       const  { return _pixelCount;            }
 
 double LEDBuffer::TimeTillDue() const
 {
-    return g_Values.AppTime.CurrentTime() - _timeStampSeconds - (_timeStampMicroseconds / (double) MICROS_PER_SECOND);
+    return _timeStampSeconds + (_timeStampMicroseconds / (double) MICROS_PER_SECOND) - g_Values.AppTime.CurrentTime();
 }
 
 bool LEDBuffer::IsBufferOlderThan(const timeval & tv) const
@@ -43,8 +45,20 @@ bool LEDBuffer::IsBufferOlderThan(const timeval & tv) const
 //
 // Parse and deposit a WiFi packet into a buffer
 
-bool LEDBuffer::UpdateFromWire(std::unique_ptr<uint8_t []> & payloadData, size_t payloadLength)
+bool LEDBuffer::ValidateWirePayload(const std::unique_ptr<uint8_t []>& payloadData,
+                                    size_t payloadLength,
+                                    size_t ledCount,
+                                    size_t* payloadByteCount)
 {
+    if (payloadByteCount)
+        *payloadByteCount = 0;
+
+    if (!payloadData)
+    {
+        debugW("No payload data received to process");
+        return false;
+    }
+
     if (payloadLength < 24)                 // Our header size
     {
         debugW("Not enough data received to process");
@@ -59,28 +73,66 @@ bool LEDBuffer::UpdateFromWire(std::unique_ptr<uint8_t []> & payloadData, size_t
 
     const size_t cbHeader = sizeof(command16) + sizeof(channel16) + sizeof(length32) + sizeof(seconds) + sizeof(micros);
 
-    _timeStampSeconds      = seconds;
-    _timeStampMicroseconds = micros;
-    _pixelCount            = length32;
+    if (length32 > (std::numeric_limits<size_t>::max() - cbHeader) / sizeof(CRGB))
+    {
+        debugW("LED payload size overflow");
+        return false;
+    }
 
-    if (payloadLength < length32 * sizeof(CRGB) + cbHeader)
+    const size_t requiredPayloadBytes = length32 * sizeof(CRGB);
+    if (payloadLength < requiredPayloadBytes + cbHeader)
     {
         debugW("command16: %hu   length32: %lu,  payloadLength: %zu\n", command16, (unsigned long)length32, payloadLength);
         debugW("Data size mismatch");
         return false;
     }
-    if (length32 > _pStrand->GetLEDCount())
+    if (length32 > ledCount)
     {
         debugW("More data than we have LEDs\n");
         return false;
     }
+
+    if (payloadByteCount)
+        *payloadByteCount = requiredPayloadBytes;
+
+    return true;
+}
+
+bool LEDBuffer::UpdateFromWire(std::unique_ptr<uint8_t []> & payloadData, size_t payloadLength)
+{
+    if (!_pStrand)
+    {
+        debugW("No strand attached to LED buffer");
+        return false;
+    }
+
+    size_t payloadBytes = 0;
+    if (!ValidateWirePayload(payloadData, payloadLength, _pStrand->GetLEDCount(), &payloadBytes))
+        return false;
+
+    uint16_t command16 = WORDFromMemory(&payloadData[0]);
+    uint16_t channel16 = WORDFromMemory(&payloadData[2]);
+    uint32_t length32  = DWORDFromMemory(&payloadData[4]);
+    uint64_t seconds   = ULONGFromMemory(&payloadData[8]);
+    uint64_t micros    = ULONGFromMemory(&payloadData[16]);
+
+    const size_t cbHeader = sizeof(command16) + sizeof(channel16) + sizeof(length32) + sizeof(seconds) + sizeof(micros);
+
     debugV("PayloadLength: %zu, command16: %hu, Length32: %lu", payloadLength, command16, (unsigned long)length32);
 
     CRGB * pRGB = reinterpret_cast<CRGB *>(&payloadData[cbHeader]);
 
-    memcpy(_leds.get(), pRGB, length32 * sizeof(CRGB));
+    // Keep this commit after the shared validation used by ProcessIncomingData.
+    // New queue slots are now reserved only after that validation passes, and
+    // existing-buffer updates still avoid committing invalid metadata.
+    _timeStampSeconds      = seconds;
+    _timeStampMicroseconds = micros;
+    _pixelCount            = length32;
+
+    memcpy(_leds.get(), pRGB, payloadBytes);
     debugV("seconds, micros: %llu.%llu", seconds, micros);
-    debugV("Color0: %08lx", (unsigned long)(uint32_t) _leds[0]);
+    if (length32 > 0)
+        debugV("Color0: %08lx", (unsigned long)(uint32_t) _leds[0]);
     return true;
 }
 
@@ -118,6 +170,7 @@ LEDBufferManager::LEDBufferManager(uint32_t cBuffers, const std::shared_ptr<GFXB
  : _ppBuffers(std::make_unique<std::vector<std::shared_ptr<LEDBuffer>>>()), // Create the circular array of ptrs
    _iNextBuffer(0),
    _iLastBuffer(0),
+   _cQueuedBuffers(0),
    _cBuffers(cBuffers)
 {
     // The initializer creates a uniquely owned table of shared pointers.
@@ -161,21 +214,29 @@ size_t LEDBufferManager::BufferCount() const
     return _cBuffers;
 }
 
+// LEDCount
+// The number of LEDs in each buffer, which is the same as the number of LEDs in the strand
+// that the buffers are configured for. If there are no buffers or the buffers aren't configured, returns 0.
+
+size_t LEDBufferManager::LEDCount() const
+{
+    return (_cBuffers > 0 && !_ppBuffers->empty() && (*_ppBuffers)[0] && (*_ppBuffers)[0]->_pStrand)
+        ? (*_ppBuffers)[0]->_pStrand->GetLEDCount()
+        : 0;
+}
+
 // Depth
 //
 // The variable, current count of buffers in use
 
 size_t LEDBufferManager::Depth() const
 {
-    if (_iNextBuffer < _iLastBuffer)
-        return (_iNextBuffer + _cBuffers - _iLastBuffer);
-    else
-        return _iNextBuffer - _iLastBuffer;
+    return _cQueuedBuffers;
 }
 
 bool LEDBufferManager::IsEmpty() const
 {
-    return _iNextBuffer == _iLastBuffer;
+    return _cQueuedBuffers == 0;
 }
 
 // PeekNewestBuffer
@@ -196,13 +257,19 @@ std::shared_ptr<LEDBuffer> LEDBufferManager::PeekNewestBuffer() const
 
 std::shared_ptr<LEDBuffer> LEDBufferManager::GetNewBuffer()
 {
-    auto pResult = (*_ppBuffers)[_iNextBuffer++];
+    if (_cBuffers == 0)
+        return nullptr;
 
-    if (IsEmpty())
-        _iLastBuffer++;
+    auto pResult = (*_ppBuffers)[_iNextBuffer];
 
-    _iLastBuffer %= _cBuffers;
-    _iNextBuffer %= _cBuffers;
+    // Full and empty used to be represented by the same head/tail indices, so
+    // an exact fill at the wrap point made the whole queue look empty. Track
+    // depth explicitly and advance the tail only when a real overwrite occurs.
+    _iNextBuffer = (_iNextBuffer + 1) % _cBuffers;
+    if (_cQueuedBuffers == _cBuffers)
+        _iLastBuffer = (_iLastBuffer + 1) % _cBuffers;
+    else
+        ++_cQueuedBuffers;
 
     _pLastBufferAdded = pResult;
 
@@ -219,8 +286,8 @@ std::shared_ptr<LEDBuffer> LEDBufferManager::GetOldestBuffer()
         return nullptr;
 
     auto pResult = (*_ppBuffers)[_iLastBuffer];
-    _iLastBuffer++;
-    _iLastBuffer %= _cBuffers;
+    _iLastBuffer = (_iLastBuffer + 1) % _cBuffers;
+    --_cQueuedBuffers;
 
     return pResult;
 }
@@ -246,6 +313,7 @@ void LEDBufferManager::Reconfigure(const std::shared_ptr<GFXBase>& pGFX)
 
     _iNextBuffer = 0;
     _iLastBuffer = 0;
+    _cQueuedBuffers = 0;
     _pLastBufferAdded.reset();
 }
 
@@ -254,7 +322,7 @@ void LEDBufferManager::Reconfigure(const std::shared_ptr<GFXBase>& pGFX)
 // Returns a pointer to the buffer at the specified logical index, or nullptr if empty
 std::shared_ptr<LEDBuffer> LEDBufferManager::operator[](size_t index) const
 {
-    if (IsEmpty())
+    if (IsEmpty() || index >= _cQueuedBuffers)
         return nullptr;
     size_t i = (_iLastBuffer + index) % _cBuffers;
     return (*_ppBuffers)[i];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -537,9 +537,9 @@ void setup()
 
     #if ENABLE_AUDIO
     {
-        // USE_M5 implies we are using M5Unified which manages the mic pins itself, so we 
+        // USE_M5 implies we are using M5Unified which manages the mic pins itself, so we
         // skip manual pin setup in that case.  For other boards, we set the audio input pin
-        // according to the current config, which allows the boot-applied pin to match what 
+        // according to the current config, which allows the boot-applied pin to match what
         // settings report and for settings changes to take effect immediately.
 
         #if !USE_M5
@@ -681,7 +681,7 @@ void setup()
         // IP; otherwise NetworkReader will start these services after connect.
         if (nd_network::IsWiFiConnected() && g_ptrSystem->HasWebServer())
             g_ptrSystem->GetWebServer().Start();
-        
+
         #if WEB_SOCKETS_ANY_ENABLED
             if (nd_network::IsWiFiConnected() && g_ptrSystem->HasWebSocketServer())
                 g_ptrSystem->GetWebSocketServer().Start();
@@ -810,7 +810,7 @@ void loop()
             #if INCOMING_WIFI_ENABLED
                 auto& bufferManager = g_ptrSystem->GetBufferManagers()[0];
                 {
-                    std::lock_guard<std::mutex> guard(g_buffer_mutex);
+                    std::lock_guard guard(g_buffer_mutex);
                     strOutput += str_sprintf("Buffer: %zu/%zu, ", (size_t)bufferManager.Depth(), (size_t)bufferManager.BufferCount());
                 }
             #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -809,7 +809,10 @@ void loop()
 
             #if INCOMING_WIFI_ENABLED
                 auto& bufferManager = g_ptrSystem->GetBufferManagers()[0];
-                strOutput += str_sprintf("Buffer: %zu/%zu, ", (size_t)bufferManager.Depth(), (size_t)bufferManager.BufferCount());
+                {
+                    std::lock_guard<std::mutex> guard(g_buffer_mutex);
+                    strOutput += str_sprintf("Buffer: %zu/%zu, ", (size_t)bufferManager.Depth(), (size_t)bufferManager.BufferCount());
+                }
             #endif
 
             const auto& taskManager = g_ptrSystem->GetTaskManager();

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -38,6 +38,8 @@
     #include <ESPmDNS.h>
     #include <esp_wifi.h>
     #include <iterator>
+    #include <limits>
+    #include <mutex>
     #include <nvs.h>
     #include <WiFi.h>
 #elif ENABLE_ESPNOW
@@ -89,6 +91,15 @@ namespace nd_network
 
 #if ENABLE_WIFI
     static DRAM_ATTR WiFiUDP l_Udp;
+
+    static bool CheckedStandardPacketSize(uint32_t itemCount, size_t itemSize, size_t& packetSize)
+    {
+        if (itemCount > (std::numeric_limits<size_t>::max() - STANDARD_DATA_HEADER_SIZE) / itemSize)
+            return false;
+
+        packetSize = STANDARD_DATA_HEADER_SIZE + itemCount * itemSize;
+        return true;
+    }
 
     // Writer function and flag combo
     struct NetworkReader::ReaderEntry
@@ -655,11 +666,17 @@ namespace nd_network
             FLASH_VERSION_NAME, g_ptrSystem->GetDevices().size(),
             config.GetActiveLEDCount(), (size_t)(ESP.getFreeHeap()/1024), abs(WiFi.RSSI()),
             IsWiFiConnected() ? WiFi.localIP().toString().c_str() : "None");
-        DebugCLI::cli_printf("BUFR:%02zu/%02zu [%lufps]",
-            (size_t)bufferManager.Depth(), (size_t)bufferManager.BufferCount(),
-            (unsigned long)g_Values.FPS);
-        DebugCLI::cli_printf("DATA:%+04.2f-%+04.2f",
-            (float)bufferManager.AgeOfOldestBuffer(), (float)bufferManager.AgeOfNewestBuffer());
+        {
+            // Buffer indices are mutated by the socket task and consumed by
+            // the render task; status reads need the same mutex or they can
+            // sample a half-updated ring state on the other core.
+            std::lock_guard<std::mutex> guard(g_buffer_mutex);
+            DebugCLI::cli_printf("BUFR:%02zu/%02zu [%lufps]",
+                (size_t)bufferManager.Depth(), (size_t)bufferManager.BufferCount(),
+                (unsigned long)g_Values.FPS);
+            DebugCLI::cli_printf("DATA:%+04.2f-%+04.2f",
+                (float)bufferManager.AgeOfOldestBuffer(), (float)bufferManager.AgeOfNewestBuffer());
+        }
 
         #if ENABLE_AUDIO
         DebugCLI::cli_printf("g_Analyzer._VU: %.2f, g_Analyzer._MinVU: %.2f, g_Analyzer._PeakVU: %.2f, g_Analyzer.gVURatio: %.2f",
@@ -789,6 +806,7 @@ void SetupOTA(const String &strHostname)
             debugI("OTA Progress: %u%%\r", p);
 
             #if USE_HUB75
+                std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
                 auto pMatrix = std::static_pointer_cast<HUB75GFX>(g_ptrSystem->GetEffectManager().GetBaseGraphics()[0]);
                 pMatrix->SetCaption(str_sprintf("Update:%d%%", p), CAPTION_TIME);
             #endif
@@ -830,6 +848,12 @@ bool ProcessIncomingData(std::unique_ptr<uint8_t[]> &payloadData, size_t payload
     #if !INCOMING_WIFI_ENABLED
         return false;
     #else
+        if (!payloadData || payloadLength < STANDARD_DATA_HEADER_SIZE)
+        {
+            debugW("Incoming packet too short: %zu", payloadLength);
+            return false;
+        }
+
         uint16_t command16 = payloadData[1] << 8 | payloadData[0];
 
         debugV("payloadLength: %zu, command16: %d", payloadLength, command16);
@@ -848,6 +872,17 @@ bool ProcessIncomingData(std::unique_ptr<uint8_t[]> &payloadData, size_t payload
 
                     debugV("ProcessIncomingData -- Bands: %u, Length: %lu, Seconds: %llu, Micros: %llu ... ",
                            (unsigned int)numbands, (unsigned long)length32, seconds, micros);
+
+                    size_t expectedLength = 0;
+                    if (numbands != NUM_BANDS ||
+                        length32 != numbands * sizeof(float) ||
+                        !nd_network::CheckedStandardPacketSize(length32, sizeof(uint8_t), expectedLength) ||
+                        payloadLength < expectedLength)
+                    {
+                        debugW("Malformed peak data packet: bands=%u length=%lu payload=%zu",
+                               (unsigned int)numbands, (unsigned long)length32, payloadLength);
+                        return false;
+                    }
 
                     // Data is transmitted as NUM_BANDS floats following the standard header
                     const uint8_t* dataStart = payloadData.get() + STANDARD_DATA_HEADER_SIZE;
@@ -878,6 +913,14 @@ bool ProcessIncomingData(std::unique_ptr<uint8_t[]> &payloadData, size_t payload
                 debugV("ProcessIncomingData -- Channel: %u, Length: %lu, Seconds: %llu, Micros: %llu ... ",
                        (unsigned int)channel16, (unsigned long)length32, seconds, micros);
 
+                size_t expectedLength = 0;
+                if (!nd_network::CheckedStandardPacketSize(length32, sizeof(CRGB), expectedLength) || payloadLength < expectedLength)
+                {
+                    debugW("Malformed pixel data packet: length=%lu payload=%zu",
+                           (unsigned long)length32, payloadLength);
+                    return false;
+                }
+
                 // The very old original implementation used channel numbers, not a mask, and only channel 0 was supported at that time, so if
                 // we see a Channel 0 asked for, it must be very old, and we massage it into the mask for Channel0 instead
                 // Another option here would be to draw on all channels (0xff) instead of just one (0x01) if 0 is specified
@@ -897,6 +940,16 @@ bool ProcessIncomingData(std::unique_ptr<uint8_t[]> &payloadData, size_t payload
                         bool bDone = false;
                         auto &bufferManager = g_ptrSystem->GetBufferManagers()[iChannel];
 
+                        // Validate against the active channel before reserving a
+                        // circular-buffer slot. Reserving first meant a rejected
+                        // packet could leave an old frame queued in the new slot.
+                        if (!LEDBuffer::ValidateWirePayload(payloadData, payloadLength, bufferManager.LEDCount()))
+                        {
+                            debugW("Pixel packet rejected for channel %d: %lu LEDs, channel has %zu",
+                                   (unsigned long)length32, iChannel, bufferManager.LEDCount());
+                            return false;
+                        }
+
                         if (!bufferManager.IsEmpty())
                         {
                             auto pNewestBuffer = bufferManager.PeekNewestBuffer();
@@ -912,7 +965,7 @@ bool ProcessIncomingData(std::unique_ptr<uint8_t[]> &payloadData, size_t payload
                         {
                             debugV("No match so adding new buffer");
                             auto pNewBuffer = bufferManager.GetNewBuffer();
-                            if (!pNewBuffer->UpdateFromWire(payloadData, payloadLength))
+                            if (!pNewBuffer || !pNewBuffer->UpdateFromWire(payloadData, payloadLength))
                                 return false;
                         }
                     }

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -670,7 +670,7 @@ namespace nd_network
             // Buffer indices are mutated by the socket task and consumed by
             // the render task; status reads need the same mutex or they can
             // sample a half-updated ring state on the other core.
-            std::lock_guard<std::mutex> guard(g_buffer_mutex);
+            std::lock_guard guard(g_buffer_mutex);
             DebugCLI::cli_printf("BUFR:%02zu/%02zu [%lufps]",
                 (size_t)bufferManager.Depth(), (size_t)bufferManager.BufferCount(),
                 (unsigned long)g_Values.FPS);
@@ -929,7 +929,7 @@ bool ProcessIncomingData(std::unique_ptr<uint8_t[]> &payloadData, size_t payload
 
                 // Go through the channel mask to see which bits are set in the channel16 specifier, and send the data to each and every
                 // channel that matches the mask.  So if the send channel 7, that means the lowest 3 channels will be set.
-                std::lock_guard<std::mutex> guard(g_buffer_mutex);
+                std::lock_guard guard(g_buffer_mutex);
 
                 for (int iChannel = 0, channelMask = 1; iChannel < g_ptrSystem->GetBufferManagers().size(); iChannel++, channelMask <<= 1)
                 {

--- a/src/ntptimeclient.cpp
+++ b/src/ntptimeclient.cpp
@@ -72,7 +72,7 @@ bool NTPTimeClient::UpdateClockFromWeb(WiFiUDP * pUDP)
 
     debugV("Updating Clock From Web...");
 
-    std::lock_guard<std::mutex> guard(l_clockMutex);
+    std::lock_guard guard(l_clockMutex);
 
     char chNtpPacket[NTP_PACKET_LENGTH];
     memset(chNtpPacket, 0, NTP_PACKET_LENGTH);

--- a/src/remotecontrol.cpp
+++ b/src/remotecontrol.cpp
@@ -38,6 +38,7 @@
 #include <esp_idf_version.h>
 #include <esp_intr_alloc.h>
 #include <freertos/FreeRTOS.h>
+#include <mutex>
 
 // IR RX has two RMT backends, picked at compile time based on IDF version:
 //
@@ -985,6 +986,7 @@ void RemoteControl::handle()
                 effectManager.ApplyGlobalColor(RemoteColorCode.color);
                 #if FULL_COLOR_REMOTE_FILL
                     auto effect = std::make_shared<ColorFillEffect>("Remote Color", RemoteColorCode.color, 1, true);
+                    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
                     if (effect->Init(g_ptrSystem->GetEffectManager().GetBaseGraphics()))
                         g_ptrSystem->GetEffectManager().SetTempEffect(effect);
                     else

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -156,13 +156,27 @@ public:
 
         // Buffer Status Line 3
         auto &bufferManager = g_ptrSystem->GetBufferManagers()[0];
+        size_t bufferDepth = 0;
+        size_t bufferCount = 0;
+        double oldestAge = 0.0;
+        double newestAge = 0.0;
+        {
+            // The display runs on its own task, so even status-only buffer
+            // reads need the producer/consumer mutex to avoid sampling torn
+            // circular-buffer indices.
+            std::lock_guard<std::mutex> guard(g_buffer_mutex);
+            bufferDepth = bufferManager.Depth();
+            bufferCount = bufferManager.BufferCount();
+            oldestAge = bufferManager.AgeOfOldestBuffer();
+            newestAge = bufferManager.AgeOfNewestBuffer();
+        }
         display.setCursor(xMargin + 0, yMargin + lineHeight * 4);
-        display.println(str_sprintf("BUFR:%02lu/%02lu %lufps ", (unsigned long)bufferManager.Depth(), (unsigned long)bufferManager.BufferCount(), (unsigned long)g_Values.FPS));
+        display.println(str_sprintf("BUFR:%02lu/%02lu %lufps ", (unsigned long)bufferDepth, (unsigned long)bufferCount, (unsigned long)g_Values.FPS));
 
         // Data Status Line 4
         display.setCursor(xMargin + 0, yMargin + lineHeight * 2);
-        display.println(str_sprintf("DATA:%+06.2lf-%+06.2lf", std::min(99.99, bufferManager.AgeOfOldestBuffer()),
-                                    std::min(99.99, bufferManager.AgeOfNewestBuffer())));
+        display.println(str_sprintf("DATA:%+06.2lf-%+06.2lf", std::min(99.99, oldestAge),
+                                    std::min(99.99, newestAge)));
 
         // Clock info Line 5
         time_t t;
@@ -195,7 +209,7 @@ public:
             int top = display.height() - lineHeight;
             int height = lineHeight - 3;
             int width = display.width() - xMargin * 2;
-            float ratio = (float)bufferManager.Depth() / (float)bufferManager.BufferCount();
+            float ratio = bufferCount == 0 ? 0.0f : (float)bufferDepth / (float)bufferCount;
             ratio = std::min(1.0f, ratio);
             int filled = (width - 2) * ratio;
 
@@ -334,9 +348,10 @@ public:
                 yh += display.fontHeight();
 
                 display.setTextColor(display.GetTextColor(), backColor);
-                w = display.textWidth(g_ptrSystem->GetEffectManager().GetCurrentEffectName());
+                String effectName = g_ptrSystem->GetEffectManager().GetCurrentEffectName();
+                w = display.textWidth(effectName);
                 display.setCursor(display.width() / 2 - w / 2, yh);
-                display.print(g_ptrSystem->GetEffectManager().GetCurrentEffectName());
+                display.print(effectName);
                 yh += display.fontHeight();
 
                 String sIP = nd_network::IsWiFiConnected() ? currentIP.c_str() : "No Wifi";

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -164,7 +164,7 @@ public:
             // The display runs on its own task, so even status-only buffer
             // reads need the producer/consumer mutex to avoid sampling torn
             // circular-buffer indices.
-            std::lock_guard<std::mutex> guard(g_buffer_mutex);
+            std::lock_guard guard(g_buffer_mutex);
             bufferDepth = bufferManager.Depth();
             bufferCount = bufferManager.BufferCount();
             oldestAge = bufferManager.AgeOfOldestBuffer();
@@ -609,7 +609,7 @@ int Screen::ActivePageCount()
 // FlipToNextPage
 void Screen::FlipToNextPage()
 {
-    std::lock_guard<std::mutex> guard(_screenMutex);
+    std::lock_guard guard(_screenMutex);
 
     // Advance to the next page
     const int activeCount = ActivePageCount();
@@ -679,7 +679,7 @@ int Screen::textWidth(const String & str)
 // Draws the OLED/LCD screen with the current stats on connection, buffer, drawing, etc.
 void IRAM_ATTR Screen::Update(bool bRedraw)
 {
-    std::lock_guard<std::mutex> guard(_screenMutex);
+    std::lock_guard guard(_screenMutex);
 
     // Initialize default page on first draw
     static bool s_initialized = false;

--- a/src/socketserver.cpp
+++ b/src/socketserver.cpp
@@ -43,6 +43,8 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
+#include <mutex>
 #include <netinet/in.h>
 #include <sys/socket.h>
 #include <sys/time.h>
@@ -54,6 +56,27 @@ extern "C"
 }
 
 #if INCOMING_WIFI_ENABLED
+
+namespace
+{
+    bool CheckedAdd(size_t left, size_t right, size_t& result)
+    {
+        if (left > std::numeric_limits<size_t>::max() - right)
+            return false;
+
+        result = left + right;
+        return true;
+    }
+
+    bool CheckedStandardPacketSize(uint32_t itemCount, size_t itemSize, size_t& packetSize)
+    {
+        if (itemCount > (std::numeric_limits<size_t>::max() - STANDARD_DATA_HEADER_SIZE) / itemSize)
+            return false;
+
+        packetSize = STANDARD_DATA_HEADER_SIZE + itemCount * itemSize;
+        return true;
+    }
+}
 
 // SocketResponse
 //
@@ -255,6 +278,12 @@ bool SocketServer::ReadUntilNBytesReceived(size_t socket, size_t cbNeeded)
 
 bool SocketServer::DecompressBuffer(const uint8_t * pBuffer, size_t cBuffer, uint8_t * pOutput, size_t expectedOutputSize)
 {
+    if (pBuffer == nullptr || pOutput == nullptr || cBuffer < 4)
+    {
+        debugE("Compressed packet too short to decompress: %zu bytes", cBuffer);
+        return false;
+    }
+
     debugV("Compressed Data: %02X %02X %02X %02X...", pBuffer[0], pBuffer[1], pBuffer[2], pBuffer[3]);
 
     struct uzlib_uncomp d = { 0 };
@@ -395,18 +424,25 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
             uint32_t reserved       = _pBuffer[15] << 24 | _pBuffer[14] << 16 | _pBuffer[13] << 8 | _pBuffer[12];
             debugV("Compressed Header: compressedSize: %lu, expandedSize: %lu, reserved: %lu", (unsigned long)compressedSize, (unsigned long)expandedSize, (unsigned long)reserved);
 
-            if (expandedSize > MAXIMUM_PACKET_SIZE)
+            size_t compressedPacketSize = 0;
+            if (!CheckedAdd(COMPRESSED_HEADER_SIZE, compressedSize, compressedPacketSize) ||
+                compressedPacketSize > MAXIMUM_PACKET_SIZE ||
+                expandedSize > MAXIMUM_PACKET_SIZE)
             {
-                debugE("Expanded packet would be %lu but buffer is only %lu !!!!\n", (unsigned long)expandedSize, (unsigned long)MAXIMUM_PACKET_SIZE);
+                debugE("Compressed packet sizes are invalid: compressed=%lu expanded=%lu max=%lu",
+                       (unsigned long)compressedSize, (unsigned long)expandedSize, (unsigned long)MAXIMUM_PACKET_SIZE);
                 break;
             }
 
-            if (false == ReadUntilNBytesReceived(new_socket, COMPRESSED_HEADER_SIZE + compressedSize))
+            // Check addition before ReadUntilNBytesReceived; an overflowed
+            // header+payload size can wrap back below MAXIMUM_PACKET_SIZE and
+            // make the socket reader under-read a malformed packet.
+            if (false == ReadUntilNBytesReceived(new_socket, compressedPacketSize))
             {
                 debugE("Could not read compressed data from stream\n");
                 break;
             }
-            debugV("Successfully read %zu bytes", (size_t)(COMPRESSED_HEADER_SIZE + compressedSize));
+            debugV("Successfully read %zu bytes", compressedPacketSize);
 
             // If our buffer is in PSRAM it would be expensive to decompress in place, as the SPIRAM doesn't like
             // non-linear access from what I can tell.  I bet it must send addr+len to request each unique read, so
@@ -449,13 +485,16 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
                     uint64_t seconds   = ULONGFromMemory(&_pBuffer.get()[8]);
                     uint64_t micros    = ULONGFromMemory(&_pBuffer.get()[16]);
 
-                    size_t totalExpected = STANDARD_DATA_HEADER_SIZE + length32;
+                    size_t totalExpected = 0;
 
                     debugV("PeakData Header: numbands=%u, length=%lu, seconds=%llu, micro=%llu", numbands, (unsigned long)length32, seconds, micros);
 
-                    if (numbands != NUM_BANDS)
+                    if (!CheckedStandardPacketSize(length32, sizeof(uint8_t), totalExpected) ||
+                        totalExpected > MAXIMUM_PACKET_SIZE ||
+                        numbands != NUM_BANDS)
                     {
-                        debugE("Expecting %d bands but received %d", NUM_BANDS, numbands);
+                        debugE("Invalid peak data packet: bands=%u length=%lu total=%zu",
+                               (unsigned int)numbands, (unsigned long)length32, totalExpected);
                         break;
                     }
 
@@ -480,7 +519,13 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
                 #else
                     // Audio disabled: consume any declared payload to keep stream in sync, then ignore it
                     uint32_t length32  = DWORDFromMemory(&_pBuffer.get()[4]);
-                    size_t totalExpected = STANDARD_DATA_HEADER_SIZE + length32;
+                    size_t totalExpected = 0;
+                    if (!CheckedStandardPacketSize(length32, sizeof(uint8_t), totalExpected) ||
+                        totalExpected > MAXIMUM_PACKET_SIZE)
+                    {
+                        debugE("Audio disabled, invalid PEAKDATA payload length %lu", (unsigned long)length32);
+                        break;
+                    }
                     if (!ReadUntilNBytesReceived(new_socket, totalExpected))
                     {
                         debugE("Audio disabled, failed to skip PEAKDATA payload of %zu bytes", (size_t)totalExpected);
@@ -502,8 +547,9 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
 
                 debugV("Uncompressed Header: channel16=%u, length=%lu, seconds=%llu, micro=%llu", channel16, (unsigned long)length32, seconds, micros);
 
-                size_t totalExpected = STANDARD_DATA_HEADER_SIZE + length32 * LED_DATA_SIZE;
-                if (totalExpected > MAXIMUM_PACKET_SIZE)
+                size_t totalExpected = 0;
+                if (!CheckedStandardPacketSize(length32, LED_DATA_SIZE, totalExpected) ||
+                    totalExpected > MAXIMUM_PACKET_SIZE)
                 {
                     debugE("Too many bytes promised (%zu) - more than we can use for our LEDs at max packet (%lu)\n", (size_t)totalExpected, (unsigned long)MAXIMUM_PACKET_SIZE);
                     break;
@@ -548,6 +594,7 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
             debugV("Sending Response Packet from Socket Server");
             auto& bufferManager = g_ptrSystem->GetBufferManagers()[0];
 
+            std::lock_guard<std::mutex> guard(g_buffer_mutex);
             SocketResponse response = {
                                         .size = sizeof(SocketResponse),
                                         .sequence     = sequence++,

--- a/src/socketserver.cpp
+++ b/src/socketserver.cpp
@@ -594,7 +594,7 @@ bool SocketServer::ProcessIncomingConnectionsLoop()
             debugV("Sending Response Packet from Socket Server");
             auto& bufferManager = g_ptrSystem->GetBufferManagers()[0];
 
-            std::lock_guard<std::mutex> guard(g_buffer_mutex);
+            std::lock_guard guard(g_buffer_mutex);
             SocketResponse response = {
                                         .size = sizeof(SocketResponse),
                                         .sequence     = sequence++,

--- a/src/soundanalyzer.cpp
+++ b/src/soundanalyzer.cpp
@@ -205,7 +205,7 @@ void SoundAnalyzerBase::ResetBeatDetection()
     debugV("Beat detector reset");
     {
         // Need a mutex because it writes the same shared beat structs that the render thread reads.
-        std::lock_guard<std::mutex> lock(_beatInfoMutex);
+        std::lock_guard guard(_beatInfoMutex);
         _lastBeatInfo = {};
         _lastNearBeatInfo = {};
     }
@@ -469,7 +469,7 @@ void SoundAnalyzerBase::SetPeakDataFromRemote(const PeakData &peaks)
 
 void SoundAnalyzerBase::RecordBeat(uint32_t now, float confidence, float strength, float bass, float mid, float treble, float flux, bool simulated)
 {
-    std::lock_guard<std::mutex> lock(_beatInfoMutex);
+    std::lock_guard guard(_beatInfoMutex);
     const float intervalMs = (_lastBeatDetectedMs == 0) ? _previousBeatIntervalMs : static_cast<float>(now - _lastBeatDetectedMs);
 
     _lastBeatDetectedMs = now;
@@ -496,7 +496,7 @@ void SoundAnalyzerBase::RecordBeat(uint32_t now, float confidence, float strengt
 
 void SoundAnalyzerBase::RecordNearBeat(uint32_t now, float score, float strength, float bass, float mid, float treble, float flux)
 {
-    std::lock_guard<std::mutex> lock(_beatInfoMutex);
+    std::lock_guard guard(_beatInfoMutex);
     _lastNearBeatInfo.sequence++;
     _lastNearBeatInfo.timestampMs = now;
     _lastNearBeatInfo.intervalMs = 0.0f;

--- a/src/systemcontainer.cpp
+++ b/src/systemcontainer.cpp
@@ -304,7 +304,11 @@ int SystemContainer::GetConfiguredAudioInputPin() const
 
 bool SystemContainer::ApplyRuntimeConfiguration(String* errorMessage)
 {
-    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+    // Runtime topology changes retarget both the graphics objects and the
+    // WiFi frame buffers. Lock all three domains together so the render task
+    // cannot draw while the socket task is filling buffers sized for the old
+    // topology.
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex, g_buffer_mutex);
 
     auto& config = GetDeviceConfig();
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -38,6 +38,7 @@
 #include <FS.h>
 #include <algorithm>
 #include <cstdlib>
+#include <mutex>
 #include <limits>
 #include <utility>
 
@@ -593,26 +594,37 @@ void CWebServer::GetEffectListText(AsyncWebServerRequest * pRequest)
     auto response = new AsyncJsonResponse();
     auto& j = response->getRoot();
     auto& effectManager = g_ptrSystem->GetEffectManager();
+    bool overflow = false;
 
-    j["currentEffect"]         = effectManager.GetCurrentEffectIndex();
-    j["millisecondsRemaining"] = effectManager.GetTimeRemainingForCurrentEffect();
-    j["eternalInterval"]       = effectManager.IsIntervalEternal();
-    j["effectInterval"]        = effectManager.GetInterval();
-
-    for (const auto& effect : effectManager.EffectsList())
     {
-        auto effectDoc = CreateJsonDocument();
+        std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
 
-        effectDoc["name"]    = effect->FriendlyName();
-        effectDoc["enabled"] = effect->IsEnabled();
-        effectDoc["core"]    = effect->IsCoreEffect();
+        j["currentEffect"]         = effectManager.GetCurrentEffectIndex();
+        j["millisecondsRemaining"] = effectManager.GetTimeRemainingForCurrentEffect();
+        j["eternalInterval"]       = effectManager.IsIntervalEternal();
+        j["effectInterval"]        = effectManager.GetInterval();
 
-        if (!j["Effects"].add(effectDoc))
+        for (const auto& effect : effectManager.EffectsList())
         {
-            debugV("JSON response buffer overflow!");
-            SendBufferOverflowResponse(pRequest);
-            return;
+            auto effectDoc = CreateJsonDocument();
+
+            effectDoc["name"]    = effect->FriendlyName();
+            effectDoc["enabled"] = effect->IsEnabled();
+            effectDoc["core"]    = effect->IsCoreEffect();
+
+            if (!j["Effects"].add(effectDoc))
+            {
+                debugV("JSON response buffer overflow!");
+                overflow = true;
+                break;
+            }
         }
+    }
+
+    if (overflow)
+    {
+        SendBufferOverflowResponse(pRequest);
+        return;
     }
 
     AddCORSHeaderAndSendResponse(pRequest, response);
@@ -757,7 +769,7 @@ void CWebServer::DeleteEffect(AsyncWebServerRequest * pRequest)
         return;
     }
 
-    if (index < g_ptrSystem->GetEffectManager().EffectCount() && g_ptrSystem->GetEffectManager().EffectsList()[index]->IsCoreEffect())
+    if (g_ptrSystem->GetEffectManager().IsCoreEffect(index))
     {
         AddCORSHeaderAndSendBadRequest(pRequest, "Can't delete core effect");
         return;
@@ -1425,17 +1437,21 @@ void CWebServer::SetUnifiedSettings(AsyncWebServerRequest * pRequest, JsonVarian
 
 bool CWebServer::CheckAndGetSettingsEffect(AsyncWebServerRequest * pRequest, std::shared_ptr<LEDStripEffect> & effect, bool post)
 {
-    const auto& effectsList = g_ptrSystem->GetEffectManager().EffectsList();
     auto effectIndex = GetEffectIndexFromParam(pRequest, post);
 
-    if (effectIndex < 0 || effectIndex >= effectsList.size())
+    if (effectIndex < 0)
     {
         AddCORSHeaderAndSendOKResponse(pRequest);
 
         return false;
     }
 
-    effect = effectsList[effectIndex];
+    effect = g_ptrSystem->GetEffectManager().EffectAt(effectIndex);
+    if (!effect)
+    {
+        AddCORSHeaderAndSendOKResponse(pRequest);
+        return false;
+    }
 
     return true;
 }
@@ -1447,7 +1463,11 @@ void CWebServer::GetEffectSettingSpecs(AsyncWebServerRequest * pRequest)
     if (!CheckAndGetSettingsEffect(pRequest, effect))
         return;
 
-    auto settingSpecs = effect->GetSettingSpecs();
+    std::vector<std::reference_wrapper<SettingSpec>> settingSpecs;
+    {
+        std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+        settingSpecs = effect->GetSettingSpecs();
+    }
 
     SendSettingSpecsResponse(pRequest, settingSpecs);
 }
@@ -1457,7 +1477,13 @@ void CWebServer::SendEffectSettingsResponse(AsyncWebServerRequest * pRequest, st
     auto response = std::make_unique<AsyncJsonResponse>();
     auto jsonObject = response->getRoot().to<JsonObject>();
 
-    if (effect->SerializeSettingsToJSON(jsonObject))
+    bool serialized = false;
+    {
+        std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+        serialized = effect->SerializeSettingsToJSON(jsonObject);
+    }
+
+    if (serialized)
     {
         AddCORSHeaderAndSendResponse(pRequest, response.release());
         return;
@@ -1483,6 +1509,10 @@ bool CWebServer::ApplyEffectSettings(AsyncWebServerRequest * pRequest, std::shar
 {
     bool settingChanged = false;
 
+    // Effect settings are live data consumed by Draw(). Apply and enumerate
+    // them under the render/effect locks so web requests cannot mutate an
+    // effect while the render task is drawing it.
+    std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
     for (auto& settingSpecWrapper : effect->GetSettingSpecs())
     {
         const auto& spec = settingSpecWrapper.get();

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -623,6 +623,7 @@ void CWebServer::GetEffectListText(AsyncWebServerRequest * pRequest)
 
     if (overflow)
     {
+        delete response;
         SendBufferOverflowResponse(pRequest);
         return;
     }

--- a/src/ws281xoutputmanager.cpp
+++ b/src/ws281xoutputmanager.cpp
@@ -482,7 +482,7 @@ void WS281xOutputManager::Reset()
 {
     // Reset can race with the draw loop during live reconfiguration or teardown,
     // so it shares the same transport mutex as Show()/ApplyConfig().
-    std::lock_guard<std::mutex> guard(WS281xGFX::TransportMutex());
+    std::lock_guard guard(WS281xGFX::TransportMutex());
 
     for (size_t i = 0; i < _channels.size(); ++i)
         ReleaseChannel(i);
@@ -572,7 +572,7 @@ bool WS281xOutputManager::ApplyConfig(const DeviceConfig& config, const std::vec
 {
     // ApplyConfig and Show share the transport mutex so GPIO/channel changes are
     // atomic with respect to the render thread's transmit path.
-    std::lock_guard<std::mutex> guard(WS281xGFX::TransportMutex());
+    std::lock_guard guard(WS281xGFX::TransportMutex());
 
     if (config.GetOutputDriver() != DeviceConfig::OutputDriver::WS281x)
     {
@@ -622,7 +622,7 @@ void WS281xOutputManager::Show(const std::vector<std::shared_ptr<GFXBase>>& devi
     // The same mutex used by ApplyConfig() keeps live transport mutations from
     // colliding with the draw loop while it is filling buffers or transmitting.
 
-    std::lock_guard<std::mutex> guard(WS281xGFX::TransportMutex());
+    std::lock_guard guard(WS281xGFX::TransportMutex());
 
     if (_activeChannelCount == 0 || _activeLEDCount == 0)
         return;
@@ -641,7 +641,7 @@ void WS281xOutputManager::Show(const std::vector<std::shared_ptr<GFXBase>>& devi
 
         const auto& device = devices[channelIndex];
         auto* output = state.outputBytes.get();
-        
+
         // Delegate to the chip-specific format. Passes the optional whites
         // plane (nullptr for plain WS2812 builds; populated by setPixelCCT /
         // setPixelWhite calls on SK6812+ builds). cctKelvin, ambient white,
@@ -658,14 +658,14 @@ void WS281xOutputManager::Show(const std::vector<std::shared_ptr<GFXBase>>& devi
         #ifndef NIGHTDRIVER_DEFAULT_AMBIENT_WW
             #define NIGHTDRIVER_DEFAULT_AMBIENT_WW 0
         #endif
-        
+
         // SK6812_WHITE_EXTRACT_RATIO: 0..255, fraction of shared-portion
         // white pulled into the dedicated W LED
-        
+
         #ifndef SK6812_WHITE_EXTRACT_RATIO
             #define SK6812_WHITE_EXTRACT_RATIO 128
         #endif
-        
+
         constexpr uint16_t kDefaultCctKelvin   = NIGHTDRIVER_DEFAULT_CCT_KELVIN;
         constexpr uint8_t  kDefaultAmbientCw   = NIGHTDRIVER_DEFAULT_AMBIENT_CW;
         constexpr uint8_t  kDefaultAmbientWw   = NIGHTDRIVER_DEFAULT_AMBIENT_WW;


### PR DESCRIPTION
Fixed the LED circular buffer full/empty ambiguity by tracking queued depth explicitly.
Fixed WiFi frame timing by correcting TimeTillDue() to return future time remaining.
Prevented malformed pixel packets from reserving or poisoning buffer slots.
Added shared wire-payload validation for LED count, payload length, and overflow checks.
Added checked packet-size arithmetic in the socket server before reads/decompression.
Protected cross-task buffer status, peek, draw-delay, and runtime reconfiguration reads with g_buffer_mutex.
Fixed HUB75 and generic matrix X-scroll routines to avoid overlapping memcpy and row-edge out-of-bounds reads.
Made effect-list access return safe snapshots instead of live vector references.
Made current-effect name access return a stable copied String.
Serialized effect-list mutation, settings changes, and listener dispatch against rendering.
Protected frame/effect listener registration and dispatch with a listener mutex.
Split task lifecycle locking into a lifecycle mutex plus short task-handle mutex to avoid Start/Stop/WakeTask races without holding a recursive lock.
Tightened web/debug/screen callers to use the safer effect and buffer APIs.

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).