### PR TITLE
Bugfixes - PSRAM and JSON

### DIFF
--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -285,8 +285,6 @@ class PatternWeather : public EffectWithId<PatternWeather>
      * Tommorow's expected high and low temperatures,
      * and an icon for tomorrow's weather forcast
      *
-     * @param highTemp address to store the high temperature
-     * @param lowTemp address to store the low temperature
      * @return bool - true if valid weather data retrieved
      */
     bool getTomorrowTemps()

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -42,6 +42,7 @@
 #include <chrono>
 #include <HTTPClient.h>
 #include <map>
+#include <mutex>
 #include <string.h>
 #include <thread>
 #include <UrlEncode.h>
@@ -150,6 +151,7 @@ class PatternWeather : public EffectWithId<PatternWeather>
     bool   dataReady          = false;
     size_t readerIndex        = SIZE_MAX;
     system_clock::time_point latestUpdate = system_clock::from_time_t(0);
+    mutable std::mutex weatherDataMutex;
 
     /**
      * @brief Should this effect show its title.
@@ -230,12 +232,15 @@ class PatternWeather : public EffectWithId<PatternWeather>
         HTTPClient http;
         String url;
 
-        if (!HasLocationChanged())
-            return false;
-
-        const String& configLocation = g_ptrSystem->GetDeviceConfig().GetLocation();
-        const String& configCountryCode = g_ptrSystem->GetDeviceConfig().GetCountryCode();
+        const String configLocation = g_ptrSystem->GetDeviceConfig().GetLocation();
+        const String configCountryCode = g_ptrSystem->GetDeviceConfig().GetCountryCode();
         const bool configLocationIsZip = g_ptrSystem->GetDeviceConfig().IsLocationZip();
+
+        {
+            std::lock_guard guard(weatherDataMutex);
+            if (configLocation == strLocation && configCountryCode == strCountryCode)
+                return false;
+        }
 
         if (configLocationIsZip)
             url = "http://api.openweathermap.org/geo/1.0/zip"
@@ -258,13 +263,18 @@ class PatternWeather : public EffectWithId<PatternWeather>
         deserializeJson(doc, http.getString());
         JsonObject coordinates = configLocationIsZip ? doc.as<JsonObject>() : doc[0].as<JsonObject>();
 
-        strLatitude = coordinates["lat"].as<String>();
-        strLongitude = coordinates["lon"].as<String>();
+        String newLatitude = coordinates["lat"].as<String>();
+        String newLongitude = coordinates["lon"].as<String>();
 
         http.end();
 
-        strLocation = configLocation;
-        strCountryCode = configCountryCode;
+        {
+            std::lock_guard guard(weatherDataMutex);
+            strLatitude = newLatitude;
+            strLongitude = newLongitude;
+            strLocation = configLocation;
+            strCountryCode = configCountryCode;
+        }
 
         return true;
     }
@@ -279,11 +289,20 @@ class PatternWeather : public EffectWithId<PatternWeather>
      * @param lowTemp address to store the low temperature
      * @return bool - true if valid weather data retrieved
      */
-    bool getTomorrowTemps(float& highTemp, float& lowTemp)
+    bool getTomorrowTemps()
     {
         HTTPClient http;
+        String latitude;
+        String longitude;
+
+        {
+            std::lock_guard guard(weatherDataMutex);
+            latitude = strLatitude;
+            longitude = strLongitude;
+        }
+
         String url = "http://api.openweathermap.org/data/2.5/forecast"
-            "?lat=" + strLatitude + "&lon=" + strLongitude + "&cnt=16&appid=" + urlEncode(g_ptrSystem->GetDeviceConfig().GetOpenWeatherAPIKey());
+            "?lat=" + latitude + "&lon=" + longitude + "&cnt=16&appid=" + urlEncode(g_ptrSystem->GetDeviceConfig().GetOpenWeatherAPIKey());
         http.begin(url);
         int httpResponseCode = http.GET();
 
@@ -305,7 +324,7 @@ class PatternWeather : public EffectWithId<PatternWeather>
             float dailyMaximum = 0.0;
             int slot = 0;
 
-            iconTomorrow = "";
+            String newIconTomorrow = "";
 
             // Look for the temperature data for tomorrow
             for (size_t i = 0; i < list.size(); ++i)
@@ -335,14 +354,21 @@ class PatternWeather : public EffectWithId<PatternWeather>
 
                     // Use the noon slot for the icon
                     if (slot == 4)
-                        iconTomorrow = entry["weather"][0]["icon"].as<String>();
+                        newIconTomorrow = entry["weather"][0]["icon"].as<String>();
                 }
             }
 
-            highTemp        = KelvinToLocal(dailyMaximum);
-            lowTemp         = KelvinToLocal(dailyMinimum);
+            float newHighTomorrow = KelvinToLocal(dailyMaximum);
+            float newLoTomorrow = KelvinToLocal(dailyMinimum);
 
