### PR TITLE
This change migrates Mesmerizer configurations from SmartMatrix to a new HUB75 layer, adds DEVKIT, DEVKIT S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ lib/*
 NightDriverStrip.code-workspace
 site/dist
 site/favicon.ico
+**/node_modules/
 src/-defines-.cpp
 src/uzlib/src/*.o
 tools/__pycache__

--- a/config/partitions_custom_16M_v3.csv
+++ b/config/partitions_custom_16M_v3.csv
@@ -1,0 +1,9 @@
+# ESP-IDF Partition Table for 16 MB flash with OTA and core dumps
+# Name,   Type, SubType, Offset,   Size,     Flags
+
+nvs,      data, nvs,     0x009000, 0x003000,
+otadata,  data, ota,     0x00c000, 0x002000,
+app0,     app,  ota_0,   0x010000, 0x400000,
+app1,     app,  ota_1,   0x410000, 0x400000,
+coredump, data, coredump,0x810000, 0x010000,
+storage,  data, spiffs,  0x820000, 0x7E0000,

--- a/include/MatrixHardware_ESP32_Custom.h
+++ b/include/MatrixHardware_ESP32_Custom.h
@@ -1,7 +1,7 @@
 #pragma once
 
 /*
- * SmartMatrix Library - Hardware-Specific Header File (ESP32 pinout collection)
+ * HUB75 hardware-specific pinout collection for ESP32 targets
  *
  * Copyright (c) 2020 Louis Beaudoin (Pixelmatix)
  *
@@ -29,40 +29,6 @@
 
 #ifndef MATRIX_HARDWARE_H
 #define MATRIX_HARDWARE_H
-// formula used is 80000000L/(cfg->clkspeed_hz + 1), must result in >=2.  Acceptable values 26.67MHz, 20MHz, 16MHz, 13.34MHz...
-#define ESP32_I2S_CLOCK_SPEED (20000000UL)
-
-//#define GPIOPINOUT ESP32_FORUM_PINOUT_WITH_LATCH // note this mode is untested as of 2018-05-17 - not being used anymore now that SmartMatrix Shield is available
-//#define GPIOPINOUT SMARTLED_SHIELD_V0_PINOUT
-
-//Upper half RGB
-#define BIT_R1  (1<<0)
-#define BIT_G1  (1<<1)
-#define BIT_B1  (1<<2)
-//Lower half RGB
-#define BIT_R2  (1<<3)
-#define BIT_G2  (1<<4)
-#define BIT_B2  (1<<5)
-
-// Control Signals
-#define BIT_LAT (1<<6)
-#define BIT_OE  (1<<7)
-
-#define BIT_A (1<<8)
-#define BIT_B (1<<9)
-#define BIT_C (1<<10)
-#define BIT_D (1<<11)
-#define BIT_E (1<<12)
-
-
-
-    // #pragma message "MatrixHardware: Custom Wrover Kit wiring"
-
-    // ADDX is output directly using GPIO
-    #define CLKS_DURING_LATCH   0
-    #define MATRIX_I2S_MODE I2S_PARALLEL_BITS_16
-    #define MATRIX_DATA_STORAGE_TYPE uint16_t
-
     /*
     HUB 75
     01 02 B0
@@ -118,20 +84,54 @@
     #define CLK_PIN GPIO_NUM_2
     */
 
-    #define R1_PIN  GPIO_NUM_2
-    #define G1_PIN  GPIO_NUM_0
-    #define B1_PIN  GPIO_NUM_32
-    #define R2_PIN  GPIO_NUM_25
-    #define G2_PIN  GPIO_NUM_33
-    #define B2_PIN  GPIO_NUM_27
-    #define A_PIN   GPIO_NUM_5
-    #define B_PIN   GPIO_NUM_4
-    #define C_PIN   GPIO_NUM_19
-    #define D_PIN   GPIO_NUM_18
-    #define E_PIN   GPIO_NUM_26
-    #define LAT_PIN GPIO_NUM_21
-    #define OE_PIN  GPIO_NUM_23
-    #define CLK_PIN GPIO_NUM_22
+    #if defined(MESMERIZER_DEVKIT_S3) && MESMERIZER_DEVKIT_S3
+        // ESP32-S3-DevKitC-1 HUB75 wiring.
+        #define R1_PIN  GPIO_NUM_18
+        #define G1_PIN  GPIO_NUM_8
+        #define B1_PIN  GPIO_NUM_17
+        #define R2_PIN  GPIO_NUM_16
+        #define G2_PIN  GPIO_NUM_1
+        #define B2_PIN  GPIO_NUM_15
+        #define A_PIN   GPIO_NUM_7
+        #define B_PIN   GPIO_NUM_48
+        #define C_PIN   GPIO_NUM_6
+        #define D_PIN   GPIO_NUM_47
+        #define E_PIN   GPIO_NUM_2
+        #define LAT_PIN GPIO_NUM_21
+        #define OE_PIN  GPIO_NUM_4
+        #define CLK_PIN GPIO_NUM_5
+    #elif defined(MESMERIZER_DEVKIT) && MESMERIZER_DEVKIT
+        // ESP32-DevKitC V4 HUB75 wiring.
+        #define R1_PIN  GPIO_NUM_18
+        #define G1_PIN  GPIO_NUM_17
+        #define B1_PIN  GPIO_NUM_19
+        #define R2_PIN  GPIO_NUM_21
+        #define G2_PIN  GPIO_NUM_23
+        #define B2_PIN  GPIO_NUM_27
+        #define A_PIN   GPIO_NUM_26
+        #define B_PIN   GPIO_NUM_16
+        #define C_PIN   GPIO_NUM_25
+        #define D_PIN   GPIO_NUM_4
+        #define E_PIN   GPIO_NUM_22
+        #define LAT_PIN GPIO_NUM_2
+        #define OE_PIN  GPIO_NUM_32
+        #define CLK_PIN GPIO_NUM_33
+    #else
+        #define R1_PIN  GPIO_NUM_2
+        #define G1_PIN  GPIO_NUM_0
+        #define B1_PIN  GPIO_NUM_32
+        #define R2_PIN  GPIO_NUM_25
+        #define G2_PIN  GPIO_NUM_33
+        #define B2_PIN  GPIO_NUM_27
+        #define A_PIN   GPIO_NUM_5
+        #define B_PIN   GPIO_NUM_4
+        #define C_PIN   GPIO_NUM_19
+        #define D_PIN   GPIO_NUM_18
+        #define E_PIN   GPIO_NUM_26
+        #define LAT_PIN GPIO_NUM_21
+        #define OE_PIN  GPIO_NUM_23
+        #define CLK_PIN GPIO_NUM_22
+    #endif
 
 //#define DEBUG_PINS_ENABLED
 //#define DEBUG_1_GPIO    GPIO_NUM_13

--- a/include/effects.h
+++ b/include/effects.h
@@ -67,6 +67,7 @@ using FactoryId = uint64_t;
 #define PTY_SPEEDDIVISOR    "sdd"
 #define PTY_DELTAHUE        "dth"
 #define PTY_MIRRORED        "mrd"
+#define PTY_FITLEDCOUNT     "flc"
 #define PTY_EVERYNTH        "ent"
 #define PTY_COLOR           "clr"
 #define PTY_BLEND           "bld"
@@ -87,3 +88,9 @@ using FactoryId = uint64_t;
 #define PTY_IGNOREGLOBALCOLOR   "igc"
 
 #define EFFECTS_CONFIG_FILE "/effects.cfg"
+
+#if EFFECTS_FULLMATRIX
+// Configure the shared TJpg_Decoder output callback before any matrix effect
+// (including the early boot splash) attempts to decode an embedded JPEG.
+void ConfigureMatrixJpegDecoder();
+#endif

--- a/include/effects/matrix/PatternPulse.h
+++ b/include/effects/matrix/PatternPulse.h
@@ -119,6 +119,7 @@ class PatternPulse : public EffectWithId<PatternPulse>
         // effects.standardNoiseSmearing();
     }
 };
+#if ENABLE_AUDIO
 class PatternPulsar : public BeatEffectBase, public EffectWithId<PatternPulsar> {
   private:
     static constexpr int kPulseBaseMinSteps = 6;
@@ -271,4 +272,5 @@ class PatternPulsar : public BeatEffectBase, public EffectWithId<PatternPulsar> 
         // effects.standardNoiseSmearing();
     }
 };
+#endif
 #endif

--- a/include/effects/matrix/PatternSMRadialWave.h
+++ b/include/effects/matrix/PatternSMRadialWave.h
@@ -14,7 +14,7 @@ class PatternSMRadialWave : public EffectWithId<PatternSMRadialWave>
 
     virtual size_t DesiredFramesPerSecond() const           // Desired framerate of the LED drawing
     {
-        return 45;
+        return 60;
     }
 
     void Start() override

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -171,14 +171,16 @@ class RainbowFillEffect : public EffectWithId<RainbowFillEffect>
     float _speedDivisor;
     int   _deltaHue;
     bool  _mirrored;
+    bool  _fitLEDCount;
 
   public:
 
-    RainbowFillEffect(float speedDivisor = 12.0f, int deltaHue = 14, bool mirrored = false)
+    RainbowFillEffect(float speedDivisor = 12.0f, int deltaHue = 14, bool mirrored = false, bool fitLEDCount = false)
   : EffectWithId<RainbowFillEffect>("RainbowFill Rainbow"),
         _speedDivisor(speedDivisor),
         _deltaHue(deltaHue),
-        _mirrored(mirrored)
+        _mirrored(mirrored),
+        _fitLEDCount(fitLEDCount)
     {
         debugV("RainbowFill constructor");
     }
