### PR TITLE
Activeline _ Add a WiFi activity output signal option, allow for zero effects in main table

### DIFF
--- a/include/effectmanager.h
+++ b/include/effectmanager.h
@@ -269,6 +269,7 @@ public:
     bool IsCoreEffect(size_t index) const;
     size_t EffectCount() const;
     bool AreEffectsEnabled() const;
+    bool HasCurrentEffect() const;
     size_t GetCurrentEffectIndex() const;
     LEDStripEffect& GetCurrentEffect() const;
     String GetCurrentEffectName() const;

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -556,30 +556,25 @@ public:
             g_ptrSystem->GetNetworkReader().FlagReader(readerIndex);
         }
 
-        String displayLocationName;
-        String displayLocation;
-        String displayIconToday;
-        String displayIconTomorrow;
-        float displayTemperature;
-        float displayHighToday;
-        float displayLoToday;
-        float displayHighTomorrow;
-        float displayLoTomorrow;
-        bool displayDataReady;
+        // Hold the weather data lock for the rest of the frame. The writer
+        // (network reader task) only takes this lock for the few microseconds
+        // it takes to assign these fields after the HTTP fetch completes, so
+        // blocking here is effectively never observable and never approaches
+        // anything the WDT would care about. We do NOT take any other lock
+        // (render / effect manager) while holding this one, which keeps the
+        // ordering one-way and inversion-proof.
+        std::lock_guard guard(weatherDataMutex);
 
-        {
-            std::lock_guard guard(weatherDataMutex);
-            displayLocationName = strLocationName;
-            displayLocation = strLocation;
-            displayIconToday = iconToday;
-            displayIconTomorrow = iconTomorrow;
-            displayTemperature = temperature;
-            displayHighToday = highToday;
-            displayLoToday = loToday;
-            displayHighTomorrow = highTomorrow;
-            displayLoTomorrow = loTomorrow;
-            displayDataReady = dataReady;
-        }
+        const String& displayLocationName = strLocationName;
+        const String& displayLocation     = strLocation;
+        const String& displayIconToday    = iconToday;
+        const String& displayIconTomorrow = iconTomorrow;
+        const float   displayTemperature  = temperature;
+        const float   displayHighToday    = highToday;
+        const float   displayLoToday      = loToday;
+        const float   displayHighTomorrow = highTomorrow;
+        const float   displayLoTomorrow   = loTomorrow;
+        const bool    displayDataReady    = dataReady;
 
         // Draw the graphics
         auto iconEntry = weatherIcons.find(displayIconToday);

--- a/include/globals.h
+++ b/include/globals.h
@@ -322,6 +322,10 @@ extern std::recursive_mutex g_effect_manager_mutex;
     #define LED_PIN0         5
 #endif
 
+#ifndef WIFI_ACTIVITY_PIN
+    #define WIFI_ACTIVITY_PIN -1
+#endif
+
 #ifndef PROJECT_NAME
 #define PROJECT_NAME        "Mesmerizer"
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -106,6 +106,7 @@ board           = adafruit_feather_esp32s3_tft
 monitor_speed   = 115200
 upload_speed    = 1500000
 build_flags     = ${dev_esp32_s3.build_flags}
+                  ${psram_common_flags.build_flags}
                   -DUSER_SETUP_LOADED
                   -DST7789_2_DRIVER
                   -DTFT_WIDTH=135
@@ -132,6 +133,7 @@ build_src_flags = ${dev_esp32_s3.build_src_flags}
                   -DESP32FEATHERTFT=1
                   -DTOGGLE_BUTTON_0=0
                   -DLED_PIN0=5
+                  -DLED_PIN1=6
 
 board_build.partitions = config/partitions_custom.csv
 lib_deps        = ${dev_esp32_s3.lib_deps}
@@ -875,7 +877,6 @@ lib_deps        = ${dev_heltec_wifi.lib_deps}
 [env:ledstrip_feather]
 extends         = dev_adafruit_feather
 build_flags     = ${dev_adafruit_feather.build_flags}
-                  ${psram_lx6_flags.build_flags}
 build_src_flags = ${dev_adafruit_feather.build_src_flags}
                   -DLEDSTRIP=1
                   -DEFFECTS_MINIMAL=1