-            debugI("Got tomorrow's temps: Lo %d, Hi %d, Icon %s", (int)lowTemp, (int)highTemp, iconTomorrow.c_str());
+            {
+                std::lock_guard guard(weatherDataMutex);
+                highTomorrow = newHighTomorrow;
+                loTomorrow = newLoTomorrow;
+                iconTomorrow = newIconTomorrow;
+            }
+
+            debugI("Got tomorrow's temps: Lo %d, Hi %d, Icon %s", (int)newLoTomorrow, (int)newHighTomorrow, newIconTomorrow.c_str());
 
             http.end();
             return true;
@@ -366,31 +392,50 @@ class PatternWeather : public EffectWithId<PatternWeather>
     bool getWeatherData()
     {
         HTTPClient http;
+        String latitude;
+        String longitude;
+
+        {
+            std::lock_guard guard(weatherDataMutex);
+            latitude = strLatitude;
+            longitude = strLongitude;
+        }
 
         String url = "http://api.openweathermap.org/data/2.5/weather"
-            "?lat=" + strLatitude + "&lon=" + strLongitude + "&appid=" + urlEncode(g_ptrSystem->GetDeviceConfig().GetOpenWeatherAPIKey());
+            "?lat=" + latitude + "&lon=" + longitude + "&appid=" + urlEncode(g_ptrSystem->GetDeviceConfig().GetOpenWeatherAPIKey());
         http.begin(url);
         int httpResponseCode = http.GET();
         if (httpResponseCode > 0)
         {
-            iconToday = "";
             auto jsonDoc = CreateJsonDocument();
             deserializeJson(jsonDoc, http.getString());
 
             // Once we have a non-zero temp we can start displaying things
-            if (0 < jsonDoc["main"]["temp"])
-                dataReady = true;
+            bool newDataReady = 0 < jsonDoc["main"]["temp"];
 
-            temperature = KelvinToLocal(jsonDoc["main"]["temp"]);
-            highToday   = KelvinToLocal(jsonDoc["main"]["temp_max"]);
-            loToday     = KelvinToLocal(jsonDoc["main"]["temp_min"]);
+            float newTemperature = KelvinToLocal(jsonDoc["main"]["temp"]);
+            float newHighToday = KelvinToLocal(jsonDoc["main"]["temp_max"]);
+            float newLoToday = KelvinToLocal(jsonDoc["main"]["temp_min"]);
 
-            iconToday = jsonDoc["weather"][0]["icon"].as<String>();
-            debugI("Got today's temps: Now %d Lo %d, Hi %d, Icon %s", (int)temperature, (int)loToday, (int)highToday, iconToday.c_str());
+            String newIconToday = jsonDoc["weather"][0]["icon"].as<String>();
+            String newLocationName;
 
             const char * pszName = jsonDoc["name"];
             if (pszName)
-                strLocationName = pszName;
+                newLocationName = pszName;
+
+            {
+                std::lock_guard guard(weatherDataMutex);
+                dataReady = newDataReady;
+                temperature = newTemperature;
+                highToday = newHighToday;
+                loToday = newLoToday;
+                iconToday = newIconToday;
+                if (!newLocationName.isEmpty())
+                    strLocationName = newLocationName;
+            }
+
+            debugI("Got today's temps: Now %d Lo %d, Hi %d, Icon %s", (int)newTemperature, (int)newLoToday, (int)newHighToday, newIconToday.c_str());
 
             http.end();
             return true;
@@ -422,7 +467,7 @@ class PatternWeather : public EffectWithId<PatternWeather>
             updateCoordinates();
 
             if (getWeatherData())
-                getTomorrowTemps(highTomorrow, loTomorrow);
+                getTomorrowTemps();
         }
     }
 
@@ -434,10 +479,11 @@ class PatternWeather : public EffectWithId<PatternWeather>
      */
     bool HasLocationChanged()
     {
-        bool locationChanged = g_ptrSystem->GetDeviceConfig().GetLocation() != strLocation;
-        bool countryChanged = g_ptrSystem->GetDeviceConfig().GetCountryCode() != strCountryCode;
+        const String configLocation = g_ptrSystem->GetDeviceConfig().GetLocation();
+        const String configCountryCode = g_ptrSystem->GetDeviceConfig().GetCountryCode();
 
-        return locationChanged || countryChanged;
+        std::lock_guard guard(weatherDataMutex);
+        return configLocation != strLocation || configCountryCode != strCountryCode;
     }
 
 public:
@@ -512,21 +558,46 @@ public:
             g_ptrSystem->GetNetworkReader().FlagReader(readerIndex);
         }
 
