### PR TITLE
Accomodate all effects usefully on 48x16 displays

### DIFF
--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -102,8 +102,13 @@
 #ifndef BRIGHTNESS_MAX
     #define BRIGHTNESS_MAX          uint8_t(255)
 #endif
-#define POWER_LIMIT_MIN             1000
-#define POWER_LIMIT_DEFAULT         4500
+#define POWER_LIMIT_MIN             1
+#define POWER_LIMIT_LEGACY_DEFAULT  4500
+#ifdef POWER_LIMIT_MW
+    #define POWER_LIMIT_DEFAULT     POWER_LIMIT_MW
+#else
+    #define POWER_LIMIT_DEFAULT     POWER_LIMIT_LEGACY_DEFAULT
+#endif
 
 // DeviceConfig holds, persists and loads device-wide configuration settings. Effect-specific settings should
 // be managed using overrides of the respective methods in LEDStripEffect (mainly FillSettingSpecs(),
@@ -262,6 +267,7 @@ class DeviceConfig : public IJSONSerializable
     static constexpr const char * NTPServerTag = NAME_OF(ntpServer);
     static constexpr const char * RememberCurrentEffectTag = NAME_OF(rememberCurrentEffect);
     static constexpr const char * PowerLimitTag = NAME_OF(powerLimit);
+    static constexpr const char * PowerLimitDefaultTag = "powerLimitDefault";
     static constexpr const char * BrightnessTag = NAME_OF(brightness);
     // No need to publish the show VU meter tag unless we're also publishing the setting
     #if SHOW_VU_METER

--- a/include/effects/matrix/PatternStocks.h
+++ b/include/effects/matrix/PatternStocks.h
@@ -41,6 +41,7 @@
 #include <string.h>
 #include <HTTPClient.h>
 #include <ArduinoJson.h>
+#include <algorithm>
 #include <chrono>
 #include <thread>
 #include <vector>
@@ -206,6 +207,29 @@ private:
     using StockDataCallback = function<void(const StockData&)>;
 
     HTTPClient http;