@@ -883,7 +884,6 @@ build_src_flags = ${dev_adafruit_feather.build_src_flags}
 [env:ledstrip_feather_hexagon]
 extends         = dev_adafruit_feather
 build_flags     = ${dev_adafruit_feather.build_flags}
-                  ${psram_lx6_flags.build_flags}
 build_src_flags = ${dev_adafruit_feather.build_src_flags}
                   -DHEXAGON=1
                   -DEFFECTS_HEXAGON=1
@@ -901,6 +901,23 @@ build_src_flags = ${dev_adafruit_feather.build_src_flags}
                   -DDEFAULT_EFFECT_INTERVAL=1000*20
                   -DHEX_MAX_DIMENSION=19
                   -DHEX_HALF_DIMENSION=10
+
+; trimlight is based off ledstrip_feather for the ESP32S3 TFT Feather, but
+; drives two WS281x output channels and renders only incoming WiFi frames.
+[env:trimlight]
+extends         = dev_adafruit_feather
+build_flags     = ${dev_adafruit_feather.build_flags}
+build_src_flags = ${dev_adafruit_feather.build_src_flags}
+                  -DMATRIX_WIDTH=271
+                  -DMATRIX_HEIGHT=1
+                  -DTRIMLIGHT=1
+                  -DPROJECT_NAME="\"Trimlight\""
+                  -DENABLE_WIFI=1
+                  -DINCOMING_WIFI_ENABLED=1
+                  -DWAIT_FOR_WIFI=0
+                  -DNUM_CHANNELS=2
+                  -DEFFECTS_TRIMLIGHT=1
+                  -DWIFI_ACTIVITY_PIN=9
 
 [env:ledstrip_feather_wrover]
 extends         = dev_wrover

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -49,8 +49,61 @@
 
 static DRAM_ATTR CRGB l_SinglePixel = CRGB::Blue;
 static DRAM_ATTR uint64_t l_usLastWifiDraw = 0;
+static DRAM_ATTR bool l_WiFiActivityActive = false;
 static uint32_t l_FrameCountThisSecond = 0;
 static uint32_t l_LastSecondBoundaryMs = 0;
+
+static uint32_t MicrosSinceLastWifiDraw()
+{
+    return micros() - static_cast<uint32_t>(l_usLastWifiDraw);
+}
+
+#if WIFI_ACTIVITY_PIN >= 0
+static bool IsWiFiDrawWindowActive()
+{
+    return l_usLastWifiDraw != 0 && MicrosSinceLastWifiDraw() <= (TIME_BEFORE_LOCAL * MICROS_PER_SECOND);
+}
+
+static void SetWiFiActivityPin(bool active)
+{
+    if (l_WiFiActivityActive == active)
+        return;
+
+    digitalWrite(WIFI_ACTIVITY_PIN, active ? HIGH : LOW);
+    l_WiFiActivityActive = active;
+}
+
+static void PrepareWiFiActivityPin()
+{
+    pinMode(WIFI_ACTIVITY_PIN, OUTPUT);
+    digitalWrite(WIFI_ACTIVITY_PIN, LOW);
+    l_WiFiActivityActive = false;
+}
+
+static void UpdateWiFiActivityPin(uint16_t wifiPixelsDrawn, uint16_t localPixelsDrawn)
+{
+    if (wifiPixelsDrawn > 0)
+    {
+        SetWiFiActivityPin(true);
+        return;
+    }
+
+    if (localPixelsDrawn > 0 || !IsWiFiDrawWindowActive())
+        SetWiFiActivityPin(false);
+}
+#else
+static void PrepareWiFiActivityPin()
+{
+}
+
+static void UpdateWiFiActivityPin(uint16_t, uint16_t)
+{
+}
+
+static void SetWiFiActivityPin(bool)
+{
+}
+#endif
 
 // The g_buffer_mutex is a global mutex used to protect access while adding or removing frames
 // from the led buffer.