@@ -187,7 +189,8 @@ class RainbowFillEffect : public EffectWithId<RainbowFillEffect>
       : EffectWithId<RainbowFillEffect>(jsonObject),
         _speedDivisor(jsonObject[PTY_SPEEDDIVISOR]),
         _deltaHue(jsonObject[PTY_DELTAHUE]),
-        _mirrored(jsonObject[PTY_MIRRORED])
+        _mirrored(jsonObject[PTY_MIRRORED]),
+        _fitLEDCount(jsonObject[PTY_FITLEDCOUNT].is<bool>() ? jsonObject[PTY_FITLEDCOUNT].as<bool>() : false)
     {
         debugV("RainbowFill JSON constructor");
     }
@@ -202,6 +205,7 @@ class RainbowFillEffect : public EffectWithId<RainbowFillEffect>
         jsonDoc[PTY_SPEEDDIVISOR] = _speedDivisor;
         jsonDoc[PTY_DELTAHUE] = _deltaHue;
         jsonDoc[PTY_MIRRORED] = _mirrored;
+        jsonDoc[PTY_FITLEDCOUNT] = _fitLEDCount;
 
         return SetIfNotOverflowed(jsonDoc, jsonObject, __PRETTY_FUNCTION__);
     }
@@ -216,7 +220,29 @@ class RainbowFillEffect : public EffectWithId<RainbowFillEffect>
 
         hue += (float) msElapsed / _speedDivisor;
         hue = fmod(hue, 256.0);
-        fillRainbowAllChannels(0, _cLEDs, hue, _deltaHue, 1, _mirrored);
+        if (_fitLEDCount && _cLEDs > 0)
+        {
+            const float hueStep = 256.0f / static_cast<float>(_cLEDs);
+
+            for (size_t i = 0; i < _cLEDs; i++)
+            {
+                CHSV hsv;
+                hsv.hue = static_cast<uint8_t>(fmod(hue + static_cast<float>(i) * hueStep, 256.0f));
+                hsv.val = 255;
+                hsv.sat = 255;
+
+                CRGB rgb;
+                hsv2rgb_rainbow(hsv, rgb);
+
+                setPixelOnAllChannels(i, rgb);
+                if (_mirrored)
+                    setPixelOnAllChannels(_cLEDs - i - 1, rgb);
+            }
+        }
+        else
+        {
+            fillRainbowAllChannels(0, _cLEDs, hue, _deltaHue, 1, _mirrored);
+        }
         delay(10);
     }
 };

--- a/include/globals.h
+++ b/include/globals.h
@@ -220,8 +220,7 @@ extern std::recursive_mutex g_effect_manager_mutex;
 // #define SOCKET_CORE             1
 // #define REMOTE_CORE             1
 
-// Some "Reliability Rules"
-// Drawing must be on Core 1 if using SmartMatrix unless you specify SMARTMATRIX_OPTIONS_ESP32_CALC_TASK_CORE_1
+// Keep drawing on Core 1 so the render workload remains isolated from audio.
 
 #define DRAWING_CORE            1
 #define NET_CORE                1
@@ -797,7 +796,9 @@ extern const int g_aRingSizeTable[];
         #endif
     #endif
 #else
-    #define AUDIO_INPUT_PIN 0
+    #ifndef AUDIO_INPUT_PIN
+        #define AUDIO_INPUT_PIN 0
+    #endif
 #endif
 
 #ifndef IR_REMOTE_PIN

--- a/include/hub75gfx.h
+++ b/include/hub75gfx.h
@@ -38,8 +38,7 @@
 
 #include "MatrixHardware_ESP32_Custom.h"
 
-#define SM_INTERNAL     // Silence build messages from their header
-#include <SmartMatrix.h>
+#include <ESP32-HUB75-MatrixPanel-I2S-DMA.h>
 
 #include <cmath>
 #include <memory>
@@ -50,8 +49,6 @@
 //
 // Matrix Panel
 //
-
-#define COLOR_DEPTH 24 // known working: 24, 48 - If the sketch uses type `rgb24` directly, COLOR_DEPTH must be 24
 
 class HUB75GFX : public GFXBase
 {
@@ -64,15 +61,9 @@ protected:
     float totalCaptionDuration = 0;
 
 public:
-    typedef RGB_TYPE(COLOR_DEPTH) SM_RGB;
-    static const uint8_t kPanelType = SMARTMATRIX_HUB75_32ROW_MOD16SCAN;                // use SMARTMATRIX_HUB75_16ROW_MOD8SCAN for common 16x32 panels
-    static const uint8_t kMatrixOptions = (SMARTMATRIX_OPTIONS_BOTTOM_TO_TOP_STACKING   /* | SMARTMATRIX_OPTIONS_ESP32_CALC_TASK_CORE_1 */); // see http://docs.pixelmatix.com/SmartMatrix for options
-    static const uint8_t kBackgroundLayerOptions = (SM_BACKGROUND_OPTIONS_NONE);
     static const uint8_t kDefaultBrightness = 255; // full (100%) brightness
 
-    static SMLayerBackground<SM_RGB, kBackgroundLayerOptions> backgroundLayer;
-    static SMLayerBackground<SM_RGB, kBackgroundLayerOptions> titleLayer;
-    static SmartMatrixHub75Calc<COLOR_DEPTH, kMatrixWidth, kMatrixHeight, kPanelType, kMatrixOptions> matrix;
+    static std::unique_ptr<MatrixPanel_I2S_DMA> matrix;
 
     HUB75GFX(size_t w, size_t h);
 
@@ -133,8 +124,15 @@ public:
     // Matrix interop
 
     static void StartMatrix();
+    static int GetRefreshRate();
     static CRGB *GetMatrixBackBuffer();
     static bool WaitForMatrixSwap(uint32_t timeoutMs = 100);
-    static void MatrixSwapBuffers(bool bSwapBackground);
+    static void MatrixSwapBuffers(bool copyPresentedFrame);
+
+private:
+    static CRGB frameBuffers[2][kMatrixWidth * kMatrixHeight];
+    static uint8_t drawBufferIndex;
+    static uint32_t lastSwapMs;
+    static void FlushFrameToMatrix();
 };
 #endif

--- a/include/improvserial.h
+++ b/include/improvserial.h
@@ -95,7 +95,8 @@ public:
         this->device_name_ = name;
 
         #if !(ENABLE_IMPROV_LOGGING)
-            SPIFFS.remove(IMPROV_LOG_FILE);
+            if (SPIFFS.exists(IMPROV_LOG_FILE))
+                SPIFFS.remove(IMPROV_LOG_FILE);
         #endif
 
         log_write("Finished Improv setup");

--- a/include/interfaces.h
+++ b/include/interfaces.h
@@ -275,7 +275,7 @@ make_unique_internal(size_t n)
 // make_unique_dma / make_shared_dma
 //
 // Construct an object in DMA-capable internal RAM. The peripherals that
-// require this (FastLED RMT, SmartMatrix HUB75, I2S audio, ADC continuous)
+// require this (FastLED RMT, HUB75 DMA, I2S audio, ADC continuous)
 // generally call heap_caps_malloc(MALLOC_CAP_DMA) directly, but these helpers
 // are available for any project-side buffer that needs to be DMA-reachable.
 template <typename T, typename... Args>

--- a/platformio.ini
+++ b/platformio.ini
@@ -465,7 +465,7 @@ extra_scripts   = ${env.extra_scripts}
 ;
 
 [mesmerizer_config]
-build_flags     = ${psram_lx6_flags.build_flags}
+build_flags     = -DCORE_DEBUG_LEVEL=3
                   -DCONFIG_ASYNC_TCP_STACK_SIZE=8192
                   -DCONFIG_ASYNC_TCP_PRIORITY=3
 build_src_flags = -DPROJECT_NAME="\"Mesmerizer\""
@@ -485,16 +485,14 @@ build_src_flags = -DPROJECT_NAME="\"Mesmerizer\""
                   -DCOLORDATA_SERVER_ENABLED=1
                   -DCOLORDATA_WEB_SOCKET_ENABLED=1
                   -DENABLE_REMOTE=1
-                  -DENABLE_AUDIO=1
                   -DMILLIS_PER_FRAME=0
                   -DMATRIX_WIDTH=64
                   -DMATRIX_HEIGHT=32
                   -DNUM_BANDS=16
                   -DIR_REMOTE_PIN=39
-                  -DAUDIO_INPUT_PIN=36
                   -DTOGGLE_BUTTON_0=0
 
-lib_deps        = https://github.com/PlummersSoftwareLLC/SmartMatrix.git
+lib_deps        = https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA.git#3.0.14
                   ${base.graphics_deps}
                   ${base.bounce_deps}
                   ${base.lib_deps}
@@ -1124,6 +1122,8 @@ build_flags     = ${dev_mesmerizer.build_flags}
 build_src_flags = ${dev_mesmerizer.build_src_flags}
                   ${mesmerizer_config.build_src_flags}
                   -DMESMERIZER=1
+                  -DENABLE_AUDIO=1
+                  -DAUDIO_INPUT_PIN=36
                   -DEFFECTS_MESMERIZER=1
 
 lib_deps        = ${mesmerizer_config.lib_deps}
@@ -1136,10 +1136,77 @@ build_flags     = ${dev_lolin_d32_pro.build_flags}
 build_src_flags = ${dev_lolin_d32_pro.build_src_flags}
                   ${mesmerizer_config.build_src_flags}
                   -DMESMERIZER=1
+                  -DENABLE_AUDIO=1
+                  -DAUDIO_INPUT_PIN=36
                   -DEFFECTS_MESMERIZER=1
 
 lib_deps        = ${mesmerizer_config.lib_deps}
                   ${base.bounce_deps}