+
+    void DrawCompactQuoteDisplay(int screenHeight)
+    {
+        const int topLineHeight = screenHeight / 2;
+
+        if (stockData.empty())
+        {
+            g().DrawTextInBand("STOCKS", 0, topLineHeight, CRGB::White);
+            g().DrawTextInBand("--", topLineHeight, screenHeight - topLineHeight, CRGB::LightGrey);
+            return;
+        }
+
+        const size_t stockIndex = std::min(static_cast<size_t>(std::max(0, iCurrentStock)), stockData.size() - 1);
+        auto it = stockData.begin();
+        std::advance(it, stockIndex);
+        const StockData& currentStock = it->second;
+
+        const String priceText = currentStock.close >= 10000 ? String(currentStock.close, 0) : String(currentStock.close, 2);
+        const CRGB priceColor = currentStock.close >= currentStock.previousClose ? CRGB::LightGreen : CRGB::Red;
+
+        g().DrawTextInBand(currentStock.symbol, 0, topLineHeight, CRGB::White);
+        g().DrawTextInBand(priceText, topLineHeight, screenHeight - topLineHeight, priceColor);
+    }
 
     void GetQuote(const String &symbol, StockDataCallback callback = nullptr)
     {
@@ -510,8 +534,12 @@ public:
     void Draw() override
     {
         auto& graphics = g();
+        const int screenWidth = static_cast<int>(graphics.GetMatrixWidth());
+        const int screenHeight = static_cast<int>(graphics.GetMatrixHeight());
+
         graphics.fillScreen(BLACK16);
-        graphics.fillRect(0, 0, MATRIX_WIDTH, 9, graphics.to16bit(CRGB(0,0,128)));
+        graphics.setFont(&Apple5x7);
+        graphics.setTextWrap(false);
 
         // Periodically refetch the stock data from the server
 
@@ -550,6 +578,13 @@ public:
 
         // Paint Frame
 
+        if (screenHeight < 32)
+        {
+            DrawCompactQuoteDisplay(screenHeight);
+            return;
+        }
+
+        graphics.fillRect(0, 0, screenWidth, 9, graphics.to16bit(CRGB(0,0,128)));
         UpdateQuoteDisplay();
     }
 

--- a/include/effects/matrix/PatternSubscribers.h
+++ b/include/effects/matrix/PatternSubscribers.h
@@ -73,6 +73,21 @@ class PatternSubscribers : public EffectWithId<PatternSubscribers>
 
     time_t latestUpdate                     = 0;
 
+    void DrawCompactSubscribers(int screenHeight)
+    {
+        const int topLineHeight = screenHeight / 2;
+        const String subscriberText = str_sprintf("%ld", subscribers);
+
+        g().DrawTextInBand(youtubeChannelName.isEmpty() ? "Subscribers" : youtubeChannelName,
+                           0,
+                           topLineHeight,
+                           CRGB::White);
+        g().DrawTextInBand(subscriberText,
+                           topLineHeight,
+                           screenHeight - topLineHeight,
+                           borderColor);
+    }
+
     void SubscriberReader()
     {
         unsigned long msSinceLastCheck = millis() - msLastCheck;
@@ -231,13 +246,24 @@ class PatternSubscribers : public EffectWithId<PatternSubscribers>
 
     void Draw() override
     {
-        g().Clear(backgroundColor);
-
-        // Draw a border around the edge of the panel
-        g().drawRect(0, 1, MATRIX_WIDTH - 1, MATRIX_HEIGHT - 2, g().to16bit(borderColor));
+        const int screenWidth = static_cast<int>(g().GetMatrixWidth());
+        const int screenHeight = static_cast<int>(g().GetMatrixHeight());
 
         // Use the centralized Apple5x7 Adafruit font
         g().setFont(&Apple5x7);
+        g().setTextWrap(false);
+
+        if (screenHeight < 32)
+        {
+            g().fillScreen(BLACK16);
+            DrawCompactSubscribers(screenHeight);
+            return;
+        }
+
+        g().Clear(backgroundColor);
+
+        // Draw a border around the edge of the panel
+        g().drawRect(0, 1, screenWidth - 1, screenHeight - 2, g().to16bit(borderColor));
 
         // Draw the channel name
         g().setTextColor(g().to16bit(CRGB::White));
@@ -259,8 +285,8 @@ class PatternSubscribers : public EffectWithId<PatternSubscribers>
 
         // Center the text horizontally and vertically on the screen
         // Note: y1 is typically negative (above baseline), so we need to account for that
-        int x = (MATRIX_WIDTH - textWidth) / 2;
-        int y = (MATRIX_HEIGHT / 2) - (textHeight / 2) - y1;  // Properly center vertically
+        int x = (screenWidth - textWidth) / 2;
+        int y = (screenHeight / 2) - (textHeight / 2) - y1;  // Properly center vertically
 
         // Draw shadow effect by printing in black at offset positions, then white on top
         g().setTextColor(g().to16bit(CRGB::Black));

--- a/include/effects/matrix/PatternWeather.h
+++ b/include/effects/matrix/PatternWeather.h
@@ -38,6 +38,7 @@
 
 #include <Arduino.h>
 #include <ArduinoJson.h>
+#include <algorithm>
 #include <array>
 #include <chrono>
 #include <HTTPClient.h>
@@ -152,6 +153,9 @@ class PatternWeather : public EffectWithId<PatternWeather>
     size_t readerIndex        = SIZE_MAX;
     system_clock::time_point latestUpdate = system_clock::from_time_t(0);
     mutable std::mutex weatherDataMutex;
+
+    static constexpr int WeatherFontHeight = 7;
+    static constexpr int WeatherFontWidth  = 5;
 
     /**
      * @brief Should this effect show its title.
@@ -484,6 +488,43 @@ class PatternWeather : public EffectWithId<PatternWeather>
         return configLocation != strLocation || configCountryCode != strCountryCode;
     }
 
+    String GetLocationDisplayText(const String& displayLocationName, const String& displayLocation, bool hasWeatherApiKey) const
+    {
+        if (!hasWeatherApiKey)
+            return "No API Key";
+
+        String showLocation = displayLocation;
+        showLocation.toUpperCase();
+        return displayLocationName.isEmpty() ? showLocation : displayLocationName;
+    }
+
+    static String GetTemperatureDisplayText(float displayTemperature, bool displayDataReady)
+    {
+        if (!displayDataReady)
+            return "--";
+
+        return String((int)displayTemperature);
+    }
+
+    void DrawCompactWeather(int screenHeight,
+                            const String& locationText,
+                            const String& temperatureText,
+                            bool showLocationLine)
+    {
+        if (showLocationLine)
+        {
+            const int topLineHeight = screenHeight / 2;
+            g().DrawTextInBand(locationText, 0, topLineHeight, WHITE16);
+            g().DrawTextInBand(temperatureText, topLineHeight, screenHeight - topLineHeight, g().to16bit(CRGB(192,192,192)));
+            return;
+        }
+
+        g().DrawTextInBand(temperatureText.isEmpty() ? locationText : temperatureText,
+                           0,
+                           screenHeight,
+                           g().to16bit(CRGB(192,192,192)));
+    }
+
 public:
 
     /**
@@ -533,13 +574,13 @@ public:
      */
     void Draw() override
     {
-        const int fontHeight = 7;
-        const int fontWidth  = 5;
-        const int xHalf      = MATRIX_WIDTH / 2 - 1;
+        const int screenWidth  = static_cast<int>(g().GetMatrixWidth());
+        const int screenHeight = static_cast<int>(g().GetMatrixHeight());
+        const int xHalf        = screenWidth / 2 - 1;
 
         g().fillScreen(BLACK16);
-        g().fillRect(0, 0, MATRIX_WIDTH, 9, g().to16bit(CRGB(0,0,128)));
         g().setFont(&Apple5x7);
+        g().setTextWrap(false);
 
         auto now = system_clock::now();
 
@@ -575,6 +616,23 @@ public:
         const float   displayHighTomorrow = highTomorrow;
         const float   displayLoTomorrow   = loTomorrow;
         const bool    displayDataReady    = dataReady;
+        const bool    hasWeatherApiKey    = !g_ptrSystem->GetDeviceConfig().GetOpenWeatherAPIKey().isEmpty();
+        const String  locationText        = GetLocationDisplayText(displayLocationName, displayLocation, hasWeatherApiKey);
+        const String  temperatureText     = hasWeatherApiKey ? GetTemperatureDisplayText(displayTemperature, displayDataReady) : "";
+
+        if (screenHeight < 16)
+        {
+            DrawCompactWeather(screenHeight, locationText, temperatureText, false);
+            return;
+        }
+
+        if (screenHeight < 32)
+        {
+            DrawCompactWeather(screenHeight, locationText, temperatureText, true);
+            return;
+        }
+
+        g().fillRect(0, 0, screenWidth, 9, g().to16bit(CRGB(0,0,128)));
 
         // Draw the graphics
         auto iconEntry = weatherIcons.find(displayIconToday);
@@ -595,22 +653,17 @@ public:
 
         // Print the town/city name
         int x = 0;
-        int y = fontHeight + 1;
+        int y = WeatherFontHeight + 1;
         g().setCursor(x, y);
         g().setTextColor(WHITE16);
-        String showLocation = displayLocation;
-        showLocation.toUpperCase();
-        if (g_ptrSystem->GetDeviceConfig().GetOpenWeatherAPIKey().isEmpty())
-            g().print("No API Key");
-        else
-            g().print((displayLocationName.isEmpty() ? showLocation : displayLocationName).substring(0, (MATRIX_WIDTH - 2 * fontWidth)/fontWidth));
+        g().print(g().FitTextToWidth(locationText, screenWidth - 2 * WeatherFontWidth));
 
         // Display the temperature, right-justified
 
         if (displayDataReady)
         {
             String strTemp((int)displayTemperature);
-            x = MATRIX_WIDTH - fontWidth * strTemp.length();
+            x = std::max(0, screenWidth - WeatherFontWidth * static_cast<int>(strTemp.length()));
             g().setCursor(x, y);
             g().setTextColor(g().to16bit(CRGB(192,192,192)));
             g().print(strTemp);
@@ -620,9 +673,9 @@ public:
 
         y+=1;
 
-        g().drawLine(0, y, MATRIX_WIDTH-1, y, CRGB(0,0,128));
-        g().drawLine(xHalf, y, xHalf, MATRIX_HEIGHT-1, CRGB(0,0,128));
-        y+=2 + fontHeight;
+        g().drawLine(0, y, screenWidth-1, y, CRGB(0,0,128));
+        g().drawLine(xHalf, y, xHalf, screenHeight-1, CRGB(0,0,128));
+        y+=2 + WeatherFontHeight;
 
         // Figure out which day of the week it is
 
@@ -633,9 +686,9 @@ public:
 
         // Draw the day of the week and tomorrow's day as well
         g().setTextColor(WHITE16);
-        g().setCursor(0, MATRIX_HEIGHT);
+        g().setCursor(0, screenHeight);
         g().print(pszToday);
-        g().setCursor(xHalf+2, MATRIX_HEIGHT);
+        g().setCursor(xHalf+2, screenHeight);
         g().print(pszTomorrow);
 
         // Draw the temperature in lighter white
@@ -648,12 +701,12 @@ public:
 
             // Draw today's HI and LO temperatures
 
-            x = xHalf - fontWidth * strHi.length();
-            y = MATRIX_HEIGHT - fontHeight;
+            x = std::max(0, xHalf - WeatherFontWidth * static_cast<int>(strHi.length()));
+            y = screenHeight - WeatherFontHeight;
             g().setCursor(x,y);
             g().print(strHi);
-            x = xHalf - fontWidth * strLo.length();
-            y+= fontHeight;
+            x = std::max(0, xHalf - WeatherFontWidth * static_cast<int>(strLo.length()));
+            y+= WeatherFontHeight;
             g().setCursor(x,y);
             g().print(strLo);
 
@@ -661,12 +714,12 @@ public:
 
             strHi = String((int)displayHighTomorrow);
             strLo = String((int)displayLoTomorrow);
-            x = MATRIX_WIDTH - fontWidth * strHi.length();
-            y = MATRIX_HEIGHT - fontHeight;
+            x = std::max(0, screenWidth - WeatherFontWidth * static_cast<int>(strHi.length()));
+            y = screenHeight - WeatherFontHeight;
             g().setCursor(x,y);
             g().print(strHi);
-            x = MATRIX_WIDTH - fontWidth * strLo.length();
-            y+= fontHeight;
+            x = std::max(0, screenWidth - WeatherFontWidth * static_cast<int>(strLo.length()));
+            y+= WeatherFontHeight;
             g().setCursor(x,y);
             g().print(strLo);
         }

--- a/include/effects/strip/stareffect.h
+++ b/include/effects/strip/stareffect.h
@@ -617,6 +617,127 @@ class StarEffect : public StarEffectBase<StarType, StarEffect<StarType>>
     using StarEffectBase<StarType, StarEffect<StarType>>::StarEffectBase;
 };
 
+// NightTwinkleEffect
+//
+// Fills the strip with a base night color, then overlays randomly triggered
+// white stars using the standard particle pre-ignition/ignition/hold/fade cycle.
+
+class NightTwinkleEffect : public EffectWithId<NightTwinkleEffect>
+{
+  protected:
+
+    class NightTwinkleStar : public ColorStar
+    {
+      public:
+        NightTwinkleStar()
+          : ColorStar(CRGB::White, 0.0f, 1.0f)
+        {
+        }
+
+        float PreignitionTime() const override { return 0.0f;  }
+        float IgnitionTime()    const override { return 0.05f; }
+        float HoldTime()        const override { return 0.10f; }
+        float FadeTime()        const override { return 0.30f; }
+    };
+
+    static constexpr const char * PTY_DENSITY = "dns";
+    static constexpr const char * PTY_STARS_PER_FRAME = "spf";
+    static constexpr float  kDefaultDensity           = 1.0f;
+    static constexpr float  kLegacyDefaultDensity     = 0.01f;
+    static constexpr size_t kDefaultStarsPerFrame     = 10;
+    static constexpr float  kReferenceLEDCount        = 144.0f;
+
+    std::deque<NightTwinkleStar> _allParticles;
+    CRGB                         _baseColor;
+    float                        _density;
+    size_t                       _starsPerFrame;
+
+    static float DensityFromJSON(const JsonObjectConst& jsonObject)
+    {
+        if (!jsonObject[PTY_DENSITY].is<float>())
+            return kDefaultDensity;
+
+        const float density = jsonObject[PTY_DENSITY].as<float>();
+        if (!jsonObject[PTY_STARS_PER_FRAME].is<size_t>())
+            return density / kLegacyDefaultDensity;
+
+        return density;
+    }
+
+    void Update()
+    {
+        while (!_allParticles.empty() && _allParticles.front().Age() >= _allParticles.front().TotalLifetime())
+            _allParticles.pop_front();
+
+        while (_allParticles.size() > cMaxStars)
+            _allParticles.pop_back();
+    }
+
+    void CreateStars()
+    {
+        const float stripScale = static_cast<float>(_cLEDs) / kReferenceLEDCount;
+        const float requestedStars = _starsPerFrame * stripScale * std::max(0.0f, _density);
+        const size_t starsToCreate = requestedStars > 0.0f
+            ? std::max<size_t>(1, static_cast<size_t>(std::round(requestedStars)))
+            : 0;
+        if (starsToCreate == 0)
+            return;
+
+        for (size_t i = 0; i < starsToCreate && _allParticles.size() < cMaxStars; ++i)
+        {
+            NightTwinkleStar star;
+            star._iPos = static_cast<float>(random_range(0U, _cLEDs - 1));
+            _allParticles.push_back(star);
+        }
+    }
+
+  public:
+
+    NightTwinkleEffect(CRGB baseColor = CRGB(0, 0, 255), float density = kDefaultDensity, size_t starsPerFrame = kDefaultStarsPerFrame)
+      : EffectWithId<NightTwinkleEffect>("NightTwinkle"),
+        _baseColor(baseColor),
+        _density(density),
+        _starsPerFrame(starsPerFrame)
+    {
+    }
+
+    NightTwinkleEffect(const JsonObjectConst& jsonObject)
+      : EffectWithId<NightTwinkleEffect>(jsonObject),
+        _baseColor(jsonObject[PTY_COLOR].is<CRGB>() ? jsonObject[PTY_COLOR].as<CRGB>() : CRGB(0, 0, 255)),
+        _density(DensityFromJSON(jsonObject)),
+        _starsPerFrame(jsonObject[PTY_STARS_PER_FRAME].is<size_t>() ? jsonObject[PTY_STARS_PER_FRAME].as<size_t>() : kDefaultStarsPerFrame)
+    {
+    }
+
+    bool SerializeToJSON(JsonObject& jsonObject) override
+    {
+        auto jsonDoc = CreateJsonDocument();
+
+        JsonObject root = jsonDoc.to<JsonObject>();
+        LEDStripEffect::SerializeToJSON(root);
+
+        jsonDoc[PTY_COLOR] = _baseColor;
+        jsonDoc[PTY_DENSITY] = _density;
+        jsonDoc[PTY_STARS_PER_FRAME] = _starsPerFrame;
+
+        return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
+    }
+
+    void Draw() override
+    {
+        Update();
+        CreateStars();
+
+        fillSolidOnAllChannels(_baseColor);
+
+        for (auto& star : _allParticles)
+        {
+            star.UpdatePosition();
+            setPixelOnAllChannels(static_cast<int>(star._iPos), _baseColor + star.ObjectColor());
+        }
+    }
+};
+
 template <typename StarType> class BlurStarEffect : public StarEffectBase<StarType, BlurStarEffect<StarType>>
 {
   public:

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -273,6 +273,14 @@ public:
     static uint16_t to16bit(const CRGB rgb); // Convert CRGB -> 16 bit 5:6:5
     static uint16_t to16bit(CRGB::HTMLColorCode code); // Convert HtmlColorCode -> 16 bit 5:6:5
 
+    String FitTextToWidth(const String& text, int maxWidth);
+    void DrawTextInRect(const String& text, int x, int y, int width, int height, uint16_t color);
+    void DrawTextInRect(const String& text, int x, int y, int width, int height, const CRGB& color);
+    void DrawTextInRect(const String& text, int x, int y, int width, int height, CRGB::HTMLColorCode color);
+    void DrawTextInBand(const String& text, int bandTop, int bandHeight, uint16_t color);
+    void DrawTextInBand(const String& text, int bandTop, int bandHeight, const CRGB& color);
+    void DrawTextInBand(const String& text, int bandTop, int bandHeight, CRGB::HTMLColorCode color);
+
     virtual void Clear(CRGB color = CRGB::Black);
 
     __attribute__((always_inline))

--- a/src/deviceconfig.cpp
+++ b/src/deviceconfig.cpp
@@ -205,6 +205,7 @@ bool DeviceConfig::SerializeToJSON(JsonObject& jsonObject, bool includeSensitive
     jsonDoc[NTPServerTag] = ntpServer;
     jsonDoc[RememberCurrentEffectTag] = rememberCurrentEffect;
     jsonDoc[PowerLimitTag] = powerLimit;
+    jsonDoc[PowerLimitDefaultTag] = POWER_LIMIT_DEFAULT;
     // Only serialize showVUMeter if the VU meter is enabled in the build
     #if SHOW_VU_METER
     jsonDoc[ShowVUMeterTag] = showVUMeter;
@@ -256,7 +257,28 @@ bool DeviceConfig::DeserializeFromJSON(const JsonObjectConst& jsonObject, bool s
     SetIfPresentIn(jsonObject, useCelsius, UseCelsiusTag);
     SetIfPresentIn(jsonObject, ntpServer, NTPServerTag);
     SetIfPresentIn(jsonObject, rememberCurrentEffect, RememberCurrentEffectTag);
-    SetIfPresentIn(jsonObject, powerLimit, PowerLimitTag);
+    if (jsonObject[PowerLimitTag].is<int>())
+    {
+        const int savedPowerLimit = jsonObject[PowerLimitTag].as<int>();
+        #ifdef POWER_LIMIT_MW
+        if (!jsonObject[PowerLimitDefaultTag].is<int>() && savedPowerLimit == POWER_LIMIT_LEGACY_DEFAULT)
+        {
+            debugW("Ignoring saved legacy powerLimit default %d; using compiled default %d", savedPowerLimit, POWER_LIMIT_DEFAULT);
+            powerLimit = POWER_LIMIT_DEFAULT;
+        }
+        else
+        #endif
+        {
+            auto [isValid, validationMessage] = ValidatePowerLimit(savedPowerLimit);
+            if (isValid)
+                powerLimit = savedPowerLimit;
+            else
+            {
+                debugW("Ignoring saved powerLimit %d: %s", savedPowerLimit, validationMessage.c_str());
+                powerLimit = POWER_LIMIT_DEFAULT;
+            }
+        }
+    }
     SetIfPresentIn(jsonObject, brightness, BrightnessTag);
     // Persisted config predates the newer brightness guardrails in some installs, so treat an invalid
     // saved brightness as "unset" and fall back to the normal 100% default instead of booting dark.
@@ -444,7 +466,8 @@ SuccessResultWithMessage DeviceConfig::ValidatePowerLimit(const String& newPower
 
 void DeviceConfig::SetPowerLimit(int newPowerLimit)
 {
-    if (newPowerLimit >= POWER_LIMIT_MIN)
+    auto [isValid, _] = ValidatePowerLimit(newPowerLimit);
+    if (isValid)
         SetAndSave(powerLimit, newPowerLimit);
 }
 

--- a/src/deviceconfig_settings_specs.cpp
+++ b/src/deviceconfig_settings_specs.cpp
@@ -42,8 +42,7 @@ const std::vector<std::reference_wrapper<SettingSpec>>& DeviceConfig::GetSetting
         settingSpecs.push_back(SettingSpec::Validate(SettingSpec{
             .Name          = PowerLimitTag,
             .FriendlyName  = "Power limit",
-            .Description   = "The maximum power in mW that the matrix attached to the board is allowed to use. As the previous sentence implies, this "
-                             "setting only applies if a matrix is used.",
+            .Description   = "The maximum power in mW that the LEDs attached to the board are allowed to use.",
             .Type          = SettingSpec::SettingType::Integer,
             .HasValidation = true,
             .MinimumValue  = (double)POWER_LIMIT_MIN,

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -80,6 +80,15 @@ void LoadEffectFactories();
 std::optional<JsonObjectConst> LoadEffectsJSONFile(JsonDocument& jsonDoc);
 void WriteCurrentEffectIndexFile();
 
+namespace
+{
+    void WriteEffectManagerConfigFile()
+    {
+        if (!SaveToJSONFile(EFFECTS_CONFIG_FILE, g_ptrSystem->GetEffectManager()) && EFFECT_PERSISTENCE_CRITICAL)
+            throw std::runtime_error("Effects serialization failed");
+    }
+}
+
 // InitEffectsManager
 //
 // Initializes the effect manager.  Reboots on failure, since it's not optional
@@ -92,8 +101,7 @@ void InitEffectsManager()
 
     l_EffectsManagerJSONWriterIndex = g_ptrSystem->GetJSONWriter().RegisterWriter([]()
     {
-        if (!SaveToJSONFile(EFFECTS_CONFIG_FILE, g_ptrSystem->GetEffectManager()) && EFFECT_PERSISTENCE_CRITICAL)
-            throw std::runtime_error("Effects serialization failed");
+        WriteEffectManagerConfigFile();
     });
     l_CurrentEffectWriterIndex = g_ptrSystem->GetJSONWriter().RegisterWriter(WriteCurrentEffectIndexFile);
 
@@ -135,10 +143,12 @@ void InitEffectsManager()
     if (!loadedPersistedEffects)
     {
         // Persist the default effect set after initialization suppression is
-        // lifted. Otherwise first boot, missing config, or an effect-set hash
-        // change would run from defaults but never write the new config until
-        // some later user mutation happened.
-        SaveEffectManagerConfig();
+        // lifted. Do the first write synchronously before the high-activity
+        // startup services are running; stale or incompatible SPIFFS config
+        // from older builds can force SPIFFS garbage collection, and doing
+        // that before render/audio/remote/network tasks start avoids an early
+        // flash-write overlap with cache-sensitive drivers.
+        WriteEffectManagerConfigFile();
     }
 }
 

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -139,7 +139,7 @@
 
 // Global effect set version
 
-#define EFFECT_SET_VERSION 6
+#define EFFECT_SET_VERSION 9
 
 // Inform the linker which effects have setting specs, and in which class member
 
@@ -194,6 +194,7 @@ void LoadEffectFactories()
             Effect<FireEffect>("Medium Fire", NUM_LEDS, 1, 3, 100, 3, 4, true, true),
             Effect<BouncingBallEffect>(3, true, true, 1),
             Effect<MeteorEffect>(4, 4, 10, 2.0, 2.0),
+            Effect<NightTwinkleEffect>(),
             Effect<StarEffect<QuietStar>>("Rainbow Twinkle Stars", RainbowColors_p, kStarEffectProbability, 1, LINEARBLEND, 2.0, 0.0, kStarEffectMusicFactor),
             Effect<PaletteEffect>(RainbowColors_p)
         );
@@ -201,6 +202,12 @@ void LoadEffectFactories()
 
     #if defined(EFFECTS_TRIMLIGHT)
         // Trimlight intentionally has no local effects. It renders only incoming WiFi frames.
+    #endif
+
+    #if defined(EFFECTS_APA102_DEMO)
+        RegisterAll(*g_ptrEffectFactories,
+            Effect<NightTwinkleEffect>()
+        );
     #endif
 
     #if defined(EFFECTS_PDPWOPR)
@@ -232,6 +239,7 @@ void LoadEffectFactories()
             Effect<StarEffect<QuietStar>>("Green Twinkle Stars", GreenColors_p, kStarEffectProbability, 1, LINEARBLEND, 2.0, 0.0, kStarEffectMusicFactor),
             Effect<StarEffect<Star>>("Blue Sparkle Stars", BlueColors_p,  kStarEffectProbability, 1, LINEARBLEND, 2.0, 0.0, kStarEffectMusicFactor),
             Effect<StarEffect<QuietStar>>("Rainbow Twinkle Stars", RainbowColors_p, kStarEffectProbability, 1, LINEARBLEND, 2.0, 0.0, kStarEffectMusicFactor),
+            Effect<NightTwinkleEffect>(),
             Effect<TwinkleEffect>(NUM_LEDS / 2, 20, 50),
             Effect<PaletteEffect>(RainbowColors_p, .25, 1, 0, 1.0, 0.0, LINEARBLEND, true, 1.0),
             Effect<PaletteEffect>(RainbowColors_p),
@@ -417,6 +425,7 @@ void LoadEffectFactories()
             Effect<StarEffect<Star>>("Blue Sparkle Stars", BlueColors_p, kStarEffectProbability, 1, LINEARBLEND, 2.0, 0.0, kStarEffectMusicFactor),
             Effect<StarEffect<QuietStar>>("Red Twinkle Stars", RedColors_p, 1.0, 1, LINEARBLEND, 2.0),
             Effect<StarEffect<Star>>("Lava Stars", LavaColors_p, kStarEffectProbability, 1, LINEARBLEND, 2.0, 0.0, kStarEffectMusicFactor),
+            Effect<NightTwinkleEffect>(),
             Effect<PaletteEffect>(RainbowColors_p),
             Effect<PaletteEffect>(RainbowColors_p, 1.0, 1.0),
             Effect<PaletteEffect>(RainbowColors_p, .25)
@@ -567,6 +576,7 @@ void LoadEffectFactories()
             Effect<StarEffect<MusicStar>>("Blue Stars", BlueColors_p,  kStarEffectProbability, 1, LINEARBLEND, 2.0, 0.0, kStarEffectMusicFactor),
             Effect<StarEffect<Star>>("Green Sparkle Stars", GreenColors_p, kStarEffectProbability, 1, LINEARBLEND, 2.0, 0.0, kStarEffectMusicFactor),
             Effect<StarEffect<MusicStar>>("Green Stars", GreenColors_p, kStarEffectProbability, 1, LINEARBLEND, 2.0, 0.0, kStarEffectMusicFactor),
+            Effect<NightTwinkleEffect>(),
             Effect<TwinkleEffect>(NUM_LEDS / 2, 20, 50),
             Effect<PaletteEffect>(RainbowColors_p, .25, 1, 0, 1.0, 0.0, LINEARBLEND, true, 1.0),
             Effect<PaletteEffect>(RainbowColors_p),

--- a/src/gfxbase.cpp
+++ b/src/gfxbase.cpp
@@ -129,6 +129,79 @@ uint16_t GFXBase::to16bit(CRGB::HTMLColorCode code)
     return to16bit(CRGB(code));
 }
 
+// Returns the longest substring of 'text' that fits within 'maxWidth' when rendered with 
+// the current font
+
+String GFXBase::FitTextToWidth(const String& text, int maxWidth)
+{
+    if (maxWidth <= 0)
+        return "";
+
+    String fitted = text;
+    int16_t x1, y1;
+    uint16_t textWidth, textHeight;
+
+    while (!fitted.isEmpty())
+    {
+        getTextBounds(fitted, 0, 0, &x1, &y1, &textWidth, &textHeight);
+        if (textWidth <= maxWidth)
+            break;
+
+        fitted.remove(fitted.length() - 1);
+    }
+
+    return fitted;
+}
+
+// Draws the specified text centered within the given rectangle, using the current font 
+// and text color.
+
+void GFXBase::DrawTextInRect(const String& text, int x, int y, int width, int height, uint16_t color)
+{
+    if (text.isEmpty() || width <= 0 || height <= 0)
+        return;
+
+    const String fitted = FitTextToWidth(text, width);
+    if (fitted.isEmpty())
+        return;
+
+    int16_t x1, y1;
+    uint16_t textWidth, textHeight;
+    getTextBounds(fitted, 0, 0, &x1, &y1, &textWidth, &textHeight);
+
+    const int drawX = x + std::max(0, (width - static_cast<int>(textWidth)) / 2 - x1);
+    const int drawY = y + (height - static_cast<int>(textHeight)) / 2 - y1;
+
+    setTextColor(color);
+    setCursor(drawX, drawY);
+    print(fitted);
+}
+
+void GFXBase::DrawTextInRect(const String& text, int x, int y, int width, int height, const CRGB& color)
+{
+    DrawTextInRect(text, x, y, width, height, to16bit(color));
+}
+
+void GFXBase::DrawTextInRect(const String& text, int x, int y, int width, int height, CRGB::HTMLColorCode color)
+{
+    DrawTextInRect(text, x, y, width, height, to16bit(color));
+}
+
+void GFXBase::DrawTextInBand(const String& text, int bandTop, int bandHeight, uint16_t color)
+{
+    DrawTextInRect(text, 0, bandTop, static_cast<int>(GetMatrixWidth()), bandHeight, color);
+}
+
+void GFXBase::DrawTextInBand(const String& text, int bandTop, int bandHeight, const CRGB& color)
+{
+    DrawTextInBand(text, bandTop, bandHeight, to16bit(color));
+}
+
+void GFXBase::DrawTextInBand(const String& text, int bandTop, int bandHeight, CRGB::HTMLColorCode color)
+{
+    DrawTextInBand(text, bandTop, bandHeight, to16bit(color));
+}
+
 void GFXBase::Clear(CRGB color)
 {
     const size_t count = _width * _height;

--- a/src/ws281xgfx.cpp
+++ b/src/ws281xgfx.cpp
@@ -330,9 +330,7 @@ void WS281xGFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsD
     }
 
     uint8_t outputBrightness = deviceConfig.GetBrightness();
-    #ifdef POWER_LIMIT_MW
-        outputBrightness = LimitBrightnessForPower(unscaledPowerMw, outputBrightness, g_Values.Fader, POWER_LIMIT_MW);
-    #endif
+    outputBrightness = LimitBrightnessForPower(unscaledPowerMw, outputBrightness, g_Values.Fader, deviceConfig.GetPowerLimit());
     outputManager.Show(g_ptrSystem->GetDevices(), pixelsDrawn, outputBrightness, g_Values.Fader);
 
     g_Values.Brite = 100.0 * outputBrightness / 255;


### PR DESCRIPTION
This reworks some of the larger effects like weather, subscribers, and stocks, to work usefully on a 48x16 display.  

I also fixed an effects manager load issue - I think it's been around a long time as a crash shortly after load if the effects set changes, or it doesn't like the data it finds.

The EffectManager loads its saved effect list from SPIFFS, specifically /effects.cfg.

What happened:

On startup, InitEffectsManager() tried to load /effects.cfg.
Because the file was from an older build, its persisted effect-set hash no longer matched the current effect factory hash.
That made LoadEffectsJSONFile() reject the old config and return no JSON. That part is intentional.
The EffectManager then loaded the default effects.
Since no valid persisted effects were loaded, the code tried to save the newly generated default effect list back to /effects.cfg.
That save happened through JSONWriter, asynchronously, shortly after startup.
The crash stack showed JSONWriter -> SaveToJSONFile("/effects.cfg") -> file.flush() -> SPIFFS_write -> SPIFFS garbage collection.
During that SPIFFS write/GC, flash/cache state collided with other active startup work and the ESP32 hit: Cache disabled but cached memory region accessed.
So the old storage mattered because it forced the fallback-to-defaults path, which triggered a fresh /effects.cfg rewrite. The crash itself happened during SPIFFS persistence, not during JSON parsing and not directly in NVS.

The fix I made changes the fallback case: when persisted effects are missing or stale, we write the default effect config synchronously inside InitEffectsManager() before the rest of the high-activity startup tasks are running. Normal later effect changes still use the JSON writer path.  

- Dave

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).