### PR TITLE
Add tags to Pages publications

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,5 +64,6 @@ jobs:
     uses: ./.github/workflows/web_installer.yml
     with:
       release-name: ${{ github.ref_name }} commit ${{ github.sha }}
+      pages-tag: staging-${{ github.ref_name }}-${{ github.sha }}
     secrets: inherit
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,4 +9,5 @@ jobs:
     uses: ./.github/workflows/web_installer.yml
     with:
       release-name: ${{ github.event.release.name }}
+      pages-tag: ${{ github.event.release.tag_name }}
     secrets: inherit

--- a/.github/workflows/web_installer.yml
+++ b/.github/workflows/web_installer.yml
@@ -7,6 +7,10 @@ on:
         description: 'Name of the Web Installer release'
         required: true
         type: string
+      pages-tag:
+        description: 'Source text used to generate the Pages branch deployment tag'
+        required: true
+        type: string
 
 jobs:
   determine-projects:
@@ -70,6 +74,8 @@ jobs:
 
   compose-and-publish-installer:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     needs: [build-project]
 
@@ -95,8 +101,22 @@ jobs:
         python tools/installer_compose.py '${{ inputs.release-name }}'
         touch WebInstaller/.nojekyll
 
+    - name: Compute Pages tag
+      id: pages_tag
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        tag_slug="$(echo "${{ inputs.pages-tag }}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//')"
+        if [ -z "${tag_slug}" ]; then
+          tag_slug="unnamed-release-${{ github.run_id }}-${{ github.run_attempt }}"
+        fi
+
+        echo "tag=pages/${tag_slug}" >> "$GITHUB_OUTPUT"
+
     - name: Push to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: pages
         folder: WebInstaller
+        tag: ${{ steps.pages_tag.outputs.tag }}


### PR DESCRIPTION
## Description

This adds tags to Pages publications (i.e. versions of the web installer published on <https://plummerssoftwarellc.github.io/NightDriverStrip/>) so they can be easily linked to the version (tag) of the GitHub release that triggered the build and publish of a particular Pages web installer. 

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).