+board_build.embed_files = ${mesmerizer_config.board_build.embed_files}
+
+; Standard ESP32 DEVKIT (4 MB flash, no PSRAM).
+[env:mesmerizer_devkit]
+extends         = dev_esp32
+build_unflags   = -std=gnu++11
+build_flags     = ${dev_esp32.build_flags}
+                  ${mesmerizer_config.build_flags}
+build_src_flags = ${dev_esp32.build_src_flags}
+                  -DPROJECT_NAME="\"Mesmerizer\""
+                  -DMESMERIZER=1
+                  -DMESMERIZER_DEVKIT=1
+                  -DSHOW_FPS_ON_MATRIX=0
+                  -DUSE_HUB75=1
+                  -DSHOW_VU_METER=0
+                  -DEFFECTS_FULLMATRIX=1
+                  -DCOLOR_ORDER=EOrder::RGB
+                  -DENABLE_AUDIO=0
+                  ; No-PSRAM DEVKIT is a local-effects-only target. Keep the
+                  ; renderer, but omit all optional networking/service tasks.
+                  -DENABLE_WIFI=0
+                  -DINCOMING_WIFI_ENABLED=0
+                  -DENABLE_WEBSERVER=0
+                  -DENABLE_NTP=0
+                  -DENABLE_OTA=0
+                  -DCOLORDATA_SERVER_ENABLED=0
+                  -DCOLORDATA_WEB_SOCKET_ENABLED=0
+                  -DEFFECTS_WEB_SOCKET_ENABLED=0
+                  -DENABLE_REMOTE=0
+                  -DENABLE_AUDIOSERIAL=0
+                  -DTIME_BEFORE_LOCAL=0
+                  -DMILLIS_PER_FRAME=0
+                  -DMATRIX_WIDTH=64
+                  -DMATRIX_HEIGHT=32
+                  -DNUM_BANDS=16
+                  -DTOGGLE_BUTTON_0=0
+                  -DMAX_BUFFERS=2
+                  -DRESERVE_MEMORY=60000
+                  -DNO_EFFECT_PERSISTENCE=1
+                  -DEFFECTS_MESMERIZER=1
+
+lib_deps        = ${mesmerizer_config.lib_deps}
+board_build.embed_files = ${mesmerizer_config.board_build.embed_files}
+
+; ESP32-S3-DevKitC-1 N16R8 (16 MB flash, 8 MB octal PSRAM).
+[env:mesmerizer_devkit_s3]
+extends         = dev_esp32_s3
+board           = esp32-s3-devkitc-1
+board_build.arduino.memory_type = qio_opi
+build_flags     = ${dev_esp32_s3.build_flags}
+                  ${psram_common_flags.build_flags}
+                  ${mesmerizer_config.build_flags}
+                  ; Route Arduino Serial to the DevKit's native USB CDC port.
+                  -DARDUINO_USB_CDC_ON_BOOT=1
+                  -DARDUINO_USB_MODE=1
+build_src_flags = ${dev_esp32_s3.build_src_flags}
+                  ${mesmerizer_config.build_src_flags}
+                  -DMESMERIZER=1
+                  -DMESMERIZER_DEVKIT_S3=1
+                  -DENABLE_AUDIO=0
+                  -DEFFECTS_MESMERIZER=1
+
+lib_deps        = ${mesmerizer_config.lib_deps}
+board_build.partitions = config/partitions_custom_16M_v3.csv
+board_upload.flash_size = 16MB
 board_build.embed_files = ${mesmerizer_config.board_build.embed_files}
 
 ;==============

