### PR TITLE
Remove panlee from web projects

### DIFF
--- a/config/web_projects.json
+++ b/config/web_projects.json
@@ -39,17 +39,6 @@
             ]
         },
         {
-            "tag": "esp32-s3",
-            "chipfamily": "ESP32-S3",
-            "name": "ESP32-S3-DevKitC-1",
-            "projects": [
-                {
-                    "tag": "panlee",
-                    "name":"Panlee"
-                }
-            ]
-        },
-        {
             "tag": "wrover",
             "chipfamily": "ESP32",
             "name": "ESP-WROVER-KIT",


### PR DESCRIPTION
## Description

Remove panlee from the web installer project list, as the project no longer exists in platformio.ini.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).