### PR TITLE
Activeline _ Add a WiFi activity output signal option, allow for zero effects in main table

### DIFF
--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -269,6 +269,7 @@ public:
     bool IsCoreEffect(size_t index) const;
     size_t EffectCount() const;
     bool AreEffectsEnabled() const;
+    bool HasCurrentEffect() const;
     size_t GetCurrentEffectIndex() const;
     LEDStripEffect& GetCurrentEffect() const;
     String GetCurrentEffectName() const;

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -558,30 +558,25 @@ public:
             g_ptrSystem->GetNetworkReader().FlagReader(readerIndex);
         }
 
-        String displayLocationName;
-        String displayLocation;
-        String displayIconToday;
-        String displayIconTomorrow;
-        float displayTemperature;
-        float displayHighToday;
-        float displayLoToday;
-        float displayHighTomorrow;
-        float displayLoTomorrow;
-        bool displayDataReady;
+        // Hold the weather data lock for the rest of the frame. The writer
+        // (network reader task) only takes this lock for the few microseconds
+        // it takes to assign these fields after the HTTP fetch completes, so
+        // blocking here is effectively never observable and never approaches
+        // anything the WDT would care about. We do NOT take any other lock
+        // (render / effect manager) while holding this one, which keeps the
+        // ordering one-way and inversion-proof.
+        std::lock_guard guard(weatherDataMutex);
 
-        {
-            std::lock_guard guard(weatherDataMutex);
-            displayLocationName = strLocationName;
-            displayLocation = strLocation;
-            displayIconToday = iconToday;
-            displayIconTomorrow = iconTomorrow;
-            displayTemperature = temperature;
-            displayHighToday = highToday;
-            displayLoToday = loToday;
-            displayHighTomorrow = highTomorrow;
-            displayLoTomorrow = loTomorrow;
-            displayDataReady = dataReady;
-        }
+        const String& displayLocationName = strLocationName;
+        const String& displayLocation     = strLocation;
+        const String& displayIconToday    = iconToday;
+        const String& displayIconTomorrow = iconTomorrow;
+        const float   displayTemperature  = temperature;
+        const float   displayHighToday    = highToday;
+        const float   displayLoToday      = loToday;
+        const float   displayHighTomorrow = highTomorrow;
+        const float   displayLoTomorrow   = loTomorrow;
+        const bool    displayDataReady    = dataReady;
 
         // Draw the graphics
         auto iconEntry = weatherIcons.find(displayIconToday);

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -556,30 +556,25 @@ public:
             g_ptrSystem->GetNetworkReader().FlagReader(readerIndex);
         }
 
-        String displayLocationName;
-        String displayLocation;
-        String displayIconToday;
-        String displayIconTomorrow;
-        float displayTemperature;
-        float displayHighToday;
-        float displayLoToday;
-        float displayHighTomorrow;
-        float displayLoTomorrow;
-        bool displayDataReady;
+        // Hold the weather data lock for the rest of the frame. The writer
+        // (network reader task) only takes this lock for the few microseconds
+        // it takes to assign these fields after the HTTP fetch completes, so
+        // blocking here is effectively never observable and never approaches
+        // anything the WDT would care about. We do NOT take any other lock
+        // (render / effect manager) while holding this one, which keeps the
+        // ordering one-way and inversion-proof.
+        std::lock_guard guard(weatherDataMutex);
 
-        {
-            std::lock_guard guard(weatherDataMutex);
-            displayLocationName = strLocationName;
-            displayLocation = strLocation;
-            displayIconToday = iconToday;
-            displayIconTomorrow = iconTomorrow;
-            displayTemperature = temperature;
-            displayHighToday = highToday;
-            displayLoToday = loToday;
-            displayHighTomorrow = highTomorrow;
-            displayLoTomorrow = loTomorrow;
-            displayDataReady = dataReady;
-        }
+        const String& displayLocationName = strLocationName;
+        const String& displayLocation     = strLocation;
+        const String& displayIconToday    = iconToday;
+        const String& displayIconTomorrow = iconTomorrow;
+        const float   displayTemperature  = temperature;
+        const float   displayHighToday    = highToday;
+        const float   displayLoToday      = loToday;
+        const float   displayHighTomorrow = highTomorrow;
+        const float   displayLoTomorrow   = loTomorrow;
+        const bool    displayDataReady    = dataReady;
 
         // Draw the graphics
         auto iconEntry = weatherIcons.find(displayIconToday);

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -285,8 +285,6 @@ class PatternWeather : public EffectWithId<PatternWeather>
      * Tommorow's expected high and low temperatures,
      * and an icon for tomorrow's weather forcast
      *
-     * @param highTemp address to store the high temperature
-     * @param lowTemp address to store the low temperature
      * @return bool - true if valid weather data retrieved
      */
     bool getTomorrowTemps()

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -42,6 +42,7 @@
 #include <chrono>
 #include <HTTPClient.h>
 #include <map>
+#include <mutex>
 #include <string.h>
 #include <thread>
 #include <UrlEncode.h>
@@ -150,6 +151,7 @@ class PatternWeather : public EffectWithId<PatternWeather>
     bool   dataReady          = false;
     size_t readerIndex        = SIZE_MAX;
     system_clock::time_point latestUpdate = system_clock::from_time_t(0);
+    mutable std::mutex weatherDataMutex;
 
     /**
      * @brief Should this effect show its title.
@@ -230,12 +232,15 @@ class PatternWeather : public EffectWithId<PatternWeather>
         HTTPClient http;
         String url;
 
-        if (!HasLocationChanged())
-            return false;
-
-        const String& configLocation = g_ptrSystem->GetDeviceConfig().GetLocation();
-        const String& configCountryCode = g_ptrSystem->GetDeviceConfig().GetCountryCode();
+        const String configLocation = g_ptrSystem->GetDeviceConfig().GetLocation();
+        const String configCountryCode = g_ptrSystem->GetDeviceConfig().GetCountryCode();
         const bool configLocationIsZip = g_ptrSystem->GetDeviceConfig().IsLocationZip();
+
+        {
+            std::lock_guard guard(weatherDataMutex);
+            if (configLocation == strLocation && configCountryCode == strCountryCode)
+                return false;
+        }
 
         if (configLocationIsZip)
             url = "http://api.openweathermap.org/geo/1.0/zip"
@@ -258,13 +263,18 @@ class PatternWeather : public EffectWithId<PatternWeather>
         deserializeJson(doc, http.getString());
         JsonObject coordinates = configLocationIsZip ? doc.as<JsonObject>() : doc[0].as<JsonObject>();
 
-        strLatitude = coordinates["lat"].as<String>();
-        strLongitude = coordinates["lon"].as<String>();
+        String newLatitude = coordinates["lat"].as<String>();
+        String newLongitude = coordinates["lon"].as<String>();
 
         http.end();
 
-        strLocation = configLocation;
-        strCountryCode = configCountryCode;
+        {
+            std::lock_guard guard(weatherDataMutex);
+            strLatitude = newLatitude;
+            strLongitude = newLongitude;
+            strLocation = configLocation;
+            strCountryCode = configCountryCode;
+        }
 
         return true;
     }
@@ -279,11 +289,20 @@ class PatternWeather : public EffectWithId<PatternWeather>
      * @param lowTemp address to store the low temperature
      * @return bool - true if valid weather data retrieved
      */
-    bool getTomorrowTemps(float& highTemp, float& lowTemp)
+    bool getTomorrowTemps()
     {
         HTTPClient http;
+        String latitude;
+        String longitude;
+
+        {
+            std::lock_guard guard(weatherDataMutex);
+            latitude = strLatitude;
+            longitude = strLongitude;
+        }
+
         String url = "http://api.openweathermap.org/data/2.5/forecast"
-            "?lat=" + strLatitude + "&lon=" + strLongitude + "&cnt=16&appid=" + urlEncode(g_ptrSystem->GetDeviceConfig().GetOpenWeatherAPIKey());
+            "?lat=" + latitude + "&lon=" + longitude + "&cnt=16&appid=" + urlEncode(g_ptrSystem->GetDeviceConfig().GetOpenWeatherAPIKey());
         http.begin(url);
         int httpResponseCode = http.GET();
 
@@ -305,7 +324,7 @@ class PatternWeather : public EffectWithId<PatternWeather>
             float dailyMaximum = 0.0;
             int slot = 0;
 
-            iconTomorrow = "";
+            String newIconTomorrow = "";
 
             // Look for the temperature data for tomorrow
             for (size_t i = 0; i < list.size(); ++i)
@@ -335,14 +354,21 @@ class PatternWeather : public EffectWithId<PatternWeather>
 
                     // Use the noon slot for the icon
                     if (slot == 4)
-                        iconTomorrow = entry["weather"][0]["icon"].as<String>();
+                        newIconTomorrow = entry["weather"][0]["icon"].as<String>();
                 }
             }
 
-            highTemp        = KelvinToLocal(dailyMaximum);
-            lowTemp         = KelvinToLocal(dailyMinimum);
+            float newHighTomorrow = KelvinToLocal(dailyMaximum);
+            float newLoTomorrow = KelvinToLocal(dailyMinimum);
 