+        String displayLocationName;
+        String displayLocation;
+        String displayIconToday;
+        String displayIconTomorrow;
+        float displayTemperature;
+        float displayHighToday;
+        float displayLoToday;
+        float displayHighTomorrow;
+        float displayLoTomorrow;
+        bool displayDataReady;
+
+        {
+            std::lock_guard guard(weatherDataMutex);
+            displayLocationName = strLocationName;
+            displayLocation = strLocation;
+            displayIconToday = iconToday;
+            displayIconTomorrow = iconTomorrow;
+            displayTemperature = temperature;
+            displayHighToday = highToday;
+            displayLoToday = loToday;
+            displayHighTomorrow = highTomorrow;
+            displayLoTomorrow = loTomorrow;
+            displayDataReady = dataReady;
+        }
+
         // Draw the graphics
-        auto iconEntry = weatherIcons.find(iconToday);
+        auto iconEntry = weatherIcons.find(displayIconToday);
         if (iconEntry != weatherIcons.end())
         {
             auto icon = iconEntry->second;
             if (JDR_OK != TJpgDec.drawJpg(0, 10, icon.contents, icon.length))        // Draw the image
-                debugW("Could not display icon %s", iconToday.c_str());
+                debugW("Could not display icon %s", displayIconToday.c_str());
         }
 
-        iconEntry = weatherIcons.find(iconTomorrow);
+        iconEntry = weatherIcons.find(displayIconTomorrow);
         if (iconEntry != weatherIcons.end())
         {
             auto icon = iconEntry->second;
             if (JDR_OK != TJpgDec.drawJpg(xHalf+1, 10, icon.contents, icon.length))        // Draw the image
-                debugW("Could not display icon %s", iconTomorrow.c_str());
+                debugW("Could not display icon %s", displayIconTomorrow.c_str());
         }
 
         // Print the town/city name
@@ -534,18 +605,18 @@ public:
         int y = fontHeight + 1;
         g().setCursor(x, y);
         g().setTextColor(WHITE16);
-        String showLocation = strLocation;
+        String showLocation = displayLocation;
         showLocation.toUpperCase();
         if (g_ptrSystem->GetDeviceConfig().GetOpenWeatherAPIKey().isEmpty())
             g().print("No API Key");
         else
-            g().print((strLocationName.isEmpty() ? showLocation : strLocationName).substring(0, (MATRIX_WIDTH - 2 * fontWidth)/fontWidth));
+            g().print((displayLocationName.isEmpty() ? showLocation : displayLocationName).substring(0, (MATRIX_WIDTH - 2 * fontWidth)/fontWidth));
 
         // Display the temperature, right-justified
 
-        if (dataReady)
+        if (displayDataReady)
         {
-            String strTemp((int)temperature);
+            String strTemp((int)displayTemperature);
             x = MATRIX_WIDTH - fontWidth * strTemp.length();
             g().setCursor(x, y);
             g().setTextColor(g().to16bit(CRGB(192,192,192)));
@@ -576,11 +647,11 @@ public:
 
         // Draw the temperature in lighter white
 
-        if (dataReady)
+        if (displayDataReady)
         {
             g().setTextColor(g().to16bit(CRGB(192,192,192)));
-            String strHi((int) highToday);
-            String strLo((int) loToday);
+            String strHi((int) displayHighToday);
+            String strLo((int) displayLoToday);
 
             // Draw today's HI and LO temperatures
 
@@ -595,8 +666,8 @@ public:
 
             // Draw tomorrow's HI and LO temperatures
 
-            strHi = String((int)highTomorrow);
-            strLo = String((int)loTomorrow);
+            strHi = String((int)displayHighTomorrow);
+            strLo = String((int)displayLoTomorrow);
             x = MATRIX_WIDTH - fontWidth * strHi.length();
             y = MATRIX_HEIGHT - fontHeight;
             g().setCursor(x,y);

--- a/include/hub75gfx.h
+++ b/include/hub75gfx.h
@@ -134,6 +134,7 @@ public:
 
     static void StartMatrix();
     static CRGB *GetMatrixBackBuffer();
+    static bool WaitForMatrixSwap(uint32_t timeoutMs = 100);
     static void MatrixSwapBuffers(bool bSwapBackground);
 };
 #endif

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -663,8 +663,16 @@ void WriteCurrentEffectIndexFile()
     std::lock_guard renderPause(g_render_mutex);
 
     #if USE_HUB75
-        HUB75GFX::WaitForMatrixSwap();
-    #endif
+    // Capture the current effect index without holding g_render_mutex to avoid nested lock order issues
+    size_t currentIndex = g_ptrSystem->GetEffectManager().GetCurrentEffectIndex();
+
+    {
+        std::lock_guard renderPause(g_render_mutex);
+
+        #if USE_HUB75
+            HUB75GFX::WaitForMatrixSwap();
+        #endif
+    }
 
     SPIFFS.remove(CURRENT_EFFECT_CONFIG_FILE);
 
@@ -676,7 +684,7 @@ void WriteCurrentEffectIndexFile()
         return;
     }
 
