### PR TITLE
APA102 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .idea/**
 .pio
 .vscode/**
+compile_commands.json
 **/.idea/**
 **/*.iml
 **/*.swn

--- a/include/apa102outputmanager.h
+++ b/include/apa102outputmanager.h
@@ -6,9 +6,11 @@
 //
 // NightDriverStrip - (c) 2026 Plummer's Software LLC.  All Rights Reserved.
 //
-// Runtime APA102 output manager. Keeps the existing CRGB strip frame buffers
-// and drives APA102/SK9822-style two-wire LEDs with one data and one clock GPIO
-// per channel.
+// Runtime APA102 output manager. Drives APA102/SK9822 strips through the
+// ESP32 hardware SPI master with DMA. Each channel binds to its own SPI
+// host (SPI2_HOST, then SPI3_HOST), so the manager supports at most two
+// simultaneous APA102 channels; that matches the number of general-purpose
+// SPI peripherals exposed by the ESP32 family.
 //
 //              2-Jun-2026         Created      Davepl
 //---------------------------------------------------------------------------
@@ -22,6 +24,8 @@
 #include <memory>
 #include <vector>
 
+#include <driver/spi_master.h>
+
 #include "deviceconfig.h"
 #include "stripoutputmanager.h"
 
@@ -29,20 +33,29 @@ class GFXBase;
 
 class APA102OutputManager : public IStripOutputManager
 {
+  public:
+    // ESP32 / ESP32-S3 expose two general-purpose SPI hosts (SPI2/SPI3); one APA102 channel per host.
+    static constexpr size_t kMaxChannels = 2;
+
+  private:
     struct ChannelState
     {
-        int8_t dataPin = -1;
-        int8_t clockPin = -1;
-        size_t ledCount = 0;
-        bool active = false;
+        spi_host_device_t   host       = SPI2_HOST;
+        spi_device_handle_t device     = nullptr;
+        int8_t              dataPin    = -1;
+        int8_t              clockPin   = -1;
+        size_t              ledCount   = 0;
+        uint8_t*            buffer     = nullptr;
+        size_t              bufferSize = 0;
+        bool                active     = false;
     };
 
-    std::array<ChannelState, NUM_CHANNELS> _channels{};
+    std::array<ChannelState, kMaxChannels> _channels{};
     size_t _activeChannelCount = 0;
     size_t _activeLEDCount = 0;
     DeviceConfig::WS281xColorOrder _colorOrder = DeviceConfig::GetCompiledWS281xColorOrder();
 
-    void ConfigureChannel(size_t channelIndex, int8_t dataPin, int8_t clockPin, size_t ledCount);
+    bool ConfigureChannel(size_t channelIndex, int8_t dataPin, int8_t clockPin, size_t ledCount, String* errorMessage);
     void ReleaseChannel(size_t channelIndex);
 
   public:

--- a/include/apa102outputmanager.h
+++ b/include/apa102outputmanager.h
@@ -2,18 +2,20 @@
 
 //+--------------------------------------------------------------------------
 //
-// File:        ws281xoutputmanager.h
+// File:        apa102outputmanager.h
 //
-// NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
+// NightDriverStrip - (c) 2026 Plummer's Software LLC.  All Rights Reserved.
 //
-// Runtime WS281x output manager. Keeps FastLED for effect math and CRGB buffers,
-// but moves GPIO/channel binding into a reconfigurable ESP32 output layer.
+// Runtime APA102 output manager. Keeps the existing CRGB strip frame buffers
+// and drives APA102/SK9822-style two-wire LEDs with one data and one clock GPIO
+// per channel.
 //
+//              2-Jun-2026         Created      Davepl
 //---------------------------------------------------------------------------
 
 #include "globals.h"
 
-#if USE_WS281X
+#if USE_APA102
 
 #include <array>
 #include <cstdint>
@@ -24,34 +26,28 @@
 #include "stripoutputmanager.h"
 
 class GFXBase;
-class Transport;
-class PixelFormat;
 
-class WS281xOutputManager : public IStripOutputManager
+class APA102OutputManager : public IStripOutputManager
 {
     struct ChannelState
     {
-        int8_t pin = -1;
+        int8_t dataPin = -1;
+        int8_t clockPin = -1;
         size_t ledCount = 0;
-        size_t byteCount = 0;
-        bool installed = false;
         bool active = false;
-        std::unique_ptr<uint8_t[]> outputBytes;
     };
 
     std::array<ChannelState, NUM_CHANNELS> _channels{};
     size_t _activeChannelCount = 0;
     size_t _activeLEDCount = 0;
     DeviceConfig::WS281xColorOrder _colorOrder = DeviceConfig::GetCompiledWS281xColorOrder();
-    std::unique_ptr<Transport>    _transport;
-    std::unique_ptr<PixelFormat>  _format;          // picked at construction by chip-type flag
 
-    bool RecreateChannel(size_t channelIndex, int8_t pin, size_t ledCount, String* errorMessage);
+    void ConfigureChannel(size_t channelIndex, int8_t dataPin, int8_t clockPin, size_t ledCount);
     void ReleaseChannel(size_t channelIndex);
 
   public:
-    WS281xOutputManager();
-    ~WS281xOutputManager() override;
+    APA102OutputManager();
+    ~APA102OutputManager() override;
 
     bool ApplyConfig(const DeviceConfig& config, const std::vector<std::shared_ptr<GFXBase>>& devices, String* errorMessage = nullptr) override;
     void Show(const std::vector<std::shared_ptr<GFXBase>>& devices, uint16_t pixelsDrawn, uint8_t brightness, uint8_t fader) override;

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -129,6 +129,7 @@ class DeviceConfig : public IJSONSerializable
     enum class OutputDriver : uint8_t
     {
         WS281x,
+        APA102,
         HUB75
     };
 
@@ -154,11 +155,14 @@ class DeviceConfig : public IJSONSerializable
         OutputDriver driver =
         #if USE_HUB75
             OutputDriver::HUB75;
+        #elif USE_APA102
+            OutputDriver::APA102;
         #else
             OutputDriver::WS281x;
         #endif
         size_t channelCount = NUM_CHANNELS;
         std::array<int8_t, NUM_CHANNELS> outputPins{};
+        std::array<int8_t, NUM_CHANNELS> clockPins{};
         WS281xColorOrder colorOrder = WS281xColorOrder::GRB;
     };
 
@@ -250,6 +254,7 @@ class DeviceConfig : public IJSONSerializable
     static constexpr const char * WS281xChannelCountTag = "ws281xChannelCount";
     static constexpr const char * WS281xPinsTag = "ws281xPins";
     static constexpr const char * WS281xColorOrderTag = "ws281xColorOrder";
+    static constexpr const char * APA102ClockPinsTag = "apa102ClockPins";
     static constexpr const char * AudioInputPinTag = NAME_OF(audioInputPin);
 
     DeviceConfig();
@@ -334,12 +339,15 @@ class DeviceConfig : public IJSONSerializable
     static constexpr size_t GetCompiledChannelCount() { return NUM_CHANNELS; }
     static constexpr int GetCompiledAudioInputPin() { return AUDIO_INPUT_PIN; }
     static std::array<int8_t, NUM_CHANNELS> GetCompiledWS281xPins();
+    static std::array<int8_t, NUM_CHANNELS> GetCompiledAPA102ClockPins();
     static WS281xColorOrder GetCompiledWS281xColorOrder();
     static String GetColorOrderName(WS281xColorOrder colorOrder);
     static OutputDriver GetCompiledOutputDriver()
     {
         #if USE_HUB75
             return OutputDriver::HUB75;
+        #elif USE_APA102
+            return OutputDriver::APA102;
         #else
             return OutputDriver::WS281x;
         #endif
@@ -356,9 +364,11 @@ class DeviceConfig : public IJSONSerializable
     OutputDriver GetOutputDriver() const { return runtimeOutputs.driver; }
     size_t GetChannelCount() const { return runtimeOutputs.channelCount; }
     const std::array<int8_t, NUM_CHANNELS>& GetWS281xPins() const { return runtimeOutputs.outputPins; }
+    const std::array<int8_t, NUM_CHANNELS>& GetAPA102DataPins() const { return runtimeOutputs.outputPins; }
+    const std::array<int8_t, NUM_CHANNELS>& GetAPA102ClockPins() const { return runtimeOutputs.clockPins; }
     WS281xColorOrder GetWS281xColorOrder() const { return runtimeOutputs.colorOrder; }
-    bool SupportsLiveTopology() const { return !IsHub75Build() && runtimeOutputs.driver == OutputDriver::WS281x; }
-    bool SupportsLiveOutputReconfigure() const { return !IsHub75Build() && runtimeOutputs.driver == OutputDriver::WS281x; }
+    bool SupportsLiveTopology() const { return !IsHub75Build() && runtimeOutputs.driver == GetCompiledOutputDriver(); }
+    bool SupportsLiveOutputReconfigure() const { return !IsHub75Build() && runtimeOutputs.driver == GetCompiledOutputDriver(); }
     bool SupportsConfigurableAudioInputPin() const
     {
         #if ENABLE_AUDIO && !USE_M5 && (USE_I2S_AUDIO || ELECROW)
@@ -397,7 +407,10 @@ class DeviceConfig : public IJSONSerializable
     ValidateResponse ValidateAudioInputPin(int pin) const;
     ValidateResponse ValidateTopology(uint16_t width, uint16_t height, bool serpentine) const;
     ValidateResponse ValidateOutputDriver(OutputDriver driver) const;
-    ValidateResponse ValidateWS281xSettings(size_t channelCount, const std::array<int8_t, NUM_CHANNELS>& pins, WS281xColorOrder colorOrder) const;
+    ValidateResponse ValidateStripSettings(size_t channelCount,
+                                           const std::array<int8_t, NUM_CHANNELS>& dataPins,
+                                           const std::array<int8_t, NUM_CHANNELS>& clockPins,
+                                           WS281xColorOrder colorOrder) const;
     ValidateResponse ValidateRuntimeConfig(const RuntimeConfig& config) const;
     bool SetRuntimeConfig(const RuntimeConfig& config, bool skipWrite = false, String* errorMessage = nullptr);
     void SetAudioInputPin(int newAudioInputPin);

--- a/include/globals.h
+++ b/include/globals.h
@@ -122,10 +122,30 @@ extern std::recursive_mutex g_effect_manager_mutex;
 
 #define FLASH_VERSION          40   // Update ONLY this to increment the version number
 
-#ifndef USE_HUB75                   // We support strips by default unless specifically defined out
-    #ifndef USE_WS281X
+// Output transport selection: exactly one of USE_HUB75 / USE_WS281X / USE_APA102.
+// USE_STRIP is derived from the two strip transports.
+#ifndef USE_HUB75
+    #define USE_HUB75 0
+#endif
+
+#ifndef USE_APA102
+    #define USE_APA102 0
+#endif
+
+#ifndef USE_WS281X
+    // Strip projects historically defaulted to WS281x whenever the build
+    // wasn't HUB75 or APA102. Preserve that default.
+    #if !USE_HUB75 && !USE_APA102
         #define USE_WS281X 1
+    #else
+        #define USE_WS281X 0
     #endif
+#endif
+
+#define USE_STRIP (USE_WS281X || USE_APA102)
+
+#if (USE_HUB75 + USE_WS281X + USE_APA102) != 1
+    #error "Define exactly one output transport: USE_HUB75, USE_WS281X, or USE_APA102"
 #endif
 
 #define XSTR(x) ND_STR(x)           // The defs will generate the stringized version of it
@@ -322,6 +342,53 @@ extern std::recursive_mutex g_effect_manager_mutex;
     #define LED_PIN0         5
 #endif
 
+#if USE_STRIP && NUM_CHANNELS >= 2 && !defined(LED_PIN1)
+    #error "NUM_CHANNELS >= 2 requires LED_PIN1 for strip output"
+#endif
+#if USE_STRIP && NUM_CHANNELS >= 3 && !defined(LED_PIN2)
+    #error "NUM_CHANNELS >= 3 requires LED_PIN2 for strip output"
+#endif
+#if USE_STRIP && NUM_CHANNELS >= 4 && !defined(LED_PIN3)
+    #error "NUM_CHANNELS >= 4 requires LED_PIN3 for strip output"
+#endif
+#if USE_STRIP && NUM_CHANNELS >= 5 && !defined(LED_PIN4)
+    #error "NUM_CHANNELS >= 5 requires LED_PIN4 for strip output"
+#endif
+#if USE_STRIP && NUM_CHANNELS >= 6 && !defined(LED_PIN5)
+    #error "NUM_CHANNELS >= 6 requires LED_PIN5 for strip output"
+#endif
+#if USE_STRIP && NUM_CHANNELS >= 7 && !defined(LED_PIN6)
+    #error "NUM_CHANNELS >= 7 requires LED_PIN6 for strip output"
+#endif
+#if USE_STRIP && NUM_CHANNELS >= 8 && !defined(LED_PIN7)
+    #error "NUM_CHANNELS >= 8 requires LED_PIN7 for strip output"
+#endif
+
+#if USE_APA102 && NUM_CHANNELS >= 1 && !defined(LED_CLOCK_PIN0)
+    #error "APA102 channel 0 requires LED_CLOCK_PIN0"
+#endif
+#if USE_APA102 && NUM_CHANNELS >= 2 && !defined(LED_CLOCK_PIN1)
+    #error "APA102 channel 1 requires LED_CLOCK_PIN1"
+#endif
+#if USE_APA102 && NUM_CHANNELS >= 3 && !defined(LED_CLOCK_PIN2)
+    #error "APA102 channel 2 requires LED_CLOCK_PIN2"
+#endif
+#if USE_APA102 && NUM_CHANNELS >= 4 && !defined(LED_CLOCK_PIN3)
+    #error "APA102 channel 3 requires LED_CLOCK_PIN3"
+#endif
+#if USE_APA102 && NUM_CHANNELS >= 5 && !defined(LED_CLOCK_PIN4)
+    #error "APA102 channel 4 requires LED_CLOCK_PIN4"
+#endif
+#if USE_APA102 && NUM_CHANNELS >= 6 && !defined(LED_CLOCK_PIN5)
+    #error "APA102 channel 5 requires LED_CLOCK_PIN5"
+#endif
+#if USE_APA102 && NUM_CHANNELS >= 7 && !defined(LED_CLOCK_PIN6)
+    #error "APA102 channel 6 requires LED_CLOCK_PIN6"
+#endif
+#if USE_APA102 && NUM_CHANNELS >= 8 && !defined(LED_CLOCK_PIN7)
+    #error "APA102 channel 7 requires LED_CLOCK_PIN7"
+#endif
+
 #ifndef WIFI_ACTIVITY_PIN
     #define WIFI_ACTIVITY_PIN -1
 #endif
@@ -416,7 +483,11 @@ extern std::recursive_mutex g_effect_manager_mutex;
 #endif
 
 #ifndef COLOR_ORDER
-#define COLOR_ORDER EOrder::GRB
+    #if USE_APA102
+        #define COLOR_ORDER EOrder::BGR
+    #else
+        #define COLOR_ORDER EOrder::GRB
+    #endif
 #endif
 
 // Define fan ordering for drawing into the fan directionally

--- a/include/stripoutputmanager.h
+++ b/include/stripoutputmanager.h
@@ -1,0 +1,51 @@
+#pragma once
+
+//+--------------------------------------------------------------------------
+//
+// File:        stripoutputmanager.h
+//
+// NightDriverStrip - (c) 2026 Plummer's Software LLC.  All Rights Reserved.
+//
+// Common interface implemented by every concrete strip output manager
+// (WS281x, APA102, ...). SystemContainer owns one of these as a single
+// runtime-swappable transport so the render path is free of #if ladders
+// over the chosen driver.
+//
+//             2-Jun-2026         Created      Davepl
+//
+//---------------------------------------------------------------------------
+
+#include "globals.h"
+
+#if USE_STRIP
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <WString.h>
+
+class GFXBase;
+class DeviceConfig;
+
+class IStripOutputManager
+{
+  public:
+    virtual ~IStripOutputManager() = default;
+
+    virtual bool ApplyConfig(const DeviceConfig& config,
+                             const std::vector<std::shared_ptr<GFXBase>>& devices,
+                             String* errorMessage = nullptr) = 0;
+
+    virtual void Show(const std::vector<std::shared_ptr<GFXBase>>& devices,
+                      uint16_t pixelsDrawn,
+                      uint8_t brightness,
+                      uint8_t fader) = 0;
+
+    virtual void Reset() = 0;
+
+    virtual size_t GetActiveChannelCount() const = 0;
+    virtual size_t GetActiveLEDCount() const = 0;
+};
+
+#endif

--- a/include/systemcontainer.h
+++ b/include/systemcontainer.h
@@ -51,6 +51,8 @@ class SocketServer;
 class WebSocketServer;
 class CWebServer;
 class WS281xOutputManager;
+class APA102OutputManager;
+class IStripOutputManager;
 class AudioService;
 class AudioSerialBridge;
 class DebugConsole;
@@ -94,8 +96,8 @@ class SystemContainer
         allocated_unique_ptr<SocketServer> _ptrSocketServer;
     #endif
 
-    #if USE_WS281X
-        allocated_unique_ptr<WS281xOutputManager> _ptrWS281xOutputManager;
+    #if USE_STRIP
+        allocated_unique_ptr<IStripOutputManager> _ptrStripOutputManager;
     #endif
 
     #if WEB_SOCKETS_ANY_ENABLED
@@ -183,10 +185,10 @@ class SystemContainer
         SocketServer& GetSocketServer() const;
     #endif
 
-    #if USE_WS281X
-        WS281xOutputManager& SetupWS281xOutputManager();
-        bool HasWS281xOutputManager() const { return !!_ptrWS281xOutputManager; }
-        WS281xOutputManager& GetWS281xOutputManager() const;
+    #if USE_STRIP
+        IStripOutputManager& SetupStripOutputManager();
+        bool HasStripOutputManager() const { return !!_ptrStripOutputManager; }
+        IStripOutputManager& GetStripOutputManager() const;
     #endif
 
     #if WEB_SOCKETS_ANY_ENABLED

--- a/platformio.ini
+++ b/platformio.ini
@@ -794,6 +794,16 @@ build_src_flags = ${dev_heltec_wifi_v3.build_src_flags}
                   -DENABLE_WIFI=1
                   -DROTATE_SCREEN=1
 
+[env:heltecdemoapa102]
+extends         = env:heltecv3demo
+build_flags     = ${env:heltecv3demo.build_flags}
+build_src_flags = ${env:heltecv3demo.build_src_flags}
+                  -DPROJECT_NAME="\"HeltecDemoAPA102\""
+                  -DUSE_APA102=1
+                  -DLED_PIN0=5
+                  -DLED_CLOCK_PIN0=3
+                  -DPOWER_LIMIT_MW=350
+
 [env:helteclorav3demo]
 extends         = dev_heltec_wifi_lora_v3
 build_flags     = ${dev_heltec_wifi_lora_v3.build_flags}

--- a/src/apa102outputmanager.cpp
+++ b/src/apa102outputmanager.cpp
@@ -4,10 +4,10 @@
 //
 // NightDriverStrip - (c) 2026 Plummer's Software LLC.  All Rights Reserved.
 //
-// APA102/SK9822 runtime output manager. APA102 is clocked, so unlike WS281x it
-// does not need RMT bit timing. We bit-bang data/clock GPIO pairs directly so
-// multi-channel builds are not constrained by the number of ESP32 hardware SPI
-// buses.
+// APA102/SK9822 runtime output manager. Uses the ESP32 hardware SPI master
+// with DMA so the render task hands the prepared frame off in one shot
+// instead of toggling GPIOs per bit. One SPI host per channel (SPI2_HOST,
+// then SPI3_HOST), so at most two simultaneous APA102 channels.
 //
 //---------------------------------------------------------------------------
 
@@ -18,9 +18,9 @@
 #include "apa102outputmanager.h"
 
 #include <algorithm>
-#include <driver/gpio.h>
-#include <soc/gpio_reg.h>
-#include <soc/soc.h>
+#include <cstring>
+#include <esp_heap_caps.h>
+#include <driver/spi_common.h>
 
 #include "gfxbase.h"
 #include "pixelformat.h"
@@ -30,6 +30,12 @@ namespace
 {
     #ifndef APA102_GLOBAL_BRIGHTNESS
         #define APA102_GLOBAL_BRIGHTNESS 31
+    #endif
+
+    #ifndef APA102_SPI_HZ
+        // 10 MHz is comfortable for both APA102 and SK9822 across typical wiring.
+        // Bump per-env if your harness is short and clean.
+        #define APA102_SPI_HZ (10 * 1000 * 1000)
     #endif
 
     constexpr uint8_t ClampGlobalBrightness(uint8_t brightness)
@@ -45,76 +51,32 @@ namespace
 
     constexpr uint8_t kGlobalBrightness = ClampGlobalBrightness(APA102_GLOBAL_BRIGHTNESS);
 
-    void SetGpioLevel(int8_t pin, bool high)
-    {
-        const uint32_t bit = 1UL << (pin & 31);
-        if (pin < 32)
-        {
-            REG_WRITE(high ? GPIO_OUT_W1TS_REG : GPIO_OUT_W1TC_REG, bit);
-            return;
-        }
+    constexpr size_t kStartFrameBytes = 4;
+    constexpr size_t kBytesPerPixel   = 4;
 
-        #if defined(GPIO_OUT1_W1TS_REG) && defined(GPIO_OUT1_W1TC_REG)
-            REG_WRITE(high ? GPIO_OUT1_W1TS_REG : GPIO_OUT1_W1TC_REG, bit);
-        #else
-            gpio_set_level(static_cast<gpio_num_t>(pin), high ? 1 : 0);
-        #endif
-    }
-
-    void WriteBit(int8_t dataPin, int8_t clockPin, bool bit)
-    {
-        SetGpioLevel(dataPin, bit);
-        SetGpioLevel(clockPin, true);
-        SetGpioLevel(clockPin, false);
-    }
-
-    void WriteByte(int8_t dataPin, int8_t clockPin, uint8_t value)
-    {
-        for (int bit = 7; bit >= 0; --bit)
-            WriteBit(dataPin, clockPin, (value & (1U << bit)) != 0);
-    }
-
-    void WriteStartFrame(int8_t dataPin, int8_t clockPin)
-    {
-        SetGpioLevel(dataPin, false);
-        for (size_t i = 0; i < 4; ++i)
-            WriteByte(dataPin, clockPin, 0x00);
-    }
-
-    void WriteEndFrame(int8_t dataPin, int8_t clockPin, size_t ledCount)
+    constexpr size_t EndFrameBytes(size_t ledCount)
     {
         // APA102 needs at least ledCount / 2 extra clock pulses after the pixel
-        // frames. Use a conservative byte count with a small fixed floor for
-        // short strips.
-        const size_t endBytes = std::max<size_t>(4, (ledCount + 15) / 16);
-        SetGpioLevel(dataPin, true);
-        for (size_t i = 0; i < endBytes; ++i)
-            WriteByte(dataPin, clockPin, 0xFF);
+        // frames; use ceil(N/16) bytes with a small fixed floor for short strips.
+        const size_t needed = (ledCount + 15) / 16;
+        return needed < 4 ? 4 : needed;
     }
 
-    void WritePixel(int8_t dataPin,
-                    int8_t clockPin,
-                    CRGB color,
-                    uint8_t brightness,
-                    uint8_t fader,
-                    DeviceConfig::WS281xColorOrder colorOrder)
+    constexpr size_t FrameBufferSize(size_t ledCount)
     {
-        const auto indices = PixelFormatHelpers::IndicesFor(colorOrder);
-        uint8_t wire[3] = {};
-        wire[indices.rIdx] = PixelFormatHelpers::Scale(color.r, brightness, fader);
-        wire[indices.gIdx] = PixelFormatHelpers::Scale(color.g, brightness, fader);
-        wire[indices.bIdx] = PixelFormatHelpers::Scale(color.b, brightness, fader);
+        return kStartFrameBytes + kBytesPerPixel * ledCount + EndFrameBytes(ledCount);
+    }
 
-        WriteByte(dataPin, clockPin, 0xE0 | kGlobalBrightness);
-        WriteByte(dataPin, clockPin, wire[0]);
-        WriteByte(dataPin, clockPin, wire[1]);
-        WriteByte(dataPin, clockPin, wire[2]);
+    constexpr spi_host_device_t HostForChannel(size_t channelIndex)
+    {
+        return channelIndex == 0 ? SPI2_HOST : SPI3_HOST;
     }
 
     void LogRuntimeAPA102Configuration(const DeviceConfig& config, const std::vector<std::shared_ptr<GFXBase>>& devices, const char* reason)
     {
-        debugI("APA102 config (%s): path=bitbang driver=%s channels=%zu matrix=%ux%u serpentine=%d colorOrder=%s leds=%zu",
+        debugI("APA102 config (%s): path=spi-dma@%uHz driver=%s channels=%zu matrix=%ux%u serpentine=%d colorOrder=%s leds=%zu",
                reason ? reason : "update",
+               static_cast<unsigned>(APA102_SPI_HZ),
                config.GetRuntimeDriverName().c_str(),
                config.GetChannelCount(),
                static_cast<unsigned>(config.GetMatrixWidth()),
@@ -128,8 +90,9 @@ namespace
         for (size_t channel = 0; channel < config.GetChannelCount() && channel < devices.size(); ++channel)
         {
             const auto& graphics = *devices[channel];
-            debugI("APA102 channel %zu: data=%d clock=%d leds=%zu matrix=%ux%u serpentine=%d buffer=%p",
+            debugI("APA102 channel %zu: host=SPI%d data=%d clock=%d leds=%zu matrix=%ux%u serpentine=%d buffer=%p",
                    channel,
+                   HostForChannel(channel) == SPI2_HOST ? 2 : 3,
                    dataPins[channel],
                    clockPins[channel],
                    graphics.GetLEDCount(),
@@ -162,44 +125,104 @@ void APA102OutputManager::Reset()
     _colorOrder = DeviceConfig::GetCompiledWS281xColorOrder();
 }
 
-void APA102OutputManager::ConfigureChannel(size_t channelIndex, int8_t dataPin, int8_t clockPin, size_t ledCount)
+bool APA102OutputManager::ConfigureChannel(size_t channelIndex, int8_t dataPin, int8_t clockPin, size_t ledCount, String* errorMessage)
 {
     auto& state = _channels[channelIndex];
 
-    if (state.active && (state.dataPin != dataPin || state.clockPin != clockPin))
+    const size_t requiredBytes = FrameBufferSize(ledCount);
+    const bool pinsChanged   = state.dataPin != dataPin || state.clockPin != clockPin;
+    const bool bufferTooSmall = state.bufferSize < requiredBytes;
+
+    // If the bus is already initialized but anything material changed, tear it down before re-binding.
+    if (state.active && (pinsChanged || bufferTooSmall))
         ReleaseChannel(channelIndex);
 
-    pinMode(dataPin, OUTPUT);
-    pinMode(clockPin, OUTPUT);
-    SetGpioLevel(dataPin, false);
-    SetGpioLevel(clockPin, false);
+    if (!state.active)
+    {
+        state.host = HostForChannel(channelIndex);
 
-    state.dataPin = dataPin;
-    state.clockPin = clockPin;
+        spi_bus_config_t busCfg = {};
+        busCfg.mosi_io_num     = dataPin;
+        busCfg.miso_io_num     = -1;
+        busCfg.sclk_io_num     = clockPin;
+        busCfg.quadwp_io_num   = -1;
+        busCfg.quadhd_io_num   = -1;
+        busCfg.max_transfer_sz = static_cast<int>(requiredBytes);
+
+        esp_err_t err = spi_bus_initialize(state.host, &busCfg, SPI_DMA_CH_AUTO);
+        if (err != ESP_OK)
+        {
+            if (errorMessage)
+                *errorMessage = String("spi_bus_initialize failed: ") + esp_err_to_name(err);
+            return false;
+        }
+
+        spi_device_interface_config_t devCfg = {};
+        devCfg.clock_speed_hz = APA102_SPI_HZ;
+        devCfg.mode           = 0;          // CPOL=0, CPHA=0 — APA102/SK9822
+        devCfg.spics_io_num   = -1;         // no chip select
+        devCfg.queue_size     = 1;
+        devCfg.flags          = SPI_DEVICE_NO_DUMMY;
+
+        err = spi_bus_add_device(state.host, &devCfg, &state.device);
+        if (err != ESP_OK)
+        {
+            spi_bus_free(state.host);
+            state.device = nullptr;
+            if (errorMessage)
+                *errorMessage = String("spi_bus_add_device failed: ") + esp_err_to_name(err);
+            return false;
+        }
+
+        state.buffer = static_cast<uint8_t*>(heap_caps_malloc(requiredBytes, MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL));
+        if (!state.buffer)
+        {
+            spi_bus_remove_device(state.device);
+            spi_bus_free(state.host);
+            state.device = nullptr;
+            if (errorMessage)
+                *errorMessage = "APA102 DMA buffer allocation failed";
+            return false;
+        }
+
+        state.bufferSize = requiredBytes;
+        state.dataPin    = dataPin;
+        state.clockPin   = clockPin;
+        state.active     = true;
+    }
+
     state.ledCount = ledCount;
-    state.active = true;
+
+    // Pre-fill the start frame (zeros) and end frame (0xFF padding); Show() only fills the pixel bytes.
+    std::memset(state.buffer, 0x00, kStartFrameBytes);
+    const size_t endOffset = kStartFrameBytes + kBytesPerPixel * ledCount;
+    std::memset(state.buffer + endOffset, 0xFF, requiredBytes - endOffset);
+
+    return true;
 }
 
 void APA102OutputManager::ReleaseChannel(size_t channelIndex)
 {
     auto& state = _channels[channelIndex];
 
-    if (state.dataPin >= 0)
+    if (state.device)
     {
-        pinMode(state.dataPin, OUTPUT);
-        SetGpioLevel(state.dataPin, false);
+        spi_bus_remove_device(state.device);
+        state.device = nullptr;
+        spi_bus_free(state.host);
     }
 
-    if (state.clockPin >= 0)
+    if (state.buffer)
     {
-        pinMode(state.clockPin, OUTPUT);
-        SetGpioLevel(state.clockPin, false);
+        heap_caps_free(state.buffer);
+        state.buffer = nullptr;
     }
 
-    state.dataPin = -1;
-    state.clockPin = -1;
-    state.ledCount = 0;
-    state.active = false;
+    state.bufferSize = 0;
+    state.dataPin    = -1;
+    state.clockPin   = -1;
+    state.ledCount   = 0;
+    state.active     = false;
 }
 
 bool APA102OutputManager::ApplyConfig(const DeviceConfig& config, const std::vector<std::shared_ptr<GFXBase>>& devices, String* errorMessage)
@@ -213,14 +236,21 @@ bool APA102OutputManager::ApplyConfig(const DeviceConfig& config, const std::vec
         return false;
     }
 
-    const size_t channelCount = std::min(config.GetChannelCount(), devices.size());
-    const size_t ledCount = config.GetActiveLEDCount();
-    const auto& dataPins = config.GetAPA102DataPins();
-    const auto& clockPins = config.GetAPA102ClockPins();
+    const size_t requestedChannels = std::min(config.GetChannelCount(), devices.size());
+    if (requestedChannels > kMaxChannels)
+    {
+        if (errorMessage)
+            *errorMessage = String("APA102 hardware-SPI driver supports at most ") + kMaxChannels + " channels";
+        return false;
+    }
+
+    const size_t ledCount  = config.GetActiveLEDCount();
+    const auto& dataPins   = config.GetAPA102DataPins();
+    const auto& clockPins  = config.GetAPA102ClockPins();
 
     for (size_t i = 0; i < _channels.size(); ++i)
     {
-        const bool shouldBeActive = i < channelCount;
+        const bool shouldBeActive = i < requestedChannels;
         if (!shouldBeActive)
         {
             ReleaseChannel(i);
@@ -229,12 +259,15 @@ bool APA102OutputManager::ApplyConfig(const DeviceConfig& config, const std::vec
 
         auto& state = _channels[i];
         if (!state.active || state.dataPin != dataPins[i] || state.clockPin != clockPins[i] || state.ledCount != ledCount)
-            ConfigureChannel(i, dataPins[i], clockPins[i], ledCount);
+        {
+            if (!ConfigureChannel(i, dataPins[i], clockPins[i], ledCount, errorMessage))
+                return false;
+        }
     }
 
-    _activeChannelCount = channelCount;
-    _activeLEDCount = ledCount;
-    _colorOrder = config.GetWS281xColorOrder();
+    _activeChannelCount = requestedChannels;
+    _activeLEDCount     = ledCount;
+    _colorOrder         = config.GetWS281xColorOrder();
 
     if (errorMessage)
         *errorMessage = "";
@@ -243,18 +276,15 @@ bool APA102OutputManager::ApplyConfig(const DeviceConfig& config, const std::vec
     return true;
 }
 
-// 
-// Show() 
 //
-// Render the given pixel data to the LED strip(s) using the APA102 protocol. This method is called on the critical path of rendering frames, 
-// so it is optimized for performance. It assumes that the caller has already acquired the transport mutex and that the channel/LED counts 
-// have been validated. The method iterates over each active channel/device, sends the APA102 start frame, then sends pixel data for each LED 
-// (up to pixelsDrawn), applying brightness and fader scaling, and finally sends the end frame. If rendering takes an unusually long time, it 
-// logs a warning with details about the configuration and elapsed time.
+// Show()
 //
-// This method is on the critical path of rendering frames to the LED strip, so it is carefully optimized for performance. It assumes that 
-// the caller has already acquired the transport mutex and that the channel/LED counts have been validated.
-
+// Render the given pixel data to the LED strip(s) using the APA102 protocol over hardware SPI + DMA.
+// Caller must already hold the transport mutex (or rely on the one we acquire here). The pre-built
+// frame buffer for each channel already contains the start frame (zeros) and end frame (0xFF
+// padding); we only fill the per-pixel bytes between them, then hand the whole buffer to the SPI
+// master in a single transaction.
+//
 void APA102OutputManager::Show(const std::vector<std::shared_ptr<GFXBase>>& devices, uint16_t pixelsDrawn, uint8_t brightness, uint8_t fader)
 {
     std::lock_guard guard(WS281xGFX::TransportMutex());
@@ -268,21 +298,38 @@ void APA102OutputManager::Show(const std::vector<std::shared_ptr<GFXBase>>& devi
     for (size_t channelIndex = 0; channelIndex < _activeChannelCount && channelIndex < devices.size(); ++channelIndex)
     {
         auto& state = _channels[channelIndex];
-        if (!state.active)
+        if (!state.active || !state.device || !state.buffer)
             continue;
 
         auto& device = devices[channelIndex];
-        const size_t ledCount = std::min(_activeLEDCount, device->GetLEDCount());
+        const size_t ledCount = std::min(state.ledCount, device->GetLEDCount());
+        const auto indices = PixelFormatHelpers::IndicesFor(_colorOrder);
 
-        WriteStartFrame(state.dataPin, state.clockPin);
-
+        uint8_t* p = state.buffer + kStartFrameBytes;
         for (size_t i = 0; i < ledCount; ++i)
         {
             CRGB color = (i < pixelsToShow) ? device->leds[i] : CRGB::Black;
-            WritePixel(state.dataPin, state.clockPin, color, brightness, fader, _colorOrder);
+            uint8_t wire[3] = {};
+            wire[indices.rIdx] = PixelFormatHelpers::Scale(color.r, brightness, fader);
+            wire[indices.gIdx] = PixelFormatHelpers::Scale(color.g, brightness, fader);
+            wire[indices.bIdx] = PixelFormatHelpers::Scale(color.b, brightness, fader);
+
+            p[0] = 0xE0 | kGlobalBrightness;
+            p[1] = wire[0];
+            p[2] = wire[1];
+            p[3] = wire[2];
+            p += kBytesPerPixel;
         }
 
-        WriteEndFrame(state.dataPin, state.clockPin, ledCount);
+        spi_transaction_t txn = {};
+        txn.length    = state.bufferSize * 8;  // bits
+        txn.tx_buffer = state.buffer;
+
+        const esp_err_t err = spi_device_transmit(state.device, &txn);
+        if (err != ESP_OK)
+        {
+            debugW("APA102 spi_device_transmit failed on channel %zu: %s", channelIndex, esp_err_to_name(err));
+        }
     }
 
     const auto showElapsedMicros = micros() - showStartMicros;

--- a/src/apa102outputmanager.cpp
+++ b/src/apa102outputmanager.cpp
@@ -1,0 +1,298 @@
+//+--------------------------------------------------------------------------
+//
+// File:        apa102outputmanager.cpp
+//
+// NightDriverStrip - (c) 2026 Plummer's Software LLC.  All Rights Reserved.
+//
+// APA102/SK9822 runtime output manager. APA102 is clocked, so unlike WS281x it
+// does not need RMT bit timing. We bit-bang data/clock GPIO pairs directly so
+// multi-channel builds are not constrained by the number of ESP32 hardware SPI
+// buses.
+//
+//---------------------------------------------------------------------------
+
+#include "globals.h"
+
+#if USE_APA102
+
+#include "apa102outputmanager.h"
+
+#include <algorithm>
+#include <driver/gpio.h>
+#include <soc/gpio_reg.h>
+#include <soc/soc.h>
+
+#include "gfxbase.h"
+#include "pixelformat.h"
+#include "ws281xgfx.h"
+
+namespace
+{
+    #ifndef APA102_GLOBAL_BRIGHTNESS
+        #define APA102_GLOBAL_BRIGHTNESS 31
+    #endif
+
+    constexpr uint8_t ClampGlobalBrightness(uint8_t brightness)
+    {
+        if (brightness == 0)
+            return 0;
+
+        if (brightness > 31)
+            return 31;
+
+        return brightness;
+    }
+
+    constexpr uint8_t kGlobalBrightness = ClampGlobalBrightness(APA102_GLOBAL_BRIGHTNESS);
+
+    void SetGpioLevel(int8_t pin, bool high)
+    {
+        const uint32_t bit = 1UL << (pin & 31);
+        if (pin < 32)
+        {
+            REG_WRITE(high ? GPIO_OUT_W1TS_REG : GPIO_OUT_W1TC_REG, bit);
+            return;
+        }
+
+        #if defined(GPIO_OUT1_W1TS_REG) && defined(GPIO_OUT1_W1TC_REG)
+            REG_WRITE(high ? GPIO_OUT1_W1TS_REG : GPIO_OUT1_W1TC_REG, bit);
+        #else
+            gpio_set_level(static_cast<gpio_num_t>(pin), high ? 1 : 0);
+        #endif
+    }
+
+    void WriteBit(int8_t dataPin, int8_t clockPin, bool bit)
+    {
+        SetGpioLevel(dataPin, bit);
+        SetGpioLevel(clockPin, true);
+        SetGpioLevel(clockPin, false);
+    }
+
+    void WriteByte(int8_t dataPin, int8_t clockPin, uint8_t value)
+    {
+        for (int bit = 7; bit >= 0; --bit)
+            WriteBit(dataPin, clockPin, (value & (1U << bit)) != 0);
+    }
+
+    void WriteStartFrame(int8_t dataPin, int8_t clockPin)
+    {
+        SetGpioLevel(dataPin, false);
+        for (size_t i = 0; i < 4; ++i)
+            WriteByte(dataPin, clockPin, 0x00);
+    }
+
+    void WriteEndFrame(int8_t dataPin, int8_t clockPin, size_t ledCount)
+    {
+        // APA102 needs at least ledCount / 2 extra clock pulses after the pixel
+        // frames. Use a conservative byte count with a small fixed floor for
+        // short strips.
+        const size_t endBytes = std::max<size_t>(4, (ledCount + 15) / 16);
+        SetGpioLevel(dataPin, true);
+        for (size_t i = 0; i < endBytes; ++i)
+            WriteByte(dataPin, clockPin, 0xFF);
+    }
+
+    void WritePixel(int8_t dataPin,
+                    int8_t clockPin,
+                    CRGB color,
+                    uint8_t brightness,
+                    uint8_t fader,
+                    DeviceConfig::WS281xColorOrder colorOrder)
+    {
+        const auto indices = PixelFormatHelpers::IndicesFor(colorOrder);
+        uint8_t wire[3] = {};
+        wire[indices.rIdx] = PixelFormatHelpers::Scale(color.r, brightness, fader);
+        wire[indices.gIdx] = PixelFormatHelpers::Scale(color.g, brightness, fader);
+        wire[indices.bIdx] = PixelFormatHelpers::Scale(color.b, brightness, fader);
+
+        WriteByte(dataPin, clockPin, 0xE0 | kGlobalBrightness);
+        WriteByte(dataPin, clockPin, wire[0]);
+        WriteByte(dataPin, clockPin, wire[1]);
+        WriteByte(dataPin, clockPin, wire[2]);
+    }
+
+    void LogRuntimeAPA102Configuration(const DeviceConfig& config, const std::vector<std::shared_ptr<GFXBase>>& devices, const char* reason)
+    {
+        debugI("APA102 config (%s): path=bitbang driver=%s channels=%zu matrix=%ux%u serpentine=%d colorOrder=%s leds=%zu",
+               reason ? reason : "update",
+               config.GetRuntimeDriverName().c_str(),
+               config.GetChannelCount(),
+               static_cast<unsigned>(config.GetMatrixWidth()),
+               static_cast<unsigned>(config.GetMatrixHeight()),
+               config.IsMatrixSerpentine(),
+               DeviceConfig::GetColorOrderName(config.GetWS281xColorOrder()).c_str(),
+               config.GetActiveLEDCount());
+
+        const auto& dataPins = config.GetAPA102DataPins();
+        const auto& clockPins = config.GetAPA102ClockPins();
+        for (size_t channel = 0; channel < config.GetChannelCount() && channel < devices.size(); ++channel)
+        {
+            const auto& graphics = *devices[channel];
+            debugI("APA102 channel %zu: data=%d clock=%d leds=%zu matrix=%ux%u serpentine=%d buffer=%p",
+                   channel,
+                   dataPins[channel],
+                   clockPins[channel],
+                   graphics.GetLEDCount(),
+                   static_cast<unsigned>(graphics.GetMatrixWidth()),
+                   static_cast<unsigned>(graphics.GetMatrixHeight()),
+                   graphics.IsSerpentine(),
+                   graphics.leds);
+        }
+    }
+}
+
+APA102OutputManager::APA102OutputManager()
+{
+}
+
+APA102OutputManager::~APA102OutputManager()
+{
+    Reset();
+}
+
+void APA102OutputManager::Reset()
+{
+    std::lock_guard guard(WS281xGFX::TransportMutex());
+
+    for (size_t i = 0; i < _channels.size(); ++i)
+        ReleaseChannel(i);
+
+    _activeChannelCount = 0;
+    _activeLEDCount = 0;
+    _colorOrder = DeviceConfig::GetCompiledWS281xColorOrder();
+}
+
+void APA102OutputManager::ConfigureChannel(size_t channelIndex, int8_t dataPin, int8_t clockPin, size_t ledCount)
+{
+    auto& state = _channels[channelIndex];
+
+    if (state.active && (state.dataPin != dataPin || state.clockPin != clockPin))
+        ReleaseChannel(channelIndex);
+
+    pinMode(dataPin, OUTPUT);
+    pinMode(clockPin, OUTPUT);
+    SetGpioLevel(dataPin, false);
+    SetGpioLevel(clockPin, false);
+
+    state.dataPin = dataPin;
+    state.clockPin = clockPin;
+    state.ledCount = ledCount;
+    state.active = true;
+}
+
+void APA102OutputManager::ReleaseChannel(size_t channelIndex)
+{
+    auto& state = _channels[channelIndex];
+
+    if (state.dataPin >= 0)
+    {
+        pinMode(state.dataPin, OUTPUT);
+        SetGpioLevel(state.dataPin, false);
+    }
+
+    if (state.clockPin >= 0)
+    {
+        pinMode(state.clockPin, OUTPUT);
+        SetGpioLevel(state.clockPin, false);
+    }
+
+    state.dataPin = -1;
+    state.clockPin = -1;
+    state.ledCount = 0;
+    state.active = false;
+}
+
+bool APA102OutputManager::ApplyConfig(const DeviceConfig& config, const std::vector<std::shared_ptr<GFXBase>>& devices, String* errorMessage)
+{
+    std::lock_guard guard(WS281xGFX::TransportMutex());
+
+    if (config.GetOutputDriver() != DeviceConfig::OutputDriver::APA102)
+    {
+        if (errorMessage)
+            *errorMessage = "recompile needed";
+        return false;
+    }
+
+    const size_t channelCount = std::min(config.GetChannelCount(), devices.size());
+    const size_t ledCount = config.GetActiveLEDCount();
+    const auto& dataPins = config.GetAPA102DataPins();
+    const auto& clockPins = config.GetAPA102ClockPins();
+
+    for (size_t i = 0; i < _channels.size(); ++i)
+    {
+        const bool shouldBeActive = i < channelCount;
+        if (!shouldBeActive)
+        {
+            ReleaseChannel(i);
+            continue;
+        }
+
+        auto& state = _channels[i];
+        if (!state.active || state.dataPin != dataPins[i] || state.clockPin != clockPins[i] || state.ledCount != ledCount)
+            ConfigureChannel(i, dataPins[i], clockPins[i], ledCount);
+    }
+
+    _activeChannelCount = channelCount;
+    _activeLEDCount = ledCount;
+    _colorOrder = config.GetWS281xColorOrder();
+
+    if (errorMessage)
+        *errorMessage = "";
+
+    LogRuntimeAPA102Configuration(config, devices, "apply");
+    return true;
+}
+
+// 
+// Show() 
+//
+// Render the given pixel data to the LED strip(s) using the APA102 protocol. This method is called on the critical path of rendering frames, 
+// so it is optimized for performance. It assumes that the caller has already acquired the transport mutex and that the channel/LED counts 
+// have been validated. The method iterates over each active channel/device, sends the APA102 start frame, then sends pixel data for each LED 
+// (up to pixelsDrawn), applying brightness and fader scaling, and finally sends the end frame. If rendering takes an unusually long time, it 
+// logs a warning with details about the configuration and elapsed time.
+//
+// This method is on the critical path of rendering frames to the LED strip, so it is carefully optimized for performance. It assumes that 
+// the caller has already acquired the transport mutex and that the channel/LED counts have been validated.
+
+void APA102OutputManager::Show(const std::vector<std::shared_ptr<GFXBase>>& devices, uint16_t pixelsDrawn, uint8_t brightness, uint8_t fader)
+{
+    std::lock_guard guard(WS281xGFX::TransportMutex());
+
+    if (_activeChannelCount == 0 || _activeLEDCount == 0)
+        return;
+
+    const size_t pixelsToShow = std::min(static_cast<size_t>(pixelsDrawn), _activeLEDCount);
+    const auto showStartMicros = micros();
+
+    for (size_t channelIndex = 0; channelIndex < _activeChannelCount && channelIndex < devices.size(); ++channelIndex)
+    {
+        auto& state = _channels[channelIndex];
+        if (!state.active)
+            continue;
+
+        auto& device = devices[channelIndex];
+        const size_t ledCount = std::min(_activeLEDCount, device->GetLEDCount());
+
+        WriteStartFrame(state.dataPin, state.clockPin);
+
+        for (size_t i = 0; i < ledCount; ++i)
+        {
+            CRGB color = (i < pixelsToShow) ? device->leds[i] : CRGB::Black;
+            WritePixel(state.dataPin, state.clockPin, color, brightness, fader, _colorOrder);
+        }
+
+        WriteEndFrame(state.dataPin, state.clockPin, ledCount);
+    }
+
+    const auto showElapsedMicros = micros() - showStartMicros;
+    if (showElapsedMicros > 50000UL)
+    {
+        debugW("APA102 show slow: channels=%zu leds=%zu elapsed=%lu us",
+               _activeChannelCount,
+               _activeLEDCount,
+               static_cast<unsigned long>(showElapsedMicros));
+    }
+}
+
+#endif

--- a/src/deviceconfig.cpp
+++ b/src/deviceconfig.cpp
@@ -66,38 +66,82 @@ namespace
         }
     }
 
-    #if USE_WS281X
+    #if USE_STRIP
     constexpr auto kCompiledWS281xColorOrder = ToRuntimeColorOrder(COLOR_ORDER);
     #else
     constexpr auto kCompiledWS281xColorOrder = DeviceConfig::WS281xColorOrder::GRB;
     #endif
 
+    // Compile-time pin tables. For non-strip builds the data pin is -1; for non-APA102 builds the clock
+    // pin is -1. These two helper macros keep the per-channel entries to a single line each.
+    
+    #if USE_STRIP
+        #define ND_DATA_PIN(p)  static_cast<int8_t>(p)
+    #else
+        #define ND_DATA_PIN(p)  static_cast<int8_t>(-1)
+    #endif
+    #if USE_APA102
+        #define ND_CLOCK_PIN(p) static_cast<int8_t>(p)
+    #else
+        #define ND_CLOCK_PIN(p) static_cast<int8_t>(-1)
+    #endif
+
     constexpr std::array<int8_t, NUM_CHANNELS> kCompiledWS281xPins = {
         #if NUM_CHANNELS >= 1
-        LED_PIN0,
+            ND_DATA_PIN(LED_PIN0),
         #endif
         #if NUM_CHANNELS >= 2
-        LED_PIN1,
+            ND_DATA_PIN(LED_PIN1),
         #endif
         #if NUM_CHANNELS >= 3
-        LED_PIN2,
+            ND_DATA_PIN(LED_PIN2),
         #endif
         #if NUM_CHANNELS >= 4
-        LED_PIN3,
+            ND_DATA_PIN(LED_PIN3),
         #endif
         #if NUM_CHANNELS >= 5
-        LED_PIN4,
+            ND_DATA_PIN(LED_PIN4),
         #endif
         #if NUM_CHANNELS >= 6
-        LED_PIN5,
+            ND_DATA_PIN(LED_PIN5),
         #endif
         #if NUM_CHANNELS >= 7
-        LED_PIN6,
+            ND_DATA_PIN(LED_PIN6),
         #endif
         #if NUM_CHANNELS >= 8
-        LED_PIN7,
+            ND_DATA_PIN(LED_PIN7),
         #endif
     };
+
+    constexpr std::array<int8_t, NUM_CHANNELS> kCompiledAPA102ClockPins = {
+        #if NUM_CHANNELS >= 1
+            ND_CLOCK_PIN(LED_CLOCK_PIN0),
+        #endif
+        #if NUM_CHANNELS >= 2
+            ND_CLOCK_PIN(LED_CLOCK_PIN1),
+        #endif
+        #if NUM_CHANNELS >= 3
+            ND_CLOCK_PIN(LED_CLOCK_PIN2),
+        #endif
+        #if NUM_CHANNELS >= 4
+            ND_CLOCK_PIN(LED_CLOCK_PIN3),
+        #endif
+        #if NUM_CHANNELS >= 5
+            ND_CLOCK_PIN(LED_CLOCK_PIN4),
+        #endif
+        #if NUM_CHANNELS >= 6
+            ND_CLOCK_PIN(LED_CLOCK_PIN5),
+        #endif
+        #if NUM_CHANNELS >= 7
+            ND_CLOCK_PIN(LED_CLOCK_PIN6),
+        #endif
+        #if NUM_CHANNELS >= 8
+            ND_CLOCK_PIN(LED_CLOCK_PIN7),
+        #endif
+    };
+
+    #undef ND_DATA_PIN
+    #undef ND_CLOCK_PIN
 }
 
 // DeviceConfig holds, persists and loads device-wide configuration settings. Effect-specific settings should
@@ -129,12 +173,20 @@ std::array<int8_t, NUM_CHANNELS> DeviceConfig::GetCompiledWS281xPins()
     return kCompiledWS281xPins;
 }
 
+std::array<int8_t, NUM_CHANNELS> DeviceConfig::GetCompiledAPA102ClockPins()
+{
+    return kCompiledAPA102ClockPins;
+}
+
 const char* DeviceConfig::DriverName(OutputDriver driver)
 {
     switch (driver)
     {
         case OutputDriver::HUB75:
             return "hub75";
+
+        case OutputDriver::APA102:
+            return "apa102";
 
         case OutputDriver::WS281x:
         default:
@@ -176,6 +228,14 @@ void DeviceConfig::LogRuntimeConfig(const char* reason) const
         activePins += String(runtimeOutputs.outputPins[i]);
     }
 
+    String activeClockPins;
+    for (size_t i = 0; i < runtimeOutputs.channelCount && i < runtimeOutputs.clockPins.size(); ++i)
+    {
+        if (!activeClockPins.isEmpty())
+            activeClockPins += ',';
+        activeClockPins += String(runtimeOutputs.clockPins[i]);
+    }
+
     debugI("Runtime config (%s): driver=%s matrix=%ux%u leds=%u serpentine=%d channels=%u colorOrder=%s audioPin=%d",
            reason,
            DriverName(runtimeOutputs.driver),
@@ -186,7 +246,7 @@ void DeviceConfig::LogRuntimeConfig(const char* reason) const
             static_cast<unsigned>(runtimeOutputs.channelCount),
            GetColorOrderName(runtimeOutputs.colorOrder).c_str(),
            audioInputPin);
-    debugI("Runtime config pins (%s): activeChannels=%s", reason, activePins.c_str());
+    debugI("Runtime config pins (%s): data=%s clock=%s", reason, activePins.c_str(), activeClockPins.c_str());
 }
 
 DeviceConfig::DeviceConfig()
@@ -195,6 +255,7 @@ DeviceConfig::DeviceConfig()
     runtimeOutputs.driver = GetCompiledOutputDriver();
     runtimeOutputs.channelCount = NUM_CHANNELS;
     runtimeOutputs.outputPins = GetCompiledWS281xPins();
+    runtimeOutputs.clockPins = GetCompiledAPA102ClockPins();
     runtimeOutputs.colorOrder = GetCompiledWS281xColorOrder();
 
     writerIndex = g_ptrSystem->GetJSONWriter().RegisterWriter(
@@ -261,6 +322,10 @@ bool DeviceConfig::SerializeToJSON(JsonObject& jsonObject, bool includeSensitive
     for (auto pin : runtimeOutputs.outputPins)
         ws281xPins.add(pin);
 
+    auto apa102ClockPins = jsonDoc[APA102ClockPinsTag].to<JsonArray>();
+    for (auto pin : runtimeOutputs.clockPins)
+        apa102ClockPins.add(pin);
+
     if (includeSensitive)
         jsonDoc[OpenWeatherApiKeyTag] = openWeatherApiKey;
 
@@ -319,6 +384,8 @@ bool DeviceConfig::DeserializeFromJSON(const JsonObjectConst& jsonObject, bool s
         const auto driverName = jsonObject[OutputDriverTag].as<String>();
         if (driverName == DriverName(OutputDriver::HUB75))
             updated.outputs.driver = OutputDriver::HUB75;
+        else if (driverName == DriverName(OutputDriver::APA102))
+            updated.outputs.driver = OutputDriver::APA102;
         else if (driverName == DriverName(OutputDriver::WS281x))
             updated.outputs.driver = OutputDriver::WS281x;
     }
@@ -344,6 +411,16 @@ bool DeviceConfig::DeserializeFromJSON(const JsonObjectConst& jsonObject, bool s
         {
             if (pinArray[i].is<int>())
                 updated.outputs.outputPins[i] = pinArray[i].as<int>();
+        }
+    }
+
+    if (jsonObject[APA102ClockPinsTag].is<JsonArrayConst>())
+    {
+        auto pinArray = jsonObject[APA102ClockPinsTag].as<JsonArrayConst>();
+        for (size_t i = 0; i < updated.outputs.clockPins.size() && i < pinArray.size(); ++i)
+        {
+            if (pinArray[i].is<int>())
+                updated.outputs.clockPins[i] = pinArray[i].as<int>();
         }
     }
 
@@ -617,14 +694,14 @@ const std::vector<std::reference_wrapper<SettingSpec>>& DeviceConfig::GetSetting
             .Widget            = SettingSpec::WidgetKind::Select,
             // Friendly labels for the raw driver identifiers the schema exposes.
             .Options           = SettingSpec::OptionsSource::SchemaPath,
-            .OptionValues      = {"ws281x", "hub75"},
-            .OptionLabels      = {"WS281x", "HUB75"},
+            .OptionValues      = {"ws281x", "apa102", "hub75"},
+            .OptionLabels      = {"WS281x", "APA102", "HUB75"},
             .OptionsSchemaPath = "outputs.allowedDrivers"
         }));
         settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
             .Name              = WS281xChannelCountTag,
-            .FriendlyName      = "WS281x channel count",
-            .Description       = "Number of active strip channels within the compiled maximum. Live updates are limited to WS281x builds.",
+            .FriendlyName      = "Strip channel count",
+            .Description       = "Number of active strip channels within the compiled maximum. Live updates are limited to strip builds.",
             .Type              = SettingSpec::SettingType::PositiveBigInteger,
             .MinimumValue      = 1.0,
             .MaximumValue      = (double)GetCompiledChannelCount(),
@@ -639,8 +716,8 @@ const std::vector<std::reference_wrapper<SettingSpec>>& DeviceConfig::GetSetting
         }));
         settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
             .Name              = WS281xColorOrderTag,
-            .FriendlyName      = "WS281x color order",
-            .Description       = "Byte order used when streaming RGB values to WS281x LEDs. This applies live on strip builds and is ignored on HUB75 builds.",
+            .FriendlyName      = "Strip color order",
+            .Description       = "Byte order used when streaming RGB values to strip LEDs. This applies live on strip builds and is ignored on HUB75 builds.",
             .Type              = SettingSpec::SettingType::String,
             .Section           = kSectionOutput,
             .Priority          = 12,
@@ -656,17 +733,26 @@ const std::vector<std::reference_wrapper<SettingSpec>>& DeviceConfig::GetSetting
         // range) are DeviceConfig internals.
         // pinSpecStrings holds the String backing; settingSpecs owns the specs.
         // Both are sized up front so no reallocation can invalidate pointers.
-        constexpr size_t kPinStringsPerChannel = 4; // name, friendly, description, apiPath
+        constexpr size_t kPinStringsPerChannel =
+        #if USE_APA102
+            8;
+        #else
+            4;
+        #endif
         const auto compiledChannelCount = GetCompiledChannelCount();
-        settingSpecs.reserve(settingSpecs.size() + compiledChannelCount);
+        settingSpecs.reserve(settingSpecs.size() + compiledChannelCount
+        #if USE_APA102
+            + compiledChannelCount
+        #endif
+        );
         pinSpecStrings.reserve(compiledChannelCount * kPinStringsPerChannel);
         const auto stableCStr = [](const String& s) { return s.c_str(); };
 
         for (size_t i = 0; i < compiledChannelCount; ++i)
         {
             const auto& nameStr        = pinSpecStrings.emplace_back(str_sprintf("ws281xPin%zu", i));
-            const auto& friendlyStr    = pinSpecStrings.emplace_back(str_sprintf("WS281x pin %zu", i + 1));
-            const auto& descriptionStr = pinSpecStrings.emplace_back(str_sprintf("GPIO assigned to WS281x channel %zu.", i + 1));
+            const auto& friendlyStr    = pinSpecStrings.emplace_back(str_sprintf("Strip data pin %zu", i + 1));
+            const auto& descriptionStr = pinSpecStrings.emplace_back(str_sprintf("GPIO assigned to strip data channel %zu.", i + 1));
             const auto& apiPathStr     = pinSpecStrings.emplace_back(str_sprintf("outputs.ws281x.pins[%zu]", i));
 
             settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
@@ -680,6 +766,25 @@ const std::vector<std::reference_wrapper<SettingSpec>>& DeviceConfig::GetSetting
                 .Priority     = 3 + static_cast<int>(i),
                 .ApiPath      = stableCStr(apiPathStr)
             }));
+
+            #if USE_APA102
+            const auto& clockNameStr        = pinSpecStrings.emplace_back(str_sprintf("apa102ClockPin%zu", i));
+            const auto& clockFriendlyStr    = pinSpecStrings.emplace_back(str_sprintf("APA102 clock pin %zu", i + 1));
+            const auto& clockDescriptionStr = pinSpecStrings.emplace_back(str_sprintf("GPIO assigned to APA102 clock for channel %zu.", i + 1));
+            const auto& clockApiPathStr     = pinSpecStrings.emplace_back(str_sprintf("outputs.apa102.clockPins[%zu]", i));
+
+            settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
+                .Name         = stableCStr(clockNameStr),
+                .FriendlyName = stableCStr(clockFriendlyStr),
+                .Description  = stableCStr(clockDescriptionStr),
+                .Type         = SettingSpec::SettingType::Integer,
+                .MinimumValue = -1.0,
+                .MaximumValue = 48.0,
+                .Section      = kSectionOutput,
+                .Priority     = 3 + static_cast<int>(compiledChannelCount) + static_cast<int>(i),
+                .ApiPath      = stableCStr(clockApiPathStr)
+            }));
+            #endif
         }
 
         settingSpecReferences.insert(settingSpecReferences.end(), settingSpecs.begin(), settingSpecs.end());
@@ -1015,7 +1120,10 @@ DeviceConfig::ValidateResponse DeviceConfig::ValidateOutputDriver(OutputDriver d
     return { true, "" };
 }
 
-DeviceConfig::ValidateResponse DeviceConfig::ValidateWS281xSettings(size_t channelCount, const std::array<int8_t, NUM_CHANNELS>& pins, WS281xColorOrder colorOrder) const
+DeviceConfig::ValidateResponse DeviceConfig::ValidateStripSettings(size_t channelCount,
+                                                                    const std::array<int8_t, NUM_CHANNELS>& dataPins,
+                                                                    const std::array<int8_t, NUM_CHANNELS>& clockPins,
+                                                                    WS281xColorOrder colorOrder) const
 {
     if (channelCount == 0)
         return { false, "channel count must be greater than zero" };
@@ -1028,25 +1136,54 @@ DeviceConfig::ValidateResponse DeviceConfig::ValidateWS281xSettings(size_t chann
         if (channelCount != GetCompiledChannelCount())
             return { false, kRecompileNeededMessage };
 
-        if (pins != GetCompiledWS281xPins())
+        if (dataPins != GetCompiledWS281xPins())
+            return { false, kRecompileNeededMessage };
+
+        if (clockPins != GetCompiledAPA102ClockPins())
             return { false, kRecompileNeededMessage };
 
         if (colorOrder != GetCompiledWS281xColorOrder())
             return { false, kRecompileNeededMessage };
+
+        return { true, "" };
     }
 
     for (size_t i = 0; i < channelCount; ++i)
     {
-        if (pins[i] < 0)
-            return { false, "active channels require valid GPIO pins" };
+        if (dataPins[i] < 0)
+            return { false, "active channels require valid data GPIO pins" };
 
-        if (!GPIO_IS_VALID_OUTPUT_GPIO(static_cast<gpio_num_t>(pins[i])))
-            return { false, "WS281x channel pins must be valid output GPIOs" };
+        if (!GPIO_IS_VALID_OUTPUT_GPIO(static_cast<gpio_num_t>(dataPins[i])))
+            return { false, "strip data pins must be valid output GPIOs" };
 
         for (size_t j = i + 1; j < channelCount; ++j)
         {
-            if (pins[i] == pins[j])
-                return { false, "WS281x channel pins must be unique" };
+            if (dataPins[i] == dataPins[j])
+                return { false, "strip data pins must be unique" };
+        }
+    }
+
+    if (GetCompiledOutputDriver() == OutputDriver::APA102)
+    {
+        for (size_t i = 0; i < channelCount; ++i)
+        {
+            if (clockPins[i] < 0)
+                return { false, "APA102 channels require valid clock GPIO pins" };
+
+            if (!GPIO_IS_VALID_OUTPUT_GPIO(static_cast<gpio_num_t>(clockPins[i])))
+                return { false, "APA102 clock pins must be valid output GPIOs" };
+
+            if (clockPins[i] == dataPins[i])
+                return { false, "APA102 data and clock pins must be different" };
+
+            for (size_t j = i + 1; j < channelCount; ++j)
+            {
+                if (clockPins[i] == clockPins[j])
+                    return { false, "APA102 clock pins must be unique" };
+
+                if (clockPins[i] == dataPins[j] || dataPins[i] == clockPins[j])
+                    return { false, "APA102 data and clock pins must be unique" };
+            }
         }
     }
 
@@ -1063,9 +1200,12 @@ DeviceConfig::ValidateResponse DeviceConfig::ValidateRuntimeConfig(const Runtime
     if (!topologyValid)
         return { false, topologyMessage };
 
-    auto [ws281xValid, ws281xMessage] = ValidateWS281xSettings(config.outputs.channelCount, config.outputs.outputPins, config.outputs.colorOrder);
-    if (!ws281xValid)
-        return { false, ws281xMessage };
+    auto [stripValid, stripMessage] = ValidateStripSettings(config.outputs.channelCount,
+                                                            config.outputs.outputPins,
+                                                            config.outputs.clockPins,
+                                                            config.outputs.colorOrder);
+    if (!stripValid)
+        return { false, stripMessage };
 
     return { true, "" };
 }
@@ -1087,6 +1227,7 @@ bool DeviceConfig::SetRuntimeConfig(const RuntimeConfig& config, bool skipWrite,
         || runtimeOutputs.driver != config.outputs.driver
         || runtimeOutputs.channelCount != config.outputs.channelCount
         || runtimeOutputs.outputPins != config.outputs.outputPins
+        || runtimeOutputs.clockPins != config.outputs.clockPins
         || runtimeOutputs.colorOrder != config.outputs.colorOrder;
 
     runtimeTopology = config.topology;

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -79,7 +79,7 @@
     #include "hub75gfx.h"
 #endif
 
-#ifdef USE_WS281X
+#if USE_STRIP
     #include "ws281xgfx.h"
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,8 +225,8 @@ void ConfirmUpdate();
 
 #include "websocketserver.h"
 
-#if USE_WS281X
-#include "ws281xgfx.h"
+#if USE_STRIP
+    #include "ws281xgfx.h"
 #endif
 
 
@@ -618,8 +618,8 @@ void setup()
     #elif HEXAGON
         // Hexagon is for a PCB wtih 271 LEDss arranged in the face of a hexagon
         HexagonGFX::InitializeHardware(devices);
-    #elif USE_WS281X
-        // WS281xGFX is used for simple strips or for matrices woven from strips
+    #elif USE_STRIP
+        // WS281xGFX owns the CRGB framebuffers for strip outputs.
         WS281xGFX::InitializeHardware(devices);
     #endif
 
@@ -788,7 +788,7 @@ void loop()
             strOutput += str_sprintf("Mem: %zu, LargestBlk: %zu, PSRAM Free: %zu/%zu, ", (size_t)ESP.getFreeHeap(), (size_t)ESP.getMaxAllocHeap(), (size_t)ESP.getFreePsram(), (size_t)ESP.getPsramSize());
             strOutput += str_sprintf("LED FPS: %lu ", (unsigned long)g_Values.FPS);
 
-            #if USE_WS281X
+            #if USE_STRIP
                 strOutput += str_sprintf("LED Bright: %3.0lf%%, LED Watts: %lu, ", g_Values.Brite, (unsigned long)g_Values.Watts);
             #endif
 

--- a/src/systemcontainer.cpp
+++ b/src/systemcontainer.cpp
@@ -46,9 +46,15 @@
 #include "taskmgr.h"
 #include "webserver.h"
 #include "websocketserver.h"
-#if USE_WS281X
+#if USE_STRIP
 #include "ws281xgfx.h"
+#include "stripoutputmanager.h"
+#endif
+#if USE_WS281X
 #include "ws281xoutputmanager.h"
+#endif
+#if USE_APA102
+#include "apa102outputmanager.h"
 #endif
 
 // SystemContainer
@@ -154,11 +160,11 @@ SocketServer& SystemContainer::GetSocketServer() const
 }
 #endif
 
-#if USE_WS281X
-WS281xOutputManager& SystemContainer::GetWS281xOutputManager() const
+#if USE_STRIP
+IStripOutputManager& SystemContainer::GetStripOutputManager() const
 {
-    CheckPointer(!!_ptrWS281xOutputManager, "WS281xOutputManager");
-    return *_ptrWS281xOutputManager;
+    CheckPointer(!!_ptrStripOutputManager, "StripOutputManager");
+    return *_ptrStripOutputManager;
 }
 #endif
 
@@ -319,13 +325,13 @@ bool SystemContainer::ApplyRuntimeConfiguration(String* errorMessage)
         return false;
     }
 
-    #if USE_WS281X
+    #if USE_STRIP
     try
     {
         if (_ptrDevices)
         {
             // Reconfiguring the already-owned GFX objects keeps the rest of the renderer stable while
-            // still letting the active WS281x layout, channel count, and pins move inside build limits.
+            // still letting the active strip layout, channel count, and pins move inside build limits.
             for (auto& device : *_ptrDevices)
                 device->ConfigureTopology(config.GetMatrixWidth(), config.GetMatrixHeight(), config.IsMatrixSerpentine());
         }
@@ -341,9 +347,9 @@ bool SystemContainer::ApplyRuntimeConfiguration(String* errorMessage)
             _ptrSocketServer->SetLEDCount(config.GetActiveLEDCount());
         #endif
 
-        // The mutable WS281x output layer is now always owned by NightDriver so live pin/count/color-order
-        // changes stay on one transport path instead of handing off between different ESP32 RMT backends.
-        if (_ptrDevices && !SetupWS281xOutputManager().ApplyConfig(config, *_ptrDevices, errorMessage))
+        // The mutable strip output layer is now always owned by NightDriver so live pin/count/color-order
+        // changes stay on one transport path instead of handing off between different driver backends.
+        if (_ptrDevices && !SetupStripOutputManager().ApplyConfig(config, *_ptrDevices, errorMessage))
             return false;
 
         if (_ptrEffectManager && !_ptrEffectManager->ReinitializeEffects())
@@ -409,12 +415,18 @@ SocketServer& SystemContainer::SetupSocketServer(NetworkPort port, int ledCount)
 }
 #endif
 
-#if USE_WS281X
-WS281xOutputManager& SystemContainer::SetupWS281xOutputManager()
+#if USE_STRIP
+IStripOutputManager& SystemContainer::SetupStripOutputManager()
 {
-    if (!_ptrWS281xOutputManager)
-        _ptrWS281xOutputManager = make_unique_internal<WS281xOutputManager>();
-    return *_ptrWS281xOutputManager;
+    if (!_ptrStripOutputManager)
+    {
+        #if USE_WS281X
+            _ptrStripOutputManager = make_unique_internal<WS281xOutputManager>();
+        #elif USE_APA102
+            _ptrStripOutputManager = make_unique_internal<APA102OutputManager>();
+        #endif
+    }
+    return *_ptrStripOutputManager;
 }
 #endif
 

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -126,6 +126,14 @@ namespace
         ws281x["compiledColorOrder"] = DeviceConfig::GetColorOrderName(DeviceConfig::GetCompiledWS281xColorOrder());
         AppendPins(ws281x["pins"].to<JsonArray>(), deviceConfig.GetWS281xPins());
 
+        auto apa102 = outputs["apa102"].to<JsonObject>();
+        apa102["channelCount"] = deviceConfig.GetChannelCount();
+        apa102["compiledMaxChannels"] = DeviceConfig::GetCompiledChannelCount();
+        apa102["colorOrder"] = DeviceConfig::GetColorOrderName(deviceConfig.GetWS281xColorOrder());
+        apa102["compiledColorOrder"] = DeviceConfig::GetColorOrderName(DeviceConfig::GetCompiledWS281xColorOrder());
+        AppendPins(apa102["dataPins"].to<JsonArray>(), deviceConfig.GetAPA102DataPins());
+        AppendPins(apa102["clockPins"].to<JsonArray>(), deviceConfig.GetAPA102ClockPins());
+
         auto effects = root["effects"].to<JsonObject>();
         effects["effectInterval"] = effectManager.GetInterval();
     }
@@ -176,6 +184,23 @@ namespace
         allowedColorOrders.add("BRG");
         allowedColorOrders.add("BGR");
         AppendPins(ws281x["compiledPins"].to<JsonArray>(), DeviceConfig::GetCompiledWS281xPins());
+
+        auto apa102 = outputs["apa102"].to<JsonObject>();
+        apa102["compiledMaxChannels"] = compiledChannels;
+        apa102["compiledMaxLEDs"] = DeviceConfig::GetCompiledLEDCount();
+        apa102["compiledColorOrder"] = DeviceConfig::GetColorOrderName(DeviceConfig::GetCompiledWS281xColorOrder());
+        auto apa102AllowedChannelCounts = apa102["allowedChannelCounts"].to<JsonArray>();
+        for (size_t channel = 1; channel <= compiledChannels; ++channel)
+            apa102AllowedChannelCounts.add(channel);
+        auto apa102AllowedColorOrders = apa102["allowedColorOrders"].to<JsonArray>();
+        apa102AllowedColorOrders.add("RGB");
+        apa102AllowedColorOrders.add("RBG");
+        apa102AllowedColorOrders.add("GRB");
+        apa102AllowedColorOrders.add("GBR");
+        apa102AllowedColorOrders.add("BRG");
+        apa102AllowedColorOrders.add("BGR");
+        AppendPins(apa102["compiledDataPins"].to<JsonArray>(), DeviceConfig::GetCompiledWS281xPins());
+        AppendPins(apa102["compiledClockPins"].to<JsonArray>(), DeviceConfig::GetCompiledAPA102ClockPins());
 
         auto device = root["device"].to<JsonObject>();
         auto remote = device["remote"].to<JsonObject>();
@@ -1214,7 +1239,11 @@ bool CWebServer::SetSettingsIfPresent(AsyncWebServerRequest * pRequest, String* 
     runtimeConfigChanged = PushPostParamIfPresent<size_t>(pRequest, DeviceConfig::MatrixHeightTag, SET_VALUE(runtimeConfig.topology.height = value)) || runtimeConfigChanged;
     runtimeConfigChanged = PushPostParamIfPresent<bool>(pRequest, DeviceConfig::MatrixSerpentineTag, SET_VALUE(runtimeConfig.topology.serpentine = value)) || runtimeConfigChanged;
     runtimeConfigChanged = PushPostParamIfPresent<size_t>(pRequest, DeviceConfig::WS281xChannelCountTag, SET_VALUE(runtimeConfig.outputs.channelCount = value)) || runtimeConfigChanged;
-    runtimeConfigChanged = PushPostParamIfPresent<String>(pRequest, DeviceConfig::OutputDriverTag, SET_VALUE(runtimeConfig.outputs.driver = value == "hub75" ? DeviceConfig::OutputDriver::HUB75 : DeviceConfig::OutputDriver::WS281x)) || runtimeConfigChanged;
+    runtimeConfigChanged = PushPostParamIfPresent<String>(pRequest, DeviceConfig::OutputDriverTag, SET_VALUE(
+        if (value == "hub75") runtimeConfig.outputs.driver = DeviceConfig::OutputDriver::HUB75;
+        else if (value == "apa102") runtimeConfig.outputs.driver = DeviceConfig::OutputDriver::APA102;
+        else runtimeConfig.outputs.driver = DeviceConfig::OutputDriver::WS281x;
+    )) || runtimeConfigChanged;
     runtimeConfigChanged = PushPostParamIfPresent<String>(pRequest, DeviceConfig::WS281xColorOrderTag, SET_VALUE(
         if (value == "RGB") runtimeConfig.outputs.colorOrder = DeviceConfig::WS281xColorOrder::RGB;
         else if (value == "RBG") runtimeConfig.outputs.colorOrder = DeviceConfig::WS281xColorOrder::RBG;
@@ -1338,7 +1367,9 @@ void CWebServer::SetUnifiedSettings(AsyncWebServerRequest * pRequest, JsonVarian
         if (outputs["driver"].is<String>())
         {
             const auto driver = outputs["driver"].as<String>();
-            runtimeConfig.outputs.driver = driver == "hub75" ? DeviceConfig::OutputDriver::HUB75 : DeviceConfig::OutputDriver::WS281x;
+            if (driver == "hub75") runtimeConfig.outputs.driver = DeviceConfig::OutputDriver::HUB75;
+            else if (driver == "apa102") runtimeConfig.outputs.driver = DeviceConfig::OutputDriver::APA102;
+            else runtimeConfig.outputs.driver = DeviceConfig::OutputDriver::WS281x;
         }
 
         if (outputs["ws281x"].is<JsonObjectConst>())
@@ -1362,6 +1393,40 @@ void CWebServer::SetUnifiedSettings(AsyncWebServerRequest * pRequest, JsonVarian
                 {
                     if (pins[i].is<int>())
                         runtimeConfig.outputs.outputPins[i] = pins[i].as<int>();
+                }
+            }
+        }
+
+        if (outputs["apa102"].is<JsonObjectConst>())
+        {
+            auto apa102 = outputs["apa102"].as<JsonObjectConst>();
+            if (apa102["channelCount"].is<size_t>()) runtimeConfig.outputs.channelCount = apa102["channelCount"].as<size_t>();
+            if (apa102["colorOrder"].is<String>())
+            {
+                const auto colorOrder = apa102["colorOrder"].as<String>();
+                if (colorOrder == "RGB") runtimeConfig.outputs.colorOrder = DeviceConfig::WS281xColorOrder::RGB;
+                else if (colorOrder == "RBG") runtimeConfig.outputs.colorOrder = DeviceConfig::WS281xColorOrder::RBG;
+                else if (colorOrder == "GRB") runtimeConfig.outputs.colorOrder = DeviceConfig::WS281xColorOrder::GRB;
+                else if (colorOrder == "GBR") runtimeConfig.outputs.colorOrder = DeviceConfig::WS281xColorOrder::GBR;
+                else if (colorOrder == "BRG") runtimeConfig.outputs.colorOrder = DeviceConfig::WS281xColorOrder::BRG;
+                else if (colorOrder == "BGR") runtimeConfig.outputs.colorOrder = DeviceConfig::WS281xColorOrder::BGR;
+            }
+            if (apa102["dataPins"].is<JsonArrayConst>())
+            {
+                auto pins = apa102["dataPins"].as<JsonArrayConst>();
+                for (size_t i = 0; i < runtimeConfig.outputs.outputPins.size() && i < pins.size(); ++i)
+                {
+                    if (pins[i].is<int>())
+                        runtimeConfig.outputs.outputPins[i] = pins[i].as<int>();
+                }
+            }
+            if (apa102["clockPins"].is<JsonArrayConst>())
+            {
+                auto pins = apa102["clockPins"].as<JsonArrayConst>();
+                for (size_t i = 0; i < runtimeConfig.outputs.clockPins.size() && i < pins.size(); ++i)
+                {
+                    if (pins[i].is<int>())
+                        runtimeConfig.outputs.clockPins[i] = pins[i].as<int>();
                 }
             }
         }

--- a/src/ws281xgfx.cpp
+++ b/src/ws281xgfx.cpp
@@ -43,6 +43,12 @@
 #if USE_WS281X
 #include "ws281xoutputmanager.h"
 #endif
+#if USE_APA102
+#include "apa102outputmanager.h"
+#endif
+#if USE_STRIP
+#include "stripoutputmanager.h"
+#endif
 
 namespace
 {
@@ -256,18 +262,18 @@ void WS281xGFX::InitializeHardware(std::vector<std::shared_ptr<GFXBase>>& device
 
     for (int i = 0; i < NUM_CHANNELS; i++)
     {
-        debugW("Allocating WS281xGFX for channel %d", i);
+        debugW("Allocating strip GFX for channel %d", i);
         auto device = make_shared_psram<WS281xGFX>(deviceConfig.GetMatrixWidth(), deviceConfig.GetMatrixHeight());
         device->ConfigureTopology(deviceConfig.GetMatrixWidth(), deviceConfig.GetMatrixHeight(), deviceConfig.IsMatrixSerpentine());
         devices.push_back(device);
     }
 
-    // Use a single WS281x transport path for both boot and live reconfiguration. The compiled pin macros still
+    // Use a single strip transport path for both boot and live reconfiguration. The compiled pin macros still
     // define the default configuration, but driving LEDs through one runtime-capable manager avoids fragile
-    // handoffs between different ESP32 RMT implementations.
-    #if USE_WS281X
-    auto& outputManager = g_ptrSystem->SetupWS281xOutputManager();
+    // handoffs between different driver implementations.
+    #if USE_STRIP
     String errorMessage;
+    auto& outputManager = g_ptrSystem->SetupStripOutputManager();
     if (!outputManager.ApplyConfig(deviceConfig, devices, &errorMessage))
         throw std::runtime_error(errorMessage.c_str());
     #endif
@@ -288,14 +294,12 @@ void WS281xGFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsD
         return;
     }
 
-    #if USE_WS281X
+    #if USE_STRIP
     auto& effectManager = g_ptrSystem->GetEffectManager();
     const auto& deviceConfig = g_ptrSystem->GetDeviceConfig();
 
-    if (!g_ptrSystem->HasWS281xOutputManager())
-    {
+    if (!g_ptrSystem->HasStripOutputManager())
         return;
-    }
 
     for (int i = 0; i < NUM_CHANNELS; i++)
     {
@@ -314,7 +318,7 @@ void WS281xGFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsD
         }
     }
 
-    auto& outputManager = g_ptrSystem->GetWS281xOutputManager();
+    auto& outputManager = g_ptrSystem->GetStripOutputManager();
     uint32_t unscaledPowerMw = 0;
     const size_t activeChannelCount = std::min<size_t>(outputManager.GetActiveChannelCount(), NUM_CHANNELS);
     const size_t activeLEDCount = outputManager.GetActiveLEDCount();
@@ -355,11 +359,11 @@ void HexagonGFX::InitializeHardware(std::vector<std::shared_ptr<GFXBase>>& devic
         devices.push_back(make_shared_psram<HexagonGFX>(NUM_LEDS));
     }
 
-    #if USE_WS281X
     // Hexagon layouts are always driven through the runtime manager because their physical mapping is
     // board-specific and does not benefit from the compiled FastLED fallback assumptions used by strips.
-    auto& outputManager = g_ptrSystem->SetupWS281xOutputManager();
+    #if USE_STRIP
     String errorMessage;
+    auto& outputManager = g_ptrSystem->SetupStripOutputManager();
     if (!outputManager.ApplyConfig(g_ptrSystem->GetDeviceConfig(), devices, &errorMessage))
         throw std::runtime_error(errorMessage.c_str());
     #endif


### PR DESCRIPTION
Add APA102 Support

I'm adding APA102 (clocked 2‑wire, also covers SK9822) as a first-class strip transport alongside WS281x. 

Driver selection — breaking-ish for build flags

Output transport is now exactly one of USE_HUB75 / USE_WS281X / USE_APA102. The legacy USE_STRIP macro is derived ((USE_WS281X || USE_APA102)), no longer settable from build_flags. If you were defining USE_STRIP directly anywhere, stop — globals.h enforces (USE_HUB75 + USE_WS281X + USE_APA102) != 1 #error. WS281x is still the default when nothing is specified, so existing envs are unaffected.

APA102 envs must also define LED_CLOCK_PIN0..N next to the usual LED_PIN0..N. See the new [env:heltecdemoapa102] in platformio.ini for the template.

Architecture — new strip abstraction

New IStripOutputManager interface (stripoutputmanager.h) — pure-virtual ApplyConfig / Show / Reset / GetActiveChannelCount / GetActiveLEDCount.

WS281xOutputManager and APA102OutputManager both implement it.

SystemContainer now owns a single _ptrStripOutputManager of base type and exposes one SetupStripOutputManager() / HasStripOutputManager() / GetStripOutputManager() triple. The per-driver Get/Has/SetupWS281xOutputManager etc. are gone — update any in-flight code that used them.

All render-path dispatch in ws281xgfx.cpp (WS281xGFX::InitializeHardware, PostProcessFrame, 
HexagonGFX::InitializeHardware) goes through the base interface — no more #if USE_WS281X / #elif USE_APA102 ladders.

Driver itself

APA102OutputManager bit-bangs the SPI-like protocol via raw REG_WRITE to GPIO_OUT_W1TS/W1TC (no SPI peripheral dependency, arbitrary per-channel pin pairs, runtime-reconfigurable).
Shares WS281xGFX::TransportMutex() with WS281x so Show() paths can't race during live reconfiguration.
Honors the existing runtime color-order setting; APA102 global brightness is folded into the per-LED start frame.

A smarter man might use the ESP32's hardware SPI, but I am not yet that man.  If someone else does it, and I read it, then I will be.

DeviceConfig / web API

kCompiledWS281xPins and kCompiledAPA102ClockPins arrays in deviceconfig.cpp (collapsed via local ND_DATA_PIN / ND_CLOCK_PIN macros) now expose -1 for inactive channels per build.
webserver.cpp exposes the compiled/configured APA102 clock-pin set and color order alongside the WS281x equivalents; ValidateStripSettings validates the clock-pin array on APA102 builds.
What to watch in review

The allocated_unique_ptr<Derived> → allocated_unique_ptr<IStripOutputManager> upcast relies on heap_caps_unique_deleter being type-erased (it stores destroy/dealloc fn-pointers, not a templated type). Verified, but worth a second pair of eyes.
The unified mutex means any future driver added under IStripOutputManager must also serialize through WS281xGFX::TransportMutex() (consider renaming to StripTransportMutex() in a follow-up).

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).