-            debugI("Got tomorrow's temps: Lo %d, Hi %d, Icon %s", (int)lowTemp, (int)highTemp, iconTomorrow.c_str());
+            {
+                std::lock_guard guard(weatherDataMutex);
+                highTomorrow = newHighTomorrow;
+                loTomorrow = newLoTomorrow;
+                iconTomorrow = newIconTomorrow;
+            }
+
+            debugI("Got tomorrow's temps: Lo %d, Hi %d, Icon %s", (int)newLoTomorrow, (int)newHighTomorrow, newIconTomorrow.c_str());
 
             http.end();
             return true;
@@ -366,31 +392,50 @@ class PatternWeather : public EffectWithId<PatternWeather>
     bool getWeatherData()
     {
         HTTPClient http;
+        String latitude;
+        String longitude;
+
+        {
+            std::lock_guard guard(weatherDataMutex);
+            latitude = strLatitude;
+            longitude = strLongitude;
+        }
 
         String url = "http://api.openweathermap.org/data/2.5/weather"
-            "?lat=" + strLatitude + "&lon=" + strLongitude + "&appid=" + urlEncode(g_ptrSystem->GetDeviceConfig().GetOpenWeatherAPIKey());
+            "?lat=" + latitude + "&lon=" + longitude + "&appid=" + urlEncode(g_ptrSystem->GetDeviceConfig().GetOpenWeatherAPIKey());
         http.begin(url);
         int httpResponseCode = http.GET();
         if (httpResponseCode > 0)
         {
-            iconToday = "";
             auto jsonDoc = CreateJsonDocument();
             deserializeJson(jsonDoc, http.getString());
 
             // Once we have a non-zero temp we can start displaying things
-            if (0 < jsonDoc["main"]["temp"])
-                dataReady = true;
+            bool newDataReady = 0 < jsonDoc["main"]["temp"];
 
-            temperature = KelvinToLocal(jsonDoc["main"]["temp"]);
-            highToday   = KelvinToLocal(jsonDoc["main"]["temp_max"]);
-            loToday     = KelvinToLocal(jsonDoc["main"]["temp_min"]);
+            float newTemperature = KelvinToLocal(jsonDoc["main"]["temp"]);
+            float newHighToday = KelvinToLocal(jsonDoc["main"]["temp_max"]);
+            float newLoToday = KelvinToLocal(jsonDoc["main"]["temp_min"]);
 
-            iconToday = jsonDoc["weather"][0]["icon"].as<String>();
-            debugI("Got today's temps: Now %d Lo %d, Hi %d, Icon %s", (int)temperature, (int)loToday, (int)highToday, iconToday.c_str());
+            String newIconToday = jsonDoc["weather"][0]["icon"].as<String>();
+            String newLocationName;
 
             const char * pszName = jsonDoc["name"];
             if (pszName)
-                strLocationName = pszName;
+                newLocationName = pszName;
+
+            {
+                std::lock_guard guard(weatherDataMutex);
+                dataReady = newDataReady;
+                temperature = newTemperature;
+                highToday = newHighToday;
+                loToday = newLoToday;
+                iconToday = newIconToday;
+                if (!newLocationName.isEmpty())
+                    strLocationName = newLocationName;
+            }
+
+            debugI("Got today's temps: Now %d Lo %d, Hi %d, Icon %s", (int)newTemperature, (int)newLoToday, (int)newHighToday, newIconToday.c_str());
 
             http.end();
             return true;
@@ -422,7 +467,7 @@ class PatternWeather : public EffectWithId<PatternWeather>
             updateCoordinates();
 
             if (getWeatherData())
-                getTomorrowTemps(highTomorrow, loTomorrow);
+                getTomorrowTemps();
         }
     }
 
@@ -434,10 +479,11 @@ class PatternWeather : public EffectWithId<PatternWeather>
      */
     bool HasLocationChanged()
     {
-        bool locationChanged = g_ptrSystem->GetDeviceConfig().GetLocation() != strLocation;
-        bool countryChanged = g_ptrSystem->GetDeviceConfig().GetCountryCode() != strCountryCode;
+        const String configLocation = g_ptrSystem->GetDeviceConfig().GetLocation();
+        const String configCountryCode = g_ptrSystem->GetDeviceConfig().GetCountryCode();
 
-        return locationChanged || countryChanged;
+        std::lock_guard guard(weatherDataMutex);
+        return configLocation != strLocation || configCountryCode != strCountryCode;
     }
 
 public:
@@ -512,21 +558,46 @@ public:
             g_ptrSystem->GetNetworkReader().FlagReader(readerIndex);
         }
 
+        String displayLocationName;
+        String displayLocation;
+        String displayIconToday;
+        String displayIconTomorrow;
+        float displayTemperature;
+        float displayHighToday;
+        float displayLoToday;
+        float displayHighTomorrow;
+        float displayLoTomorrow;
+        bool displayDataReady;
+
+        {
+            std::lock_guard guard(weatherDataMutex);
+            displayLocationName = strLocationName;
+            displayLocation = strLocation;
+            displayIconToday = iconToday;
+            displayIconTomorrow = iconTomorrow;
+            displayTemperature = temperature;
+            displayHighToday = highToday;
+            displayLoToday = loToday;
+            displayHighTomorrow = highTomorrow;
+            displayLoTomorrow = loTomorrow;
+            displayDataReady = dataReady;
+        }
+
         // Draw the graphics
-        auto iconEntry = weatherIcons.find(iconToday);
+        auto iconEntry = weatherIcons.find(displayIconToday);
         if (iconEntry != weatherIcons.end())
         {
             auto icon = iconEntry->second;
             if (JDR_OK != TJpgDec.drawJpg(0, 10, icon.contents, icon.length))        // Draw the image
-                debugW("Could not display icon %s", iconToday.c_str());
+                debugW("Could not display icon %s", displayIconToday.c_str());
         }
 
-        iconEntry = weatherIcons.find(iconTomorrow);
+        iconEntry = weatherIcons.find(displayIconTomorrow);
         if (iconEntry != weatherIcons.end())
         {
             auto icon = iconEntry->second;
             if (JDR_OK != TJpgDec.drawJpg(xHalf+1, 10, icon.contents, icon.length))        // Draw the image
-                debugW("Could not display icon %s", iconTomorrow.c_str());
+                debugW("Could not display icon %s", displayIconTomorrow.c_str());
         }
 
         // Print the town/city name
@@ -534,18 +605,18 @@ public:
         int y = fontHeight + 1;
         g().setCursor(x, y);
         g().setTextColor(WHITE16);
-        String showLocation = strLocation;
+        String showLocation = displayLocation;
         showLocation.toUpperCase();
         if (g_ptrSystem->GetDeviceConfig().GetOpenWeatherAPIKey().isEmpty())
             g().print("No API Key");
         else
-            g().print((strLocationName.isEmpty() ? showLocation : strLocationName).substring(0, (MATRIX_WIDTH - 2 * fontWidth)/fontWidth));
+            g().print((displayLocationName.isEmpty() ? showLocation : displayLocationName).substring(0, (MATRIX_WIDTH - 2 * fontWidth)/fontWidth));
 
         // Display the temperature, right-justified
 