-    auto bytesWritten = file.print(g_ptrSystem->GetEffectManager().GetCurrentEffectIndex());
+    auto bytesWritten = file.print(currentIndex);
 
     file.flush();
     file.close();

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -651,11 +651,21 @@ void RemoveEffectManagerConfig()
 {
     RemoveJSONFile(EFFECTS_CONFIG_FILE);
     // We take the liberty of also removing the file with the current effect config index
+    std::lock_guard renderPause(g_render_mutex);
+    #if USE_HUB75
+        HUB75GFX::WaitForMatrixSwap();
+    #endif
     SPIFFS.remove(CURRENT_EFFECT_CONFIG_FILE);
 }
 
 void WriteCurrentEffectIndexFile()
 {
+    std::lock_guard renderPause(g_render_mutex);
+
+    #if USE_HUB75
+        HUB75GFX::WaitForMatrixSwap();
+    #endif
+
     SPIFFS.remove(CURRENT_EFFECT_CONFIG_FILE);
 
     File file = SPIFFS.open(CURRENT_EFFECT_CONFIG_FILE, FILE_WRITE);
@@ -667,10 +677,11 @@ void WriteCurrentEffectIndexFile()
     }
 
     auto bytesWritten = file.print(g_ptrSystem->GetEffectManager().GetCurrentEffectIndex());
-    debugI("Number of bytes written to file %s: %zu", CURRENT_EFFECT_CONFIG_FILE, (size_t)bytesWritten);
 
     file.flush();
     file.close();