@@ -126,10 +179,10 @@ uint16_t LocalDraw()
     {
         auto& effectManager = g_ptrSystem->GetEffectManager();
 
-        if (effectManager.EffectCount() > 0)
+        if (effectManager.HasCurrentEffect())
         {
             // If we've never drawn from wifi before, now would also be a good time to local draw
-            if (l_usLastWifiDraw == 0 || (micros() - l_usLastWifiDraw > (TIME_BEFORE_LOCAL * MICROS_PER_SECOND)))
+            if (l_usLastWifiDraw == 0 || (MicrosSinceLastWifiDraw() > (TIME_BEFORE_LOCAL * MICROS_PER_SECOND)))
             {
                 effectManager.Update(); // Draw the current built in effect
 
@@ -147,7 +200,7 @@ uint16_t LocalDraw()
             }
             else
             {
-                debugV("Not drawing local effect because last wifi draw was %lf seconds ago.", (micros() - l_usLastWifiDraw) / (float)MICROS_PER_SECOND);
+                debugV("Not drawing local effect because last wifi draw was %lf seconds ago.", MicrosSinceLastWifiDraw() / (float)MICROS_PER_SECOND);
                 // It's important to return 0 when you do not draw so that the caller knows we did not
                 // render any pixels, and we can/should wait until the next frame.  Otherwise, the caller might
                 // draw the strip needlessly, which can take significant time.
@@ -177,7 +230,9 @@ int CalcDelayUntilNextFrame(double frameStartTime, uint16_t localPixelsDrawn, ui
         double fpsRaw = 0.0;
         {
             std::lock_guard effectGuard(g_effect_manager_mutex);
-            fpsRaw = static_cast<double>(g_ptrSystem->GetEffectManager().GetCurrentEffect().DesiredFramesPerSecond());
+            auto& effectManager = g_ptrSystem->GetEffectManager();
+            if (effectManager.HasCurrentEffect())
+                fpsRaw = static_cast<double>(effectManager.GetCurrentEffect().DesiredFramesPerSecond());
         }
         // If FPS is invalid (<= 0 or non-finite), treat as unlimited (0s minimum frame time).
         const double minimumFrameTime = (!std::isfinite(fpsRaw) || fpsRaw <= 0.0) ? 0.0 : (1.0 / fpsRaw);
@@ -308,6 +363,7 @@ void IRAM_ATTR RenderService::Run()
     // If this board has an onboard RGB pixel, set it up now
 
     PrepareOnboardPixel();
+    PrepareWiFiActivityPin();
 
     // Start the effect
 
@@ -379,6 +435,7 @@ void IRAM_ATTR RenderService::Run()
             }
 
             graphics.PostProcessFrame(localPixelsDrawn, wifiPixelsDrawn);
+            UpdateWiFiActivityPin(wifiPixelsDrawn, localPixelsDrawn);
         }
 
         // Delay at least 2ms and not more than 1s until next frame is due
@@ -392,4 +449,6 @@ void IRAM_ATTR RenderService::Run()
         if (g_Values.UpdateStarted)
             delay(500);
     }
+
+    SetWiFiActivityPin(false);
 }

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -151,7 +151,18 @@ void EffectManager::StartEffect()
     // If there's a temporary effect override from the remote control active, we start that, else
     // we start the current regular effect
 
-    std::shared_ptr<LEDStripEffect> & effect = _tempEffect ? _tempEffect : _vEffects[_iCurrentEffect];
+    if (!_tempEffect && _vEffects.empty())
+    {
+        _iCurrentEffect = 0;
+        _effectStartTime = millis();
+        debugV("No effect to start");
+        return;
+    }
+
+    if (!_vEffects.empty() && _iCurrentEffect >= _vEffects.size())
+        _iCurrentEffect = 0;
+
+    auto effect = _tempEffect ? _tempEffect : _vEffects[_iCurrentEffect];
 
     #if USE_HUB75
         auto& matrix = static_cast<HUB75GFX&>(*_gfx[0]);
@@ -193,6 +204,9 @@ void EffectManager::DispatchBeatIfNeeded()
 
     // Beat callbacks are sequenced here so every active effect sees the same
     // detector output, including BeatEffectBase-derived effects via OnBeat().
+    if (!_tempEffect && _vEffects.empty())
+        return;
+
     auto& currentEffect = GetCurrentEffect();
 
     const auto nearBeat = g_Analyzer.LastNearBeat();
@@ -409,6 +423,12 @@ bool EffectManager::AreEffectsEnabled() const
     return std::any_of(_vEffects.begin(), _vEffects.end(), [](const auto& pEffect){ return pEffect->IsEnabled(); } );
 }
 