-        if (dataReady)
+        if (displayDataReady)
         {
-            String strTemp((int)temperature);
+            String strTemp((int)displayTemperature);
             x = MATRIX_WIDTH - fontWidth * strTemp.length();
             g().setCursor(x, y);
             g().setTextColor(g().to16bit(CRGB(192,192,192)));
@@ -576,11 +647,11 @@ public:
 
         // Draw the temperature in lighter white
 
-        if (dataReady)
+        if (displayDataReady)
         {
             g().setTextColor(g().to16bit(CRGB(192,192,192)));
-            String strHi((int) highToday);
-            String strLo((int) loToday);
+            String strHi((int) displayHighToday);
+            String strLo((int) displayLoToday);
 
             // Draw today's HI and LO temperatures
 
@@ -595,8 +666,8 @@ public:
 
             // Draw tomorrow's HI and LO temperatures
 
-            strHi = String((int)highTomorrow);
-            strLo = String((int)loTomorrow);
+            strHi = String((int)displayHighTomorrow);
+            strLo = String((int)displayLoTomorrow);
             x = MATRIX_WIDTH - fontWidth * strHi.length();
             y = MATRIX_HEIGHT - fontHeight;
             g().setCursor(x,y);

--- a/include/globals.h
+++ b/include/globals.h
@@ -322,6 +322,10 @@ extern std::recursive_mutex g_effect_manager_mutex;
     #define LED_PIN0         5
 #endif
 
+#ifndef WIFI_ACTIVITY_PIN
+    #define WIFI_ACTIVITY_PIN -1
+#endif
+
 #ifndef PROJECT_NAME
 #define PROJECT_NAME        "Mesmerizer"
 #endif

--- a/include/hub75gfx.h
+++ b/include/hub75gfx.h
@@ -134,6 +134,7 @@ public:
 
     static void StartMatrix();
     static CRGB *GetMatrixBackBuffer();
+    static bool WaitForMatrixSwap(uint32_t timeoutMs = 100);
     static void MatrixSwapBuffers(bool bSwapBackground);
 };
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -106,6 +106,7 @@ board           = adafruit_feather_esp32s3_tft
 monitor_speed   = 115200
 upload_speed    = 1500000
 build_flags     = ${dev_esp32_s3.build_flags}
+                  ${psram_common_flags.build_flags}
                   -DUSER_SETUP_LOADED
                   -DST7789_2_DRIVER
                   -DTFT_WIDTH=135
@@ -132,6 +133,7 @@ build_src_flags = ${dev_esp32_s3.build_src_flags}
                   -DESP32FEATHERTFT=1
                   -DTOGGLE_BUTTON_0=0
                   -DLED_PIN0=5
+                  -DLED_PIN1=6
 
 board_build.partitions = config/partitions_custom.csv
 lib_deps        = ${dev_esp32_s3.lib_deps}
@@ -875,7 +877,6 @@ lib_deps        = ${dev_heltec_wifi.lib_deps}
 [env:ledstrip_feather]
 extends         = dev_adafruit_feather
 build_flags     = ${dev_adafruit_feather.build_flags}
-                  ${psram_lx6_flags.build_flags}
 build_src_flags = ${dev_adafruit_feather.build_src_flags}
                   -DLEDSTRIP=1
                   -DEFFECTS_MINIMAL=1
@@ -883,7 +884,6 @@ build_src_flags = ${dev_adafruit_feather.build_src_flags}
 [env:ledstrip_feather_hexagon]
 extends         = dev_adafruit_feather
 build_flags     = ${dev_adafruit_feather.build_flags}
-                  ${psram_lx6_flags.build_flags}
 build_src_flags = ${dev_adafruit_feather.build_src_flags}
                   -DHEXAGON=1
                   -DEFFECTS_HEXAGON=1
@@ -901,6 +901,23 @@ build_src_flags = ${dev_adafruit_feather.build_src_flags}
                   -DDEFAULT_EFFECT_INTERVAL=1000*20
                   -DHEX_MAX_DIMENSION=19
                   -DHEX_HALF_DIMENSION=10
+
+; trimlight is based off ledstrip_feather for the ESP32S3 TFT Feather, but
+; drives two WS281x output channels and renders only incoming WiFi frames.
+[env:trimlight]
+extends         = dev_adafruit_feather
+build_flags     = ${dev_adafruit_feather.build_flags}
+build_src_flags = ${dev_adafruit_feather.build_src_flags}
+                  -DMATRIX_WIDTH=271
+                  -DMATRIX_HEIGHT=1
+                  -DTRIMLIGHT=1
+                  -DPROJECT_NAME="\"Trimlight\""
+                  -DENABLE_WIFI=1
+                  -DINCOMING_WIFI_ENABLED=1
+                  -DWAIT_FOR_WIFI=0
+                  -DNUM_CHANNELS=2
+                  -DEFFECTS_TRIMLIGHT=1
+                  -DWIFI_ACTIVITY_PIN=9
 
 [env:ledstrip_feather_wrover]
 extends         = dev_wrover

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -49,8 +49,61 @@
 
 static DRAM_ATTR CRGB l_SinglePixel = CRGB::Blue;
 static DRAM_ATTR uint64_t l_usLastWifiDraw = 0;
+static DRAM_ATTR bool l_WiFiActivityActive = false;
 static uint32_t l_FrameCountThisSecond = 0;
 static uint32_t l_LastSecondBoundaryMs = 0;
+
+static uint32_t MicrosSinceLastWifiDraw()
+{
+    return micros() - static_cast<uint32_t>(l_usLastWifiDraw);
+}
+
+#if WIFI_ACTIVITY_PIN >= 0
+static bool IsWiFiDrawWindowActive()
+{
+    return l_usLastWifiDraw != 0 && MicrosSinceLastWifiDraw() <= (TIME_BEFORE_LOCAL * MICROS_PER_SECOND);
+}
+
+static void SetWiFiActivityPin(bool active)
+{
+    if (l_WiFiActivityActive == active)
+        return;
+
+    digitalWrite(WIFI_ACTIVITY_PIN, active ? HIGH : LOW);
+    l_WiFiActivityActive = active;
+}
+
+static void PrepareWiFiActivityPin()
+{
+    pinMode(WIFI_ACTIVITY_PIN, OUTPUT);
+    digitalWrite(WIFI_ACTIVITY_PIN, LOW);
+    l_WiFiActivityActive = false;
+}
+
+static void UpdateWiFiActivityPin(uint16_t wifiPixelsDrawn, uint16_t localPixelsDrawn)
+{
+    if (wifiPixelsDrawn > 0)
+    {
+        SetWiFiActivityPin(true);
+        return;
+    }
+
+    if (localPixelsDrawn > 0 || !IsWiFiDrawWindowActive())
+        SetWiFiActivityPin(false);
+}
+#else
+static void PrepareWiFiActivityPin()
+{
+}
+
+static void UpdateWiFiActivityPin(uint16_t, uint16_t)
+{
+}
+
+static void SetWiFiActivityPin(bool)
+{
+}
+#endif
 
 // The g_buffer_mutex is a global mutex used to protect access while adding or removing frames
 // from the led buffer.
@@ -126,10 +179,10 @@ uint16_t LocalDraw()
     {
         auto& effectManager = g_ptrSystem->GetEffectManager();
 
-        if (effectManager.EffectCount() > 0)
+        if (effectManager.HasCurrentEffect())
         {
             // If we've never drawn from wifi before, now would also be a good time to local draw
-            if (l_usLastWifiDraw == 0 || (micros() - l_usLastWifiDraw > (TIME_BEFORE_LOCAL * MICROS_PER_SECOND)))
+            if (l_usLastWifiDraw == 0 || (MicrosSinceLastWifiDraw() > (TIME_BEFORE_LOCAL * MICROS_PER_SECOND)))
             {
                 effectManager.Update(); // Draw the current built in effect
 
@@ -147,7 +200,7 @@ uint16_t LocalDraw()
             }
             else
             {
-                debugV("Not drawing local effect because last wifi draw was %lf seconds ago.", (micros() - l_usLastWifiDraw) / (float)MICROS_PER_SECOND);
+                debugV("Not drawing local effect because last wifi draw was %lf seconds ago.", MicrosSinceLastWifiDraw() / (float)MICROS_PER_SECOND);
                 // It's important to return 0 when you do not draw so that the caller knows we did not
                 // render any pixels, and we can/should wait until the next frame.  Otherwise, the caller might
                 // draw the strip needlessly, which can take significant time.
@@ -177,7 +230,9 @@ int CalcDelayUntilNextFrame(double frameStartTime, uint16_t localPixelsDrawn, ui
         double fpsRaw = 0.0;
         {
             std::lock_guard effectGuard(g_effect_manager_mutex);
-            fpsRaw = static_cast<double>(g_ptrSystem->GetEffectManager().GetCurrentEffect().DesiredFramesPerSecond());
+            auto& effectManager = g_ptrSystem->GetEffectManager();
+            if (effectManager.HasCurrentEffect())
+                fpsRaw = static_cast<double>(effectManager.GetCurrentEffect().DesiredFramesPerSecond());
         }
         // If FPS is invalid (<= 0 or non-finite), treat as unlimited (0s minimum frame time).
         const double minimumFrameTime = (!std::isfinite(fpsRaw) || fpsRaw <= 0.0) ? 0.0 : (1.0 / fpsRaw);
@@ -308,6 +363,7 @@ void IRAM_ATTR RenderService::Run()
     // If this board has an onboard RGB pixel, set it up now
 
     PrepareOnboardPixel();
+    PrepareWiFiActivityPin();
 
     // Start the effect
 
@@ -379,6 +435,7 @@ void IRAM_ATTR RenderService::Run()
             }
 
             graphics.PostProcessFrame(localPixelsDrawn, wifiPixelsDrawn);
+            UpdateWiFiActivityPin(wifiPixelsDrawn, localPixelsDrawn);
         }
 
         // Delay at least 2ms and not more than 1s until next frame is due
@@ -392,4 +449,6 @@ void IRAM_ATTR RenderService::Run()
         if (g_Values.UpdateStarted)
             delay(500);
     }
+
+    SetWiFiActivityPin(false);
 }

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -663,8 +663,16 @@ void WriteCurrentEffectIndexFile()
     std::lock_guard renderPause(g_render_mutex);
 
     #if USE_HUB75
-        HUB75GFX::WaitForMatrixSwap();
-    #endif
+    // Capture the current effect index without holding g_render_mutex to avoid nested lock order issues
+    size_t currentIndex = g_ptrSystem->GetEffectManager().GetCurrentEffectIndex();
+
+    {
+        std::lock_guard renderPause(g_render_mutex);
+
+        #if USE_HUB75
+            HUB75GFX::WaitForMatrixSwap();
+        #endif
+    }
 
     SPIFFS.remove(CURRENT_EFFECT_CONFIG_FILE);
 
@@ -676,7 +684,7 @@ void WriteCurrentEffectIndexFile()
         return;
     }
 
-    auto bytesWritten = file.print(g_ptrSystem->GetEffectManager().GetCurrentEffectIndex());
+    auto bytesWritten = file.print(currentIndex);
 
     file.flush();
     file.close();

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -151,7 +151,18 @@ void EffectManager::StartEffect()
     // If there's a temporary effect override from the remote control active, we start that, else
     // we start the current regular effect
 