--- a/site/app.js
+++ b/site/app.js
@@ -1127,6 +1127,7 @@ $$$$$$$b   *u    ^$L            $$  $$$$$$$$$$$$u@       $$  d$$$$$$
     control.addEventListener("change", () => {
       const validation = validateFieldValue(spec, control.value);
       if (!validation.valid) {
+        setDraftValue(control.value);
         setFieldError(true, validation.message);
         return;
       }
@@ -1339,12 +1340,8 @@ $$$$$$$b   *u    ^$L            $$  $$$$$$$$$$$$u@       $$  d$$$$$$
     }
 
     const message = `Matrix dimensions ${width} x ${height} require ${requestedLeds} LEDs, but this firmware supports ${maxLeds}. Lower width/height or flash a build compiled for more LEDs.`;
-    if (!errors.has("matrixWidth")) {
-      errors.set("matrixWidth", message);
-    }
-    if (!errors.has("matrixHeight")) {
-      errors.set("matrixHeight", message);
-    }
+    errors.set("matrixWidth", message);
+    errors.set("matrixHeight", message);
   }
 
   function getCompiledMaxLEDs() {

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -28,6 +28,9 @@
 
 #include "globals.h"
 
+#include <algorithm>
+#include <cstring>
+
 #include "console.h"
 #include "debug_cli.h"
 #include "logger.h"

--- a/src/deviceconfig_settings_specs.cpp
+++ b/src/deviceconfig_settings_specs.cpp
@@ -18,6 +18,19 @@ const std::vector<std::reference_wrapper<SettingSpec>>& DeviceConfig::GetSetting
 {
     if (settingSpecs.empty())
     {
+        // Build the table in one allocation. On no-PSRAM boards this metadata
+        // is created after the HUB75 DMA buffers, so geometric vector growth
+        // can temporarily require both old and new contiguous blocks.
+        constexpr size_t kFixedSettingSpecCapacity = 26;
+        const auto compiledChannelCount = GetCompiledChannelCount();
+        const size_t outputSettingSpecCount = compiledChannelCount
+        #if USE_APA102
+            * 2
+        #endif
+        ;
+        settingSpecs.reserve(kFixedSettingSpecCapacity + outputSettingSpecCount);
+        settingSpecReferences.reserve(kFixedSettingSpecCapacity + outputSettingSpecCount);
+
         // Section keys used below correspond to entries in the section catalog
         // emitted by FillUnifiedSettingsSchemaJson(). Keep them in sync.
         constexpr const char* kSectionSystem     = "system";
@@ -323,12 +336,6 @@ const std::vector<std::reference_wrapper<SettingSpec>>& DeviceConfig::GetSetting
         #else
             4;
         #endif
-        const auto compiledChannelCount = GetCompiledChannelCount();
-        settingSpecs.reserve(settingSpecs.size() + compiledChannelCount
-        #if USE_APA102
-            * 2
-        #endif
-        );
         pinSpecStrings.reserve(compiledChannelCount * kPinStringsPerChannel);
         const auto stableCStr = [](const String& s) { return s.c_str(); };
 

--- a/src/deviceconfig_unified.cpp
+++ b/src/deviceconfig_unified.cpp
@@ -13,6 +13,7 @@
 #include "globals.h"
 
 #include <array>
+#include <limits>
 #include <optional>
 
 #include "audioservice.h"
@@ -119,6 +120,28 @@ ResultWithMessage<std::optional<int>> DeviceConfig::ResolveUnifiedAudioInputPin(
     }
 
     return { requestedAudioInputPin, "" };
+}
+
+namespace
+{
+    ResultWithMessage<std::optional<uint16_t>> ParseTopologyDimension(JsonObjectConst topology, const char* key)
+    {
+        auto value = topology[key];
+        if (value.isNull())
+            return { std::nullopt, "" };
+
+        if (!value.is<size_t>())
+            return { std::nullopt, String(key) + " must be a positive integer" };
+
+        const size_t dimension = value.as<size_t>();
+        if (dimension == 0)
+            return { std::nullopt, String(key) + " must be greater than zero" };
+
+        if (dimension > std::numeric_limits<uint16_t>::max())
+            return { std::nullopt, String(key) + " is too large" };
+
+        return { static_cast<uint16_t>(dimension), "" };
+    }
 }
 
 void DeviceConfig::SerializeUnifiedSettings(JsonObject root) const
@@ -313,14 +336,21 @@ SuccessResultWithMessage DeviceConfig::ParseAndValidateUnifiedSettings(JsonObjec
     if (root["topology"].is<JsonObjectConst>())
     {
         auto topology = root["topology"].as<JsonObjectConst>();
-        if (topology["width"].is<uint16_t>())
+        auto [requestedWidth, widthMessage] = ParseTopologyDimension(topology, "width");
+        if (!requestedWidth.has_value() && !widthMessage.isEmpty())
+            return { false, widthMessage };
+        if (requestedWidth.has_value())
         {
-            out.requestedRuntimeConfig.topology.width = topology["width"].as<uint16_t>();
+            out.requestedRuntimeConfig.topology.width = requestedWidth.value();
             out.runtimeConfigTouched = true;
         }
-        if (topology["height"].is<uint16_t>())
+
+        auto [requestedHeight, heightMessage] = ParseTopologyDimension(topology, "height");
+        if (!requestedHeight.has_value() && !heightMessage.isEmpty())
+            return { false, heightMessage };
+        if (requestedHeight.has_value())
         {
-            out.requestedRuntimeConfig.topology.height = topology["height"].as<uint16_t>();
+            out.requestedRuntimeConfig.topology.height = requestedHeight.value();
             out.runtimeConfigTouched = true;
         }
         if (topology["serpentine"].is<bool>())

--- a/src/deviceconfig_validation.cpp
+++ b/src/deviceconfig_validation.cpp
@@ -20,8 +20,19 @@ SuccessResultWithMessage DeviceConfig::ValidateTopology(uint16_t width, uint16_t
     if (width == 0 || height == 0)
         return { false, "matrix dimensions must be greater than zero" };
 
-    if (static_cast<size_t>(width) * height > GetCompiledLEDCount())
-        return { false, DeviceConfigInternal::RecompileNeededMessage() };
+    const size_t requestedLEDCount = static_cast<size_t>(width) * height;
+    const size_t compiledLEDCount = GetCompiledLEDCount();
+    if (requestedLEDCount > compiledLEDCount)
+    {
+        return {
+            false,
+            String("Matrix dimensions ") + width + " x " + height
+                + " require " + static_cast<unsigned long>(requestedLEDCount)
+                + " LEDs, but this firmware was compiled for "
+                + static_cast<unsigned long>(compiledLEDCount)
+                + ". Lower width/height or flash a build compiled for more LEDs."
+        };
+    }
 
     if (IsHub75Build())
     {

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -116,6 +116,11 @@ std::shared_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color);    // Defined i
 
 uint16_t WiFiDraw()
 {
+    // Builds with INCOMING_WIFI_ENABLED=0 never create the buffer managers,
+    // but this path is still reachable whenever WiFi itself is connected.
+    if (!g_ptrSystem->HasBufferManagers())
+        return 0;
+
     std::lock_guard guard(g_buffer_mutex);
 
     uint16_t pixelsDrawn = 0;
@@ -334,8 +339,8 @@ void ShowOnboardPixel()
 //
 // Start/Stop/IsRunning are inherited final from ITaskService; this class
 // only supplies the task config and the per-frame render loop body. The
-// render task is pinned to DRAWING_CORE because SmartMatrix and FastLED
-// both impose core affinity expectations on whatever drives them.
+// The render task is pinned to DRAWING_CORE to isolate the display workload
+// from audio sampling and other timing-sensitive services.
 
 ITaskService::TaskConfig RenderService::GetTaskConfig() const
 {

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -38,6 +38,7 @@
 #include "deviceconfig.h"
 #include "effectfactories.h"
 #include "effectmanager.h"
+#include "effects.h"
 #include "gfxbase.h"
 #include "jsonserializer.h"
 #include "ledstripeffect.h"
@@ -69,6 +70,9 @@ extern DRAM_ATTR bool l_EffectManagerInitializing;
     {
         debugW("InitSplashEffectManager");
 
+        #if EFFECTS_FULLMATRIX
+            ConfigureMatrixJpegDecoder();
+        #endif
         g_ptrSystem->SetupEffectManager(make_shared_psram<SplashLogoEffect>(), g_ptrSystem->GetDevices());
     }
 
@@ -84,6 +88,10 @@ namespace
 {
     void WriteEffectManagerConfigFile()
     {
+        #if NO_EFFECT_PERSISTENCE
+            return;
+        #endif
+
         if (!SaveToJSONFile(EFFECTS_CONFIG_FILE, g_ptrSystem->GetEffectManager()) && EFFECT_PERSISTENCE_CRITICAL)
             throw std::runtime_error("Effects serialization failed");
     }

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -141,6 +141,11 @@
 
 #define EFFECT_SET_VERSION 9
 
+// Central Adafruit-GFX font used by the matrix information effects.
+#if USE_MATRIX
+#include "FontGfx_apple5x7.h"
+#endif
+
 // Inform the linker which effects have setting specs, and in which class member
 
 //#if USE_HUB75 && ENABLE_WIFI
@@ -149,14 +154,21 @@
     INIT_EFFECT_SETTING_SPECS(PatternStocks, mySettingSpecs);
 #endif
 
-// Apple5x7 font definition - needed for WiFi-enabled matrix patterns using Adafruit-style fonts
-// Define this unconditionally (guarded by ENABLE_WIFI) so the symbol is always available regardless of M5/LGFX usage.
-#if USE_MATRIX
-#include <FontGfx_apple5x7.h>           // Requires the SmartMatrix dependency to pick up this font
-#endif
-
 // Default and JSON factory functions + decoration for effects
 DRAM_ATTR allocated_unique_ptr<EffectFactories> g_ptrEffectFactories = nullptr;
+
+#if EFFECTS_FULLMATRIX
+void ConfigureMatrixJpegDecoder()
+{
+    TJpgDec.setJpgScale(1);
+    TJpgDec.setCallback([](int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t *bitmap)
+    {
+        auto& gfx = g_ptrSystem->GetEffectManager().g();
+        gfx.drawRGBBitmap(x, y, bitmap, w, h);
+        return true;
+    });
+}
+#endif
 
 // This function sets up the effect factories for the effects for whatever project is being built. The ADD_EFFECT macro variations
 //   are provided and used for convenience.
@@ -185,6 +197,13 @@ void LoadEffectFactories()
         RegisterAll(*g_ptrEffectFactories,
             Effect<StatusEffect>(CRGB::White),
             Effect<RainbowFillEffect>(6, 2)
+        );
+    #endif
+
+    #if defined(EFFECTS_IMPERIAL)
+        // Imperial effect set: one 134-LED strip running RainbowFill.
+        RegisterAll(*g_ptrEffectFactories,
+            Effect<RainbowFillEffect>(6.0f, 8, true, true)
         );
     #endif
 
@@ -313,26 +332,24 @@ void LoadEffectFactories()
     #endif
 
     #if defined(EFFECTS_FULLMATRIX)
-        TJpgDec.setJpgScale(1);
-        TJpgDec.setCallback([](int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t *bitmap)
-        {
-            auto& gfx = g_ptrSystem->GetEffectManager().g();
-            gfx.drawRGBBitmap(x, y, bitmap, w, h);
-            return true;
-        });
+        ConfigureMatrixJpegDecoder();
 
         // Full matrix effect set for advanced displays (Mesmerizer, etc.)
+        #if ENABLE_AUDIO
         RegisterAll(*g_ptrEffectFactories,
             Effect<SpectrumBarEffect>("Audiograph", 16, 4, 0),
             Effect<SpectrumAnalyzerEffect>("Spectrum", NUM_BANDS, spectrumAltColors, false, 0, 0, 1.6, 1.6),
-            Effect<SpectrumAnalyzerEffect>("AudioWave", MATRIX_WIDTH, CRGB(0,0,40), 0, 1.25, 1.25, true),
+            Effect<SpectrumAnalyzerEffect>("AudioWave", MATRIX_WIDTH, CRGB(0,0,40), 0, 1.25, 1.25, true)
+        );
+        #endif
+
+        RegisterAll(*g_ptrEffectFactories,
             Effect<PatternSMRadialWave>(),
             Effect<PatternAnimatedGIF>("Fire Log", GIFIdentifier::Firelog),
             Effect<PatternAnimatedGIF>("Pacman", GIFIdentifier::Pacman),
             Effect<PatternPongClock>(),
             Effect<PatternAnimatedGIF>("Colorball", GIFIdentifier::ColorSphere),
             Effect<PatternSMFire2021>(),
-            Effect<GhostWave>("GhostWave", 0, 30, false, 10),
             Effect<PatternSMGamma>(),
             Effect<PatternAnimatedGIF>("Rings", GIFIdentifier::ThreeRings),
             Effect<PatternAnimatedGIF>("Atomic", GIFIdentifier::Atomic),
@@ -344,7 +361,12 @@ void LoadEffectFactories()
             Effect<PatternAnimatedGIF>("Nyancat", GIFIdentifier::Nyancat),
             Effect<PatternAnimatedGIF>("On Air", GIFIdentifier::OnAir),
             Effect<PatternLife>(),
-            Effect<PatternCircuit>(),
+            Effect<PatternCircuit>()
+        );
+
+        #if ENABLE_AUDIO
+        RegisterAll(*g_ptrEffectFactories,
+            Effect<GhostWave>("GhostWave", 0, 30, false, 10),
             Effect<SpectrumAnalyzerEffect>("USA", NUM_BANDS, USAColors_p, true, 0, 0, 0.75, 0.75),
             Effect<SpectrumAnalyzerEffect>("Spectrum 2", 32, spectrumBasicColors, false, 100, 0, 0.75, 0.75),
             Effect<SpectrumAnalyzerEffect>("Spectrum++", NUM_BANDS, spectrumBasicColors, false, 0, 40, -1.0, 2.0),
@@ -352,6 +374,7 @@ void LoadEffectFactories()
             Effect<GhostWave>("WaveOut", 0, 0, true, 0),
             Effect<StarEffect<MusicStar>>("Stars", RainbowColors_p, 1.0, 1, LINEARBLEND, 2.0, 0.5, 10.0)
         );
+        #endif
 
         #if ENABLE_WIFI
         RegisterAll(*g_ptrEffectFactories,
@@ -363,7 +386,6 @@ void LoadEffectFactories()
 
         RegisterAll(*g_ptrEffectFactories,
             Effect<PatternSMSmoke>(),
-            Effect<GhostWave>("PlasmaWave", 0, 255, false),
             Effect<PatternSMNoise>("Shikon", PatternSMNoise::EffectType::Shikon_t),
             Effect<PatternSMRadialFire>(),
             Effect<PatternSMFlowFields>(),
@@ -385,7 +407,6 @@ void LoadEffectFactories()
             Effect<PatternSunburst>(),
             Effect<PatternClock>(),
             Effect<PatternAlienText>(),
-            Effect<PatternPulsar>(),
             Effect<PatternBounce>(),
             Effect<PatternWave>(),
             Effect<PatternSwirl>(),
@@ -394,6 +415,13 @@ void LoadEffectFactories()
             Effect<PatternMunch>(),
             Effect<PatternMaze>()
         );
+
+        #if ENABLE_AUDIO
+        RegisterAll(*g_ptrEffectFactories,
+            Effect<GhostWave>("PlasmaWave", 0, 255, false),
+            Effect<PatternPulsar>()
+        );
+        #endif
     #endif
 
     #if defined(EFFECTS_UMBRELLA)

--- a/src/hub75gfx.cpp
+++ b/src/hub75gfx.cpp
@@ -4,27 +4,9 @@
 //
 // NightDriverStrip - (c) 2018 Plummer's Software LLC.  All Rights Reserved.
 //
-// This file is part of the NightDriver software project.
-//
-//    NightDriver is free software: you can redistribute it and/or modify
-//    it under the terms of the GNU General Public License as published by
-//    the Free Software Foundation, either version 3 of the License, or
-//    (at your option) any later version.
-//
-//    NightDriver is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//    GNU General Public License for more details.
-//
-//    You should have received a copy of the GNU General Public License
-//    along with Nightdriver.  It is normally found in copying.txt
-//    If not, see <https://www.gnu.org/licenses/>.
-//
-// Description:
-//
-//    Code for handling HUB75 matrix panels with the SmartMatrix library
-//
-// History:     May-24-2021         Davepl      Commented
+// Unified HUB75 backend using ESP32-HUB75-MatrixPanel-DMA. The library uses
+// the original ESP32 I2S parallel peripheral and the ESP32-S3 LCD/GDMA
+// peripheral behind one API.
 //
 //---------------------------------------------------------------------------
 
@@ -33,6 +15,7 @@
 #if USE_HUB75
 
 #include <algorithm>
+#include <cstring>
 
 #include "deviceconfig.h"
 #include "effectmanager.h"
@@ -42,41 +25,16 @@
 #include "systemcontainer.h"
 #include "values.h"
 
-// The declarations create the "layers" that make up the matrix display
-
-SMLayerBackground<HUB75GFX::SM_RGB, HUB75GFX::kBackgroundLayerOptions> HUB75GFX::backgroundLayer(kMatrixWidth, kMatrixHeight);
-SMLayerBackground<HUB75GFX::SM_RGB, HUB75GFX::kBackgroundLayerOptions> HUB75GFX::titleLayer(kMatrixWidth, kMatrixHeight);
-SmartMatrixHub75Calc<COLOR_DEPTH, HUB75GFX::kMatrixWidth, HUB75GFX::kMatrixHeight, HUB75GFX::kPanelType, HUB75GFX::kMatrixOptions> HUB75GFX::matrix;
-
-namespace
-{
-    template <typename Layer>
-    bool WaitForLayerSwap(Layer& layer, const char* layerName, uint32_t timeoutMs)
-    {
-        const uint32_t startMs = millis();
-
-        while (layer.isSwapPending())
-        {
-            if (millis() - startMs >= timeoutMs)
-            {
-                debugW("Timed out waiting for SmartMatrix %s layer swap", layerName);
-                return false;
-            }
-
-            delay(1);
-        }
-
-        return true;
-    }
-}
+std::unique_ptr<MatrixPanel_I2S_DMA> HUB75GFX::matrix;
+CRGB HUB75GFX::frameBuffers[2][HUB75GFX::kMatrixWidth * HUB75GFX::kMatrixHeight] = {};
+uint8_t HUB75GFX::drawBufferIndex = 0;
+uint32_t HUB75GFX::lastSwapMs = 0;
 
 HUB75GFX::HUB75GFX(size_t w, size_t h) : GFXBase(w, h)
 {
 }
 
-HUB75GFX::~HUB75GFX()
-{
-}
+HUB75GFX::~HUB75GFX() = default;
 
 void HUB75GFX::InitializeHardware(std::vector<std::shared_ptr<GFXBase>>& devices)
 {
@@ -84,33 +42,28 @@ void HUB75GFX::InitializeHardware(std::vector<std::shared_ptr<GFXBase>>& devices
 
     for (int i = 0; i < NUM_CHANNELS; i++)
     {
-        auto tmp_matrix = make_shared_psram<HUB75GFX>(MATRIX_WIDTH, MATRIX_HEIGHT);
-        devices.push_back(tmp_matrix);
-        tmp_matrix->loadPalette(0);
+        auto tmpMatrix = make_shared_psram<HUB75GFX>(MATRIX_WIDTH, MATRIX_HEIGHT);
+        devices.push_back(tmpMatrix);
+        tmpMatrix->loadPalette(0);
     }
 
-    // We don't need color correction on the title layer, but we want it on the main background
-
-    titleLayer.enableColorCorrection(false);
-    backgroundLayer.enableColorCorrection(true);
-
-    // Starting an effect might need to draw, so we need to set the leds up before doing so
     static_cast<HUB75GFX&>(*devices[0]).setLeds(GetMatrixBackBuffer());
 }
 
 void HUB75GFX::SetBrightness(byte amount)
 {
-    matrix.setBrightness(amount);
+    if (matrix)
+        matrix->setBrightness8(amount);
 }
 
-// EstimatePowerDraw
-//
-// Estimate the total power load for the board and matrix by walking the pixels and adding our previously measured
-// power draw per pixel based on what color and brightness each pixel is
+int HUB75GFX::GetRefreshRate()
+{
+    return matrix ? matrix->calculated_refresh_rate : 0;
+}
 
 int HUB75GFX::EstimatePowerDraw()
 {
-    constexpr auto kBaseLoad       = 1500;          // Experimentally derived values
+    constexpr auto kBaseLoad       = 1500;
     constexpr auto mwPerPixelRed   = 4.10f;
     constexpr auto mwPerPixelGreen = 0.82f;
     constexpr auto mwPerPixelBlue  = 1.75f;
@@ -123,75 +76,48 @@ int HUB75GFX::EstimatePowerDraw()
         totalPower += pixel.g * mwPerPixelGreen / 255.0f;
         totalPower += pixel.b * mwPerPixelBlue  / 255.0f;
     }
-    return (int) totalPower;
+    return static_cast<int>(totalPower);
 }
 
-// Whereas an WS281xGFX would track its own memory for the CRGB array, we simply point to the buffer already used for
-// the matrix display memory.  That also eliminated having a local draw buffer that is then copied, because the effects
-// can render directly to the right back buffer automatically.
-
-void HUB75GFX::setLeds(CRGB *pLeds)
+void HUB75GFX::setLeds(CRGB* pLeds)
 {
     leds = pLeds;
 }
 
 void HUB75GFX::fillLeds(const CRGB* pLEDs)
 {
-    // A mesmerizer panel has the same layout as in memory, so we can memcpy.
-
     memcpy(leds, pLEDs, sizeof(CRGB) * GetLEDCount());
 }
 
 void HUB75GFX::Clear(CRGB color)
 {
-    // NB: We directly clear the backbuffer because otherwise effects would start with a snapshot of the effect
-    //     before them on the next buffer swap.  So we clear the backbuffer and then the leds, which point to
-    //     the current front buffer.  TLDR:  We clear both the front and back buffers to avoid flicker between effects.
-
-    if (color.g == color.r && color.r == color.b)
-    {
-        memset((void *) leds, color.r, sizeof(CRGB) * _ledcount);
-        memset((void *) backgroundLayer.backBuffer(), color.r, sizeof(HUB75GFX::SM_RGB) * _ledcount);
-    }
-    else
-    {
-        SM_RGB* buf = (SM_RGB*)backgroundLayer.backBuffer();
-        for (size_t i = 0; i < _ledcount; ++i)
-        {
-            buf[i]  = rgb24(color.r, color.g, color.b);
-            leds[i] = color;
-        }
-    }
+    std::fill_n(frameBuffers[0], _ledcount, color);
+    std::fill_n(frameBuffers[1], _ledcount, color);
+    leds = frameBuffers[drawBufferIndex];
 }
 
-const String & HUB75GFX::GetCaption()
+const String& HUB75GFX::GetCaption()
 {
     return strCaption;
 }
 
 float HUB75GFX::GetCaptionTransparency()
 {
-    unsigned long now = millis();
-    if (strCaption == nullptr)
+    const unsigned long now = millis();
+    if (strCaption.isEmpty() || now > captionStartTime + totalCaptionDuration)
         return 0.0f;
 
-    if (now > (captionStartTime + totalCaptionDuration))
-        return 0.0f;
-
-    float elapsed = now - captionStartTime;
-
+    const float elapsed = now - captionStartTime;
     if (elapsed < captionFadeInTime)
         return elapsed / captionFadeInTime;
-
     if (elapsed > captionFadeInTime + captionDuration)
-        return 1.0f - ((elapsed - captionFadeInTime - captionDuration) / captionFadeOutTime);
-
+        return std::max(0.0f, 1.0f - ((elapsed - captionFadeInTime - captionDuration) / captionFadeOutTime));
     return 1.0f;
 }
 
-void HUB75GFX::SetCaption(const String & str, uint32_t duration)
+void HUB75GFX::SetCaption(const String& str, uint32_t duration)
 {
-    captionDuration = (float)duration;
+    captionDuration = static_cast<float>(duration);
     totalCaptionDuration = captionFadeInTime + captionDuration + captionFadeOutTime;
     strCaption = str;
     captionStartTime = millis();
@@ -200,240 +126,204 @@ void HUB75GFX::SetCaption(const String & str, uint32_t duration)
 void HUB75GFX::MoveInwardX(int startY, int endY)
 {
     const int halfWidth = MATRIX_WIDTH / 2;
-    if (leds == nullptr || halfWidth <= 1)
+    if (!leds || halfWidth <= 1)
         return;
 
     startY = std::max(0, startY);
     endY = std::min(MATRIX_HEIGHT - 1, endY);
-
     for (int y = startY; y <= endY; y++)
     {
-        auto pLinemem = leds + y * MATRIX_WIDTH;
-        auto pLinemem2 = pLinemem + (MATRIX_WIDTH / 2);
-        // These shifts overlap within a row. memcpy was undefined behavior and
-        // the old right-half count read one pixel past the row, which could
-        // corrupt adjacent display memory.
-        memmove(pLinemem + 1, pLinemem, sizeof(CRGB) * (halfWidth - 1));
-        memmove(pLinemem2, pLinemem2 + 1, sizeof(CRGB) * (halfWidth - 1));
+        auto pLine = leds + y * MATRIX_WIDTH;
+        auto pLine2 = pLine + halfWidth;
+        memmove(pLine + 1, pLine, sizeof(CRGB) * (halfWidth - 1));
+        memmove(pLine2, pLine2 + 1, sizeof(CRGB) * (halfWidth - 1));
     }
 }
 
 void HUB75GFX::MoveOutwardsX(int startY, int endY)
 {
     const int halfWidth = MATRIX_WIDTH / 2;
-    if (leds == nullptr || halfWidth <= 1)
+    if (!leds || halfWidth <= 1)
         return;
 
     startY = std::max(0, startY);
     endY = std::min(MATRIX_HEIGHT - 1, endY);
-
     for (int y = startY; y <= endY; y++)
     {
-        auto pLinemem = leds + y * MATRIX_WIDTH;
-        auto pLinemem2 = pLinemem + (MATRIX_WIDTH / 2);
-        memmove(pLinemem, pLinemem + 1, sizeof(CRGB) * (halfWidth - 1));
-        memmove(pLinemem2 + 1, pLinemem2, sizeof(CRGB) * (halfWidth - 1));
+        auto pLine = leds + y * MATRIX_WIDTH;
+        auto pLine2 = pLine + halfWidth;
+        memmove(pLine, pLine + 1, sizeof(CRGB) * (halfWidth - 1));
+        memmove(pLine2 + 1, pLine2, sizeof(CRGB) * (halfWidth - 1));
     }
 }
 
 void HUB75GFX::StartMatrix()
 {
-    matrix.addLayer(&backgroundLayer);
-    matrix.addLayer(&titleLayer);
+    HUB75_I2S_CFG::i2s_pins pins = {
+        R1_PIN, G1_PIN, B1_PIN, R2_PIN, G2_PIN, B2_PIN,
+        A_PIN, B_PIN, C_PIN, D_PIN, E_PIN, LAT_PIN, OE_PIN, CLK_PIN
+    };
 
-    // When the matrix starts, you can ask it to leave N bytes of memory free, and this amount must be tuned.  Too much free
-    // will cause a dim panel with a low refresh, too little will starve other things.  We currently have enough RAM for
-    // use so begin() is not being called with a reserve parameter, but it can be if memory becomes scarce.
+    HUB75_I2S_CFG config(MATRIX_WIDTH, MATRIX_HEIGHT, 1, pins);
+    config.double_buff = true;
+    config.i2sspeed = HUB75_I2S_CFG::HZ_20M;
+    config.min_refresh_rate = MATRIX_REFRESH_RATE;
 
-    matrix.setCalcRefreshRateDivider(MATRIX_CALC_DIVIDER);
-    matrix.setRefreshRate(MATRIX_REFRESH_RATE);
-    matrix.setMaxCalculationCpuPercentage(95);
-    matrix.begin();
+    matrix = std::make_unique<MatrixPanel_I2S_DMA>(config);
+    if (!matrix->begin())
+        throw std::runtime_error("HUB75 DMA matrix initialization failed");
 
-    Serial.printf("Matrix Refresh Rate: %lu\n", (unsigned long)matrix.getRefreshRate());
+    matrix->setBrightness8(kDefaultBrightness);
+    matrix->clearScreen();
+    matrix->flipDMABuffer();
+    matrix->clearScreen();
 
-    //backgroundLayer.setRefreshRate(100);
-    backgroundLayer.fillScreen(rgb24(0, 64, 0));
-    backgroundLayer.setFont(font6x10);
-    backgroundLayer.drawString(8, kMatrixHeight / 2 - 6, rgb24(255, 255, 255), "NightDriver");
-    backgroundLayer.swapBuffers(false);
+    std::fill_n(frameBuffers[0], kMatrixWidth * kMatrixHeight, CRGB::Black);
+    std::fill_n(frameBuffers[1], kMatrixWidth * kMatrixHeight, CRGB::Black);
+    lastSwapMs = millis();
 
-    matrix.setBrightness(255);
+    Serial.printf("Matrix Refresh Rate: %d\n", GetRefreshRate());
 }
 
 void HUB75GFX::PrepareFrame()
 {
-    // We treat the internal matrix buffer as our own little playground to draw in, but that assumes they're
-    // both 24-bits RGB triplets.  Or at least the same size!
-
-    static_assert(sizeof(CRGB) == sizeof(SM_RGB), "Code assumes 24 bits in both places");
-
     EVERY_N_MILLIS(MILLIS_PER_FRAME)
     {
         auto& graphics = g_ptrSystem->GetEffectManager().g();
-
-        matrix.setCalcRefreshRateDivider(MATRIX_CALC_DIVIDER);
-        matrix.setRefreshRate(MATRIX_REFRESH_RATE);
-
-        auto& pMatrix = static_cast<HUB75GFX&>(graphics);
-        pMatrix.setLeds(GetMatrixBackBuffer());
-
-        // We set ourselves to the lower of the fader value or the brightness value,
-        // so that we can fade between effects without having to change the brightness
-        // setting.
-
-        auto& effectManager = g_ptrSystem->GetEffectManager();
-        if (effectManager.HasCurrentEffect() && effectManager.GetCurrentEffect().ShouldShowTitle() && pMatrix.GetCaptionTransparency() > 0.00)
-        {
-            titleLayer.setFont(font3x5);
-            uint8_t brite = (uint8_t)(pMatrix.GetCaptionTransparency() * 255.0);
-            debugV("Caption: %d", brite);
-
-            rgb24 chromaKeyColor = rgb24(255, 0, 255);
-            rgb24 shadowColor = rgb24(0, 0, 0);
-            rgb24 titleColor = rgb24(255, 255, 255);
-
-            titleLayer.setChromaKeyColor(chromaKeyColor);
-            titleLayer.setFont(font6x10);
-
-            const size_t kCharWidth = 6;
-            const size_t kCharHeight = 10;
-
-            const auto caption = pMatrix.GetCaption();
-
-            int y = MATRIX_HEIGHT - 2 - kCharHeight;
-            int w = caption.length() * kCharWidth;
-
-            unsigned long elapsed = millis() - captionStartTime;
-
-            int x;
-            if (w > MATRIX_WIDTH)
-            {
-                // Scroll if too wide to fit
-                float progress = (float)elapsed / totalCaptionDuration;
-                x = MATRIX_WIDTH - (int)(progress * (w + MATRIX_WIDTH));
-            }
-
-            else
-            {
-                // Center if it fits
-                x = (MATRIX_WIDTH / 2) - (w / 2) + 1;
-            }
-
-            // Generic fill that's way faster than the rectangle base impl
-            for (int i = y * _width; i < (y + 1 + kCharHeight) * _width; ++i)
-                titleLayer.backBuffer()[i] = chromaKeyColor;
-
-            auto szCaption = caption.c_str();
-            titleLayer.drawString(x - 1, y, shadowColor, szCaption);
-            titleLayer.drawString(x + 1, y, shadowColor, szCaption);
-            titleLayer.drawString(x, y - 1, shadowColor, szCaption);
-            titleLayer.drawString(x, y + 1, shadowColor, szCaption);
-            titleLayer.drawString(x, y, titleColor, szCaption);
-
-            // We enable the chromakey overlay just for the strip of screen where it appears.  This support is only
-            // present in the private fork of SmartMatrix that is linked to the mesmerizer project.
-
-            if (WaitForLayerSwap(titleLayer, "title", 100))
-                titleLayer.swapBuffers(false);
-            titleLayer.enableChromaKey(true, y, y + kCharHeight);
-            titleLayer.setBrightness(brite); // 255 would obscure it entirely
-        }
-        else
-        {
-            titleLayer.enableChromaKey(false);
-            titleLayer.setBrightness(0);
-        }
-
-
+        static_cast<HUB75GFX&>(graphics).setLeds(GetMatrixBackBuffer());
     }
 }
 
-// PostProcessFrame
-//
-// Things we do with the matrix after rendering a frame, such as setting the brightness and swapping the backbuffer forward
-
 void HUB75GFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDrawn)
 {
-    // If we drew no pixels, there's nothing to post process
-    if ((localPixelsDrawn + wifiPixelsDrawn) == 0)
+    if (localPixelsDrawn + wifiPixelsDrawn == 0)
         return;
 
     auto& pMatrix = static_cast<HUB75GFX&>(g_ptrSystem->GetEffectManager().g());
 
-    constexpr auto kCaptionPower = 500;                                                 // A guess as the power the caption will consume
-    g_Values.MatrixPowerMilliwatts = pMatrix.EstimatePowerDraw();                             // What our drawn pixels will consume
+    const auto& effectManager = g_ptrSystem->GetEffectManager();
+    const bool showCaption = effectManager.HasCurrentEffect() &&
+                             effectManager.GetCurrentEffect().ShouldShowTitle() &&
+                             pMatrix.GetCaptionTransparency() > 0.0f;
 
-    if (pMatrix.GetCaptionTransparency() > 0)
+    constexpr auto kCaptionPower = 500;
+    g_Values.MatrixPowerMilliwatts = pMatrix.EstimatePowerDraw();
+    if (showCaption)
         g_Values.MatrixPowerMilliwatts += kCaptionPower;
 
     const double kMaxPower = g_ptrSystem->GetDeviceConfig().GetPowerLimit();
-    uint8_t scaledBrightness = std::clamp(kMaxPower / g_Values.MatrixPowerMilliwatts, 0.0, 1.0) * 255;
-
-    // If the target brightness is lower than current, we drop to it immediately, but if it is higher, we ramp the brightness back in
-    // somewhat slowly to avoid flicker.  We do this by using a weighted average of the current and former brightness.  To avoid
-    // an asymptote near the max, we always increase by at least one step if we're lower than the target.
+    const uint8_t scaledBrightness = std::clamp(kMaxPower / g_Values.MatrixPowerMilliwatts, 0.0, 1.0) * 255;
 
     constexpr auto kWeightedAverageAmount = 10;
     if (scaledBrightness <= g_Values.MatrixScaledBrightness)
         g_Values.MatrixScaledBrightness = scaledBrightness;
     else
-        g_Values.MatrixScaledBrightness = std::max(g_Values.MatrixScaledBrightness + 1,
-                                                    (( g_Values.MatrixScaledBrightness * (kWeightedAverageAmount-1) ) + scaledBrightness) / kWeightedAverageAmount);
+        g_Values.MatrixScaledBrightness = std::max(
+            g_Values.MatrixScaledBrightness + 1,
+            ((g_Values.MatrixScaledBrightness * (kWeightedAverageAmount - 1)) + scaledBrightness) / kWeightedAverageAmount);
 
-    // We set ourselves to the lower of the fader value or the brightness value, or the power constrained value,
-    // whichever is lowest, so that we can fade between effects without having to change the brightness setting.
-
-    auto targetBrightness = min({ g_ptrSystem->GetDeviceConfig().GetBrightness(), g_Values.Fader, g_Values.MatrixScaledBrightness });
-
-    debugV("MW: %lu, Setting Scaled Brightness to: %lu", (unsigned long)g_Values.MatrixPowerMilliwatts, (unsigned long)targetBrightness);
+    const auto targetBrightness = min({
+        g_ptrSystem->GetDeviceConfig().GetBrightness(),
+        g_Values.Fader,
+        g_Values.MatrixScaledBrightness
+    });
     pMatrix.SetBrightness(targetBrightness);
 
-    #if SHOW_FPS_ON_MATRIX
-        // Display status on bottom of matrix in format FPS: 00 CPU0: 000 CPU1: 000 Aud: 00
-        backgroundLayer.setFont(font3x5);
-        auto& taskManager = g_ptrSystem->GetTaskManager();
-        String output = "LED: " + String(g_Values.FPS) + " AUD: " + String(g_Analyzer.AudioFPS());
-        backgroundLayer.drawString(2, MATRIX_HEIGHT  - 12, rgb24(255, 255, 255), rgb24(0, 0, 0), output.c_str());
-        output = "CP0: " + String((int)taskManager.GetCPUUsagePercent(0)) + " CP1: " + String((int)taskManager.GetCPUUsagePercent(1));
-        backgroundLayer.drawString(2, MATRIX_HEIGHT  - 6, rgb24(255, 255, 255), rgb24(0, 0, 0), output.c_str());
-    #endif
-
-    auto& effectManager = g_ptrSystem->GetEffectManager();
-    const bool effectRequiresDoubleBuffering = effectManager.HasCurrentEffect() && effectManager.GetCurrentEffect().RequiresDoubleBuffering();
-    MatrixSwapBuffers((wifiPixelsDrawn > 0) || effectRequiresDoubleBuffering || pMatrix.GetCaptionTransparency() > 0.0);
-
+    const bool requiresDoubleBuffering = effectManager.HasCurrentEffect() && effectManager.GetCurrentEffect().RequiresDoubleBuffering();
+    MatrixSwapBuffers(wifiPixelsDrawn > 0 || requiresDoubleBuffering || showCaption);
     FastLED.countFPS();
 }
 
-CRGB *HUB75GFX::GetMatrixBackBuffer()
+CRGB* HUB75GFX::GetMatrixBackBuffer()
 {
     for (auto& device : g_ptrSystem->GetDevices())
         device->UpdatePaletteCycle();
-
-    return (CRGB *)backgroundLayer.backBuffer();
+    return frameBuffers[drawBufferIndex];
 }
 
-void HUB75GFX::MatrixSwapBuffers(bool bSwapBackground)
+void HUB75GFX::FlushFrameToMatrix()
 {
-    // If an effect redraws itself entirely ever frame, it can skip saving the most recent buffer, so
-    // can swap without waiting for a copy.
-    matrix.setCalcRefreshRateDivider(MATRIX_CALC_DIVIDER);
-    matrix.setRefreshRate(MATRIX_REFRESH_RATE);
-    matrix.setMaxCalculationCpuPercentage(95);
-
-    if (!WaitForMatrixSwap())
+    if (!matrix)
         return;
 
-    backgroundLayer.swapBuffers(false);
+    const CRGB* frame = frameBuffers[drawBufferIndex];
+    for (int y = 0; y < MATRIX_HEIGHT; ++y)
+    {
+        for (int x = 0; x < MATRIX_WIDTH; ++x)
+        {
+            const CRGB& pixel = frame[y * MATRIX_WIDTH + x];
+            matrix->drawPixelRGB888(x, y, pixel.r, pixel.g, pixel.b);
+        }
+    }
 
-    if (bSwapBackground && WaitForMatrixSwap())
-        backgroundLayer.copyRefreshToDrawing();
+    auto& gfx = static_cast<HUB75GFX&>(g_ptrSystem->GetEffectManager().g());
+    const auto& effectManager = g_ptrSystem->GetEffectManager();
+    const bool shouldShowTitle = effectManager.HasCurrentEffect() &&
+                                 effectManager.GetCurrentEffect().ShouldShowTitle();
+    const float captionAlpha = shouldShowTitle ? gfx.GetCaptionTransparency() : 0.0f;
+    if (captionAlpha > 0.0f)
+    {
+        const String caption = gfx.GetCaption();
+        constexpr int charWidth = 6;
+        constexpr int charHeight = 8;
+        const int textWidth = caption.length() * charWidth;
+        const unsigned long elapsed = millis() - gfx.captionStartTime;
+        const int x = textWidth > MATRIX_WIDTH
+            ? MATRIX_WIDTH - static_cast<int>((elapsed / gfx.totalCaptionDuration) * (textWidth + MATRIX_WIDTH))
+            : (MATRIX_WIDTH - textWidth) / 2;
+        const int y = MATRIX_HEIGHT - charHeight - 1;
+        const uint8_t brightness = static_cast<uint8_t>(captionAlpha * 255.0f);
+
+        matrix->setTextWrap(false);
+        matrix->setTextSize(1);
+        matrix->setTextColor(matrix->color565(brightness, brightness, brightness));
+        matrix->setCursor(x, y);
+        matrix->print(caption);
+    }
+
+    #if SHOW_FPS_ON_MATRIX
+        auto& taskManager = g_ptrSystem->GetTaskManager();
+        matrix->setTextWrap(false);
+        matrix->setTextSize(1);
+        matrix->setTextColor(matrix->color565(255, 255, 255), matrix->color565(0, 0, 0));
+        matrix->setCursor(0, MATRIX_HEIGHT - 16);
+        matrix->printf("LED:%lu AUD:%d", static_cast<unsigned long>(g_Values.FPS), g_Analyzer.AudioFPS());
+        matrix->setCursor(0, MATRIX_HEIGHT - 8);
+        matrix->printf("C0:%d C1:%d", static_cast<int>(taskManager.GetCPUUsagePercent(0)), static_cast<int>(taskManager.GetCPUUsagePercent(1)));
+    #endif
+}
+
+void HUB75GFX::MatrixSwapBuffers(bool copyPresentedFrame)
+{
+    if (!matrix || !WaitForMatrixSwap())
+        return;
+
+    const uint8_t presentedIndex = drawBufferIndex;
+    FlushFrameToMatrix();
+    matrix->flipDMABuffer();
+    lastSwapMs = millis();
+
+    drawBufferIndex ^= 1;
+    if (copyPresentedFrame)
+        memcpy(frameBuffers[drawBufferIndex], frameBuffers[presentedIndex], sizeof(frameBuffers[0]));
 }
 
 bool HUB75GFX::WaitForMatrixSwap(uint32_t timeoutMs)
 {
-    return WaitForLayerSwap(backgroundLayer, "background", timeoutMs);
+    if (!matrix || GetRefreshRate() <= 0)
+        return true;
+
+    const uint32_t frameMs = std::max<uint32_t>(1, (1000U + GetRefreshRate() - 1) / GetRefreshRate());
+    const uint32_t elapsed = millis() - lastSwapMs;
+    if (elapsed >= frameMs)
+        return true;
+
+    const uint32_t waitMs = frameMs - elapsed;
+    if (waitMs > timeoutMs)
+        return false;
+
+    delay(waitMs);
+    return true;
 }
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -667,8 +667,8 @@ void setup()
         splashGraphics.PrepareFrame();
         splashManager.Update();
         splashGraphics.PostProcessFrame(splashGraphics.GetLEDCount(), 0);
-    
-        #endif
+
+    #endif
 
     InitEffectsManager();
 
@@ -767,7 +767,7 @@ void setup()
 void loop()
 {
     // Add button support to the DEVKIT boards so you can step the effect
-    
+
     #if (defined(MESMERIZER_DEVKIT) || defined(MESMERIZER_DEVKIT_S3)) && defined(TOGGLE_BUTTON_0)
         static Bounce2::Button s_nextEffectButton;
         static bool s_nextEffectButtonInitialized = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -344,6 +344,7 @@ void setup()
     // Route all ESP-IDF log output through ConsoleManager so CRLF translation
     // and Serial.flush() are applied on every log line.
     Logger::InstallLogHook();
+    Logger::SetLevel(LogLevel::Info);
 
     // Initialize SPIFFS for file access to non-volatile storage
     if (!SPIFFS.begin(true))
@@ -394,8 +395,6 @@ void setup()
 
     // Start the Task Manager which takes over the watchdog role and measures CPU usage
     auto& taskManager = g_ptrSystem->SetupTaskManager();
-
-    esp_log_level_set("*", ESP_LOG_DEBUG);       // set all components to an appropriate logging level
 
     // Display a simple startup header on the serial port
     PrintOutputHeader();
@@ -643,13 +642,33 @@ void setup()
         #endif
     #endif
 
-    g_ptrSystem->SetupBufferManagers();
+    // Network LED frame buffers are sizeable and serve no purpose in a
+    // local-effects-only build. In particular, omitting two 64x32 buffers
+    // gives the no-PSRAM DEVKIT enough internal RAM to launch its renderer.
+    #if INCOMING_WIFI_ENABLED
+        g_ptrSystem->SetupBufferManagers();
+    #endif
 
     // Show splash effect on matrix
     #if USE_HUB75
         debugI("Initializing splash effect manager...");
         InitSplashEffectManager();
-    #endif
+
+        // The normal render service is intentionally started only after the
+        // full effect manager has been loaded.  Render one splash frame here
+        // so the panel has immediate visual feedback while effects, WiFi, and
+        // the remaining services initialize.  Without this synchronous draw,
+        // InitEffectsManager() replaces the temporary splash effect before a
+        // render task ever gets a chance to display it.
+
+        auto& splashManager  = g_ptrSystem->GetEffectManager();
+        auto& splashGraphics = splashManager.g();
+        splashManager.StartEffect();
+        splashGraphics.PrepareFrame();
+        splashManager.Update();
+        splashGraphics.PostProcessFrame(splashGraphics.GetLEDCount(), 0);
+    
+        #endif
 
     InitEffectsManager();
 
@@ -747,8 +766,32 @@ void setup()
 
 void loop()
 {
+    // Add button support to the DEVKIT boards so you can step the effect
+    
+    #if (defined(MESMERIZER_DEVKIT) || defined(MESMERIZER_DEVKIT_S3)) && defined(TOGGLE_BUTTON_0)
+        static Bounce2::Button s_nextEffectButton;
+        static bool s_nextEffectButtonInitialized = false;
+        if (!s_nextEffectButtonInitialized)
+        {
+            s_nextEffectButton.attach(TOGGLE_BUTTON_0, INPUT_PULLUP);
+            s_nextEffectButton.interval(5);
+            s_nextEffectButton.setPressedState(LOW);
+            s_nextEffectButtonInitialized = true;
+            debugI("Next-effect button initialized on GPIO %d", TOGGLE_BUTTON_0);
+        }
+    #endif
+
     while(true)
     {
+        #if (defined(MESMERIZER_DEVKIT) || defined(MESMERIZER_DEVKIT_S3)) && defined(TOGGLE_BUTTON_0)
+            s_nextEffectButton.update();
+            if (s_nextEffectButton.pressed() && g_ptrSystem->HasEffectManager())
+            {
+                debugI("Next-effect button pressed");
+                g_ptrSystem->GetEffectManager().NextEffect();
+            }
+        #endif
+
         // Improv owns the serial stream when WiFi is enabled. It forwards any
         // non-Improv bytes to the serial CLI through its unknown-byte callback.
 #if ENABLE_WIFI
@@ -777,8 +820,14 @@ void loop()
             }
         #endif
 
-        EVERY_N_SECONDS(5)
+        // Keep operational telemetry independent of FastLED's timer macros.
+        // This runs on the Arduino loop task and deliberately catches up from
+        // the current time rather than emitting a burst after a long stall.
+        static uint32_t s_lastStatusUpdateMs = 0;
+        const uint32_t statusNowMs = millis();
+        if (s_lastStatusUpdateMs == 0 || statusNowMs - s_lastStatusUpdateMs >= 5000)
         {
+            s_lastStatusUpdateMs = statusNowMs;
             String strOutput;
 
             #if ENABLE_WIFI
@@ -793,7 +842,7 @@ void loop()
             #endif
 
             #if USE_HUB75
-                strOutput += str_sprintf("Refresh: %d Hz, Power: %d mW, Brite: %3.0lf%%, ", HUB75GFX::matrix.getRefreshRate(), g_Values.MatrixPowerMilliwatts, g_Values.MatrixScaledBrightness / 2.55);
+                strOutput += str_sprintf("Refresh: %d Hz, Power: %d mW, Brite: %3.0lf%%, ", HUB75GFX::GetRefreshRate(), g_Values.MatrixPowerMilliwatts, g_Values.MatrixScaledBrightness / 2.55);
             #endif
 
             #if ENABLE_AUDIO
@@ -815,12 +864,17 @@ void loop()
             const auto& taskManager = g_ptrSystem->GetTaskManager();
             strOutput += str_sprintf("CPU: %03.0f%%, %03.0f%%, FreeDraw: %4.3lf", taskManager.GetCPUUsagePercent(0), taskManager.GetCPUUsagePercent(1), g_Values.FreeDrawTime);
 
-            debugI("%s", strOutput.c_str());
+            // Status is user-facing operational telemetry, not diagnostic
+            // chatter. Send it directly to the console sinks so a runtime log
+            // threshold cannot suppress it and no second large formatting
+            // buffer needs to be allocated by Logger::Logf().
+            ConsoleManager::Instance().Broadcast(LogLevel::Info, TAG, strOutput.c_str());
         }
 
-        // Once an update is underway, we loop tightly on ArduinoOTA.handle.  Otherwise, we delay a bit to share the CPU.
-
-        if (!g_Values.UpdateStarted)
-            delay(1);
+        // Yield explicitly; Improv and OTA polling are non-blocking and do
+        // not otherwise guarantee that the Arduino loop task gives time back.
+        // A single tick also keeps ArduinoOTA.handle() serviced tightly once
+        // an update is underway.
+        delay(1);
     }
 }

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -650,14 +650,15 @@ namespace nd_network
 
     void DoStatsCommand(const DebugCLI::cli_argv &)
     {
-        auto &bufferManager = g_ptrSystem->GetBufferManagers()[0];
         const auto& config = g_ptrSystem->GetDeviceConfig();
 
         DebugCLI::cli_printf("%s:%zux%zu %zuK %ddB:%s",
             FLASH_VERSION_NAME, g_ptrSystem->GetDevices().size(),
             config.GetActiveLEDCount(), (size_t)(ESP.getFreeHeap()/1024), abs(WiFi.RSSI()),
             IsWiFiConnected() ? WiFi.localIP().toString().c_str() : "None");
+        if (g_ptrSystem->HasBufferManagers())
         {
+            auto &bufferManager = g_ptrSystem->GetBufferManagers()[0];
             // Buffer indices are mutated by the socket task and consumed by
             // the render task; status reads need the same mutex or they can
             // sample a half-updated ring state on the other core.

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -155,12 +155,13 @@ public:
         }
 
         // Buffer Status Line 3
-        auto &bufferManager = g_ptrSystem->GetBufferManagers()[0];
         size_t bufferDepth = 0;
         size_t bufferCount = 0;
         double oldestAge = 0.0;
         double newestAge = 0.0;
+        if (g_ptrSystem->HasBufferManagers())
         {
+            auto &bufferManager = g_ptrSystem->GetBufferManagers()[0];
             // The display runs on its own task, so even status-only buffer
             // reads need the producer/consumer mutex to avoid sampling torn
             // circular-buffer indices.

--- a/src/systemcontainer.cpp
+++ b/src/systemcontainer.cpp
@@ -212,10 +212,17 @@ SystemContainer::BufferManagerContainer& SystemContainer::SetupBufferManagers()
     }
 
     #if USE_PSRAM
-        uint32_t memtouse = ESP.getFreePsram() - RESERVE_MEMORY;
+        const uint32_t freeMemory = ESP.getFreePsram();
     #else
-        uint32_t memtouse = ESP.getFreeHeap() - RESERVE_MEMORY;
+        const uint32_t freeMemory = ESP.getFreeHeap();
     #endif
+
+    // Saturate at zero when the requested reserve exceeds available memory.
+    // Subtracting unsigned values directly wraps around and produces a bogus,
+    // enormous buffer count on memory-constrained boards.
+    const uint32_t memtouse = freeMemory > RESERVE_MEMORY
+        ? freeMemory - RESERVE_MEMORY
+        : 0;
 
     uint32_t memtoalloc = 0;
     for (const auto& device : *_ptrDevices)

--- a/src/webserver.cpp
+++ b/src/webserver.cpp
@@ -193,9 +193,6 @@ void CWebServer::begin()
     _staticStats.FreeSketchSpace = ESP.getFreeSketchSpace();
     _staticStats.FlashChipSize = ESP.getFlashChipSize();
 
-    if (!EnsureDeviceSettingSpecsJson())
-        debugW("WebServer: failed to pre-cache device setting specs JSON.");
-
     debugI("Connecting Web Endpoints");
 
     // SPIFFS file requests

--- a/src/webserver_settings.cpp
+++ b/src/webserver_settings.cpp
@@ -216,8 +216,14 @@ bool CWebServer::EnsureDeviceSettingSpecsJson()
         return true;
 
     String json;
-    if (!BuildSettingSpecsJson(json, LoadDeviceSettingSpecs()))
+    try
     {
+        if (!BuildSettingSpecsJson(json, LoadDeviceSettingSpecs()))
+            return false;
+    }
+    catch (const std::bad_alloc&)
+    {
+        debugE("Insufficient memory to build device setting specs JSON.");
         return false;
     }
 


### PR DESCRIPTION
Highlights:
Added ESP32-DevKitC V4 Mesmerizer configuration using the supplied HUB75 pin mapping. No PSRAM
Local effects only
Network and optional services disabled
BOOT button advances effects

Added ESP32-S3-DevKitC-1 N16R8 configuration.
8 MB octal PSRAM
16 MB flash
Dual 4 MB OTA application partitions
Native USB CDC logging
Audio disabled
BOOT button advances effects

Unified classic WROVER, Lolin, DEVKIT, and S3 Mesmerizer configurations on the new HUB75 DMA backend.

Restored splash-screen rendering during startup without waiting for Wi-Fi.

Preserved effect title behavior, including ShouldShowTitle() opt-outs for Weather and Stocks.

Corrected periodic serial status output and S3 USB CDC routing.

Added memory protections for low-memory targets:
Conditional network-frame buffer allocation
Allocation-safe logging
Reduced temporary settings-schema allocations
Graceful JSON allocation failure handling
Safer topology validation

Fixed JPEG decoder initialization before the early splash render.

Integrated the latest changes from main onto the new hub75 branch.

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).