+bool EffectManager::HasCurrentEffect() const
+{
+    std::lock_guard effectGuard(g_effect_manager_mutex);
+    return _tempEffect || !_vEffects.empty();
+}
+
 size_t EffectManager::GetCurrentEffectIndex() const
 {
     std::lock_guard effectGuard(g_effect_manager_mutex);
@@ -418,7 +438,11 @@ size_t EffectManager::GetCurrentEffectIndex() const
 LEDStripEffect& EffectManager::GetCurrentEffect() const
 {
     std::lock_guard effectGuard(g_effect_manager_mutex);
-    return *(_tempEffect ? _tempEffect : _vEffects[_iCurrentEffect]);
+    if (!_tempEffect && _vEffects.empty())
+        throw std::runtime_error("No current effect");
+
+    const size_t index = _vEffects.empty() ? 0 : std::min(_iCurrentEffect, _vEffects.size() - 1);
+    return *(_tempEffect ? _tempEffect : _vEffects[index]);
 }
 
 String EffectManager::GetCurrentEffectName() const
@@ -430,7 +454,10 @@ String EffectManager::GetCurrentEffectName() const
     if (_tempEffect)
         return _tempEffect->FriendlyName();
 
-    return _vEffects[_iCurrentEffect]->FriendlyName();
+    if (_vEffects.empty())
+        return "No Effect";
+
+    return _vEffects[std::min(_iCurrentEffect, _vEffects.size() - 1)]->FriendlyName();
 }
 
 void EffectManager::SetCurrentEffectIndex(size_t i)
@@ -463,6 +490,9 @@ uint EffectManager::GetTimeUsedByCurrentEffect() const
 uint EffectManager::GetTimeRemainingForCurrentEffect() const
 {
     std::lock_guard effectGuard(g_effect_manager_mutex);
+    if (!_tempEffect && _vEffects.empty())
+        return 0;
+
     // If the Interval is set to zero, we treat that as an infinite interval and don't even look at the time used so far
     uint timeUsedByCurrentEffect = GetTimeUsedByCurrentEffect();
     uint interval = GetEffectiveInterval();
@@ -473,7 +503,11 @@ uint EffectManager::GetTimeRemainingForCurrentEffect() const
 uint EffectManager::GetEffectiveInterval() const
 {
     std::lock_guard effectGuard(g_effect_manager_mutex);
-    auto& currentEffect = *(_tempEffect ? _tempEffect : _vEffects[_iCurrentEffect]);
+    if (!_tempEffect && _vEffects.empty())
+        return IsIntervalEternal() ? std::numeric_limits<uint>::max() : _effectInterval;
+
+    const size_t index = _vEffects.empty() ? 0 : std::min(_iCurrentEffect, _vEffects.size() - 1);
+    auto& currentEffect = *(_tempEffect ? _tempEffect : _vEffects[index]);
     // This allows you to return a MaximumEffectTime and your effect won't be shown longer than that
     return min((IsIntervalEternal() ? std::numeric_limits<uint>::max() : _effectInterval),
                (currentEffect.HasMaximumEffectTime() ? currentEffect.MaximumEffectTime() : std::numeric_limits<uint>::max()));
@@ -731,7 +765,10 @@ bool EffectManager::Init()
         }
         debugV("Loaded Effect: %s", _vEffect->FriendlyName().c_str());
     }
-    debugV("First Effect: %s", GetCurrentEffectName().c_str());
+    if (_vEffects.empty())
+        debugV("No local effects loaded");
+    else
+        debugV("First Effect: %s", GetCurrentEffectName().c_str());
 
     if (g_ptrSystem->GetDeviceConfig().ApplyGlobalColors())
         ApplyGlobalPaletteColors();
@@ -779,7 +816,9 @@ bool EffectManager::ShowVU(bool bShow)
 bool EffectManager::IsVUVisible() const
 {
     std::lock_guard effectGuard(g_effect_manager_mutex);
-    return g_ptrSystem->GetDeviceConfig().ShowVUMeter() && GetCurrentEffect().CanDisplayVUMeter();
+    return g_ptrSystem->GetDeviceConfig().ShowVUMeter() &&
+           (_tempEffect || !_vEffects.empty()) &&
+           GetCurrentEffect().CanDisplayVUMeter();
 }
 
 