-    std::shared_ptr<LEDStripEffect> & effect = _tempEffect ? _tempEffect : _vEffects[_iCurrentEffect];
+    if (!_tempEffect && _vEffects.empty())
+    {
+        _iCurrentEffect = 0;
+        _effectStartTime = millis();
+        debugV("No effect to start");
+        return;
+    }
+
+    if (!_vEffects.empty() && _iCurrentEffect >= _vEffects.size())
+        _iCurrentEffect = 0;
+
+    auto effect = _tempEffect ? _tempEffect : _vEffects[_iCurrentEffect];
 
     #if USE_HUB75
         auto& matrix = static_cast<HUB75GFX&>(*_gfx[0]);
@@ -193,6 +204,9 @@ void EffectManager::DispatchBeatIfNeeded()
 
     // Beat callbacks are sequenced here so every active effect sees the same
     // detector output, including BeatEffectBase-derived effects via OnBeat().
+    if (!_tempEffect && _vEffects.empty())
+        return;
+
     auto& currentEffect = GetCurrentEffect();
 
     const auto nearBeat = g_Analyzer.LastNearBeat();
@@ -409,6 +423,12 @@ bool EffectManager::AreEffectsEnabled() const
     return std::any_of(_vEffects.begin(), _vEffects.end(), [](const auto& pEffect){ return pEffect->IsEnabled(); } );
 }
 
+bool EffectManager::HasCurrentEffect() const
+{
+    std::lock_guard effectGuard(g_effect_manager_mutex);
+    return _tempEffect || !_vEffects.empty();
+}
+
 size_t EffectManager::GetCurrentEffectIndex() const
 {
     std::lock_guard effectGuard(g_effect_manager_mutex);
@@ -418,7 +438,11 @@ size_t EffectManager::GetCurrentEffectIndex() const
 LEDStripEffect& EffectManager::GetCurrentEffect() const
 {
     std::lock_guard effectGuard(g_effect_manager_mutex);
-    return *(_tempEffect ? _tempEffect : _vEffects[_iCurrentEffect]);
+    if (!_tempEffect && _vEffects.empty())
+        throw std::runtime_error("No current effect");
+
+    const size_t index = _vEffects.empty() ? 0 : std::min(_iCurrentEffect, _vEffects.size() - 1);
+    return *(_tempEffect ? _tempEffect : _vEffects[index]);
 }
 
 String EffectManager::GetCurrentEffectName() const
@@ -430,7 +454,10 @@ String EffectManager::GetCurrentEffectName() const
     if (_tempEffect)
         return _tempEffect->FriendlyName();
 
-    return _vEffects[_iCurrentEffect]->FriendlyName();
+    if (_vEffects.empty())
+        return "No Effect";
+
+    return _vEffects[std::min(_iCurrentEffect, _vEffects.size() - 1)]->FriendlyName();
 }
 
 void EffectManager::SetCurrentEffectIndex(size_t i)
@@ -463,6 +490,9 @@ uint EffectManager::GetTimeUsedByCurrentEffect() const
 uint EffectManager::GetTimeRemainingForCurrentEffect() const
 {
     std::lock_guard effectGuard(g_effect_manager_mutex);
+    if (!_tempEffect && _vEffects.empty())
+        return 0;
+
     // If the Interval is set to zero, we treat that as an infinite interval and don't even look at the time used so far
     uint timeUsedByCurrentEffect = GetTimeUsedByCurrentEffect();
     uint interval = GetEffectiveInterval();
@@ -473,7 +503,11 @@ uint EffectManager::GetTimeRemainingForCurrentEffect() const
 uint EffectManager::GetEffectiveInterval() const
 {
     std::lock_guard effectGuard(g_effect_manager_mutex);
-    auto& currentEffect = *(_tempEffect ? _tempEffect : _vEffects[_iCurrentEffect]);
+    if (!_tempEffect && _vEffects.empty())
+        return IsIntervalEternal() ? std::numeric_limits<uint>::max() : _effectInterval;
+
+    const size_t index = _vEffects.empty() ? 0 : std::min(_iCurrentEffect, _vEffects.size() - 1);
+    auto& currentEffect = *(_tempEffect ? _tempEffect : _vEffects[index]);
     // This allows you to return a MaximumEffectTime and your effect won't be shown longer than that
     return min((IsIntervalEternal() ? std::numeric_limits<uint>::max() : _effectInterval),
                (currentEffect.HasMaximumEffectTime() ? currentEffect.MaximumEffectTime() : std::numeric_limits<uint>::max()));
@@ -728,7 +762,10 @@ bool EffectManager::Init()
         }
         debugV("Loaded Effect: %s", _vEffect->FriendlyName().c_str());
     }
-    debugV("First Effect: %s", GetCurrentEffectName().c_str());
+    if (_vEffects.empty())
+        debugV("No local effects loaded");
+    else
+        debugV("First Effect: %s", GetCurrentEffectName().c_str());
 
     if (g_ptrSystem->GetDeviceConfig().ApplyGlobalColors())
         ApplyGlobalPaletteColors();
@@ -776,7 +813,9 @@ bool EffectManager::ShowVU(bool bShow)
 bool EffectManager::IsVUVisible() const
 {
     std::lock_guard effectGuard(g_effect_manager_mutex);
-    return g_ptrSystem->GetDeviceConfig().ShowVUMeter() && GetCurrentEffect().CanDisplayVUMeter();
+    return g_ptrSystem->GetDeviceConfig().ShowVUMeter() &&
+           (_tempEffect || !_vEffects.empty()) &&
+           GetCurrentEffect().CanDisplayVUMeter();
 }
 
 
@@ -843,9 +882,19 @@ void EffectManager::construct(bool clearTempEffect)
     _bPlayAll = false;
 
     if (clearTempEffect && _tempEffect)