+
+    debugI("Number of bytes written to file %s: %zu", CURRENT_EFFECT_CONFIG_FILE, (size_t)bytesWritten);
 
     if (bytesWritten == 0)
     {

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -660,19 +660,14 @@ void RemoveEffectManagerConfig()
 
 void WriteCurrentEffectIndexFile()
 {
+    // Capture the current effect index without holding g_render_mutex to avoid nested lock order issues.
+    size_t currentIndex = g_ptrSystem->GetEffectManager().GetCurrentEffectIndex();
+
     std::lock_guard renderPause(g_render_mutex);
 
     #if USE_HUB75
-    // Capture the current effect index without holding g_render_mutex to avoid nested lock order issues
-    size_t currentIndex = g_ptrSystem->GetEffectManager().GetCurrentEffectIndex();
-
-    {
-        std::lock_guard renderPause(g_render_mutex);
-
-        #if USE_HUB75
-            HUB75GFX::WaitForMatrixSwap();
-        #endif
-    }
+        HUB75GFX::WaitForMatrixSwap();
+    #endif
 
     SPIFFS.remove(CURRENT_EFFECT_CONFIG_FILE);
 

--- a/src/gfxbase.cpp
+++ b/src/gfxbase.cpp
@@ -36,6 +36,7 @@
 #include <cmath>
 #include <gfxfont.h>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <unordered_map>
 
@@ -43,6 +44,12 @@
 #include "effects/matrix/Boid.h"
 #include "gfxbase.h"
 #include "systemcontainer.h"
+
+namespace
+{
+    DRAM_ATTR allocated_unique_ptr<GFXBase::PolarMapArray> g_polarMap;
+    DRAM_ATTR std::mutex g_polarMapMutex;
+}
 
 // 32 Entries in the 5-bit gamma table
 const uint8_t GFXBase::gamma5[32] =
@@ -1567,49 +1574,42 @@ uint16_t XY(uint16_t x, uint16_t y)
 
 const GFXBase::PolarMapArray& GFXBase::getPolarMap()
 {
-    static allocated_unique_ptr<PolarMapArray> rMap_ptr;
-    static std::mutex rMap_mutex;
-
-    // Double-checked locking for thread-safe, on-demand initialization
-    if (!rMap_ptr)
+    std::lock_guard guard(g_polarMapMutex);
+    if (!g_polarMap)
     {
-        std::lock_guard guard(rMap_mutex);
-        if (!rMap_ptr)
+        // Allocate from PSRAM using the project's helper.
+        g_polarMap = make_unique_psram<PolarMapArray>();
+
+        auto& rMap = *g_polarMap;
+        const uint16_t C_X = kMatrixWidth / 2;
+        const uint16_t C_Y = kMatrixHeight / 2;
+        const float mapp = 255.0f / kMatrixWidth;
+
+        for (int16_t x = -C_X; x < C_X + (kMatrixWidth % 2); x++)
         {
-            // Allocate from PSRAM using the project's helper
-            rMap_ptr = make_unique_psram<PolarMapArray>();
-
-            auto& rMap = *rMap_ptr;
-            const uint16_t C_X = kMatrixWidth / 2;
-            const uint16_t C_Y = kMatrixHeight / 2;
-            const float mapp = 255.0f / kMatrixWidth;
-
-            for (int16_t x = -C_X; x < C_X + (kMatrixWidth % 2); x++)
+            for (int16_t y = -C_Y; y < C_Y + (kMatrixHeight% 2); y++)
             {
-                for (int16_t y = -C_Y; y < C_Y + (kMatrixHeight% 2); y++)
-                {
-                    float angle_rad = atan2f(static_cast<float>(y), static_cast<float>(x));
-                    float radius_float = hypotf(static_cast<float>(x), static_cast<float>(y));
+                float angle_rad = atan2f(static_cast<float>(y), static_cast<float>(x));
+                float radius_float = hypotf(static_cast<float>(x), static_cast<float>(y));
 
-                    rMap[x + C_X][y + C_Y].angle = 128.0f * (angle_rad / (float)M_PI);
-                    rMap[x + C_X][y + C_Y].scaled_radius = radius_float * mapp;
-                    rMap[x + C_X][y + C_Y].unscaled_radius = radius_float;
-                }
+                rMap[x + C_X][y + C_Y].angle = 128.0f * (angle_rad / (float)M_PI);
+                rMap[x + C_X][y + C_Y].scaled_radius = radius_float * mapp;
+                rMap[x + C_X][y + C_Y].unscaled_radius = radius_float;
             }
-
-            // A note on the radius calculations:
-            //
-            // `unscaled_radius` is the true geometric distance from the center of the
-            // matrix to the pixel. This is useful for effects that need the real
-            // physical distance.
-            //
-            // `scaled_radius` maps the geometric radius to a range that is more
-            // suitable for use with 8-bit FastLED functions (like inoise8).
-            // The scaling is normalized by the matrix width, which is a common
-            // technique to make radial effects work consistently across different
-            // matrix sizes.
         }
+
+        // A note on the radius calculations:
+        //
+        // `unscaled_radius` is the true geometric distance from the center of the
+        // matrix to the pixel. This is useful for effects that need the real
+        // physical distance.
+        //
+        // `scaled_radius` maps the geometric radius to a range that is more
+        // suitable for use with 8-bit FastLED functions (like inoise8).
+        // The scaling is normalized by the matrix width, which is a common
+        // technique to make radial effects work consistently across different
+        // matrix sizes.
     }
 
-    return *rMap_ptr;
+    return *g_polarMap;
 }

--- a/src/hub75gfx.cpp
+++ b/src/hub75gfx.cpp
@@ -48,6 +48,28 @@ SMLayerBackground<HUB75GFX::SM_RGB, HUB75GFX::kBackgroundLayerOptions> HUB75GFX:
 SMLayerBackground<HUB75GFX::SM_RGB, HUB75GFX::kBackgroundLayerOptions> HUB75GFX::titleLayer(kMatrixWidth, kMatrixHeight);
 SmartMatrixHub75Calc<COLOR_DEPTH, HUB75GFX::kMatrixWidth, HUB75GFX::kMatrixHeight, HUB75GFX::kPanelType, HUB75GFX::kMatrixOptions> HUB75GFX::matrix;
 
+namespace
+{
+    template <typename Layer>
+    bool WaitForLayerSwap(Layer& layer, const char* layerName, uint32_t timeoutMs)
+    {
+        const uint32_t startMs = millis();
+
+        while (layer.isSwapPending())
+        {
+            if (millis() - startMs >= timeoutMs)
+            {
+                debugW("Timed out waiting for SmartMatrix %s layer swap", layerName);
+                return false;
+            }
+
+            delay(1);
+        }
+
+        return true;
+    }
+}
+
 HUB75GFX::HUB75GFX(size_t w, size_t h) : GFXBase(w, h)
 {
 }
@@ -311,7 +333,8 @@ void HUB75GFX::PrepareFrame()
             // We enable the chromakey overlay just for the strip of screen where it appears.  This support is only
             // present in the private fork of SmartMatrix that is linked to the mesmerizer project.
 
-            titleLayer.swapBuffers(false);
+            if (WaitForLayerSwap(titleLayer, "title", 100))
+                titleLayer.swapBuffers(false);
             titleLayer.enableChromaKey(true, y, y + kCharHeight);
             titleLayer.setBrightness(brite); // 255 would obscure it entirely
         }
@@ -396,7 +419,18 @@ void HUB75GFX::MatrixSwapBuffers(bool bSwapBackground)
     matrix.setRefreshRate(MATRIX_REFRESH_RATE);
     matrix.setMaxCalculationCpuPercentage(95);
 
-    backgroundLayer.swapBuffers(bSwapBackground);
+    if (!WaitForMatrixSwap())
+        return;
+
+    backgroundLayer.swapBuffers(false);
+
+    if (bSwapBackground && WaitForMatrixSwap())
+        backgroundLayer.copyRefreshToDrawing();
+}
+
+bool HUB75GFX::WaitForMatrixSwap(uint32_t timeoutMs)
+{
+    return WaitForLayerSwap(backgroundLayer, "background", timeoutMs);
 }
 
 #endif

--- a/src/jsonserializer.cpp
+++ b/src/jsonserializer.cpp
@@ -29,6 +29,7 @@
 
 #include "globals.h"
 