@@ -846,9 +885,19 @@ void EffectManager::construct(bool clearTempEffect)
     _bPlayAll = false;
 
     if (clearTempEffect && _tempEffect)
-    {
         _clearTempEffectWhenExpired = true;
 
+    if (_vEffects.empty())
+    {
+        _iCurrentEffect = 0;
+        return;
+    }
+
+    if (_iCurrentEffect >= _vEffects.size())
+        _iCurrentEffect = _vEffects.size() - 1;
+
+    if (clearTempEffect && _tempEffect)
+    {
         // This ensures that we start the correct effect after the temporary one.
         //   The switching to the next effect is taken care of by NextEffect(), which starts with
         //   increasing _iCurrentEffect. We therefore need to set it to the previous effect, to
@@ -910,10 +959,7 @@ bool EffectManager::DeserializeFromJSON(const JsonObjectConst& jsonObject)
 
     // If no effects were successfully loaded from JSON, it loads the default effects.
     if (_vEffects.empty())
-    {
         LoadDefaultEffects();
-        return true;
-    }
 
     // "eef" was the array of effect enabled flags. They have now been integrated in the effects themselves;
     //   this code is there to "migrate" users who already had a serialized effect config on their device
@@ -940,7 +986,9 @@ bool EffectManager::DeserializeFromJSON(const JsonObjectConst& jsonObject)
         _iCurrentEffect = jsonObject["cei"];
 
     // Make sure that if we read an index, it's sane
-    if (_iCurrentEffect >= EffectCount())
+    if (_vEffects.empty())
+        _iCurrentEffect = 0;
+    else if (_iCurrentEffect >= EffectCount())
         _iCurrentEffect = EffectCount() - 1;
 
     construct(true);
@@ -1127,17 +1175,24 @@ bool EffectManager::DeleteEffect(size_t index)
 
     DisableEffect(index, true);
 
-    if (index == _iCurrentEffect)
-        NextEffect();
+    if (index == _iCurrentEffect && _vEffects.size() > 1)
+        NextEffect(true);
 
     _vEffects.erase(_vEffects.begin() + index);
 
-    if (index <= _iCurrentEffect)
+    if (_vEffects.empty())
     {
-        _iCurrentEffect--;
-        SaveCurrentEffectIndex();
+        _iCurrentEffect = 0;
+    }
+    else if (index <= _iCurrentEffect)
+    {
+        if (_iCurrentEffect > 0)
+            _iCurrentEffect--;
+        else if (_iCurrentEffect >= _vEffects.size())
+            _iCurrentEffect = _vEffects.size() - 1;
     }
 
+    SaveCurrentEffectIndex();
     SaveEffectManagerConfig();
 
     {
@@ -1151,6 +1206,9 @@ bool EffectManager::DeleteEffect(size_t index)
 void EffectManager::CheckEffectTimerExpired()
 {
     std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
+    if (!_tempEffect && _vEffects.empty())
+        return;
 
     if (IsIntervalEternal() && !GetCurrentEffect().HasMaximumEffectTime())
         return;
@@ -1175,6 +1233,13 @@ void EffectManager::NextEffect(bool skipSave)
 {
     std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
 
+    if (_vEffects.empty())
+    {
+        _iCurrentEffect = 0;
+        _effectStartTime = millis();
+        return;
+    }
+
     auto enabled = AreEffectsEnabled();
 
     do
@@ -1185,7 +1250,8 @@ void EffectManager::NextEffect(bool skipSave)
     } while (enabled && false == _bPlayAll && false == IsEffectEnabled(_iCurrentEffect));
 
     StartEffect();
-    SaveCurrentEffectIndex();
+    if (!skipSave)
+        SaveCurrentEffectIndex();
 
     {
         std::lock_guard listenerGuard(_listenerMutex);
@@ -1198,6 +1264,13 @@ void EffectManager::NextEffect(bool skipSave)
 void EffectManager::PreviousEffect()
 {
     std::scoped_lock guard(g_render_mutex, g_effect_manager_mutex);
+
+    if (_vEffects.empty())
+    {
+        _iCurrentEffect = 0;
+        _effectStartTime = millis();
+        return;
+    }
 
     auto enabled = AreEffectsEnabled();
 
@@ -1229,6 +1302,12 @@ void EffectManager::Update()
 
     if ((_gfx[0])->GetLEDCount() == 0)
         return;
+
+    if (!_tempEffect && _vEffects.empty())
+    {
+        ApplyFadeLogic();
+        return;
+    }
 
     CheckEffectTimerExpired();
     DispatchBeatIfNeeded();

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -198,6 +198,10 @@ void LoadEffectFactories()
         );
     #endif
 
+    #if defined(EFFECTS_TRIMLIGHT)
+        // Trimlight intentionally has no local effects. It renders only incoming WiFi frames.
+    #endif
+
     #if defined(EFFECTS_PDPWOPR)
         // PDPWOPR project effects
         RegisterAll(*g_ptrEffectFactories,
@@ -586,20 +590,6 @@ void LoadEffectFactories()
         );
 
     #endif
-
-    // Default fallback if no set contributed any effect
-    if (g_ptrEffectFactories->IsEmpty())
-    {
-        RegisterAll(*g_ptrEffectFactories,
-            Effect<RainbowFillEffect>(6, 2)
-        );
-    }
-
-    // If this assert fires, you have not defined any effects in the table above.  If adding a new config, you need to
-    // add the list of effects in this table as shown for the various other existing configs.  You MUST have at least
-    // one effect even if it's the Status effect.
-
-    assert(!g_ptrEffectFactories->IsEmpty());
 
     auto factoriesHashString = fnv1a::hash_to_string(fnv1a::hash<uint64_t>(g_ptrEffectFactories->FactoryIDs()));
     g_ptrEffectFactories->HashString(factoriesHashString);

--- a/src/hub75gfx.cpp
+++ b/src/hub75gfx.cpp
@@ -282,7 +282,8 @@ void HUB75GFX::PrepareFrame()
         // so that we can fade between effects without having to change the brightness
         // setting.
 
-        if (g_ptrSystem->GetEffectManager().GetCurrentEffect().ShouldShowTitle() && pMatrix.GetCaptionTransparency() > 0.00)
+        auto& effectManager = g_ptrSystem->GetEffectManager();
+        if (effectManager.HasCurrentEffect() && effectManager.GetCurrentEffect().ShouldShowTitle() && pMatrix.GetCaptionTransparency() > 0.00)
         {
             titleLayer.setFont(font3x5);
             uint8_t brite = (uint8_t)(pMatrix.GetCaptionTransparency() * 255.0);
@@ -398,7 +399,9 @@ void HUB75GFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDr
         backgroundLayer.drawString(2, MATRIX_HEIGHT  - 6, rgb24(255, 255, 255), rgb24(0, 0, 0), output.c_str());
     #endif
 
-    MatrixSwapBuffers((wifiPixelsDrawn > 0) || g_ptrSystem->GetEffectManager().GetCurrentEffect().RequiresDoubleBuffering() || pMatrix.GetCaptionTransparency() > 0.0);
+    auto& effectManager = g_ptrSystem->GetEffectManager();
+    const bool effectRequiresDoubleBuffering = effectManager.HasCurrentEffect() && effectManager.GetCurrentEffect().RequiresDoubleBuffering();
+    MatrixSwapBuffers((wifiPixelsDrawn > 0) || effectRequiresDoubleBuffering || pMatrix.GetCaptionTransparency() > 0.0);
 
     FastLED.countFPS();
 }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -341,7 +341,8 @@ public:
                 // Title lines
                 int yh = 2;
                 display.setTextColor(display.GetBorderColor(), backColor);
-                String sEffect = String("Effect: ") + String(currentEffect + 1) + String("/") + String(g_ptrSystem->GetEffectManager().EffectCount());
+                const auto effectCount = g_ptrSystem->GetEffectManager().EffectCount();
+                String sEffect = String("Effect: ") + String(effectCount == 0 ? 0 : currentEffect + 1) + String("/") + String(effectCount);
                 auto w = display.textWidth(sEffect);
                 display.setCursor(display.width() / 2 - w / 2, yh);
                 display.print(sEffect.c_str());


### PR DESCRIPTION
Adds a new optional WIFI_ACTIVITY pin that goes HIGH during WiFi drawing. Also allows projects to contain zero active effects such that they render no output (and signal no activity) until wifi drawing goes active.

This PR replaces #886 with a clean branch rebased from current upstream/main and only the intended commits replayed, to avoid re-reviewing already-merged shared history.