-    {
         _clearTempEffectWhenExpired = true;
 
+    if (_vEffects.empty())
+    {
+        _iCurrentEffect = 0;
+        return;
+    }
+
+    if (_iCurrentEffect >= _vEffects.size())
+        _iCurrentEffect = _vEffects.size() - 1;
+
+    if (clearTempEffect && _tempEffect)
+    {
         // This ensures that we start the correct effect after the temporary one.
         //   The switching to the next effect is taken care of by NextEffect(), which starts with
         //   increasing _iCurrentEffect. We therefore need to set it to the previous effect, to
@@ -907,10 +956,7 @@ bool EffectManager::DeserializeFromJSON(const JsonObjectConst& jsonObject)
 
     // If no effects were successfully loaded from JSON, it loads the default effects.
     if (_vEffects.empty())
-    {
         LoadDefaultEffects();
-        return true;
-    }
 
     // "eef" was the array of effect enabled flags. They have now been integrated in the effects themselves;
     //   this code is there to "migrate" users who already had a serialized effect config on their device
@@ -937,7 +983,9 @@ bool EffectManager::DeserializeFromJSON(const JsonObjectConst& jsonObject)
         _iCurrentEffect = jsonObject["cei"];
 
     // Make sure that if we read an index, it's sane
-    if (_iCurrentEffect >= EffectCount())
+    if (_vEffects.empty())
+        _iCurrentEffect = 0;
+    else if (_iCurrentEffect >= EffectCount())
         _iCurrentEffect = EffectCount() - 1;
 
     construct(true);
@@ -1124,17 +1172,24 @@ bool EffectManager::DeleteEffect(size_t index)
 
     DisableEffect(index, true);
 
-    if (index == _iCurrentEffect)
-        NextEffect();
+    if (index == _iCurrentEffect && _vEffects.size() > 1)
+        NextEffect(true);
 
     _vEffects.erase(_vEffects.begin() + index);
 
-    if (index <= _iCurrentEffect)
+    if (_vEffects.empty())
     {
-        _iCurrentEffect--;
-        SaveCurrentEffectIndex();
+        _iCurrentEffect = 0;
+    }
+    else if (index <= _iCurrentEffect)
+    {
+        if (_iCurrentEffect > 0)
+            _iCurrentEffect--;
+        else if (_iCurrentEffect >= _vEffects.size())
+            _iCurrentEffect = _vEffects.size() - 1;
     }
 
+    SaveCurrentEffectIndex();
     SaveEffectManagerConfig();
 
     {
@@ -1148,6 +1203,9 @@ bool EffectManager::DeleteEffect(size_t index)
 void EffectManager::CheckEffectTimerExpired()
 {
     std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
+    if (!_tempEffect && _vEffects.empty())
+        return;
 
     if (IsIntervalEternal() && !GetCurrentEffect().HasMaximumEffectTime())
         return;
@@ -1172,6 +1230,13 @@ void EffectManager::NextEffect(bool skipSave)
 {
     std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
 
+    if (_vEffects.empty())
+    {
+        _iCurrentEffect = 0;
+        _effectStartTime = millis();
+        return;
+    }
+
     auto enabled = AreEffectsEnabled();
 
     do
@@ -1182,7 +1247,8 @@ void EffectManager::NextEffect(bool skipSave)
     } while (enabled && false == _bPlayAll && false == IsEffectEnabled(_iCurrentEffect));
 
     StartEffect();
-    SaveCurrentEffectIndex();
+    if (!skipSave)
+        SaveCurrentEffectIndex();
 
     {
         std::lock_guard listenerGuard(_listenerMutex);
@@ -1195,6 +1261,13 @@ void EffectManager::NextEffect(bool skipSave)
 void EffectManager::PreviousEffect()
 {
     std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
+    if (_vEffects.empty())
+    {
+        _iCurrentEffect = 0;
+        _effectStartTime = millis();
+        return;
+    }
 
     auto enabled = AreEffectsEnabled();
 
@@ -1226,6 +1299,12 @@ void EffectManager::Update()
 
     if ((_gfx[0])->GetLEDCount() == 0)
         return;
+
+    if (!_tempEffect && _vEffects.empty())
+    {
+        ApplyFadeLogic();
+        return;
+    }
 
     CheckEffectTimerExpired();
     DispatchBeatIfNeeded();

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -651,11 +651,21 @@ void RemoveEffectManagerConfig()
 {
     RemoveJSONFile(EFFECTS_CONFIG_FILE);
     // We take the liberty of also removing the file with the current effect config index
+    std::lock_guard renderPause(g_render_mutex);
+    #if USE_HUB75
+        HUB75GFX::WaitForMatrixSwap();
+    #endif
     SPIFFS.remove(CURRENT_EFFECT_CONFIG_FILE);
 }
 
 void WriteCurrentEffectIndexFile()
 {
+    std::lock_guard renderPause(g_render_mutex);
+
+    #if USE_HUB75
+        HUB75GFX::WaitForMatrixSwap();
+    #endif
+
     SPIFFS.remove(CURRENT_EFFECT_CONFIG_FILE);
 
     File file = SPIFFS.open(CURRENT_EFFECT_CONFIG_FILE, FILE_WRITE);
@@ -667,10 +677,11 @@ void WriteCurrentEffectIndexFile()
     }
 
     auto bytesWritten = file.print(g_ptrSystem->GetEffectManager().GetCurrentEffectIndex());
-    debugI("Number of bytes written to file %s: %zu", CURRENT_EFFECT_CONFIG_FILE, (size_t)bytesWritten);
 
     file.flush();
     file.close();
+
+    debugI("Number of bytes written to file %s: %zu", CURRENT_EFFECT_CONFIG_FILE, (size_t)bytesWritten);
 
     if (bytesWritten == 0)
     {

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -660,19 +660,14 @@ void RemoveEffectManagerConfig()
 
 void WriteCurrentEffectIndexFile()
 {
+    // Capture the current effect index without holding g_render_mutex to avoid nested lock order issues.
+    size_t currentIndex = g_ptrSystem->GetEffectManager().GetCurrentEffectIndex();
+
     std::lock_guard renderPause(g_render_mutex);
 
     #if USE_HUB75
-    // Capture the current effect index without holding g_render_mutex to avoid nested lock order issues
-    size_t currentIndex = g_ptrSystem->GetEffectManager().GetCurrentEffectIndex();
-
-    {
-        std::lock_guard renderPause(g_render_mutex);
-
-        #if USE_HUB75
-            HUB75GFX::WaitForMatrixSwap();
-        #endif
-    }
+        HUB75GFX::WaitForMatrixSwap();
+    #endif
 
     SPIFFS.remove(CURRENT_EFFECT_CONFIG_FILE);
 

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -151,7 +151,18 @@ void EffectManager::StartEffect()
     // If there's a temporary effect override from the remote control active, we start that, else
     // we start the current regular effect
 
-    std::shared_ptr<LEDStripEffect> & effect = _tempEffect ? _tempEffect : _vEffects[_iCurrentEffect];
+    if (!_tempEffect && _vEffects.empty())
+    {
+        _iCurrentEffect = 0;
+        _effectStartTime = millis();
+        debugV("No effect to start");
+        return;
+    }
+
+    if (!_vEffects.empty() && _iCurrentEffect >= _vEffects.size())
+        _iCurrentEffect = 0;
+
+    auto effect = _tempEffect ? _tempEffect : _vEffects[_iCurrentEffect];
 
     #if USE_HUB75
         auto& matrix = static_cast<HUB75GFX&>(*_gfx[0]);
@@ -193,6 +204,9 @@ void EffectManager::DispatchBeatIfNeeded()
 
     // Beat callbacks are sequenced here so every active effect sees the same
     // detector output, including BeatEffectBase-derived effects via OnBeat().
+    if (!_tempEffect && _vEffects.empty())
+        return;
+
     auto& currentEffect = GetCurrentEffect();
 
     const auto nearBeat = g_Analyzer.LastNearBeat();
@@ -409,6 +423,12 @@ bool EffectManager::AreEffectsEnabled() const
     return std::any_of(_vEffects.begin(), _vEffects.end(), [](const auto& pEffect){ return pEffect->IsEnabled(); } );
 }
 
+bool EffectManager::HasCurrentEffect() const
+{
+    std::lock_guard effectGuard(g_effect_manager_mutex);
+    return _tempEffect || !_vEffects.empty();
+}
+
 size_t EffectManager::GetCurrentEffectIndex() const
 {
     std::lock_guard effectGuard(g_effect_manager_mutex);
@@ -418,7 +438,11 @@ size_t EffectManager::GetCurrentEffectIndex() const
 LEDStripEffect& EffectManager::GetCurrentEffect() const
 {
     std::lock_guard effectGuard(g_effect_manager_mutex);
-    return *(_tempEffect ? _tempEffect : _vEffects[_iCurrentEffect]);
+    if (!_tempEffect && _vEffects.empty())
+        throw std::runtime_error("No current effect");
+
+    const size_t index = _vEffects.empty() ? 0 : std::min(_iCurrentEffect, _vEffects.size() - 1);
+    return *(_tempEffect ? _tempEffect : _vEffects[index]);
 }
 
 String EffectManager::GetCurrentEffectName() const
@@ -430,7 +454,10 @@ String EffectManager::GetCurrentEffectName() const
     if (_tempEffect)
         return _tempEffect->FriendlyName();
 
-    return _vEffects[_iCurrentEffect]->FriendlyName();
+    if (_vEffects.empty())
+        return "No Effect";
+
+    return _vEffects[std::min(_iCurrentEffect, _vEffects.size() - 1)]->FriendlyName();
 }
 
 void EffectManager::SetCurrentEffectIndex(size_t i)
@@ -463,6 +490,9 @@ uint EffectManager::GetTimeUsedByCurrentEffect() const
 uint EffectManager::GetTimeRemainingForCurrentEffect() const
 {
     std::lock_guard effectGuard(g_effect_manager_mutex);
+    if (!_tempEffect && _vEffects.empty())
+        return 0;
+
     // If the Interval is set to zero, we treat that as an infinite interval and don't even look at the time used so far
     uint timeUsedByCurrentEffect = GetTimeUsedByCurrentEffect();
     uint interval = GetEffectiveInterval();
@@ -473,7 +503,11 @@ uint EffectManager::GetTimeRemainingForCurrentEffect() const
 uint EffectManager::GetEffectiveInterval() const
 {
     std::lock_guard effectGuard(g_effect_manager_mutex);
-    auto& currentEffect = *(_tempEffect ? _tempEffect : _vEffects[_iCurrentEffect]);
+    if (!_tempEffect && _vEffects.empty())
+        return IsIntervalEternal() ? std::numeric_limits<uint>::max() : _effectInterval;
+
+    const size_t index = _vEffects.empty() ? 0 : std::min(_iCurrentEffect, _vEffects.size() - 1);
+    auto& currentEffect = *(_tempEffect ? _tempEffect : _vEffects[index]);
     // This allows you to return a MaximumEffectTime and your effect won't be shown longer than that
     return min((IsIntervalEternal() ? std::numeric_limits<uint>::max() : _effectInterval),
                (currentEffect.HasMaximumEffectTime() ? currentEffect.MaximumEffectTime() : std::numeric_limits<uint>::max()));
@@ -731,7 +765,10 @@ bool EffectManager::Init()
         }
         debugV("Loaded Effect: %s", _vEffect->FriendlyName().c_str());
     }
-    debugV("First Effect: %s", GetCurrentEffectName().c_str());
+    if (_vEffects.empty())
+        debugV("No local effects loaded");
+    else
+        debugV("First Effect: %s", GetCurrentEffectName().c_str());
 
     if (g_ptrSystem->GetDeviceConfig().ApplyGlobalColors())
         ApplyGlobalPaletteColors();
@@ -779,7 +816,9 @@ bool EffectManager::ShowVU(bool bShow)
 bool EffectManager::IsVUVisible() const
 {
     std::lock_guard effectGuard(g_effect_manager_mutex);
-    return g_ptrSystem->GetDeviceConfig().ShowVUMeter() && GetCurrentEffect().CanDisplayVUMeter();
+    return g_ptrSystem->GetDeviceConfig().ShowVUMeter() &&
+           (_tempEffect || !_vEffects.empty()) &&
+           GetCurrentEffect().CanDisplayVUMeter();
 }
 
 
@@ -846,9 +885,19 @@ void EffectManager::construct(bool clearTempEffect)
     _bPlayAll = false;
 
     if (clearTempEffect && _tempEffect)
-    {
         _clearTempEffectWhenExpired = true;
 
+    if (_vEffects.empty())
+    {
+        _iCurrentEffect = 0;
+        return;
+    }
+
+    if (_iCurrentEffect >= _vEffects.size())
+        _iCurrentEffect = _vEffects.size() - 1;
+
+    if (clearTempEffect && _tempEffect)
+    {
         // This ensures that we start the correct effect after the temporary one.
         //   The switching to the next effect is taken care of by NextEffect(), which starts with
         //   increasing _iCurrentEffect. We therefore need to set it to the previous effect, to
@@ -910,10 +959,7 @@ bool EffectManager::DeserializeFromJSON(const JsonObjectConst& jsonObject)
 
     // If no effects were successfully loaded from JSON, it loads the default effects.
     if (_vEffects.empty())
-    {
         LoadDefaultEffects();
-        return true;
-    }
 
     // "eef" was the array of effect enabled flags. They have now been integrated in the effects themselves;
     //   this code is there to "migrate" users who already had a serialized effect config on their device
@@ -940,7 +986,9 @@ bool EffectManager::DeserializeFromJSON(const JsonObjectConst& jsonObject)
         _iCurrentEffect = jsonObject["cei"];
 
     // Make sure that if we read an index, it's sane
-    if (_iCurrentEffect >= EffectCount())
+    if (_vEffects.empty())
+        _iCurrentEffect = 0;
+    else if (_iCurrentEffect >= EffectCount())
         _iCurrentEffect = EffectCount() - 1;
 
     construct(true);
@@ -1127,17 +1175,24 @@ bool EffectManager::DeleteEffect(size_t index)
 
     DisableEffect(index, true);
 
-    if (index == _iCurrentEffect)
-        NextEffect();
+    if (index == _iCurrentEffect && _vEffects.size() > 1)
+        NextEffect(true);
 
     _vEffects.erase(_vEffects.begin() + index);
 
-    if (index <= _iCurrentEffect)
+    if (_vEffects.empty())
     {
-        _iCurrentEffect--;
-        SaveCurrentEffectIndex();
+        _iCurrentEffect = 0;
+    }
+    else if (index <= _iCurrentEffect)
+    {
+        if (_iCurrentEffect > 0)
+            _iCurrentEffect--;
+        else if (_iCurrentEffect >= _vEffects.size())
+            _iCurrentEffect = _vEffects.size() - 1;
     }
 
+    SaveCurrentEffectIndex();
     SaveEffectManagerConfig();
 
     {
@@ -1151,6 +1206,9 @@ bool EffectManager::DeleteEffect(size_t index)
 void EffectManager::CheckEffectTimerExpired()
 {
     std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
+    if (!_tempEffect && _vEffects.empty())
+        return;
 
     if (IsIntervalEternal() && !GetCurrentEffect().HasMaximumEffectTime())
         return;
@@ -1175,6 +1233,13 @@ void EffectManager::NextEffect(bool skipSave)
 {
     std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
 
+    if (_vEffects.empty())
+    {
+        _iCurrentEffect = 0;
+        _effectStartTime = millis();
+        return;
+    }
+
     auto enabled = AreEffectsEnabled();
 
     do
@@ -1185,7 +1250,8 @@ void EffectManager::NextEffect(bool skipSave)
     } while (enabled && false == _bPlayAll && false == IsEffectEnabled(_iCurrentEffect));
 
     StartEffect();
-    SaveCurrentEffectIndex();
+    if (!skipSave)
+        SaveCurrentEffectIndex();
 
     {
         std::lock_guard listenerGuard(_listenerMutex);
@@ -1198,6 +1264,13 @@ void EffectManager::NextEffect(bool skipSave)
 void EffectManager::PreviousEffect()
 {
     std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
+    if (_vEffects.empty())
+    {
+        _iCurrentEffect = 0;
+        _effectStartTime = millis();
+        return;
+    }
 
     auto enabled = AreEffectsEnabled();
 
@@ -1229,6 +1302,12 @@ void EffectManager::Update()
 
     if ((_gfx[0])->GetLEDCount() == 0)
         return;
+
+    if (!_tempEffect && _vEffects.empty())
+    {
+        ApplyFadeLogic();
+        return;
+    }
 
     CheckEffectTimerExpired();
     DispatchBeatIfNeeded();

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -198,6 +198,10 @@ void LoadEffectFactories()
         );
     #endif
 
+    #if defined(EFFECTS_TRIMLIGHT)
+        // Trimlight intentionally has no local effects. It renders only incoming WiFi frames.
+    #endif
+
     #if defined(EFFECTS_PDPWOPR)
         // PDPWOPR project effects
         RegisterAll(*g_ptrEffectFactories,
@@ -586,20 +590,6 @@ void LoadEffectFactories()
         );
 
     #endif
-
-    // Default fallback if no set contributed any effect
-    if (g_ptrEffectFactories->IsEmpty())
-    {
-        RegisterAll(*g_ptrEffectFactories,
-            Effect<RainbowFillEffect>(6, 2)
-        );
-    }
-
-    // If this assert fires, you have not defined any effects in the table above.  If adding a new config, you need to
-    // add the list of effects in this table as shown for the various other existing configs.  You MUST have at least
-    // one effect even if it's the Status effect.
-
-    assert(!g_ptrEffectFactories->IsEmpty());
 
     auto factoriesHashString = fnv1a::hash_to_string(fnv1a::hash<uint64_t>(g_ptrEffectFactories->FactoryIDs()));
     g_ptrEffectFactories->HashString(factoriesHashString);

--- a/src/gfxbase.cpp
+++ b/src/gfxbase.cpp
@@ -36,6 +36,7 @@
 #include <cmath>
 #include <gfxfont.h>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <unordered_map>
 
@@ -43,6 +44,12 @@
 #include "effects/matrix/Boid.h"
 #include "gfxbase.h"
 #include "systemcontainer.h"
+
+namespace
+{
+    DRAM_ATTR allocated_unique_ptr<GFXBase::PolarMapArray> g_polarMap;
+    DRAM_ATTR std::mutex g_polarMapMutex;
+}
 
 // 32 Entries in the 5-bit gamma table
 const uint8_t GFXBase::gamma5[32] =
@@ -1567,49 +1574,42 @@ uint16_t XY(uint16_t x, uint16_t y)
 
 const GFXBase::PolarMapArray& GFXBase::getPolarMap()
 {
-    static allocated_unique_ptr<PolarMapArray> rMap_ptr;
-    static std::mutex rMap_mutex;
-
-    // Double-checked locking for thread-safe, on-demand initialization
-    if (!rMap_ptr)
+    std::lock_guard guard(g_polarMapMutex);
+    if (!g_polarMap)
     {
-        std::lock_guard guard(rMap_mutex);
-        if (!rMap_ptr)
+        // Allocate from PSRAM using the project's helper.
+        g_polarMap = make_unique_psram<PolarMapArray>();
+
+        auto& rMap = *g_polarMap;
+        const uint16_t C_X = kMatrixWidth / 2;
+        const uint16_t C_Y = kMatrixHeight / 2;
+        const float mapp = 255.0f / kMatrixWidth;
+
+        for (int16_t x = -C_X; x < C_X + (kMatrixWidth % 2); x++)
         {
-            // Allocate from PSRAM using the project's helper
-            rMap_ptr = make_unique_psram<PolarMapArray>();
-
-            auto& rMap = *rMap_ptr;
-            const uint16_t C_X = kMatrixWidth / 2;
-            const uint16_t C_Y = kMatrixHeight / 2;
-            const float mapp = 255.0f / kMatrixWidth;
-
-            for (int16_t x = -C_X; x < C_X + (kMatrixWidth % 2); x++)
+            for (int16_t y = -C_Y; y < C_Y + (kMatrixHeight% 2); y++)
             {
-                for (int16_t y = -C_Y; y < C_Y + (kMatrixHeight% 2); y++)
-                {
-                    float angle_rad = atan2f(static_cast<float>(y), static_cast<float>(x));
-                    float radius_float = hypotf(static_cast<float>(x), static_cast<float>(y));
+                float angle_rad = atan2f(static_cast<float>(y), static_cast<float>(x));
+                float radius_float = hypotf(static_cast<float>(x), static_cast<float>(y));
 
-                    rMap[x + C_X][y + C_Y].angle = 128.0f * (angle_rad / (float)M_PI);
-                    rMap[x + C_X][y + C_Y].scaled_radius = radius_float * mapp;
-                    rMap[x + C_X][y + C_Y].unscaled_radius = radius_float;
-                }
+                rMap[x + C_X][y + C_Y].angle = 128.0f * (angle_rad / (float)M_PI);
+                rMap[x + C_X][y + C_Y].scaled_radius = radius_float * mapp;
+                rMap[x + C_X][y + C_Y].unscaled_radius = radius_float;
             }
-
-            // A note on the radius calculations:
-            //
-            // `unscaled_radius` is the true geometric distance from the center of the
-            // matrix to the pixel. This is useful for effects that need the real
-            // physical distance.
-            //
-            // `scaled_radius` maps the geometric radius to a range that is more
-            // suitable for use with 8-bit FastLED functions (like inoise8).
-            // The scaling is normalized by the matrix width, which is a common
-            // technique to make radial effects work consistently across different
-            // matrix sizes.
         }
+
+        // A note on the radius calculations:
+        //
+        // `unscaled_radius` is the true geometric distance from the center of the
+        // matrix to the pixel. This is useful for effects that need the real
+        // physical distance.
+        //
+        // `scaled_radius` maps the geometric radius to a range that is more
+        // suitable for use with 8-bit FastLED functions (like inoise8).
+        // The scaling is normalized by the matrix width, which is a common
+        // technique to make radial effects work consistently across different
+        // matrix sizes.
     }
 
-    return *rMap_ptr;
+    return *g_polarMap;
 }

--- a/src/hub75gfx.cpp
+++ b/src/hub75gfx.cpp
@@ -48,6 +48,28 @@ SMLayerBackground<HUB75GFX::SM_RGB, HUB75GFX::kBackgroundLayerOptions> HUB75GFX:
 SMLayerBackground<HUB75GFX::SM_RGB, HUB75GFX::kBackgroundLayerOptions> HUB75GFX::titleLayer(kMatrixWidth, kMatrixHeight);
 SmartMatrixHub75Calc<COLOR_DEPTH, HUB75GFX::kMatrixWidth, HUB75GFX::kMatrixHeight, HUB75GFX::kPanelType, HUB75GFX::kMatrixOptions> HUB75GFX::matrix;
 
+namespace
+{
+    template <typename Layer>
+    bool WaitForLayerSwap(Layer& layer, const char* layerName, uint32_t timeoutMs)
+    {
+        const uint32_t startMs = millis();
+
+        while (layer.isSwapPending())
+        {
+            if (millis() - startMs >= timeoutMs)
+            {
+                debugW("Timed out waiting for SmartMatrix %s layer swap", layerName);
+                return false;
+            }
+
+            delay(1);
+        }
+
+        return true;
+    }
+}
+
 HUB75GFX::HUB75GFX(size_t w, size_t h) : GFXBase(w, h)
 {
 }
@@ -311,7 +333,8 @@ void HUB75GFX::PrepareFrame()
             // We enable the chromakey overlay just for the strip of screen where it appears.  This support is only
             // present in the private fork of SmartMatrix that is linked to the mesmerizer project.
 
-            titleLayer.swapBuffers(false);
+            if (WaitForLayerSwap(titleLayer, "title", 100))
+                titleLayer.swapBuffers(false);
             titleLayer.enableChromaKey(true, y, y + kCharHeight);
             titleLayer.setBrightness(brite); // 255 would obscure it entirely
         }
@@ -396,7 +419,18 @@ void HUB75GFX::MatrixSwapBuffers(bool bSwapBackground)
     matrix.setRefreshRate(MATRIX_REFRESH_RATE);
     matrix.setMaxCalculationCpuPercentage(95);
 
-    backgroundLayer.swapBuffers(bSwapBackground);
+    if (!WaitForMatrixSwap())
+        return;
+
+    backgroundLayer.swapBuffers(false);
+
+    if (bSwapBackground && WaitForMatrixSwap())
+        backgroundLayer.copyRefreshToDrawing();
+}
+
+bool HUB75GFX::WaitForMatrixSwap(uint32_t timeoutMs)
+{
+    return WaitForLayerSwap(backgroundLayer, "background", timeoutMs);
 }
 
 #endif

--- a/src/hub75gfx.cpp
+++ b/src/hub75gfx.cpp
@@ -282,7 +282,8 @@ void HUB75GFX::PrepareFrame()
         // so that we can fade between effects without having to change the brightness
         // setting.
 
-        if (g_ptrSystem->GetEffectManager().GetCurrentEffect().ShouldShowTitle() && pMatrix.GetCaptionTransparency() > 0.00)
+        auto& effectManager = g_ptrSystem->GetEffectManager();
+        if (effectManager.HasCurrentEffect() && effectManager.GetCurrentEffect().ShouldShowTitle() && pMatrix.GetCaptionTransparency() > 0.00)
         {
             titleLayer.setFont(font3x5);
             uint8_t brite = (uint8_t)(pMatrix.GetCaptionTransparency() * 255.0);
@@ -398,7 +399,9 @@ void HUB75GFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDr
         backgroundLayer.drawString(2, MATRIX_HEIGHT  - 6, rgb24(255, 255, 255), rgb24(0, 0, 0), output.c_str());
     #endif
 
-    MatrixSwapBuffers((wifiPixelsDrawn > 0) || g_ptrSystem->GetEffectManager().GetCurrentEffect().RequiresDoubleBuffering() || pMatrix.GetCaptionTransparency() > 0.0);
+    auto& effectManager = g_ptrSystem->GetEffectManager();
+    const bool effectRequiresDoubleBuffering = effectManager.HasCurrentEffect() && effectManager.GetCurrentEffect().RequiresDoubleBuffering();
+    MatrixSwapBuffers((wifiPixelsDrawn > 0) || effectRequiresDoubleBuffering || pMatrix.GetCaptionTransparency() > 0.0);
 
     FastLED.countFPS();
 }

--- a/src/jsonserializer.cpp
+++ b/src/jsonserializer.cpp
@@ -29,6 +29,7 @@
 
 #include "globals.h"
 
+#include <esp_heap_caps.h>
 #include <FS.h>
 #include <functional>
 #include <memory>
@@ -37,6 +38,10 @@
 #include "jsonserializer.h"
 #include "systemcontainer.h"
 #include "taskmgr.h"
+
+#if USE_HUB75
+#include "hub75gfx.h"
+#endif
 
 #if USE_PSRAM
 
@@ -72,6 +77,41 @@
     }
 
 #endif
+
+namespace
+{
+#if USE_PSRAM
+    struct JsonInternalAllocator : ArduinoJson::Allocator
+    {
+        void* allocate(size_t size) override
+        {
+            return heap_caps_malloc(size, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+        }
+
+        void deallocate(void* pointer) override
+        {
+            heap_caps_free(pointer);
+        }
+
+        void* reallocate(void* ptr, size_t new_size) override
+        {
+            return heap_caps_realloc(ptr, new_size, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+        }
+    };
+
+    JsonDocument CreateInternalJsonDocument()
+    {
+        static auto jsonInternalAllocator = JsonInternalAllocator();
+
+        return JsonDocument(&jsonInternalAllocator);
+    }
+#else
+    JsonDocument CreateInternalJsonDocument()
+    {
+        return JsonDocument();
+    }
+#endif
+}
 
 // SetIfNotOverflowed
 //
@@ -231,7 +271,7 @@ bool LoadJSONFile(const String & fileName, JsonDocument& jsonDoc)
 
 bool SaveToJSONFile(const String & fileName, IJSONSerializable& object)
 {
-    auto jsonDoc = CreateJsonDocument();
+    auto jsonDoc = CreateInternalJsonDocument();
     auto jsonObject = jsonDoc.to<JsonObject>();
 
     if (!object.SerializeToJSON(jsonObject))
@@ -239,6 +279,18 @@ bool SaveToJSONFile(const String & fileName, IJSONSerializable& object)
         debugE("Could not serialize object to JSON, skipping write to %s!", fileName.c_str());
         return false;
     }
+
+    if (jsonDoc.overflowed())
+    {
+        debugE("JSON document overflowed while preparing %s, skipping write!", fileName.c_str());
+        return false;
+    }
+
+    std::lock_guard renderPause(g_render_mutex);
+
+    #if USE_HUB75
+        HUB75GFX::WaitForMatrixSwap();
+    #endif
 
     SPIFFS.remove(fileName);
 
@@ -251,10 +303,11 @@ bool SaveToJSONFile(const String & fileName, IJSONSerializable& object)
     }
 
     size_t bytesWritten = serializeJson(jsonDoc, file);
-    debugI("Number of bytes written to JSON file %s: %zu", fileName.c_str(), (size_t)bytesWritten);
 
     file.flush();
     file.close();
+
+    debugI("Number of bytes written to JSON file %s: %zu", fileName.c_str(), (size_t)bytesWritten);
 
     if (bytesWritten == 0)
     {
@@ -268,6 +321,10 @@ bool SaveToJSONFile(const String & fileName, IJSONSerializable& object)
 
 bool RemoveJSONFile(const String & fileName)
 {
+    std::lock_guard renderPause(g_render_mutex);
+    #if USE_HUB75
+        HUB75GFX::WaitForMatrixSwap();
+    #endif
     return SPIFFS.remove(fileName);
 }
 
@@ -277,7 +334,7 @@ size_t JSONWriter::RegisterWriter(const std::function<void()>& writer)
 
     // Add the writer with its flag unset
     std::lock_guard guard(writersMutex);
-    writers.push_back(std::make_shared<WriterEntry>(writer));
+    writers.push_back(make_shared_internal<WriterEntry>(writer));
     return writers.size() - 1;
 }
 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -496,7 +496,7 @@ namespace nd_network
 
     size_t NetworkReader::RegisterReader(const std::function<void()> &reader, unsigned long interval, bool flag)
     {
-        auto entry = std::make_shared<ReaderEntry>(reader, interval);
+        auto entry = make_shared_internal<ReaderEntry>(reader, interval);
         readers.push_back(entry);
         if (interval) entry->lastReadMs.store(millis());
         if (flag) FlagReader(readers.size() - 1);

--- a/src/remotecontrol.cpp
+++ b/src/remotecontrol.cpp
@@ -531,9 +531,21 @@ public:
         config.rx_config.idle_threshold      = 20000; // 20ms idle = end of frame
 
         if (rmt_config(&config) != ESP_OK) return false;
-        if (rmt_driver_install(_channel, 1024, ESP_INTR_FLAG_IRAM) != ESP_OK) return false;
-        if (rmt_get_ringbuf_handle(_channel, &_ringbuf) != ESP_OK) return false;
-        if (rmt_rx_start(_channel, true) != ESP_OK) return false;
+
+        // The legacy RMT RX driver creates its ringbuffer with xRingbufferCreate(),
+        // which uses default malloc. With PSRAM-default routing enabled that buffer
+        // can live in external RAM, so an IRAM ISR can crash if it fires while the
+        // flash/PSRAM cache is disabled. Remote input can tolerate dropped frames
+        // during flash writes, so keep this interrupt out of the cache-disabled path.
+
+        if (rmt_driver_install(_channel, 1024, 0) != ESP_OK) 
+            return false;
+        
+        if (rmt_get_ringbuf_handle(_channel, &_ringbuf) != ESP_OK) 
+            return false;
+        
+        if (rmt_rx_start(_channel, true) != ESP_OK) 
+            return false;
 
         _begun = true;
         return true;

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -341,7 +341,8 @@ public:
                 // Title lines
                 int yh = 2;
                 display.setTextColor(display.GetBorderColor(), backColor);
-                String sEffect = String("Effect: ") + String(currentEffect + 1) + String("/") + String(g_ptrSystem->GetEffectManager().EffectCount());
+                const auto effectCount = g_ptrSystem->GetEffectManager().EffectCount();
+                String sEffect = String("Effect: ") + String(effectCount == 0 ? 0 : currentEffect + 1) + String("/") + String(effectCount);
                 auto w = display.textWidth(sEffect);
                 display.setCursor(display.width() / 2 - w / 2, yh);
                 display.print(sEffect.c_str());

--- a/src/systemcontainer.cpp
+++ b/src/systemcontainer.cpp
@@ -240,21 +240,21 @@ SystemContainer::BufferManagerContainer& SystemContainer::SetupBufferManagers()
 EffectManager& SystemContainer::SetupEffectManager(const std::shared_ptr<LEDStripEffect>& effect, DeviceContainer& devices)
 {
     if (!_ptrEffectManager)
-        _ptrEffectManager = make_unique_psram<EffectManager>(effect, devices);
+        _ptrEffectManager = make_unique_internal<EffectManager>(effect, devices);
     return *_ptrEffectManager;
 }
 
 EffectManager& SystemContainer::SetupEffectManager(DeviceContainer& devices)
 {
     if (!_ptrEffectManager)
-        _ptrEffectManager = make_unique_psram<EffectManager>(devices);
+        _ptrEffectManager = make_unique_internal<EffectManager>(devices);
     return *_ptrEffectManager;
 }
 
 EffectManager& SystemContainer::SetupEffectManager(const ArduinoJson::JsonObjectConst& jsonObject, DeviceContainer& devices)
 {
     if (!_ptrEffectManager)
-        _ptrEffectManager = make_unique_psram<EffectManager>(jsonObject, devices);
+        _ptrEffectManager = make_unique_internal<EffectManager>(jsonObject, devices);
     return *_ptrEffectManager;
 }
 
@@ -263,7 +263,7 @@ TaskManager& SystemContainer::SetupTaskManager()
 {
     if (!_ptrTaskManager)
     {
-        _ptrTaskManager = make_unique_psram<TaskManager>();
+        _ptrTaskManager = make_unique_internal<TaskManager>();
         _ptrTaskManager->begin();
     }
 
@@ -285,13 +285,13 @@ void SystemContainer::SetupConfig()
     
     if (!_ptrJSONWriter)
     {
-        _ptrJSONWriter = make_unique_psram<JSONWriter>();
+        _ptrJSONWriter = make_unique_internal<JSONWriter>();
         _ptrJSONWriter->Start();
     }
 
     // Create and load device config from SPIFFS if possible
     if (!_ptrDeviceConfig)
-        _ptrDeviceConfig = make_unique_psram<DeviceConfig>();
+        _ptrDeviceConfig = make_unique_internal<DeviceConfig>();
 }
 
 int SystemContainer::GetConfiguredAudioInputPin() const
@@ -372,7 +372,7 @@ bool SystemContainer::ApplyRuntimeConfiguration(String* errorMessage)
 NetworkReader& SystemContainer::SetupNetworkReader()
 {
     if (!_ptrNetworkReader)
-        _ptrNetworkReader = make_unique_psram<NetworkReader>();
+        _ptrNetworkReader = make_unique_internal<NetworkReader>();
     return *_ptrNetworkReader;
 }
 #endif
@@ -381,7 +381,7 @@ NetworkReader& SystemContainer::SetupNetworkReader()
 CWebServer& SystemContainer::SetupWebServer()
 {
     if (!_ptrWebServer)
-        _ptrWebServer = make_unique_psram<CWebServer>();
+        _ptrWebServer = make_unique_internal<CWebServer>();
     return *_ptrWebServer;
 }
 #endif
@@ -392,7 +392,7 @@ RemoteControl& SystemContainer::SetupRemoteControl()
     if (!_ptrRemoteControl)
     {
         debugI("Remote configured: enabled=1 pin=%d", IR_REMOTE_PIN);
-        _ptrRemoteControl = make_unique_psram<RemoteControl>();
+        _ptrRemoteControl = make_unique_internal<RemoteControl>();
     }
     return *_ptrRemoteControl;
 }
@@ -402,7 +402,7 @@ RemoteControl& SystemContainer::SetupRemoteControl()
 SocketServer& SystemContainer::SetupSocketServer(NetworkPort port, int ledCount)
 {
     if (!_ptrSocketServer)
-        _ptrSocketServer = make_unique_psram<SocketServer>(port, ledCount);
+        _ptrSocketServer = make_unique_internal<SocketServer>(port, ledCount);
     else
         _ptrSocketServer->SetLEDCount(ledCount);
     return *_ptrSocketServer;
@@ -413,7 +413,7 @@ SocketServer& SystemContainer::SetupSocketServer(NetworkPort port, int ledCount)
 WS281xOutputManager& SystemContainer::SetupWS281xOutputManager()
 {
     if (!_ptrWS281xOutputManager)
-        _ptrWS281xOutputManager = make_unique_psram<WS281xOutputManager>();
+        _ptrWS281xOutputManager = make_unique_internal<WS281xOutputManager>();
     return *_ptrWS281xOutputManager;
 }
 #endif
@@ -422,7 +422,7 @@ WS281xOutputManager& SystemContainer::SetupWS281xOutputManager()
 WebSocketServer& SystemContainer::SetupWebSocketServer(CWebServer& webServer)
 {
     if (!_ptrWebSocketServer)
-        _ptrWebSocketServer = make_unique_psram<WebSocketServer>(webServer);
+        _ptrWebSocketServer = make_unique_internal<WebSocketServer>(webServer);
     return *_ptrWebSocketServer;
 }
 #endif
@@ -438,7 +438,7 @@ Screen& SystemContainer::SetupHardwareDisplay(int w, int h)
 AudioService& SystemContainer::SetupAudioService()
 {
     if (!_ptrAudioService)
-        _ptrAudioService = make_unique_psram<AudioService>();
+        _ptrAudioService = make_unique_internal<AudioService>();
     return *_ptrAudioService;
 }
 
@@ -452,7 +452,7 @@ AudioService& SystemContainer::GetAudioService() const
 AudioSerialBridge& SystemContainer::SetupAudioSerialBridge()
 {
     if (!_ptrAudioSerialBridge)
-        _ptrAudioSerialBridge = make_unique_psram<AudioSerialBridge>();
+        _ptrAudioSerialBridge = make_unique_internal<AudioSerialBridge>();
     return *_ptrAudioSerialBridge;
 }
 
@@ -467,7 +467,7 @@ AudioSerialBridge& SystemContainer::GetAudioSerialBridge() const
 DebugConsole& SystemContainer::SetupDebugConsole()
 {
     if (!_ptrDebugConsole)
-        _ptrDebugConsole = make_unique_psram<DebugConsole>();
+        _ptrDebugConsole = make_unique_internal<DebugConsole>();
     return *_ptrDebugConsole;
 }
 
@@ -482,7 +482,7 @@ DebugConsole& SystemContainer::GetDebugConsole() const
 ColorStreamerService& SystemContainer::SetupColorStreamerService()
 {
     if (!_ptrColorStreamerService)
-        _ptrColorStreamerService = make_unique_psram<ColorStreamerService>();
+        _ptrColorStreamerService = make_unique_internal<ColorStreamerService>();
     return *_ptrColorStreamerService;
 }
 
@@ -496,7 +496,7 @@ ColorStreamerService& SystemContainer::GetColorStreamerService() const
 RenderService& SystemContainer::SetupRenderService()
 {
     if (!_ptrRenderService)
-        _ptrRenderService = make_unique_psram<RenderService>();
+        _ptrRenderService = make_unique_internal<RenderService>();
     return *_ptrRenderService;
 }
 


### PR DESCRIPTION
Adds a new optional WIFI_ACTIVITY pin that goes HIGH during WiFi drawing.  Also allows projects to contain zero active effects such that they render no output (and signal no activity) until wifi drawing goes active.

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).