+#include <esp_heap_caps.h>
 #include <FS.h>
 #include <functional>
 #include <memory>
@@ -37,6 +38,10 @@
 #include "jsonserializer.h"
 #include "systemcontainer.h"
 #include "taskmgr.h"
+
+#if USE_HUB75
+#include "hub75gfx.h"
+#endif
 
 #if USE_PSRAM
 
@@ -72,6 +77,41 @@
     }
 
 #endif
+
+namespace
+{
+#if USE_PSRAM
+    struct JsonInternalAllocator : ArduinoJson::Allocator
+    {
+        void* allocate(size_t size) override
+        {
+            return heap_caps_malloc(size, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+        }
+
+        void deallocate(void* pointer) override
+        {
+            heap_caps_free(pointer);
+        }
+
+        void* reallocate(void* ptr, size_t new_size) override
+        {
+            return heap_caps_realloc(ptr, new_size, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+        }
+    };
+
+    JsonDocument CreateInternalJsonDocument()
+    {
+        static auto jsonInternalAllocator = JsonInternalAllocator();
+
+        return JsonDocument(&jsonInternalAllocator);
+    }
+#else
+    JsonDocument CreateInternalJsonDocument()
+    {
+        return JsonDocument();
+    }
+#endif
+}
 
 // SetIfNotOverflowed
 //
@@ -231,7 +271,7 @@ bool LoadJSONFile(const String & fileName, JsonDocument& jsonDoc)
 
 bool SaveToJSONFile(const String & fileName, IJSONSerializable& object)
 {
-    auto jsonDoc = CreateJsonDocument();
+    auto jsonDoc = CreateInternalJsonDocument();
     auto jsonObject = jsonDoc.to<JsonObject>();
 
     if (!object.SerializeToJSON(jsonObject))
@@ -239,6 +279,18 @@ bool SaveToJSONFile(const String & fileName, IJSONSerializable& object)
         debugE("Could not serialize object to JSON, skipping write to %s!", fileName.c_str());
         return false;
     }
+
+    if (jsonDoc.overflowed())
+    {
+        debugE("JSON document overflowed while preparing %s, skipping write!", fileName.c_str());
+        return false;
+    }
+
+    std::lock_guard renderPause(g_render_mutex);
+
+    #if USE_HUB75
+        HUB75GFX::WaitForMatrixSwap();
+    #endif
 
     SPIFFS.remove(fileName);
 
@@ -251,10 +303,11 @@ bool SaveToJSONFile(const String & fileName, IJSONSerializable& object)
     }
 
     size_t bytesWritten = serializeJson(jsonDoc, file);
-    debugI("Number of bytes written to JSON file %s: %zu", fileName.c_str(), (size_t)bytesWritten);
 
     file.flush();
     file.close();
+
+    debugI("Number of bytes written to JSON file %s: %zu", fileName.c_str(), (size_t)bytesWritten);
 
     if (bytesWritten == 0)
     {
@@ -268,6 +321,10 @@ bool SaveToJSONFile(const String & fileName, IJSONSerializable& object)
 
 bool RemoveJSONFile(const String & fileName)
 {
+    std::lock_guard renderPause(g_render_mutex);
+    #if USE_HUB75
+        HUB75GFX::WaitForMatrixSwap();
+    #endif
     return SPIFFS.remove(fileName);
 }
 
@@ -277,7 +334,7 @@ size_t JSONWriter::RegisterWriter(const std::function<void()>& writer)
 
     // Add the writer with its flag unset
     std::lock_guard guard(writersMutex);
-    writers.push_back(std::make_shared<WriterEntry>(writer));
+    writers.push_back(make_shared_internal<WriterEntry>(writer));
     return writers.size() - 1;
 }
 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -496,7 +496,7 @@ namespace nd_network
 
     size_t NetworkReader::RegisterReader(const std::function<void()> &reader, unsigned long interval, bool flag)
     {
-        auto entry = std::make_shared<ReaderEntry>(reader, interval);
+        auto entry = make_shared_internal<ReaderEntry>(reader, interval);
         readers.push_back(entry);
         if (interval) entry->lastReadMs.store(millis());
         if (flag) FlagReader(readers.size() - 1);

--- a/src/remotecontrol.cpp
+++ b/src/remotecontrol.cpp
@@ -531,9 +531,21 @@ public:
         config.rx_config.idle_threshold      = 20000; // 20ms idle = end of frame
 
         if (rmt_config(&config) != ESP_OK) return false;
-        if (rmt_driver_install(_channel, 1024, ESP_INTR_FLAG_IRAM) != ESP_OK) return false;
-        if (rmt_get_ringbuf_handle(_channel, &_ringbuf) != ESP_OK) return false;
-        if (rmt_rx_start(_channel, true) != ESP_OK) return false;
+
+        // The legacy RMT RX driver creates its ringbuffer with xRingbufferCreate(),
+        // which uses default malloc. With PSRAM-default routing enabled that buffer
+        // can live in external RAM, so an IRAM ISR can crash if it fires while the
+        // flash/PSRAM cache is disabled. Remote input can tolerate dropped frames
+        // during flash writes, so keep this interrupt out of the cache-disabled path.
+
+        if (rmt_driver_install(_channel, 1024, 0) != ESP_OK) 
+            return false;
+        
+        if (rmt_get_ringbuf_handle(_channel, &_ringbuf) != ESP_OK) 
+            return false;
+        
+        if (rmt_rx_start(_channel, true) != ESP_OK) 
+            return false;
 
         _begun = true;
         return true;

--- a/src/systemcontainer.cpp
+++ b/src/systemcontainer.cpp
@@ -240,21 +240,21 @@ SystemContainer::BufferManagerContainer& SystemContainer::SetupBufferManagers()
 EffectManager& SystemContainer::SetupEffectManager(const std::shared_ptr<LEDStripEffect>& effect, DeviceContainer& devices)
 {
     if (!_ptrEffectManager)
-        _ptrEffectManager = make_unique_psram<EffectManager>(effect, devices);
+        _ptrEffectManager = make_unique_internal<EffectManager>(effect, devices);
     return *_ptrEffectManager;
 }
 
 EffectManager& SystemContainer::SetupEffectManager(DeviceContainer& devices)
 {
     if (!_ptrEffectManager)
-        _ptrEffectManager = make_unique_psram<EffectManager>(devices);
+        _ptrEffectManager = make_unique_internal<EffectManager>(devices);
     return *_ptrEffectManager;
 }
 
 EffectManager& SystemContainer::SetupEffectManager(const ArduinoJson::JsonObjectConst& jsonObject, DeviceContainer& devices)
 {
     if (!_ptrEffectManager)
-        _ptrEffectManager = make_unique_psram<EffectManager>(jsonObject, devices);
+        _ptrEffectManager = make_unique_internal<EffectManager>(jsonObject, devices);
     return *_ptrEffectManager;
 }
 
@@ -263,7 +263,7 @@ TaskManager& SystemContainer::SetupTaskManager()
 {
     if (!_ptrTaskManager)
     {
-        _ptrTaskManager = make_unique_psram<TaskManager>();
+        _ptrTaskManager = make_unique_internal<TaskManager>();
         _ptrTaskManager->begin();
     }
 
@@ -285,13 +285,13 @@ void SystemContainer::SetupConfig()
     
     if (!_ptrJSONWriter)
     {
-        _ptrJSONWriter = make_unique_psram<JSONWriter>();
+        _ptrJSONWriter = make_unique_internal<JSONWriter>();
         _ptrJSONWriter->Start();
     }
 
     // Create and load device config from SPIFFS if possible
     if (!_ptrDeviceConfig)
-        _ptrDeviceConfig = make_unique_psram<DeviceConfig>();
+        _ptrDeviceConfig = make_unique_internal<DeviceConfig>();
 }
 
 int SystemContainer::GetConfiguredAudioInputPin() const
@@ -372,7 +372,7 @@ bool SystemContainer::ApplyRuntimeConfiguration(String* errorMessage)
 NetworkReader& SystemContainer::SetupNetworkReader()
 {
     if (!_ptrNetworkReader)
-        _ptrNetworkReader = make_unique_psram<NetworkReader>();
+        _ptrNetworkReader = make_unique_internal<NetworkReader>();
     return *_ptrNetworkReader;
 }
 #endif
@@ -381,7 +381,7 @@ NetworkReader& SystemContainer::SetupNetworkReader()
 CWebServer& SystemContainer::SetupWebServer()
 {
     if (!_ptrWebServer)
-        _ptrWebServer = make_unique_psram<CWebServer>();
+        _ptrWebServer = make_unique_internal<CWebServer>();
     return *_ptrWebServer;
 }
 #endif
@@ -392,7 +392,7 @@ RemoteControl& SystemContainer::SetupRemoteControl()
     if (!_ptrRemoteControl)
     {
         debugI("Remote configured: enabled=1 pin=%d", IR_REMOTE_PIN);
-        _ptrRemoteControl = make_unique_psram<RemoteControl>();
+        _ptrRemoteControl = make_unique_internal<RemoteControl>();
     }
     return *_ptrRemoteControl;
 }
@@ -402,7 +402,7 @@ RemoteControl& SystemContainer::SetupRemoteControl()
 SocketServer& SystemContainer::SetupSocketServer(NetworkPort port, int ledCount)
 {
     if (!_ptrSocketServer)
-        _ptrSocketServer = make_unique_psram<SocketServer>(port, ledCount);
+        _ptrSocketServer = make_unique_internal<SocketServer>(port, ledCount);
     else
         _ptrSocketServer->SetLEDCount(ledCount);
     return *_ptrSocketServer;
@@ -413,7 +413,7 @@ SocketServer& SystemContainer::SetupSocketServer(NetworkPort port, int ledCount)
 WS281xOutputManager& SystemContainer::SetupWS281xOutputManager()
 {
     if (!_ptrWS281xOutputManager)
-        _ptrWS281xOutputManager = make_unique_psram<WS281xOutputManager>();
+        _ptrWS281xOutputManager = make_unique_internal<WS281xOutputManager>();
     return *_ptrWS281xOutputManager;
 }
 #endif
@@ -422,7 +422,7 @@ WS281xOutputManager& SystemContainer::SetupWS281xOutputManager()
 WebSocketServer& SystemContainer::SetupWebSocketServer(CWebServer& webServer)
 {
     if (!_ptrWebSocketServer)
-        _ptrWebSocketServer = make_unique_psram<WebSocketServer>(webServer);
+        _ptrWebSocketServer = make_unique_internal<WebSocketServer>(webServer);
     return *_ptrWebSocketServer;
 }
 #endif
@@ -438,7 +438,7 @@ Screen& SystemContainer::SetupHardwareDisplay(int w, int h)
 AudioService& SystemContainer::SetupAudioService()
 {
     if (!_ptrAudioService)
-        _ptrAudioService = make_unique_psram<AudioService>();
+        _ptrAudioService = make_unique_internal<AudioService>();
     return *_ptrAudioService;
 }
 
@@ -452,7 +452,7 @@ AudioService& SystemContainer::GetAudioService() const
 AudioSerialBridge& SystemContainer::SetupAudioSerialBridge()
 {
     if (!_ptrAudioSerialBridge)
-        _ptrAudioSerialBridge = make_unique_psram<AudioSerialBridge>();
+        _ptrAudioSerialBridge = make_unique_internal<AudioSerialBridge>();
     return *_ptrAudioSerialBridge;
 }
 
@@ -467,7 +467,7 @@ AudioSerialBridge& SystemContainer::GetAudioSerialBridge() const
 DebugConsole& SystemContainer::SetupDebugConsole()
 {
     if (!_ptrDebugConsole)
-        _ptrDebugConsole = make_unique_psram<DebugConsole>();
+        _ptrDebugConsole = make_unique_internal<DebugConsole>();
     return *_ptrDebugConsole;
 }
 
@@ -482,7 +482,7 @@ DebugConsole& SystemContainer::GetDebugConsole() const
 ColorStreamerService& SystemContainer::SetupColorStreamerService()
 {
     if (!_ptrColorStreamerService)
-        _ptrColorStreamerService = make_unique_psram<ColorStreamerService>();
+        _ptrColorStreamerService = make_unique_internal<ColorStreamerService>();
     return *_ptrColorStreamerService;
 }
 
@@ -496,7 +496,7 @@ ColorStreamerService& SystemContainer::GetColorStreamerService() const
 RenderService& SystemContainer::SetupRenderService()
 {
     if (!_ptrRenderService)
-        _ptrRenderService = make_unique_psram<RenderService>();
+        _ptrRenderService = make_unique_internal<RenderService>();
     return *_ptrRenderService;
 }
 


### PR DESCRIPTION
Changed JSON persistence to use internal RAM for save-time JSON documents. The normal JSON allocator can use PSRAM, but SPIFFS writes can disable cache, so the save path now keeps its working JSON document in internal RAM. This reduces the chance of touching PSRAM during flash/cache-disabled windows.

Wrapped config file writes/removes with the render mutex and, for HUB75 builds, wait for any pending SmartMatrix buffer swap before touching SPIFFS. This covers /device.cfg, /effects.cfg, and /current.cfg. The goal is to avoid flash writes racing with the draw loop or panel refresh state.

Changed JSON/current-effect logging so “bytes written” is logged only after flush/close succeeds. Previously the log could appear before the write was fully settled, which made the crash timing look more directly tied to JSONWriter than it really was.

Added a timeout/yielding wait for SmartMatrix layer swaps. SmartMatrix’s swap path can otherwise spin while waiting for swapPending to clear, starving Idle1 and tripping the task watchdog. The wait now calls delay(1) and times out with a warning instead of hard-spinning forever.

Moved long-lived system services and JSON/network registration entries to internal allocation. These objects contain task/concurrency state and are touched across service boundaries, so they are safer in internal RAM than PSRAM under cache-disabled or ISR-adjacent conditions.

Changed the legacy ESP-IDF 4.x RMT remote driver install to stop using ESP_INTR_FLAG_IRAM. The legacy RMT RX driver creates its ringbuffer with default malloc, which can land in PSRAM after PSRAM-default routing is enabled. If that IRAM ISR fires while cache is disabled, it can crash in xRingbufferSendFromISR(). Remote input can tolerate dropped frames during flash writes, so keeping the ISR out of cache-disabled windows is the safer tradeoff.

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).