### PR TITLE
M5TAB support

### DIFF
--- a/config/partitions_custom.csv
+++ b/config/partitions_custom.csv
@@ -1,8 +1,8 @@
 # Standard 4M partition layout with OTA (Over the air updates)
 
 # Name,   Type, SubType,     Offset,      Size, Flags
-nvs,        data,   nvs,     0x00b000,    0x002000,
-otadata,    data,   ota,     0x00d000,    0x002000,
+nvs,        data,   nvs,     0x00b000,    0x003000,
+otadata,    data,   ota,     0x00e000,    0x002000,
 app0,       app,    ota_0,   0x010000,    0x1A0000,
 app1,       app,    ota_1,   0x1B0000,    0x1A0000,
 storage,    data,   spiffs,  0x350000,    0x0B0000

--- a/config/partitions_custom_8M.csv
+++ b/config/partitions_custom_8M.csv
@@ -4,8 +4,8 @@
 
 # Note that our NVS code assumes name 'storage' for the NVS partition
 
-nvs,         data,   nvs,       0x009000,  0x002000,
-otadata,     data,   ota,       0x00b000,  0x002000,
+nvs,         data,   nvs,       0x009000,  0x003000,
+otadata,     data,   ota,       0x00c000,  0x002000,
 app0,        app,    ota_0,     0x010000,  0x320000,
 app1,        app,    ota_1,     0x330000,  0x320000,
 storage,     data,   spiffs,    0x650000,  0x1B0000 

--- a/config/partitions_custom_feather.csv
+++ b/config/partitions_custom_feather.csv
@@ -1,7 +1,7 @@
 # Standard 4M partition layout with OTA, tuned for Feather S3 firmware size
 # Name,   Type, SubType,     Offset,      Size, Flags
-nvs,        data,   nvs,     0x00B000,    0x002000,
-otadata,    data,   ota,     0x00D000,    0x002000,
+nvs,        data,   nvs,     0x00B000,    0x003000,
+otadata,    data,   ota,     0x00E000,    0x002000,
 app0,       app,    ota_0,   0x010000,    0x1B0000,
 app1,       app,    ota_1,   0x1C0000,    0x1B0000,
 storage,    data,   spiffs,  0x370000,    0x090000

--- a/config/partitions_custom_feather.csv
+++ b/config/partitions_custom_feather.csv
@@ -2,6 +2,6 @@
 # Name,   Type, SubType,     Offset,      Size, Flags
 nvs,        data,   nvs,     0x00B000,    0x003000,
 otadata,    data,   ota,     0x00E000,    0x002000,
-app0,       app,    ota_0,   0x010000,    0x1B0000,
-app1,       app,    ota_1,   0x1C0000,    0x1B0000,
-storage,    data,   spiffs,  0x370000,    0x090000
+app0,       app,    ota_0,   0x010000,    0x1E0000,
+app1,       app,    ota_1,   0x1F0000,    0x1E0000,
+storage,    data,   spiffs,  0x3D0000,    0x030000

--- a/config/partitions_custom_noota.csv
+++ b/config/partitions_custom_noota.csv
@@ -5,7 +5,7 @@
 
 # Note that our NVS code assumes name 'storage' for the NVS partition
 
-nvs,        data,   nvs,     0x00b000,    0x002000,
-otadata,    data,   ota,     0x00d000,    0x002000,
+nvs,        data,   nvs,     0x00b000,    0x003000,
+otadata,    data,   ota,     0x00e000,    0x002000,
 app0,       app,    ota_0,   0x010000,    0x320000,
-storage,    data,   spiffs,  0x330000,    0x0D0000 
+storage,    data,   spiffs,  0x330000,    0x0D0000

--- a/include/deviceconfig.h
+++ b/include/deviceconfig.h
@@ -142,7 +142,8 @@ class DeviceConfig : public IJSONSerializable
     {
         WS281x,
         APA102,
-        HUB75
+        HUB75,
+        M5LCD
     };
 
     enum class WS281xColorOrder : uint8_t
@@ -167,6 +168,8 @@ class DeviceConfig : public IJSONSerializable
         OutputDriver driver =
         #if USE_HUB75
             OutputDriver::HUB75;
+        #elif USE_M5LCD
+            OutputDriver::M5LCD;
         #elif USE_APA102
             OutputDriver::APA102;
         #else
@@ -241,6 +244,7 @@ class DeviceConfig : public IJSONSerializable
     void SaveToJSON() const;
     static const char* DriverName(OutputDriver driver);
     static bool IsHub75Build();
+    static bool IsFixedMatrixBuild();
     void LogRuntimeConfig(const char* reason) const;
 
     template <typename T>
@@ -373,7 +377,7 @@ class DeviceConfig : public IJSONSerializable
     static constexpr uint16_t GetCompiledMatrixHeight() { return MATRIX_HEIGHT; }
     static constexpr bool GetCompiledMatrixSerpentine()
     {
-        #if USE_HUB75
+        #if USE_HUB75 || USE_M5LCD
             return false;
         #else
             return true;
@@ -390,6 +394,8 @@ class DeviceConfig : public IJSONSerializable
     {
         #if USE_HUB75
             return OutputDriver::HUB75;
+        #elif USE_M5LCD
+            return OutputDriver::M5LCD;
         #elif USE_APA102
             return OutputDriver::APA102;
         #else
@@ -411,8 +417,8 @@ class DeviceConfig : public IJSONSerializable
     const std::array<int8_t, NUM_CHANNELS>& GetAPA102DataPins() const { return runtimeOutputs.outputPins; }
     const std::array<int8_t, NUM_CHANNELS>& GetAPA102ClockPins() const { return runtimeOutputs.clockPins; }
     WS281xColorOrder GetWS281xColorOrder() const { return runtimeOutputs.colorOrder; }
-    bool SupportsLiveTopology() const { return !IsHub75Build() && runtimeOutputs.driver == GetCompiledOutputDriver(); }
-    bool SupportsLiveOutputReconfigure() const { return !IsHub75Build() && runtimeOutputs.driver == GetCompiledOutputDriver(); }
+    bool SupportsLiveTopology() const { return !IsFixedMatrixBuild() && runtimeOutputs.driver == GetCompiledOutputDriver(); }
+    bool SupportsLiveOutputReconfigure() const { return !IsFixedMatrixBuild() && runtimeOutputs.driver == GetCompiledOutputDriver(); }
     bool SupportsConfigurableAudioInputPin() const
     {
         #if ENABLE_AUDIO && !USE_M5 && (USE_I2S_AUDIO || ELECROW)

--- a/include/effects.h
+++ b/include/effects.h
@@ -92,5 +92,5 @@ using FactoryId = uint64_t;
 #if EFFECTS_FULLMATRIX
 // Configure the shared TJpg_Decoder output callback before any matrix effect
 // (including the early boot splash) attempts to decode an embedded JPEG.
-void ConfigureMatrixJpegDecoder();
+void ConfigureMatrixJpegDecoder(uint16_t sourceWidth = 0, uint16_t sourceHeight = 0);
 #endif

--- a/include/effects/matrix/PatternAnimatedGIF.h
+++ b/include/effects/matrix/PatternAnimatedGIF.h
@@ -291,12 +291,24 @@ public:
         uint16_t gifWidth = gif->second._width;
         uint16_t gifHeight = gif->second._height;
 
-        // Map the complete GIF canvas to the complete matrix canvas. GIF
-        // assets were authored for several small aspect ratios (32x32,
-        // 64x32, 64x12); independent axes ensure every one fills modern
-        // widescreen matrices instead of remaining letterboxed.
-        const float scaleX = static_cast<float>(MATRIX_WIDTH) / gifWidth;
-        const float scaleY = static_cast<float>(MATRIX_HEIGHT) / gifHeight;
+        float scaleX;
+        float scaleY;
+        if (MATRIX_WIDTH > 64 || MATRIX_HEIGHT > 32)
+        {
+            // Large framebuffer builds need to use the available surface.
+            scaleX = static_cast<float>(MATRIX_WIDTH) / gifWidth;
+            scaleY = static_cast<float>(MATRIX_HEIGHT) / gifHeight;
+        }
+        else
+        {
+            // Preserve the original small-panel behavior: only downscale,
+            // retain aspect ratio, and center the result.
+            const float scale = std::min(
+                1.0f, std::min(static_cast<float>(MATRIX_WIDTH) / gifWidth,
+                               static_cast<float>(MATRIX_HEIGHT) / gifHeight));
+            scaleX = scale;
+            scaleY = scale;
+        }
 
         // Calculate the destination dimensions after scaling
         uint16_t dstWidth = (uint16_t)(gifWidth * scaleX);

--- a/include/effects/matrix/PatternAnimatedGIF.h
+++ b/include/effects/matrix/PatternAnimatedGIF.h
@@ -192,20 +192,28 @@ class PatternAnimatedGIF : public EffectWithId<PatternAnimatedGIF>
     static void drawPixelCallback(int16_t x, int16_t y, uint8_t red, uint8_t green, uint8_t blue)
     {
         auto& g = g_ptrSystem->GetEffectManager().g(0);
+        const auto& state = SharedGIFDecoderState();
+        const CRGB color(red, green, blue);
 
-        // Apply scaling transformation
-        int16_t scaledX = (int16_t)(x * SharedGIFDecoderState()._scaleX) + SharedGIFDecoderState()._offsetX;
-        int16_t scaledY = (int16_t)(y * SharedGIFDecoderState()._scaleY) + SharedGIFDecoderState()._offsetY;
-
-        if (false == g.isValidPixel(scaledX, scaledY))
+        if (state._scaleX >= 1.0f && state._scaleY >= 1.0f)
         {
-            debugV("drawPixelCallback: scaled pixel out of bounds: %d, %d (from source %d, %d)", scaledX, scaledY, x, y);
+            // Use adjacent transformed source boundaries so fractional scales
+            // cover every destination pixel without gaps.
+            const int16_t x0 = static_cast<int16_t>(x * state._scaleX) + state._offsetX;
+            const int16_t y0 = static_cast<int16_t>(y * state._scaleY) + state._offsetY;
+            const int16_t x1 = static_cast<int16_t>((x + 1) * state._scaleX) + state._offsetX;
+            const int16_t y1 = static_cast<int16_t>((y + 1) * state._scaleY) + state._offsetY;
+
+            g.fillRectangle(x0, y0, x1, y1, color);
             return;
         }
 
-        // If we're scaling down (scale < 1.0), we might want to sample multiple source pixels
-        // For now, we use simple nearest-neighbor scaling
-        g.leds[XY(scaledX, scaledY)] = CRGB(red, green, blue);
+        // Preserve the existing nearest-neighbor behavior when fitting a GIF
+        // onto a matrix smaller than its source dimensions.
+        const int16_t scaledX = static_cast<int16_t>(x * state._scaleX) + state._offsetX;
+        const int16_t scaledY = static_cast<int16_t>(y * state._scaleY) + state._offsetY;
+        if (g.isValidPixel(scaledX, scaledY))
+            g.leds[g.xy(scaledX, scaledY)] = color;
     }
 
     // drawLineCallback
@@ -283,20 +291,12 @@ public:
         uint16_t gifWidth = gif->second._width;
         uint16_t gifHeight = gif->second._height;
 
-        float scaleX = 1.0f;
-        float scaleY = 1.0f;
-
-        // If GIF is larger than matrix, calculate scaling to fit
-        if (gifWidth > MATRIX_WIDTH || gifHeight > MATRIX_HEIGHT)
-        {
-            scaleX = (float)MATRIX_WIDTH / (float)gifWidth;
-            scaleY = (float)MATRIX_HEIGHT / (float)gifHeight;
-
-            // Use the smaller scale factor to maintain aspect ratio (best fit)
-            float scale = min(scaleX, scaleY);
-            scaleX = scale;
-            scaleY = scale;
-        }
+        // Map the complete GIF canvas to the complete matrix canvas. GIF
+        // assets were authored for several small aspect ratios (32x32,
+        // 64x32, 64x12); independent axes ensure every one fills modern
+        // widescreen matrices instead of remaining letterboxed.
+        const float scaleX = static_cast<float>(MATRIX_WIDTH) / gifWidth;
+        const float scaleY = static_cast<float>(MATRIX_HEIGHT) / gifHeight;
 
         // Calculate the destination dimensions after scaling
         uint16_t dstWidth = (uint16_t)(gifWidth * scaleX);

--- a/include/effects/matrix/PatternCircuit.h
+++ b/include/effects/matrix/PatternCircuit.h
@@ -154,23 +154,23 @@ private:
             }
         }
 
-        void move(uint8_t distance)
+        void move(uint8_t horizontalDistance, uint8_t verticalDistance)
         {
             switch (direction)
             {
             case UP:
-                pixels[0].y = (pixels[0].y + distance) % MATRIX_HEIGHT;
+                pixels[0].y = (pixels[0].y + verticalDistance) % MATRIX_HEIGHT;
                 break;
             case LEFT:
-                pixels[0].x = (pixels[0].x + distance) % MATRIX_WIDTH;
+                pixels[0].x = (pixels[0].x + horizontalDistance) % MATRIX_WIDTH;
                 break;
             case DOWN:
                 pixels[0].y =
-                    (pixels[0].y + MATRIX_HEIGHT - distance % MATRIX_HEIGHT) % MATRIX_HEIGHT;
+                    (pixels[0].y + MATRIX_HEIGHT - verticalDistance % MATRIX_HEIGHT) % MATRIX_HEIGHT;
                 break;
             case RIGHT:
                 pixels[0].x =
-                    (pixels[0].x + MATRIX_WIDTH - distance % MATRIX_WIDTH) % MATRIX_WIDTH;
+                    (pixels[0].x + MATRIX_WIDTH - horizontalDistance % MATRIX_WIDTH) % MATRIX_WIDTH;
                 break;
             }
         }
@@ -226,8 +226,11 @@ public:
         // fill_palette(colors, SNAKE_LENGTH, initialHue++, 5, graphics.currentPalette, 255, LINEARBLEND);
         fill_palette(colors, SNAKE_LENGTH, 0, 4, ForestColors_p, 255, LINEARBLEND);
         constexpr uint8_t kReferenceMatrixWidth = 64;
-        constexpr uint8_t kMovementStep =
+        constexpr uint8_t kReferenceMatrixHeight = 32;
+        constexpr uint8_t kHorizontalMovementStep =
             std::max(1, (MATRIX_WIDTH + kReferenceMatrixWidth / 2) / kReferenceMatrixWidth);
+        constexpr uint8_t kVerticalMovementStep =
+            std::max(1, (MATRIX_HEIGHT + kReferenceMatrixHeight / 2) / kReferenceMatrixHeight);
         for (int i = 0; i < snakeCount; i++)
         {
             Path *path = &snakes[i];
@@ -239,7 +242,7 @@ public:
                 path->newDirection();
             }
 
-            path->move(kMovementStep);
+            path->move(kHorizontalMovementStep, kVerticalMovementStep);
             path->draw(g(), colors);
         }
     }

--- a/include/effects/matrix/PatternCircuit.h
+++ b/include/effects/matrix/PatternCircuit.h
@@ -154,21 +154,23 @@ private:
             }
         }
 
-        void move()
+        void move(uint8_t distance)
         {
             switch (direction)
             {
             case UP:
-                pixels[0].y = (pixels[0].y + 1) % MATRIX_HEIGHT;
+                pixels[0].y = (pixels[0].y + distance) % MATRIX_HEIGHT;
                 break;
             case LEFT:
-                pixels[0].x = (pixels[0].x + 1) % MATRIX_WIDTH;
+                pixels[0].x = (pixels[0].x + distance) % MATRIX_WIDTH;
                 break;
             case DOWN:
-                pixels[0].y = pixels[0].y == 0 ? MATRIX_HEIGHT - 1 : pixels[0].y - 1;
+                pixels[0].y =
+                    (pixels[0].y + MATRIX_HEIGHT - distance % MATRIX_HEIGHT) % MATRIX_HEIGHT;
                 break;
             case RIGHT:
-                pixels[0].x = pixels[0].x == 0 ? MATRIX_WIDTH - 1 : pixels[0].x - 1;
+                pixels[0].x =
+                    (pixels[0].x + MATRIX_WIDTH - distance % MATRIX_WIDTH) % MATRIX_WIDTH;
                 break;
             }
         }
@@ -198,9 +200,9 @@ public:
     PatternCircuit(const JsonObjectConst& jsonObject) : EffectWithId<PatternCircuit>(jsonObject) { construct(); }
     ~PatternCircuit() = default;
 
-    unsigned long msStart;
+    unsigned long msStart = 0;
 
-    void start()
+    void Start() override
     {
         for (int i = 0; i < snakeCount; i++)
             snakes[i].reset();
@@ -213,15 +215,19 @@ public:
         // Reset after 20 seconds
         const auto kResetEveryNSeconds = 20;
         if (millis() - msStart > kResetEveryNSeconds * MILLIS_PER_SECOND)
-            start();
+            Start();
 
-        for (int i = 0; i < MATRIX_WIDTH * MATRIX_HEIGHT / 10; i++)
-        {
-            g().leds[XY(random(0, MATRIX_WIDTH), random(0, MATRIX_HEIGHT))].fadeToBlackBy(32);
-        }
+        // Fading 10% of the pixels by 32 has an average whole-frame fade of
+        // about 3, but selecting those pixels required thousands of random()
+        // calls per frame on larger matrices. A sequential fade is visually
+        // equivalent and substantially faster.
+        g().DimAll(252);
 
         // fill_palette(colors, SNAKE_LENGTH, initialHue++, 5, graphics.currentPalette, 255, LINEARBLEND);
         fill_palette(colors, SNAKE_LENGTH, 0, 4, ForestColors_p, 255, LINEARBLEND);
+        constexpr uint8_t kReferenceMatrixWidth = 64;
+        constexpr uint8_t kMovementStep =
+            std::max(1, (MATRIX_WIDTH + kReferenceMatrixWidth / 2) / kReferenceMatrixWidth);
         for (int i = 0; i < snakeCount; i++)
         {
             Path *path = &snakes[i];
@@ -233,7 +239,7 @@ public:
                 path->newDirection();
             }
 
-            path->move();
+            path->move(kMovementStep);
             path->draw(g(), colors);
         }
     }

--- a/include/effects/matrix/PatternLife.h
+++ b/include/effects/matrix/PatternLife.h
@@ -270,12 +270,17 @@ public:
         // We have to first extract the alive bits alone because we don't want the hue and brightness
         // data to mess with the CRC.
 
-        bool alive[MATRIX_WIDTH][MATRIX_HEIGHT];
-        for (int i = 0; i < MATRIX_WIDTH; i++)
-            for (int j = 0; j < MATRIX_HEIGHT; j++)
-                alive[i][j] = world[i][j].alive;
-
-        auto crc = uzlib_crc32(alive, sizeof(alive), 0xffffffff);
+        // Feed the CRC one short row at a time. A full MATRIX_WIDTH by
+        // MATRIX_HEIGHT temporary here overflowed the renderer task stack on
+        // larger matrices (14.4 KB at 160x90).
+        std::array<uint8_t, MATRIX_HEIGHT> aliveRow;
+        uint32_t crc = 0xffffffff;
+        for (int i = 0; i < MATRIX_WIDTH; ++i)
+        {
+            for (int j = 0; j < MATRIX_HEIGHT; ++j)
+                aliveRow[j] = world[i][j].alive;
+            crc = uzlib_crc32(aliveRow.data(), aliveRow.size(), crc);
+        }
         for (int i = 0; i < CRC_LENGTH - 1; i++)
             checksums[i] = checksums[i+1];
         checksums[CRC_LENGTH - 1] = crc;

--- a/include/effects/matrix/PatternMisc.h
+++ b/include/effects/matrix/PatternMisc.h
@@ -118,29 +118,53 @@ class PatternRose : public EffectWithId<PatternRose>
         uint8_t dim = beatsin8(2, 170, 250);
         g().DimAll(dim);
 
+        // The original Aurora effect was fixed at 32x32. Scale its concentric
+        // orbits to the current aspect ratio and derive the point count from
+        // the shorter axis. Keeping the geometry in 16-bit values prevents
+        // the constants and bounds from wrapping once a dimension exceeds 32.
+        constexpr uint16_t pointCount = std::min(MATRIX_WIDTH, MATRIX_HEIGHT);
+        constexpr uint16_t halfPointCount = pointCount / 2;
 
-        for (uint16_t i = 0; i < MATRIX_HEIGHT; i++)
+        const auto scaleCoordinate = [](uint16_t coordinate, uint16_t extent)
         {
-            CRGB color;
+            return static_cast<uint8_t>(
+                (static_cast<uint32_t>(coordinate) * (extent - 1) +
+                 pointCount / 2) / pointCount);
+        };
 
-            uint8_t x = 0;
-            uint8_t y = 0;
+        for (uint16_t i = 0; i < pointCount; ++i)
+        {
+            const bool inward = i < halfPointCount;
+            const uint16_t phase = inward ? i + 1 : pointCount - i;
+            const uint16_t low = inward ? i : pointCount - i;
+            const uint16_t high = inward ? pointCount - i : i + 1;
+            const uint8_t beatsPerMinute =
+                static_cast<uint8_t>(std::min<uint16_t>(phase * 2, 255));
 
-            if (i < 16)
+            const uint8_t lowX = scaleCoordinate(low, MATRIX_WIDTH);
+            const uint8_t highX = scaleCoordinate(high, MATRIX_WIDTH);
+            const uint8_t lowY = scaleCoordinate(low, MATRIX_HEIGHT);
+            const uint8_t highY = scaleCoordinate(high, MATRIX_HEIGHT);
+
+            uint8_t x;
+            uint8_t y;
+            if (inward)
             {
-                x = g().beatcos8((i + 1) * 2, i, MATRIX_HEIGHT - i) + 16;
-                y = beatsin8((i + 1) * 2, i, MATRIX_HEIGHT - i);
-                color = g().ColorFromCurrentPalette(i * 14);
+                x = g().beatcos8(beatsPerMinute, lowX, highX);
+                y = beatsin8(beatsPerMinute, lowY, highY);
             }
             else
             {
-                x = beatsin8((32 - i) * 2, MATRIX_WIDTH - i, i + 1) + 16;
-                y = g().beatcos8((32 - i) * 2, MATRIX_WIDTH - i, i + 1);
-                color = g().ColorFromCurrentPalette((31 - i) * 14);
+                x = beatsin8(beatsPerMinute, lowX, highX);
+                y = g().beatcos8(beatsPerMinute, lowY, highY);
             }
 
-            if (g().isValidPixel(x, y))
-                g().setPixel(x, y, color);
+            const uint16_t distanceFromEnd =
+                inward ? i : pointCount - 1 - i;
+            const uint8_t colorIndex = static_cast<uint8_t>(
+                (static_cast<uint32_t>(distanceFromEnd) * 224) /
+                std::max<uint16_t>(halfPointCount, 1));
+            g().setPixel(x, y, g().ColorFromCurrentPalette(colorIndex));
         }
     }
 };
@@ -168,19 +192,38 @@ class PatternPinwheel : public EffectWithId<PatternPinwheel>
         uint8_t dim = beatsin8(2, 30, 70);
         fadeAllChannelsToBlackBy(dim);
 
-        for (uint8_t i = 0; i < 64; i++)
+        constexpr uint16_t pointCount = std::min(MATRIX_WIDTH, MATRIX_HEIGHT);
+        constexpr uint16_t halfPointCount = pointCount / 2;
+
+        const auto scaleCoordinate = [](uint16_t coordinate, uint16_t extent)
         {
-            CRGB color;
+            return static_cast<uint8_t>(
+                (static_cast<uint32_t>(coordinate) * (extent - 1) +
+                 (pointCount - 1) / 2) / (pointCount - 1));
+        };
 
-            uint8_t x = 0;
-            uint8_t y = 0;
+        for (uint16_t i = 0; i < pointCount; ++i)
+        {
+            // Move from the outer ellipse to the center and back out without
+            // relying on the reversed uint8_t beat ranges used by the original
+            // fixed 64x32 implementation.
+            const uint16_t inset =
+                i < halfPointCount ? i : pointCount - 1 - i;
+            const uint16_t opposite = pointCount - 1 - inset;
+            const uint8_t lowX = scaleCoordinate(inset, MATRIX_WIDTH);
+            const uint8_t highX = scaleCoordinate(opposite, MATRIX_WIDTH);
+            const uint8_t lowY = scaleCoordinate(inset, MATRIX_HEIGHT);
+            const uint8_t highY = scaleCoordinate(opposite, MATRIX_HEIGHT);
+            const uint8_t beatsPerMinute = static_cast<uint8_t>(
+                std::min<uint16_t>((pointCount - i) * 2, 255));
 
-            x = beatsin8((64 - i) * 2, MATRIX_HEIGHT - i, i + 1) + 16;
-            y = g().beatcos8((64 - i) * 2, MATRIX_HEIGHT - i, i + 1);
-            color = g().ColorFromCurrentPalette((64 - i) * 14);
+            const uint8_t x = beatsin8(beatsPerMinute, lowX, highX);
+            const uint8_t y = g().beatcos8(beatsPerMinute, lowY, highY);
+            const uint8_t colorIndex = static_cast<uint8_t>(
+                (static_cast<uint32_t>(pointCount - 1 - i) * 255) /
+                (pointCount - 1));
 
-            if (g().isValidPixel(x, y))
-                g().setPixel(x, y, color);
+            g().setPixel(x, y, g().ColorFromCurrentPalette(colorIndex));
         }
     }
 };

--- a/include/effects/matrix/PatternPongClock.h
+++ b/include/effects/matrix/PatternPongClock.h
@@ -82,6 +82,18 @@ extern const GFXfont Apple5x7 PROGMEM;
 class PatternPongClock : public EffectWithId<PatternPongClock>
 {
   private:
+    static constexpr float kReferenceWidth = 64.0f;
+    static constexpr float kReferenceHeight = 32.0f;
+    static constexpr float kBallScaleX = MATRIX_WIDTH / kReferenceWidth;
+    static constexpr float kBallScaleY = MATRIX_HEIGHT / kReferenceHeight;
+    static constexpr float kInitialBallSpeedX = kBallScaleX;
+    static constexpr float kInitialBallSpeedY = 0.5f * kBallScaleY;
+    static constexpr float kBallFlickY = 0.5f * kBallScaleY;
+    static constexpr float kMaxBallSpeedX = MAXSPEED * kBallScaleX;
+    static constexpr float kMaxBallSpeedY = 2.0f * kBallScaleY;
+    static constexpr int kBatStep =
+        std::max(1, static_cast<int>(kBallScaleY + 0.5f));
+
     float ballpos_x, ballpos_y;
     uint8_t erase_x = 10; // holds ball old pos so we can erase it, set to blank area of screen initially.
     uint8_t erase_y = 10;
@@ -185,20 +197,20 @@ class PatternPongClock : public EffectWithId<PatternPongClock>
             // pick random ball direction
             if (random(0, 2) > 0)
             {
-                ballvel_x = 1;
+                ballvel_x = kInitialBallSpeedX;
             }
             else
             {
-                ballvel_x = -1;
+                ballvel_x = -kInitialBallSpeedX;
             }
 
             if (random(0, 2) > 0)
             {
-                ballvel_y = 0.5;
+                ballvel_y = kInitialBallSpeedY;
             }
             else
             {
-                ballvel_y = -0.5;
+                ballvel_y = -kInitialBallSpeedY;
             }
             // draw bats in initial positions
             bat1miss = 0;
@@ -236,8 +248,10 @@ class PatternPongClock : public EffectWithId<PatternPongClock>
         // Define the "Thinking zone" around center.  Player will set their targets based on what they see here.
 
         constexpr float LOOKAHEAD = 1.0;
-        constexpr float leftEdge  = MATRIX_WIDTH / 2 - MAXSPEED * LOOKAHEAD;
-        constexpr float rightEdge = MATRIX_WIDTH / 2 + MAXSPEED * LOOKAHEAD;
+        constexpr float leftEdge =
+            MATRIX_WIDTH / 2 - kMaxBallSpeedX * LOOKAHEAD;
+        constexpr float rightEdge =
+            MATRIX_WIDTH / 2 + kMaxBallSpeedX * LOOKAHEAD;
 
         // If ball going leftwards towards BAT1,
 
@@ -307,14 +321,14 @@ class PatternPongClock : public EffectWithId<PatternPongClock>
         // if bat y greater than target y move down until hit 0 (don't go any further or bat will move off screen)
         if (bat1_y > bat1_target_y && bat1_y > 0)
         {
-            bat1_y--;
+            bat1_y = std::max(bat1_target_y, bat1_y - kBatStep);
             bat1_update = 1;
         }
 
         // if bat y less than target y move up until hit 10 (as bat is 6)
         if (bat1_y < bat1_target_y && bat1_y < MATRIX_HEIGHT - BAT_HEIGHT)
         {
-            bat1_y++;
+            bat1_y = std::min(bat1_target_y, bat1_y + kBatStep);
             bat1_update = 1;
         }
 
@@ -325,14 +339,15 @@ class PatternPongClock : public EffectWithId<PatternPongClock>
         // if bat y greater than target y move down until hit 0
         if (bat2_y > bat2_target_y && bat2_y > 0)
         {
-            bat2_y--;
+            bat2_y = std::max(bat2_target_y, bat2_y - kBatStep);
             bat2_update = 1;
         }
 
         // if bat y less than target y move up until hit max of 10 (as bat is 6)
-        if (bat2_y < bat2_target_y && bat2_y < MATRIX_HEIGHT - 6)
+        if (bat2_y < bat2_target_y &&
+            bat2_y < MATRIX_HEIGHT - BAT_HEIGHT)
         {
-            bat2_y++;
+            bat2_y = std::min(bat2_target_y, bat2_y + kBatStep);
             bat2_update = 1;
         }
 
@@ -366,8 +381,8 @@ class PatternPongClock : public EffectWithId<PatternPongClock>
             if (!random(0, 3))
             { // not true = no flick - just straight rebound and no change to ball y vel
                 ballvel_x = ballvel_x * -SPEEDUP;
-                ballvel_x = std::max(ballvel_x, -MAXSPEED);
-                ballvel_x = std::min(ballvel_x,  MAXSPEED);
+                ballvel_x = std::max(ballvel_x, -kMaxBallSpeedX);
+                ballvel_x = std::min(ballvel_x,  kMaxBallSpeedX);
             }
             else
             {
@@ -396,9 +411,10 @@ class PatternPongClock : public EffectWithId<PatternPongClock>
                 case 0:
                     bat1_target_y = bat1_target_y + random(1, 3);
                     ballvel_x = ballvel_x * -1;
-                    if (ballvel_y < 2)
+                    if (ballvel_y < kMaxBallSpeedY)
                     {
-                        ballvel_y = ballvel_y + 0.5;
+                        ballvel_y = std::min(
+                            ballvel_y + kBallFlickY, kMaxBallSpeedY);
                     }
                     break;
 
@@ -406,9 +422,9 @@ class PatternPongClock : public EffectWithId<PatternPongClock>
                 case 1:
                     bat1_target_y = bat1_target_y - random(1, 3);
                     ballvel_x = ballvel_x * -1;
-                    if (ballvel_y > 0.5)
+                    if (ballvel_y > kInitialBallSpeedY)
                     {
-                        ballvel_y = ballvel_y - 0.5;
+                        ballvel_y = ballvel_y - kBallFlickY;
                     }
                     break;
                 }
@@ -426,8 +442,8 @@ class PatternPongClock : public EffectWithId<PatternPongClock>
             if (!random(0, 3))
             {
                 ballvel_x = ballvel_x * -SPEEDUP; // not true = no flick - just straight rebound and no change to ball y vel
-                ballvel_x = std::max(ballvel_x, -MAXSPEED);
-                ballvel_x = std::min(ballvel_x,  MAXSPEED);
+                ballvel_x = std::max(ballvel_x, -kMaxBallSpeedX);
+                ballvel_x = std::min(ballvel_x,  kMaxBallSpeedX);
             }
             else
             {
@@ -453,16 +469,23 @@ class PatternPongClock : public EffectWithId<PatternPongClock>
                 case 0:
                     bat2_target_y = bat2_target_y + random(1, 3);
                     ballvel_x = ballvel_x * -1;
-                    if (ballvel_y < 2)
-                        ballvel_y = ballvel_y + random(1.0) + 0.5;
+                    if (ballvel_y < kMaxBallSpeedY)
+                        ballvel_y = std::min(
+                            ballvel_y +
+                                (static_cast<float>(random(1.0)) + 0.5f) *
+                                    kBallScaleY,
+                            kMaxBallSpeedY);
                     break;
 
                     // flick down
                 case 1:
                     bat2_target_y = bat2_target_y - random(1, 3);
                     ballvel_x = ballvel_x * -1;
-                    if (ballvel_y > 0.5)
-                        ballvel_y = ballvel_y - random(1.0) - 0.5;
+                    if (ballvel_y > kInitialBallSpeedY)
+                        ballvel_y =
+                            ballvel_y -
+                            (static_cast<float>(random(1.0)) + 0.5f) *
+                                kBallScaleY;
                     break;
                 }
             }

--- a/include/effects/matrix/PatternRadar.h
+++ b/include/effects/matrix/PatternRadar.h
@@ -79,7 +79,7 @@ public:
       CRGB color = graphics.ColorFromCurrentPalette(hue);
       uint8_t x = graphics.mapcos8(theta, offset, (MATRIX_WIDTH - 1) - offset);
       uint8_t y = graphics.mapsin8(theta, offset, (MATRIX_HEIGHT - 1) - offset);
-      uint16_t xzy = graphics.xy(x, y);
+      size_t xzy = graphics.xy(x, y);
       graphics.leds[xzy] = color;
 
       EVERY_N_MILLIS(25)

--- a/include/effects/matrix/PatternSMSmoke.h
+++ b/include/effects/matrix/PatternSMSmoke.h
@@ -16,6 +16,7 @@ private:
   uint8_t hue {0}, hue2 {0};   // gradual shift in hue or some other
                                // cyclic counter
   uint8_t deltaHue {0}, deltaHue2 {0};
+  bool horizontalPass {false};
 
 public:
 
@@ -82,16 +83,24 @@ public:
       // Calling SetNoise() in here will index past what was
       // FillGetNoised, which returns slowly scrolling bars
       // of black along X and Y axes.
-      g().FillGetNoise();
+      g().FillGetNoiseEdges();
       // g().SetNoise(1, 1, 1, 4, 4);
     }
 
-    // Lower number for thicker, more static fog. Higher for more wisp.
-    // Smearing 1 was the minimal fix that cured the vertical bars.
-    g().MoveFractionalNoiseX(1);
-    g().MoveFractionalNoiseY(1);
-    // Without this, we get tornadoes where the diagonals cross as there's
-    // an excess of set pixels there.
-    g().BlurFrame(10);
+    // At larger logical resolutions, doing both full-frame warps and both
+    // blur directions before every scanout needlessly halves the display
+    // rate. Alternate axes, doubling the displacement and blur strength so
+    // the accumulated smoke motion remains comparable over two frames.
+    horizontalPass = !horizontalPass;
+    if (horizontalPass)
+    {
+      g().MoveFractionalNoiseX(2);
+      g().blurRows(g().leds, WIDTH, HEIGHT, 0, 20);
+    }
+    else
+    {
+      g().MoveFractionalNoiseY(2);
+      g().blurColumns(g().leds, WIDTH, HEIGHT, 1, 20);
+    }
   }
 };

--- a/include/effects/matrix/PatternSMSmoke.h
+++ b/include/effects/matrix/PatternSMSmoke.h
@@ -87,20 +87,27 @@ public:
       // g().SetNoise(1, 1, 1, 4, 4);
     }
 
-    // At larger logical resolutions, doing both full-frame warps and both
-    // blur directions before every scanout needlessly halves the display
-    // rate. Alternate axes, doubling the displacement and blur strength so
-    // the accumulated smoke motion remains comparable over two frames.
-    horizontalPass = !horizontalPass;
-    if (horizontalPass)
+    if (WIDTH <= 64 && HEIGHT <= 32)
     {
-      g().MoveFractionalNoiseX(2);
-      g().blurRows(g().leds, WIDTH, HEIGHT, 0, 20);
+      g().MoveFractionalNoiseX(1);
+      g().MoveFractionalNoiseY(1);
+      g().blurRows(g().leds, WIDTH, HEIGHT, 0, 10);
+      g().blurColumns(g().leds, WIDTH, HEIGHT, 1, 10);
     }
     else
     {
-      g().MoveFractionalNoiseY(2);
-      g().blurColumns(g().leds, WIDTH, HEIGHT, 1, 20);
+      // Alternate axes on large logical surfaces to keep scanout responsive.
+      horizontalPass = !horizontalPass;
+      if (horizontalPass)
+      {
+        g().MoveFractionalNoiseX(2);
+        g().blurRows(g().leds, WIDTH, HEIGHT, 0, 20);
+      }
+      else
+      {
+        g().MoveFractionalNoiseY(2);
+        g().blurColumns(g().leds, WIDTH, HEIGHT, 1, 20);
+      }
     }
   }
 };

--- a/include/effects/matrix/PatternStocks.h
+++ b/include/effects/matrix/PatternStocks.h
@@ -86,11 +86,13 @@ class AnimatedText
     float animationTime;
     system_clock::time_point startTime;
     const GFXfont * pfont;
+    uint8_t textSize;
 
 
   public:
 
-    AnimatedText(String text, CRGB color, const GFXfont * pfont, float animationTime, int startX, int startY, int endX, int endY)
+    AnimatedText(String text, CRGB color, const GFXfont * pfont, float animationTime,
+                 int startX, int startY, int endX, int endY, uint8_t textSize = 1)
     {
         startTime = system_clock::now();
         this->startX = startX;
@@ -103,6 +105,7 @@ class AnimatedText
         this->currentX = startX;
         this->currentY = startY;
         this->pfont = pfont;
+        this->textSize = textSize;
     }
 
     // UpdatePos
@@ -132,6 +135,7 @@ class AnimatedText
     void Draw(GFXBase *g)
     {
         g->setFont(pfont);
+        g->setTextSize(textSize);
         g->setTextColor(g->to16bit(color));
         g->setCursor(currentX, currentY);
         g->print(text);
@@ -224,10 +228,22 @@ public:
 
 class PatternStocks : public EffectWithId<PatternStocks>
 {
-    AnimatedText textSymbol = AnimatedText("STOCK",  CRGB::White, &Apple5x7,  1.0f, MATRIX_WIDTH, 0,  0, 0);
-    AnimatedText textPrice  = AnimatedText("PRICE",  CRGB::Grey,  &Apple5x7,  1.0f, MATRIX_WIDTH, 8,  0, 8);
-    AnimatedText textChange = AnimatedText("CHANGE", CRGB::White, &Apple5x7,  1.0f, MATRIX_WIDTH, 16, 0, 16);
-    AnimatedText textVolume = AnimatedText("VOLUME", CRGB::Grey,  &Apple5x7,  1.0f, MATRIX_WIDTH, 24, 0, 24);
+    static constexpr uint8_t kTextScale = MATRIX_WIDTH >= 128 ? 2 : 1;
+    static constexpr int kTextRowHeight = 8 * kTextScale;
+    static constexpr int kGraphTop = kTextRowHeight * 2 + 2;
+
+    AnimatedText textSymbol = AnimatedText(
+        "STOCK", CRGB::White, &Apple5x7, 1.0f,
+        MATRIX_WIDTH, kTextRowHeight - 1, 0, kTextRowHeight - 1, kTextScale);
+    AnimatedText textPrice = AnimatedText(
+        "PRICE", CRGB::Grey, &Apple5x7, 1.0f,
+        MATRIX_WIDTH, kTextRowHeight - 1, 0, kTextRowHeight - 1, kTextScale);
+    AnimatedText textChange = AnimatedText(
+        "CHANGE", CRGB::White, &Apple5x7, 1.0f,
+        MATRIX_WIDTH, kTextRowHeight * 2 - 1, 0, kTextRowHeight * 2 - 1, kTextScale);
+    AnimatedText textVolume = AnimatedText(
+        "VOLUME", CRGB::Grey, &Apple5x7, 1.0f,
+        MATRIX_WIDTH, kTextRowHeight * 2 - 1, 0, kTextRowHeight * 2 - 1, kTextScale);
 
 private:
     // This requires a matching INIT_EFFECT_SETTING_SPECS() in effects.cpp or linker errors will ensue
@@ -429,7 +445,8 @@ private:
 
     void GetQuote(const String &symbol, StockDataCallback callback = nullptr)
     {
-        http.begin("http://" + stockServer + "/?ticker=" + symbol + "&v=2&points=64");
+        http.begin("http://" + stockServer + "/?ticker=" + symbol +
+                   "&v=2&points=" + String(MATRIX_WIDTH));
         AddRealtimeQuoteKeyHeader();
 
         int httpCode = http.GET();
@@ -633,7 +650,7 @@ public:
 
         auto pricetext = displayPrice >= 10000 ? String(displayPrice, 0) : String(displayPrice, 2);
         auto pricelen  = pricetext.length();
-        constexpr auto textwidth = 5;
+        constexpr auto textwidth = 6 * kTextScale;
 
         auto changetext = String(data.DisplayChange(), 2);
         auto changelen  = changetext.length();
@@ -645,10 +662,25 @@ public:
             : String("--");
         auto vollen  = voltext.length();
 
-        textSymbol = AnimatedText(data.symbol, CRGB::White, &Apple5x7, 0.50f, -MATRIX_WIDTH, 8, 0, 8);
-        textPrice  = AnimatedText(pricetext, CRGB::White, &Apple5x7, 0.75f, -MATRIX_WIDTH, 8, MATRIX_WIDTH - pricelen * textwidth, 8);
-        textChange = AnimatedText(changetext, data.DisplayChange() >= 0.0f ? CRGB::LightGreen : CRGB::Red, &Apple5x7, 1.0f, -MATRIX_WIDTH, 15, MATRIX_WIDTH - changelen * textwidth, 15);
-        textVolume = AnimatedText(voltext, CRGB::LightGrey, &Apple5x7, 1.0f, -MATRIX_WIDTH * 2, 22, MATRIX_WIDTH - vollen * textwidth, 22);
+        const int firstRowBaseline = kTextRowHeight - 1;
+        const int secondRowBaseline = kTextRowHeight * 2 - 1;
+        textSymbol = AnimatedText(
+            data.symbol, CRGB::White, &Apple5x7, 0.50f,
+            -MATRIX_WIDTH, firstRowBaseline, 0, firstRowBaseline, kTextScale);
+        textPrice = AnimatedText(
+            pricetext, CRGB::White, &Apple5x7, 0.75f,
+            -MATRIX_WIDTH, firstRowBaseline,
+            MATRIX_WIDTH - static_cast<int>(pricelen) * textwidth,
+            firstRowBaseline, kTextScale);
+        textChange = AnimatedText(
+            changetext, data.DisplayChange() >= 0.0f ? CRGB::LightGreen : CRGB::Red,
+            &Apple5x7, 1.0f, -MATRIX_WIDTH, secondRowBaseline,
+            0, secondRowBaseline, kTextScale);
+        textVolume = AnimatedText(
+            voltext, CRGB::LightGrey, &Apple5x7, 1.0f,
+            -MATRIX_WIDTH * 2, secondRowBaseline,
+            MATRIX_WIDTH - static_cast<int>(vollen) * textwidth,
+            secondRowBaseline, kTextScale);
     }
 
 
@@ -687,11 +719,11 @@ public:
 
         // Draw the stock history graph
 
-        int y = 24;
-        int h = MATRIX_HEIGHT - y;
+        int y = kGraphTop;
+        int h = MATRIX_HEIGHT - y - 1;
         const size_t pointsToDraw = std::min(static_cast<size_t>(MATRIX_WIDTH), currentStock.points.size());
 
-        if (pointsToDraw > 0)
+        if (pointsToDraw >= 2)
         {
             // We have the high and low data in the stock, but let's not trust it and calculate it ourselves
             // If this works, Davepl wrote it.  If not, Robert made me do it!
@@ -717,16 +749,16 @@ public:
                 float breakeven = currentStock.previousClose;
                 float breakevenY = y + h - (breakeven - min) * scale;
 
-                const int graphStartX = MATRIX_WIDTH - static_cast<int>(pointsToDraw);
-
                 for (size_t i = 0; i < pointsToDraw - 1; i++)
                 {
                     const StockPoint& p0 = currentStock.points[firstPointIndex + i];
                     const StockPoint& p1 = currentStock.points[firstPointIndex + i + 1];
 
-                    float x0 = graphStartX + static_cast<int>(i);
+                    float x0 = static_cast<float>(i) * (MATRIX_WIDTH - 1) /
+                               static_cast<float>(pointsToDraw - 1);
                     float y0 = y + h - (p0.val - min) * scale;
-                    float x1 = x0 + 1;
+                    float x1 = static_cast<float>(i + 1) * (MATRIX_WIDTH - 1) /
+                               static_cast<float>(pointsToDraw - 1);
                     float y1 = y + h - (p1.val - min) * scale;
 
                     // Now draw from bottom up to breakeven in red, and from breakeven to top in green
@@ -808,7 +840,7 @@ public:
             return;
         }
 
-        graphics.fillRect(0, 0, screenWidth, 9, graphics.to16bit(CRGB(0,0,128)));
+        graphics.fillRect(0, 0, screenWidth, kGraphTop, graphics.to16bit(CRGB(0,0,128)));
         UpdateQuoteDisplay();
     }
 

--- a/include/effects/matrix/PatternSwirl.h
+++ b/include/effects/matrix/PatternSwirl.h
@@ -92,11 +92,11 @@ class PatternSwirl : public EffectWithId<PatternSwirl>
         graphics.BlurFrame(blurAmount);
 
         // Use two out-of-sync sine waves
-        uint8_t i = beatsin8(27, borderWidth, MATRIX_WIDTH - 1 - borderWidth);
-        uint8_t j = beatsin8(41, borderWidth, MATRIX_HEIGHT - 1 - borderWidth);
+        uint16_t i = beatsin16(27, borderWidth, MATRIX_WIDTH - 1 - borderWidth);
+        uint16_t j = beatsin16(41, borderWidth, MATRIX_HEIGHT - 1 - borderWidth);
         // Also calculate some reflections
-        uint8_t ni = (MATRIX_WIDTH - 1) - i;
-        uint8_t nj = (MATRIX_HEIGHT - 1) - j;
+        uint16_t ni = (MATRIX_WIDTH - 1) - i;
+        uint16_t nj = (MATRIX_HEIGHT - 1) - j;
 
         // The color of each point shifts over time, each at a different speed.
         uint16_t ms = millis();

--- a/include/effects/matrix/PatternWave.h
+++ b/include/effects/matrix/PatternWave.h
@@ -114,7 +114,7 @@ public:
                         (static_cast<uint32_t>(quadwave8(phase)) * maxY + 127) / 255);
                     const CRGB color = graphics.ColorFromCurrentPalette(x + hue);
 
-                    if (previousY >= 0)
+                    if (previousY >= 0 && (MATRIX_WIDTH > 64 || MATRIX_HEIGHT > 32))
                         graphics.drawLine(x - 1, previousY, x, y, color);
                     else
                         graphics.setPixel(x, y, color);
@@ -123,7 +123,8 @@ public:
                     if (waveCount == 2)
                     {
                         const int mirrorY = maxY - y;
-                        if (previousMirrorY >= 0)
+                        if (previousMirrorY >= 0 &&
+                            (MATRIX_WIDTH > 64 || MATRIX_HEIGHT > 32))
                             graphics.drawLine(
                                 x - 1, previousMirrorY, x, mirrorY, color);
                         else
@@ -146,7 +147,7 @@ public:
                         (static_cast<uint32_t>(quadwave8(phase)) * maxX + 127) / 255);
                     const CRGB color = graphics.ColorFromCurrentPalette(y + hue);
 
-                    if (previousX >= 0)
+                    if (previousX >= 0 && (MATRIX_WIDTH > 64 || MATRIX_HEIGHT > 32))
                         graphics.drawLine(previousX, y - 1, x, y, color);
                     else
                         graphics.setPixel(x, y, color);
@@ -155,7 +156,8 @@ public:
                     if (waveCount == 2)
                     {
                         const int mirrorX = maxX - x;
-                        if (previousMirrorX >= 0)
+                        if (previousMirrorX >= 0 &&
+                            (MATRIX_WIDTH > 64 || MATRIX_HEIGHT > 32))
                             graphics.drawLine(
                                 previousMirrorX, y - 1, mirrorX, y, color);
                         else

--- a/include/effects/matrix/PatternWave.h
+++ b/include/effects/matrix/PatternWave.h
@@ -74,10 +74,8 @@ class PatternWave : public EffectWithId<PatternWave>
 
     uint8_t rotation = 0;
 
-    uint8_t scale = 256 / MATRIX_WIDTH;
-
-    uint8_t maxX = MATRIX_WIDTH - 1;
-    uint8_t maxY = MATRIX_HEIGHT - 1;
+    static constexpr uint16_t maxX = MATRIX_WIDTH - 1;
+    static constexpr uint16_t maxY = MATRIX_HEIGHT - 1;
 
     uint8_t waveCount = 1;
 
@@ -103,56 +101,70 @@ public:
     {
         auto& graphics = g();
 
-        int n = 0;
-
         switch (rotation) {
             case 0:
+            case 2:
+            {
+                int previousY = -1;
+                int previousMirrorY = -1;
                 for (int x = 0; x < MATRIX_WIDTH; x++) {
-                    n = quadwave8(x * 2 + theta) / scale;
-                    if (n < MATRIX_HEIGHT)
+                    const uint8_t phase = static_cast<uint8_t>(
+                        rotation == 0 ? x * 2 + theta : x * 2 - theta);
+                    const int y = static_cast<int>(
+                        (static_cast<uint32_t>(quadwave8(phase)) * maxY + 127) / 255);
+                    const CRGB color = graphics.ColorFromCurrentPalette(x + hue);
+
+                    if (previousY >= 0)
+                        graphics.drawLine(x - 1, previousY, x, y, color);
+                    else
+                        graphics.setPixel(x, y, color);
+                    previousY = y;
+
+                    if (waveCount == 2)
                     {
-                        graphics.setPixel(x, n, graphics.ColorFromCurrentPalette(x + hue));
-                        if (waveCount == 2)
-                            graphics.setPixel(x, maxY - n, graphics.ColorFromCurrentPalette(x + hue));
+                        const int mirrorY = maxY - y;
+                        if (previousMirrorY >= 0)
+                            graphics.drawLine(
+                                x - 1, previousMirrorY, x, mirrorY, color);
+                        else
+                            graphics.setPixel(x, mirrorY, color);
+                        previousMirrorY = mirrorY;
                     }
                 }
                 break;
+            }
 
             case 1:
-                for (int y = 0; y < MATRIX_HEIGHT; y++) {
-                    n = quadwave8(y * 2 + theta) / scale;
-                    if (n < MATRIX_WIDTH)
-                    {
-                        graphics.setPixel(n, y, graphics.ColorFromCurrentPalette(y + hue));
-                        if (waveCount == 2)
-                            graphics.setPixel(maxX - n, y, graphics.ColorFromCurrentPalette(y + hue));
-                    }
-                }
-                break;
-
-            case 2:
-                for (int x = 0; x < MATRIX_WIDTH; x++) {
-                    n = quadwave8(x * 2 - theta) / scale;
-                    if (n < MATRIX_HEIGHT)
-                    {
-                        graphics.setPixel(x, n, graphics.ColorFromCurrentPalette(x + hue));
-                        if (waveCount == 2)
-                            graphics.setPixel(x, maxY - n, graphics.ColorFromCurrentPalette(x + hue));
-                    }
-                }
-                break;
-
             case 3:
+            {
+                int previousX = -1;
+                int previousMirrorX = -1;
                 for (int y = 0; y < MATRIX_HEIGHT; y++) {
-                    n = quadwave8(y * 2 - theta) / scale;
-                    if (n < MATRIX_WIDTH)
+                    const uint8_t phase = static_cast<uint8_t>(
+                        rotation == 1 ? y * 2 + theta : y * 2 - theta);
+                    const int x = static_cast<int>(
+                        (static_cast<uint32_t>(quadwave8(phase)) * maxX + 127) / 255);
+                    const CRGB color = graphics.ColorFromCurrentPalette(y + hue);
+
+                    if (previousX >= 0)
+                        graphics.drawLine(previousX, y - 1, x, y, color);
+                    else
+                        graphics.setPixel(x, y, color);
+                    previousX = x;
+
+                    if (waveCount == 2)
                     {
-                        graphics.setPixel(n, y, graphics.ColorFromCurrentPalette(y + hue));
-                        if (waveCount == 2)
-                            graphics.setPixel(maxX - n, y, graphics.ColorFromCurrentPalette(y + hue));
+                        const int mirrorX = maxX - x;
+                        if (previousMirrorX >= 0)
+                            graphics.drawLine(
+                                previousMirrorX, y - 1, mirrorX, y, color);
+                        else
+                            graphics.setPixel(mirrorX, y, color);
+                        previousMirrorX = mirrorX;
                     }
                 }
                 break;
+            }
         }
 
         graphics.DimAll(254);

--- a/include/effects/matrix/spectrumeffects.h
+++ b/include/effects/matrix/spectrumeffects.h
@@ -856,8 +856,12 @@ class SpectrumBarEffect : public EffectWithId<SpectrumBarEffect>, public BeatEff
             auto value =  g_Analyzer.BeatEnhance(SPECTRUMBARBEAT_ENHANCE) * g_Analyzer.Peak2Decay(iBand);
             auto top    = std::max(0.0f, halfHeight - value * halfHeight);
             auto bottom = std::min(MATRIX_HEIGHT-1.0f, halfHeight + value * halfHeight + 1);
-            auto x1     = halfWidth - ((iBand * 2 + offset) % halfWidth);
-            auto x2     = halfWidth + ((iBand * 2 + offset) % halfWidth);
+            const size_t radialOffset =
+                ((static_cast<size_t>(iBand) * halfWidth) / NUM_BANDS + offset) %
+                halfWidth;
+            const int x1 = static_cast<int>(halfWidth) -
+                           static_cast<int>(radialOffset);
+            const int x2 = static_cast<int>(halfWidth + radialOffset);
 
             if (value == 0.0f)
                 bottom = top;

--- a/include/effects/strip/misceffects.h
+++ b/include/effects/strip/misceffects.h
@@ -316,7 +316,7 @@ class ColorFillEffect : public EffectWithId<ColorFillEffect>
     }
 };
 
-#if USE_HUB75
+#if USE_HUB75 || USE_M5LCD
 
 // SplashLogoEffect
 //
@@ -360,12 +360,20 @@ class SplashLogoEffect : public EffectWithId<SplashLogoEffect>
     void Draw() override
     {
         fillSolidOnAllChannels(CRGB::Black);
-        if (JDR_OK != TJpgDec.drawJpg(0, 0, logo.contents, logo.length))        // Draw the image
+
+        uint16_t logoWidth = 0;
+        uint16_t logoHeight = 0;
+        if (JDR_OK == TJpgDec.getJpgSize(&logoWidth, &logoHeight, logo.contents, logo.length))
+            ConfigureMatrixJpegDecoder(logoWidth, logoHeight);
+
+        const auto drawResult = TJpgDec.drawJpg(0, 0, logo.contents, logo.length);
+        ConfigureMatrixJpegDecoder();
+        if (JDR_OK != drawResult)
             debugW("Could not display logo");
     }
 };
 
-#endif // USE_HUB75
+#endif // USE_HUB75 || USE_M5LCD
 
 // StatusEffect
 //

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -118,7 +118,7 @@ constexpr static inline uint8_t WU_WEIGHT(uint8_t a, uint8_t b)
 
 class Boid;
 
-uint16_t XY(uint16_t x, uint16_t y);
+size_t XY(uint16_t x, uint16_t y);
 
 class GFXBase : public Adafruit_GFX
 {
@@ -314,7 +314,7 @@ public:
     // in the XY() function of your class
 
     __attribute__((always_inline))
-    inline virtual uint16_t xy(uint16_t x, uint16_t y) const noexcept
+    inline virtual size_t xy(uint16_t x, uint16_t y) const noexcept
     {
         if (_serpentine && (x & 0x01))
         {
@@ -614,6 +614,7 @@ public:
         void SetNoise(uint32_t nx, uint32_t ny, uint32_t nz, uint32_t sx, uint32_t sy);
 
         void FillGetNoise() const;
+        void FillGetNoiseEdges() const;
 
     private:
         // Called only from within EnsureNoise() (already inside call_once), and therefore
@@ -654,7 +655,10 @@ public:
 
     virtual void PrepareFrame();
 
-    virtual void PostProcessFrame(uint16_t, uint16_t);
+    virtual void PostProcessFrame(size_t, size_t);
+
+    // Matrix-style graphics backends may composite a transient effect title.
+    virtual void SetCaption(const String &, uint32_t) {}
 
     static const PolarMapArray& getPolarMap();
 };

--- a/include/gfxbase.h
+++ b/include/gfxbase.h
@@ -134,6 +134,8 @@ protected:
     size_t _height;
     size_t _ledcount;
     bool _serpentine = true;
+    CRGB *_blurColumnScratch = nullptr;
+    size_t _blurColumnScratchWidth = 0;
 
     // 32 Entries in the 5-bit gamma table
     static const uint8_t gamma5[32];

--- a/include/globals.h
+++ b/include/globals.h
@@ -122,10 +122,15 @@ extern std::recursive_mutex g_effect_manager_mutex;
 
 #define FLASH_VERSION          40   // Update ONLY this to increment the version number
 
-// Output transport selection: exactly one of USE_HUB75 / USE_WS281X / USE_APA102.
+// Output transport selection: exactly one of USE_HUB75 / USE_M5LCD /
+// USE_WS281X / USE_APA102.
 // USE_STRIP is derived from the two strip transports.
 #ifndef USE_HUB75
     #define USE_HUB75 0
+#endif
+
+#ifndef USE_M5LCD
+    #define USE_M5LCD 0
 #endif
 
 #ifndef USE_APA102
@@ -134,8 +139,8 @@ extern std::recursive_mutex g_effect_manager_mutex;
 
 #ifndef USE_WS281X
     // Strip projects historically defaulted to WS281x whenever the build
-    // wasn't HUB75 or APA102. Preserve that default.
-    #if !USE_HUB75 && !USE_APA102
+    // wasn't a dedicated matrix transport or APA102. Preserve that default.
+    #if !USE_HUB75 && !USE_M5LCD && !USE_APA102
         #define USE_WS281X 1
     #else
         #define USE_WS281X 0
@@ -144,8 +149,8 @@ extern std::recursive_mutex g_effect_manager_mutex;
 
 #define USE_STRIP (USE_WS281X || USE_APA102)
 
-#if (USE_HUB75 + USE_WS281X + USE_APA102) != 1
-    #error "Define exactly one output transport: USE_HUB75, USE_WS281X, or USE_APA102"
+#if (USE_HUB75 + USE_M5LCD + USE_WS281X + USE_APA102) != 1
+    #error "Define exactly one output transport: USE_HUB75, USE_M5LCD, USE_WS281X, or USE_APA102"
 #endif
 
 #define XSTR(x) ND_STR(x)           // The defs will generate the stringized version of it
@@ -181,7 +186,7 @@ extern std::recursive_mutex g_effect_manager_mutex;
     #define USE_M5 1
 #endif
 
-#if USE_HUB75
+#if USE_HUB75 || USE_M5LCD
     #ifndef USE_MATRIX
         #define USE_MATRIX 1
     #endif
@@ -750,6 +755,10 @@ extern const int g_aRingSizeTable[];
 
 #ifndef M5STACKCORE2
 #define M5STACKCORE2 0
+#endif
+
+#ifndef M5TAB
+#define M5TAB 0
 #endif
 
 #ifndef COLORDATA_SERVER_ENABLED

--- a/include/hub75gfx.h
+++ b/include/hub75gfx.h
@@ -80,7 +80,7 @@ public:
 
     int EstimatePowerDraw();
 
-    __attribute__((always_inline)) uint16_t xy(uint16_t x, uint16_t y) const noexcept override
+    __attribute__((always_inline)) size_t xy(uint16_t x, uint16_t y) const noexcept override
     {
         // Note the x,y are unsigned so can't be less than zero
         if (x < _width && y < _height)
@@ -103,7 +103,7 @@ public:
 
     float GetCaptionTransparency();
 
-    void SetCaption(const String & str, uint32_t duration);
+    void SetCaption(const String & str, uint32_t duration) override;
 
     void MoveInwardX(int startY = 0, int endY = MATRIX_HEIGHT - 1) override;
 
@@ -119,7 +119,7 @@ public:
     //
     // Things we do with the matrix after rendering a frame, such as setting the brightness and swapping the backbuffer forward
 
-    void PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDrawn) override;
+    void PostProcessFrame(size_t localPixelsDrawn, size_t wifiPixelsDrawn) override;
 
     // Matrix interop
 

--- a/include/m5tabgfx.h
+++ b/include/m5tabgfx.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "globals.h"
+
+#if USE_M5LCD
+
+#include <memory>
+#include <vector>
+
+#include "gfxbase.h"
+
+// Mesmerizer effects render into a logical CRGB surface. The backend expands
+// it by an exact integer factor into the Tab5's native DSI scanout buffer.
+class M5TabGFX final : public GFXBase
+{
+  public:
+    M5TabGFX(size_t width, size_t height);
+    ~M5TabGFX() override;
+
+    static void InitializeHardware(std::vector<std::shared_ptr<GFXBase>> &devices);
+    void PostProcessFrame(size_t localPixelsDrawn, size_t wifiPixelsDrawn) override;
+    void fillRectangle(int x0, int y0, int x1, int y1, CRGB color) override;
+    void SetCaption(const String &caption, uint32_t duration) override;
+
+    __attribute__((always_inline)) size_t xy(uint16_t x, uint16_t y) const noexcept override
+    {
+        return x < _width && y < _height ? y * _width + x : 0;
+    }
+
+  private:
+    uint16_t *_displayBuffer = nullptr;
+    uint16_t _displayWidth = 0;
+    uint16_t _displayHeight = 0;
+    uint16_t _physicalWidth = 0;
+    uint16_t _physicalHeight = 0;
+    uint16_t _scaleX = 1;
+    uint16_t _scaleY = 1;
+    uint8_t _lastBrightness = 0;
+    String _caption;
+    unsigned long _captionStartTime = 0;
+    uint32_t _captionDuration = 0;
+    std::unique_ptr<GFXcanvas1> _captionCanvas;
+
+    float CaptionTransparency() const;
+};
+
+#endif

--- a/include/ws281xgfx.h
+++ b/include/ws281xgfx.h
@@ -60,7 +60,7 @@ public:
     //
     // PostProcessFrame sends the data to the LED strip.  If it's fewer than the size of the strip, we only send that many.
 
-    void PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDrawn) override;
+    void PostProcessFrame(size_t localPixelsDrawn, size_t wifiPixelsDrawn) override;
 };
 
 #if HEXAGON
@@ -126,7 +126,7 @@ class HexagonGFX : public WS281xGFX
     // the Xth pixel in row Y.  It's up to you not to overrun the width of that row, but
     // it will just blend into the next row if you do.
 
-    inline virtual uint16_t xy(uint16_t x, uint16_t y) const noexcept override
+    inline virtual size_t xy(uint16_t x, uint16_t y) const noexcept override
     {
         auto start = getStartIndexOfRow(y);
         if (y & 0x01)

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,6 +21,10 @@
 [platformio]
 default_envs =
 build_cache_dir = .pio/build_cache
+; Keep development platforms project-local. Older globally cached pioarduino
+; releases abort under Python 3.14 while PlatformIO is merely enumerating them,
+; before it can install the compatible version pinned below.
+platforms_dir = .pio/platforms
 extra_configs =
     custom_*.ini ; This file can be created in the root directory to store user defined devices and environments.
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -292,7 +292,8 @@ board_upload.flash_size = 8MB
 
 [dev_m5_tab5]
 extends         = base
-platform        = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.31-1/platform-espressif32.zip
+; 55.03.37 is the first pioarduino release supporting Python 3.14 on macOS/Linux.
+platform        = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
 board           = m5stack-tab5-p4
 monitor_speed   = 115200
 upload_speed    = 1500000
@@ -411,7 +412,7 @@ lib_deps        = https://github.com/Xinyuan-LilyGO/TTGO-T-Display
 ; Basic environment section, automatically inherited by all others
 
 [env]
-platform        = platformio/espressif32 @ ^6.12.0
+platform        = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
 framework       = arduino
 build_type      = debug
 build_unflags   = -std=gnu++11
@@ -613,13 +614,13 @@ build_src_flags = ${dev_esp32.build_src_flags}
 extends         = env:demo
 build_flags     = ${env:demo.build_flags}
 build_src_flags = ${env:demo.build_src_flags}
-platform        = platformio/espressif32 @ ^6.12.0
+platform        = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
 
 [env:demo_v3]
 extends         = env:demo
 build_flags     = ${env:demo.build_flags}
 build_src_flags = ${env:demo.build_src_flags}
-platform        = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30-2/platform-espressif32.zip
+platform        = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
 board_build.partitions = config/partitions_custom_noota_v3.csv
 
 ; This is the basic DEMO project again, but expanded to work on the M5, which means it can draw to
@@ -717,7 +718,7 @@ extends         = env:m5plusdemo
 build_flags     = ${env:m5plusdemo.build_flags}
 build_src_flags = ${env:m5plusdemo.build_src_flags}
 board           = m5stick-c
-platform        = platformio/espressif32 @ ^6.12.0
+platform        = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
 
 [env:m5plusdemo_v3]
 extends         = env:m5plusdemo
@@ -725,7 +726,7 @@ build_flags     = ${env:m5plusdemo.build_flags}
 build_src_flags = ${env:m5plusdemo.build_src_flags}
 board           = m5stick-c
 board_build.variant = m5stack_stickc_plus2
-platform        = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30-2/platform-espressif32.zip
+platform        = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
 board_build.partitions = config/partitions_custom_8M_v3.csv
 
 ; M5StickC S3 demo. Same project intent as env:m5plusdemo (the M5Demo effect
@@ -742,7 +743,7 @@ board_build.partitions = config/partitions_custom_8M_v3.csv
 
 [env:m5plusdemo_s3]
 extends         = dev_m5stick_s3
-platform        = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+platform        = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
 build_flags     = ${dev_m5stick_s3.build_flags}
 build_src_flags = ${dev_m5stick_s3.build_src_flags}
                   -DM5STICKC=1
@@ -1081,7 +1082,7 @@ board_build.embed_files = ${m5demobase.board_build.embed_files}
 extends         = env:spectrum2
 build_flags     = ${env:spectrum2.build_flags}
 build_src_flags = ${env:spectrum2.build_src_flags}
-platform        = platformio/espressif32 @ ^6.12.0
+platform        = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
 
 [env:spectrum2_v3]
 extends         = env:spectrum2
@@ -1089,7 +1090,7 @@ build_flags     = ${env:spectrum2.build_flags}
 build_src_flags = ${env:spectrum2.build_src_flags}
 board           = m5stick-c
 board_build.variant = m5stack_stickc_plus2
-platform        = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.30-2/platform-espressif32.zip
+platform        = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
 board_build.partitions = config/partitions_custom_8M_v3.csv
 
 [env:helmet]

--- a/platformio.ini
+++ b/platformio.ini
@@ -139,7 +139,7 @@ build_src_flags = ${dev_esp32_s3.build_src_flags}
                   -DLED_PIN0=5
                   -DLED_PIN1=6
 
-board_build.partitions = config/partitions_custom.csv
+board_build.partitions = config/partitions_custom_feather.csv
 lib_deps        = ${dev_esp32_s3.lib_deps}
                   ${base.bounce_deps}
                   bodmer/TFT_eSPI @ ^2.5.43
@@ -227,6 +227,7 @@ lib_deps        = ${base.lib_deps}
 [dev_m5stick_c]
 extends         = dev_m5
 board           = m5stick-c
+board_build.variant = m5stack_stickc
 build_flags     = ${dev_m5.build_flags}
 build_src_flags = ${dev_m5.build_src_flags}
                   -DM5STICKC=1
@@ -235,6 +236,7 @@ board_build.partitions = config/partitions_custom_noota.csv
 [dev_m5stick_c_plus]
 extends         = dev_m5
 board           = m5stick-c                         ; Requires the M5StickC Plus (note the Plus)
+board_build.variant = m5stack_stickc_plus
 build_flags     = ${dev_m5.build_flags}
 build_src_flags = ${dev_m5.build_src_flags}
                   -DM5STICKCPLUS=1
@@ -243,6 +245,7 @@ board_build.partitions = config/partitions_custom_noota.csv
 [dev_m5stick_c_plus2]
 extends         = dev_m5
 board           = m5stick-c                         ; Requires the M5StickC Plus2 (note the Plus2)
+board_build.variant = m5stack_stickc_plus2
 upload_speed    = 2000000
 build_flags     = ${dev_m5.build_flags}
                   ${psram_lx6_flags.build_flags}
@@ -409,8 +412,7 @@ build_src_flags =
 [ttgo_deps]
 build_flags     =
 build_src_flags =
-lib_deps        = https://github.com/Xinyuan-LilyGO/TTGO-T-Display
-                  bodmer/TFT_eSPI @ ^2.5.43
+lib_deps        = bodmer/TFT_eSPI @ ^2.5.43
 
 ; ================================================================
 ; Basic environment section, automatically inherited by all others
@@ -1487,6 +1489,7 @@ board_build.flash_mode = dio
 board_build.flash_freq = 40m
 
 build_flags     = ${dev_esp32.build_flags}
+                  ${psram_lx6_flags.build_flags}
                   -DUSER_SETUP_LOADED
                   -DST7789_DRIVER
                   -DTFT_SDA_READ
@@ -1537,7 +1540,6 @@ build_src_flags = ${dev_esp32.build_src_flags}
 
 lib_deps        = ${base.lib_deps}
                   ${base.bounce_deps}
-                  ${psram_lx6_flags.build_flags}
                   ${ttgo_deps.lib_deps}
 
 [env:xmastrees]

--- a/platformio.ini
+++ b/platformio.ini
@@ -200,6 +200,7 @@ lib_deps        = ${dev_esp32_s3.lib_deps}
 [dev_lolin_d32_pro]
 extends         = base
 build_flags     = ${base.build_flags}
+                  ${psram_lx6_flags.build_flags}
 build_src_flags = ${base.build_src_flags}
 board           = lolin_d32_pro
 monitor_speed   = 115200
@@ -288,6 +289,22 @@ build_src_flags = ${dev_m5.build_src_flags}
                   -DM5STACKCORE2=1
 board_build.partitions = config/partitions_custom_8M.csv
 board_upload.flash_size = 8MB
+
+[dev_m5_tab5]
+extends         = base
+platform        = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.31-1/platform-espressif32.zip
+board           = m5stack-tab5-p4
+monitor_speed   = 115200
+upload_speed    = 1500000
+build_flags     = ${base.build_flags}
+                  ${psram_common_flags.build_flags}
+build_src_flags = ${base.build_src_flags}
+                  -DM5TAB=1
+lib_deps        = ${base.lib_deps}
+                  m5stack/M5Unified @ ^0.2.19
+                  m5stack/M5GFX @ ^0.2.26
+board_build.partitions = config/partitions_custom_16M_v3.csv
+board_upload.flash_size = 16MB
 
 [dev_elecrow_mesmerizer]
 extends         = dev_esp32_s3
@@ -499,6 +516,35 @@ lib_deps        = https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA.gi
 
 board_build.embed_files = ${embed_web_ui_assets.board_build.embed_files}
                           ${embed_matrix_assets.board_build.embed_files}
+
+[mesmerizer_tab_config]
+build_flags     = ${mesmerizer_config.build_flags}
+build_src_flags = -DPROJECT_NAME="\"Mesmerizer Tab\""
+                  -DMESMERIZER=1
+                  -DSHOW_FPS_ON_MATRIX=0
+                  -DUSE_M5LCD=1
+                  -DSHOW_VU_METER=1
+                  -DEFFECTS_FULLMATRIX=1
+                  -DCOLOR_ORDER=EOrder::RGB
+                  -DENABLE_WIFI=1
+                  -DINCOMING_WIFI_ENABLED=1
+                  -DWAIT_FOR_WIFI=0
+                  -DTIME_BEFORE_LOCAL=2
+                  -DENABLE_WEBSERVER=1
+                  -DENABLE_NTP=1
+                  -DENABLE_OTA=1
+                  -DCOLORDATA_SERVER_ENABLED=1
+                  -DCOLORDATA_WEB_SOCKET_ENABLED=1
+                  -DENABLE_REMOTE=1
+                  -DIR_REMOTE_PIN=-1
+                  -DMILLIS_PER_FRAME=0
+                  -DMATRIX_WIDTH=160
+                  -DMATRIX_HEIGHT=90
+                  -DMIN_BUFFERS=3
+                  -DMAX_BUFFERS=3
+                  -DNUM_BANDS=16
+
+board_build.embed_files = ${mesmerizer_config.board_build.embed_files}
 
 ; ====================
 ; Project Environments
@@ -1129,10 +1175,25 @@ build_src_flags = ${dev_mesmerizer.build_src_flags}
 lib_deps        = ${mesmerizer_config.lib_deps}
 board_build.embed_files = ${mesmerizer_config.board_build.embed_files}
 
+[env:mesmerizer_tab]
+extends         = dev_m5_tab5
+build_type      = release
+build_flags     = ${dev_m5_tab5.build_flags}
+                  ${mesmerizer_tab_config.build_flags}
+build_src_flags = ${dev_m5_tab5.build_src_flags}
+                  ${mesmerizer_tab_config.build_src_flags}
+                  -DENABLE_AUDIO=1
+                  -DEFFECTS_MESMERIZER=1
+
+lib_deps        = ${dev_m5_tab5.lib_deps}
+                  ${base.graphics_deps}
+board_build.embed_files = ${mesmerizer_tab_config.board_build.embed_files}
+
 [env:mesmerizer_lolin]
 extends         = dev_lolin_d32_pro
 build_flags     = ${dev_lolin_d32_pro.build_flags}
                   ${mesmerizer_config.build_flags}
+                  ${psram_common_flags.build_flags}
 build_src_flags = ${dev_lolin_d32_pro.build_src_flags}
                   ${mesmerizer_config.build_src_flags}
                   -DMESMERIZER=1

--- a/src/deviceconfig.cpp
+++ b/src/deviceconfig.cpp
@@ -85,6 +85,9 @@ const char* DeviceConfig::DriverName(OutputDriver driver)
 {
     switch (driver)
     {
+        case OutputDriver::M5LCD:
+            return "m5lcd";
+
         case OutputDriver::HUB75:
             return "hub75";
 
@@ -121,6 +124,11 @@ bool DeviceConfig::IsHub75Build()
     return GetCompiledOutputDriver() == OutputDriver::HUB75;
 }
 
+bool DeviceConfig::IsFixedMatrixBuild()
+{
+    return IsHub75Build() || GetCompiledOutputDriver() == OutputDriver::M5LCD;
+}
+
 void DeviceConfig::LogRuntimeConfig(const char* reason) const
 {
     String activePins;
@@ -154,7 +162,7 @@ void DeviceConfig::LogRuntimeConfig(const char* reason) const
 
 DeviceConfig::DeviceConfig()
 {
-    runtimeTopology.serpentine = !IsHub75Build();
+    runtimeTopology.serpentine = !IsFixedMatrixBuild();
     runtimeOutputs.driver = GetCompiledOutputDriver();
     runtimeOutputs.channelCount = NUM_CHANNELS;
     runtimeOutputs.outputPins = GetCompiledWS281xPins();
@@ -311,6 +319,8 @@ bool DeviceConfig::DeserializeFromJSON(const JsonObjectConst& jsonObject, bool s
         const auto driverName = jsonObject[OutputDriverTag].as<String>();
         if (driverName == DriverName(OutputDriver::HUB75))
             updated.outputs.driver = OutputDriver::HUB75;
+        else if (driverName == DriverName(OutputDriver::M5LCD))
+            updated.outputs.driver = OutputDriver::M5LCD;
         else if (driverName == DriverName(OutputDriver::APA102))
             updated.outputs.driver = OutputDriver::APA102;
         else if (driverName == DriverName(OutputDriver::WS281x))

--- a/src/deviceconfig_settings_specs.cpp
+++ b/src/deviceconfig_settings_specs.cpp
@@ -279,8 +279,8 @@ const std::vector<std::reference_wrapper<SettingSpec>>& DeviceConfig::GetSetting
             .ApiPath           = "outputs.driver",
             .Widget            = SettingSpec::WidgetKind::Select,
             .Options           = SettingSpec::OptionsSource::SchemaPath,
-            .OptionValues      = {"ws281x", "apa102", "hub75"},
-            .OptionLabels      = {"WS281x", "APA102", "HUB75"},
+            .OptionValues      = {"ws281x", "apa102", "hub75", "m5lcd"},
+            .OptionLabels      = {"WS281x", "APA102", "HUB75", "M5 LCD"},
             .OptionsSchemaPath = "outputs.allowedDrivers"
         }));
         settingSpecs.push_back(SettingSpec::Validate(SettingSpec{

--- a/src/deviceconfig_unified.cpp
+++ b/src/deviceconfig_unified.cpp
@@ -45,6 +45,8 @@ std::optional<DeviceConfig::OutputDriver> DeviceConfig::ParseOutputDriverName(co
 {
     if (name == "hub75")
         return OutputDriver::HUB75;
+    if (name == "m5lcd")
+        return OutputDriver::M5LCD;
     if (name == "apa102")
         return OutputDriver::APA102;
     if (name == "ws281x")
@@ -218,11 +220,11 @@ void DeviceConfig::SerializeUnifiedSettingsSchema(JsonObject root) const
 {
     auto topology = root["topology"].to<JsonObject>();
     topology["compiledMaxWidth"] =
-        GetCompiledOutputDriver() == OutputDriver::HUB75
+        IsFixedMatrixBuild()
             ? GetCompiledMatrixWidth()
             : GetCompiledLEDCount();
     topology["compiledMaxHeight"] =
-        GetCompiledOutputDriver() == OutputDriver::HUB75
+        IsFixedMatrixBuild()
             ? GetCompiledMatrixHeight()
             : GetCompiledLEDCount();
     topology["compiledNominalWidth"] = GetCompiledMatrixWidth();

--- a/src/deviceconfig_validation.cpp
+++ b/src/deviceconfig_validation.cpp
@@ -34,7 +34,7 @@ SuccessResultWithMessage DeviceConfig::ValidateTopology(uint16_t width, uint16_t
         };
     }
 
-    if (IsHub75Build())
+    if (IsFixedMatrixBuild())
     {
         if (width != GetCompiledMatrixWidth() || height != GetCompiledMatrixHeight())
             return { false, DeviceConfigInternal::RecompileNeededMessage() };
@@ -65,7 +65,7 @@ SuccessResultWithMessage DeviceConfig::ValidateStripSettings(size_t channelCount
     if (channelCount > GetCompiledChannelCount())
         return { false, DeviceConfigInternal::RecompileNeededMessage() };
 
-    if (IsHub75Build())
+    if (IsFixedMatrixBuild())
     {
         if (channelCount != GetCompiledChannelCount())
             return { false, DeviceConfigInternal::RecompileNeededMessage() };

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -80,7 +80,7 @@ static void PrepareWiFiActivityPin()
     l_WiFiActivityActive = false;
 }
 
-static void UpdateWiFiActivityPin(uint16_t wifiPixelsDrawn, uint16_t localPixelsDrawn)
+static void UpdateWiFiActivityPin(size_t wifiPixelsDrawn, size_t localPixelsDrawn)
 {
     if (wifiPixelsDrawn > 0)
     {
@@ -96,7 +96,7 @@ static void PrepareWiFiActivityPin()
 {
 }
 
-static void UpdateWiFiActivityPin(uint16_t, uint16_t)
+static void UpdateWiFiActivityPin(size_t, size_t)
 {
 }
 
@@ -114,7 +114,7 @@ std::shared_ptr<LEDStripEffect> GetSpectrumAnalyzer(CRGB color);    // Defined i
 //
 // Draws from WiFi color data if available, returns pixels drawn this frame
 
-uint16_t WiFiDraw()
+size_t WiFiDraw()
 {
     // Builds with INCOMING_WIFI_ENABLED=0 never create the buffer managers,
     // but this path is still reachable whenever WiFi itself is connected.
@@ -123,7 +123,7 @@ uint16_t WiFiDraw()
 
     std::lock_guard guard(g_buffer_mutex);
 
-    uint16_t pixelsDrawn = 0;
+    size_t pixelsDrawn = 0;
     for (auto& bufferManager : g_ptrSystem->GetBufferManagers())
     {
 
@@ -156,7 +156,7 @@ uint16_t WiFiDraw()
             if (pBuffer)
             {
                 l_usLastWifiDraw = micros();
-                debugV("Calling LEDBuffer::Draw from wire with %d/%zu pixels.", pixelsDrawn, pBuffer->_pStrand->GetLEDCount());
+                debugV("Calling LEDBuffer::Draw from wire with %zu/%zu pixels.", pixelsDrawn, pBuffer->_pStrand->GetLEDCount());
                 pBuffer->DrawBuffer();
                 // In case we drew some pixels and then drew 0 due a failure, we want to return a positive
                 // number of pixels drawn so the caller knows we did in fact render.
@@ -164,7 +164,7 @@ uint16_t WiFiDraw()
             }
         }
     }
-    debugV("WifIDraw claims to have drawn %d pixels", pixelsDrawn);
+    debugV("WifIDraw claims to have drawn %zu pixels", pixelsDrawn);
     return pixelsDrawn;
 }
 
@@ -172,7 +172,7 @@ uint16_t WiFiDraw()
 //
 // Draws from effects table rather than from WiFi data.  Returns the number of LEDs rendered.
 
-uint16_t LocalDraw()
+size_t LocalDraw()
 {
     if (!g_ptrSystem->HasEffectManager())
     {
@@ -222,7 +222,7 @@ uint16_t LocalDraw()
 //
 // Returns the amount of time to wait patiently until it's time to draw the next frame, up to one second max
 
-int CalcDelayUntilNextFrame(double frameStartTime, uint16_t localPixelsDrawn, uint16_t wifiPixelsDrawn)
+int CalcDelayUntilNextFrame(double frameStartTime, size_t localPixelsDrawn, size_t wifiPixelsDrawn)
 {
     constexpr auto kMinDelay = 0.001;
 
@@ -284,6 +284,14 @@ int CalcDelayUntilNextFrame(double frameStartTime, uint16_t localPixelsDrawn, ui
     }
 
     return g_Values.FreeDrawTime * MILLIS_PER_SECOND;
+#else
+    // Fixed-rate targets (such as the Tab5 LCD backend) do not derive their
+    // cadence from the active effect or queued WiFi frames.
+    (void)frameStartTime;
+    (void)localPixelsDrawn;
+    (void)wifiPixelsDrawn;
+    g_Values.FreeDrawTime = static_cast<double>(MILLIS_PER_FRAME) / MILLIS_PER_SECOND;
+    return MILLIS_PER_FRAME;
 #endif
 }
 
@@ -382,8 +390,8 @@ void IRAM_ATTR RenderService::Run()
     {
         g_Values.AppTime.NewFrame();
 
-        uint16_t localPixelsDrawn   = 0;
-        uint16_t wifiPixelsDrawn    = 0;
+        size_t localPixelsDrawn   = 0;
+        size_t wifiPixelsDrawn    = 0;
         double frameStartTime       = g_Values.AppTime.FrameStartTime();
 
         {

--- a/src/effectmanager.cpp
+++ b/src/effectmanager.cpp
@@ -64,7 +64,7 @@ extern DRAM_ATTR bool l_EffectManagerInitializing;
 // EffectManager initialization functions
 //
 
-#if USE_HUB75
+#if USE_HUB75 || USE_M5LCD
 
     void InitSplashEffectManager()
     {

--- a/src/effectmanager_runtime.cpp
+++ b/src/effectmanager_runtime.cpp
@@ -74,10 +74,8 @@ void EffectManager::StartEffect()
 
     auto effect = _tempEffect ? _tempEffect : _vEffects[_iCurrentEffect];
 
-    #if USE_HUB75
-        auto& matrix = static_cast<HUB75GFX&>(*_gfx[0]);
-        matrix.SetCaption(effect->FriendlyName(), CAPTION_TIME);
-    #endif
+    if (!_gfx.empty())
+        _gfx[0]->SetCaption(effect->FriendlyName(), CAPTION_TIME);
 
     // Zero the whites plane on every graphics device at effect-switch.
     //

--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -158,13 +158,80 @@
 DRAM_ATTR allocated_unique_ptr<EffectFactories> g_ptrEffectFactories = nullptr;
 
 #if EFFECTS_FULLMATRIX
-void ConfigureMatrixJpegDecoder()
+namespace
 {
+    struct JpegOutputTransform
+    {
+        uint16_t sourceWidth = 0;
+        uint16_t sourceHeight = 0;
+        uint16_t destinationWidth = 0;
+        uint16_t destinationHeight = 0;
+        int16_t offsetX = 0;
+        int16_t offsetY = 0;
+    };
+
+    JpegOutputTransform jpegOutputTransform;
+}
+
+void ConfigureMatrixJpegDecoder(uint16_t sourceWidth, uint16_t sourceHeight)
+{
+    jpegOutputTransform = {};
+    if (sourceWidth > 0 && sourceHeight > 0)
+    {
+        jpegOutputTransform.sourceWidth = sourceWidth;
+        jpegOutputTransform.sourceHeight = sourceHeight;
+
+        // Preserve the JPEG's aspect ratio while fitting it as large as
+        // possible within the logical matrix.
+        if (MATRIX_WIDTH * sourceHeight <= MATRIX_HEIGHT * sourceWidth)
+        {
+            jpegOutputTransform.destinationWidth = MATRIX_WIDTH;
+            jpegOutputTransform.destinationHeight =
+                (sourceHeight * MATRIX_WIDTH + sourceWidth / 2) / sourceWidth;
+        }
+        else
+        {
+            jpegOutputTransform.destinationHeight = MATRIX_HEIGHT;
+            jpegOutputTransform.destinationWidth =
+                (sourceWidth * MATRIX_HEIGHT + sourceHeight / 2) / sourceHeight;
+        }
+
+        jpegOutputTransform.offsetX =
+            (MATRIX_WIDTH - jpegOutputTransform.destinationWidth) / 2;
+        jpegOutputTransform.offsetY =
+            (MATRIX_HEIGHT - jpegOutputTransform.destinationHeight) / 2;
+    }
+
     TJpgDec.setJpgScale(1);
     TJpgDec.setCallback([](int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t *bitmap)
     {
         auto& gfx = g_ptrSystem->GetEffectManager().g();
-        gfx.drawRGBBitmap(x, y, bitmap, w, h);
+        const auto& transform = jpegOutputTransform;
+        if (transform.sourceWidth == 0 || transform.sourceHeight == 0)
+        {
+            gfx.drawRGBBitmap(x, y, bitmap, w, h);
+            return true;
+        }
+
+        for (uint16_t localY = 0; localY < h; ++localY)
+        {
+            const int sourceY = y + localY;
+            const int destinationY0 = transform.offsetY +
+                sourceY * transform.destinationHeight / transform.sourceHeight;
+            const int destinationY1 = transform.offsetY +
+                (sourceY + 1) * transform.destinationHeight / transform.sourceHeight;
+
+            for (uint16_t localX = 0; localX < w; ++localX)
+            {
+                const int sourceX = x + localX;
+                const int destinationX0 = transform.offsetX +
+                    sourceX * transform.destinationWidth / transform.sourceWidth;
+                const int destinationX1 = transform.offsetX +
+                    (sourceX + 1) * transform.destinationWidth / transform.sourceWidth;
+                gfx.fillRectangle(destinationX0, destinationY0, destinationX1, destinationY1,
+                                  GFXBase::from16Bit(bitmap[localY * w + localX]));
+            }
+        }
         return true;
     });
 }

--- a/src/gfxbase.cpp
+++ b/src/gfxbase.cpp
@@ -68,6 +68,7 @@ const uint8_t GFXBase::gamma6[64] =
 
 GFXBase::~GFXBase()
 {
+    heap_caps_free(_blurColumnScratch);
 }
 
 uint8_t GFXBase::beatcos8(accum88 beats_per_minute, uint8_t lowest, uint8_t highest, uint32_t timebase, uint8_t phase_offset)
@@ -615,12 +616,19 @@ void GFXBase::blurColumns(CRGB *leds, uint16_t width, uint16_t height, uint16_t 
         // Keeping one carry value per column lets us traverse both source and
         // destination rows sequentially. The former column-at-a-time walk
         // incurred a PSRAM cache miss for nearly every pixel at 1280x720.
-        CRGB *scratch = static_cast<CRGB *>(
-            heap_caps_calloc(width * 2U, sizeof(CRGB), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
-        if (!scratch)
-            throw std::runtime_error("Unable to allocate native blur scratch rows");
-        CRGB *carry = scratch;
-        CRGB *pending = scratch + width;
+        if (_blurColumnScratchWidth < width)
+        {
+            CRGB *scratch = static_cast<CRGB *>(
+                heap_caps_calloc(width * 2U, sizeof(CRGB), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
+            if (!scratch)
+                throw std::runtime_error("Unable to allocate native blur scratch rows");
+            heap_caps_free(_blurColumnScratch);
+            _blurColumnScratch = scratch;
+            _blurColumnScratchWidth = width;
+        }
+        CRGB *carry = _blurColumnScratch;
+        CRGB *pending = _blurColumnScratch + _blurColumnScratchWidth;
+        memset(carry, 0, width * sizeof(CRGB));
 
         const uint8_t keep = 255 - blur_amount;
         const uint8_t seep = blur_amount >> 1;
@@ -651,7 +659,6 @@ void GFXBase::blurColumns(CRGB *leds, uint16_t width, uint16_t height, uint16_t 
         }
         if (first < height)
             memcpy(leds + static_cast<size_t>(height - 1) * width, pending, width * sizeof(CRGB));
-        heap_caps_free(scratch);
         return;
     }
 

--- a/src/gfxbase.cpp
+++ b/src/gfxbase.cpp
@@ -545,6 +545,45 @@ CRGBW GFXBase::MaximumWhiteForKelvin(uint16_t kelvin, uint8_t brightness)
 
 void GFXBase::blurRows(CRGB *leds, uint16_t width, uint16_t height, uint16_t first, fract8 blur_amount)
 {
+    // LCD and HUB75 framebuffers are row-major. Walk them directly so a
+    // native-resolution frame remains cache-friendly in PSRAM; calling XY()
+    // several million times per frame is prohibitively expensive.
+    const bool rowMajor = width < 2 || (xy(0, 0) == 0 && xy(1, 0) == 1 && xy(0, 1) == width);
+    if (rowMajor)
+    {
+        const uint8_t keep = 255 - blur_amount;
+        const uint8_t seep = blur_amount >> 1;
+        for (uint16_t row = 0; row < height; ++row)
+        {
+            CRGB carryover = CRGB::Black;
+            CRGB pending = CRGB::Black;
+            CRGB *line = leds + static_cast<size_t>(row) * width;
+            for (uint16_t i = first; i < width; ++i)
+            {
+                CRGB cur = line[i];
+                CRGB part = cur;
+                part.nscale8(seep);
+                cur.nscale8(keep);
+                cur += carryover;
+                if (i)
+                {
+                    if (i == first)
+                        line[i - 1] += part;
+                    else
+                        line[i - 1] = pending + part;
+                }
+                pending = cur;
+                carryover = part;
+            }
+            if (first < width)
+                line[width - 1] = pending;
+            if (static_cast<uint32_t>(width) * height > 65536U &&
+                (row & 63U) == 63U)
+                delay(10);
+        }
+        return;
+    }
+
     // blur rows same as columns, for irregular matrix
     uint8_t keep = 255 - blur_amount;
     uint8_t seep = blur_amount >> 1;
@@ -570,6 +609,52 @@ void GFXBase::blurRows(CRGB *leds, uint16_t width, uint16_t height, uint16_t fir
 
 void GFXBase::blurColumns(CRGB *leds, uint16_t width, uint16_t height, uint16_t first, fract8 blur_amount)
 {
+    const bool rowMajor = width < 2 || (xy(0, 0) == 0 && xy(1, 0) == 1 && xy(0, 1) == width);
+    if (rowMajor)
+    {
+        // Keeping one carry value per column lets us traverse both source and
+        // destination rows sequentially. The former column-at-a-time walk
+        // incurred a PSRAM cache miss for nearly every pixel at 1280x720.
+        CRGB *scratch = static_cast<CRGB *>(
+            heap_caps_calloc(width * 2U, sizeof(CRGB), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
+        if (!scratch)
+            throw std::runtime_error("Unable to allocate native blur scratch rows");
+        CRGB *carry = scratch;
+        CRGB *pending = scratch + width;
+
+        const uint8_t keep = 255 - blur_amount;
+        const uint8_t seep = blur_amount >> 1;
+        for (uint16_t row = first; row < height; ++row)
+        {
+            CRGB *line = leds + static_cast<size_t>(row) * width;
+            CRGB *previous = row ? line - width : nullptr;
+            for (uint16_t col = 0; col < width; ++col)
+            {
+                CRGB cur = line[col];
+                CRGB part = cur;
+                part.nscale8(seep);
+                cur.nscale8(keep);
+                cur += carry[col];
+                if (previous)
+                {
+                    if (row == first)
+                        previous[col] += part;
+                    else
+                        previous[col] = pending[col] + part;
+                }
+                pending[col] = cur;
+                carry[col] = part;
+            }
+            if (static_cast<uint32_t>(width) * height > 65536U &&
+                (row & 63U) == 63U)
+                delay(10);
+        }
+        if (first < height)
+            memcpy(leds + static_cast<size_t>(height - 1) * width, pending, width * sizeof(CRGB));
+        heap_caps_free(scratch);
+        return;
+    }
+
     // blur columns
     uint8_t keep = 255 - blur_amount;
     uint8_t seep = blur_amount >> 1;
@@ -676,7 +761,7 @@ bool GFXBase::EnsureNoise() const
 // Dirty hack to support FastLED, which calls out of band to get the pixel index for "the" array, without
 // any indication of which array or who's asking, so we assume the first matrix. If you have trouble with
 // more than one matrix and some FastLED functions like blur2d, this would be why.
-uint16_t XY(uint16_t x, uint16_t y)
+size_t XY(uint16_t x, uint16_t y)
 {
     auto& g = g_ptrSystem->GetEffectManager().g();
     return g.xy(x, y);
@@ -700,7 +785,15 @@ const GFXBase::PolarMapArray& GFXBase::getPolarMap()
                 float angle_rad = atan2f(static_cast<float>(y), static_cast<float>(x));
                 float radius_float = hypotf(static_cast<float>(x), static_cast<float>(y));
 
-                rMap[x + C_X][y + C_Y].angle = 128.0f * (angle_rad / (float)M_PI);
+                // Encode the signed -128..128 polar angle explicitly into the
+                // cyclic 0..255 byte domain. Directly converting a negative
+                // float to uint8_t is out of range and produced target-specific
+                // results; on ESP32-P4 it flattened much of the upper half of
+                // radial effects to one angle.
+                const int16_t signedAngle = static_cast<int16_t>(
+                    128.0f * (angle_rad / static_cast<float>(M_PI)));
+                rMap[x + C_X][y + C_Y].angle =
+                    static_cast<uint8_t>(signedAngle & 0xFF);
                 rMap[x + C_X][y + C_Y].scaled_radius = radius_float * mapp;
                 rMap[x + C_X][y + C_Y].unscaled_radius = radius_float;
             }

--- a/src/gfxbase_noise.cpp
+++ b/src/gfxbase_noise.cpp
@@ -68,6 +68,38 @@
             FillGetNoiseImpl();
     }
 
+    void GFXBase::FillGetNoiseEdges() const
+    {
+        // The general fractional X/Y movers consume only noise[0][y] and
+        // noise[x][0]. Effects using just those movers do not need a full
+        // width-by-height Perlin refresh.
+        if (EnsureNoise())
+            return;
+
+        const auto updateSample = [this](uint32_t x, uint32_t y)
+        {
+            const int32_t xOffset =
+                _ptrNoise->noise_scale_x *
+                (static_cast<int32_t>(x) - static_cast<int32_t>(_width / 2));
+            const int32_t yOffset =
+                _ptrNoise->noise_scale_y *
+                (static_cast<int32_t>(y) - static_cast<int32_t>(_height / 2));
+            const uint8_t data =
+                inoise16(_ptrNoise->noise_x + xOffset,
+                         _ptrNoise->noise_y + yOffset,
+                         _ptrNoise->noise_z) >> 8;
+            const uint8_t oldData = _ptrNoise->noise[x][y];
+            _ptrNoise->noise[x][y] =
+                scale8(oldData, _ptrNoise->noisesmoothing) +
+                scale8(data, 256 - _ptrNoise->noisesmoothing);
+        };
+
+        for (uint32_t y = 0; y < _height; ++y)
+            updateSample(0, y);
+        for (uint32_t x = 1; x < _width; ++x)
+            updateSample(x, 0);
+    }
+
     template<>
     void GFXBase::MoveFractionalNoiseX<NoiseApproach::MRI>(uint8_t amt, uint8_t shift)
     {
@@ -124,6 +156,45 @@
     void GFXBase::MoveFractionalNoiseX<NoiseApproach::General>(uint8_t amt, uint8_t shift)
     {
         EnsureNoise();
+        const bool rowMajor =
+            _width < 2 || (xy(0, 0) == 0 && xy(1, 0) == 1 && xy(0, 1) == _width);
+
+        // LCD and HUB75 surfaces are row-major. Avoid routing every source and
+        // destination pixel through the global XY() helper; that lookup reaches
+        // through the system/effect manager and dominates this full-frame warp
+        // on larger logical displays such as the Tab5.
+        if (rowMajor)
+        {
+            for (uint32_t y = 0; y < _height; ++y)
+            {
+                const int32_t amount =
+                    (static_cast<int32_t>(_ptrNoise->noise[0][y]) - 128) * 2 * amt +
+                    shift * 256;
+                const int32_t delta = abs(amount) >> 8;
+                const int32_t fraction = abs(amount) & 255;
+                const uint8_t weightA = ease8InOutApprox(255 - fraction);
+                const uint8_t weightB = ease8InOutApprox(fraction);
+                CRGB *line = leds + static_cast<size_t>(y) * _width;
+
+                for (uint32_t x = 0; x < _width; ++x)
+                {
+                    const int32_t zD = amount < 0
+                        ? static_cast<int32_t>(x) - delta
+                        : static_cast<int32_t>(x) + delta;
+                    const int32_t zF = amount < 0 ? zD - 1 : zD + 1;
+
+                    CRGB pixelA = zD >= 0 && zD < static_cast<int32_t>(_width)
+                        ? line[zD]
+                        : CRGB::Black;
+                    CRGB pixelB = zF >= 0 && zF < static_cast<int32_t>(_width)
+                        ? line[zF]
+                        : CRGB::Black;
+                    line[x] = pixelA.nscale8(weightA) + pixelB.nscale8(weightB);
+                }
+            }
+            return;
+        }
+
         // Aligning with Approach::One while keeping the "Approach::Two" optimized behavior.
         // We use int32_t for the 'amount' and 'delta' as they can be large or negative.
         for (uint32_t y = 0; y < _height; y++)
@@ -218,6 +289,41 @@
     void GFXBase::MoveFractionalNoiseY<NoiseApproach::General>(uint8_t amt, uint8_t shift)
     {
         EnsureNoise();
+        const bool rowMajor =
+            _width < 2 || (xy(0, 0) == 0 && xy(1, 0) == 1 && xy(0, 1) == _width);
+
+        if (rowMajor)
+        {
+            for (uint32_t x = 0; x < _width; ++x)
+            {
+                const int32_t amount =
+                    (static_cast<int32_t>(_ptrNoise->noise[x][0]) - 128) * 2 * amt +
+                    shift * 256;
+                const int32_t delta = abs(amount) >> 8;
+                const int32_t fraction = abs(amount) & 255;
+                const uint8_t weightA = ease8InOutApprox(255 - fraction);
+                const uint8_t weightB = ease8InOutApprox(fraction);
+
+                for (uint32_t y = 0; y < _height; ++y)
+                {
+                    const int32_t zD = amount < 0
+                        ? static_cast<int32_t>(y) - delta
+                        : static_cast<int32_t>(y) + delta;
+                    const int32_t zF = amount < 0 ? zD - 1 : zD + 1;
+
+                    CRGB pixelA = zD >= 0 && zD < static_cast<int32_t>(_height)
+                        ? leds[static_cast<size_t>(zD) * _width + x]
+                        : CRGB::Black;
+                    CRGB pixelB = zF >= 0 && zF < static_cast<int32_t>(_height)
+                        ? leds[static_cast<size_t>(zF) * _width + x]
+                        : CRGB::Black;
+                    leds[static_cast<size_t>(y) * _width + x] =
+                        pixelA.nscale8(weightA) + pixelB.nscale8(weightB);
+                }
+            }
+            return;
+        }
+
         for (uint32_t x = 0; x < _width; x++)
         {
             int32_t amount = ((int32_t)_ptrNoise->noise[x][0] - 128) * 2 * amt + shift * 256;
@@ -258,6 +364,6 @@ void GFXBase::PrepareFrame()
 {
 }
 
-void GFXBase::PostProcessFrame(uint16_t, uint16_t)
+void GFXBase::PostProcessFrame(size_t, size_t)
 {
 }

--- a/src/gfxbase_transforms.cpp
+++ b/src/gfxbase_transforms.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 #include <gfxfont.h>
 #include <memory>
 #include <stdexcept>
@@ -50,19 +51,42 @@ void GFXBase::MoveInwardX(int startY, int endY)
     const int halfWidth = width / 2;
     if (leds == nullptr || halfWidth <= 1 || height <= 0)
         return;
+    constexpr int kReferenceMatrixWidth = 64;
+    const int scrollPixels = std::min(
+        halfWidth - 1,
+        std::max(1, (width + kReferenceMatrixWidth / 2) / kReferenceMatrixWidth));
 
     startY = std::max(0, startY);
     endY = std::min(height - 1, endY);
 
-    for (int y = startY; y <= endY; y++)
+    const bool rowMajor = width < 2 ||
+        (xy(0, 0) == 0 && xy(1, 0) == 1 && xy(0, 1) == static_cast<size_t>(width));
+    if (rowMajor)
     {
-        // Keep both halves inside the row. The previous loops read x+1 at
-        // width, which can corrupt unrelated pixels or memory at row edges.
-        for (int x = halfWidth - 1; x > 0; x--)
-            leds[XY(x, y)] = leds[XY(x - 1, y)];
+        for (int y = startY; y <= endY; ++y)
+        {
+            CRGB *line = leds + static_cast<size_t>(y) * width;
+            const CRGB leftEdge = line[0];
+            const CRGB rightEdge = line[width - 1];
+            memmove(line + scrollPixels, line,
+                    sizeof(CRGB) * (halfWidth - scrollPixels));
+            memmove(line + halfWidth, line + halfWidth + scrollPixels,
+                    sizeof(CRGB) * (halfWidth - scrollPixels));
+            std::fill_n(line, scrollPixels, leftEdge);
+            std::fill_n(line + width - scrollPixels, scrollPixels, rightEdge);
+        }
+        return;
+    }
 
-        for (int x = halfWidth; x < width - 1; x++)
-            leds[XY(x, y)] = leds[XY(x + 1, y)];
+    for (int step = 0; step < scrollPixels; ++step)
+    {
+        for (int y = startY; y <= endY; y++)
+        {
+            for (int x = halfWidth - 1; x > 0; x--)
+                leds[XY(x, y)] = leds[XY(x - 1, y)];
+            for (int x = halfWidth; x < width - 1; x++)
+                leds[XY(x, y)] = leds[XY(x + 1, y)];
+        }
     }
 }
 
@@ -73,17 +97,42 @@ void GFXBase::MoveOutwardsX(int startY, int endY)
     const int halfWidth = width / 2;
     if (leds == nullptr || halfWidth <= 1 || height <= 0)
         return;
+    constexpr int kReferenceMatrixWidth = 64;
+    const int scrollPixels = std::min(
+        halfWidth - 1,
+        std::max(1, (width + kReferenceMatrixWidth / 2) / kReferenceMatrixWidth));
 
     startY = std::max(0, startY);
     endY = std::min(height - 1, endY);
 
-    for (int y = startY; y <= endY; y++)
+    const bool rowMajor = width < 2 ||
+        (xy(0, 0) == 0 && xy(1, 0) == 1 && xy(0, 1) == static_cast<size_t>(width));
+    if (rowMajor)
     {
-        for (int x = 0; x < halfWidth - 1; x++)
-            leds[XY(x, y)] = leds[XY(x + 1, y)];
+        for (int y = startY; y <= endY; ++y)
+        {
+            CRGB *line = leds + static_cast<size_t>(y) * width;
+            const CRGB leftCenter = line[halfWidth - 1];
+            const CRGB rightCenter = line[halfWidth];
+            memmove(line, line + scrollPixels,
+                    sizeof(CRGB) * (halfWidth - scrollPixels));
+            memmove(line + halfWidth + scrollPixels, line + halfWidth,
+                    sizeof(CRGB) * (halfWidth - scrollPixels));
+            std::fill_n(line + halfWidth - scrollPixels, scrollPixels, leftCenter);
+            std::fill_n(line + halfWidth, scrollPixels, rightCenter);
+        }
+        return;
+    }
 
-        for (int x = width - 1; x > halfWidth; x--)
-            leds[XY(x, y)] = leds[XY(x - 1, y)];
+    for (int step = 0; step < scrollPixels; ++step)
+    {
+        for (int y = startY; y <= endY; y++)
+        {
+            for (int x = 0; x < halfWidth - 1; x++)
+                leds[XY(x, y)] = leds[XY(x + 1, y)];
+            for (int x = width - 1; x > halfWidth; x--)
+                leds[XY(x, y)] = leds[XY(x - 1, y)];
+        }
     }
 }
 

--- a/src/hub75gfx.cpp
+++ b/src/hub75gfx.cpp
@@ -128,6 +128,10 @@ void HUB75GFX::MoveInwardX(int startY, int endY)
     const int halfWidth = MATRIX_WIDTH / 2;
     if (!leds || halfWidth <= 1)
         return;
+    constexpr int kReferenceMatrixWidth = 64;
+    const int scrollPixels = std::min(
+        halfWidth - 1,
+        std::max(1, (MATRIX_WIDTH + kReferenceMatrixWidth / 2) / kReferenceMatrixWidth));
 
     startY = std::max(0, startY);
     endY = std::min(MATRIX_HEIGHT - 1, endY);
@@ -135,8 +139,12 @@ void HUB75GFX::MoveInwardX(int startY, int endY)
     {
         auto pLine = leds + y * MATRIX_WIDTH;
         auto pLine2 = pLine + halfWidth;
-        memmove(pLine + 1, pLine, sizeof(CRGB) * (halfWidth - 1));
-        memmove(pLine2, pLine2 + 1, sizeof(CRGB) * (halfWidth - 1));
+        const CRGB leftEdge = pLine[0];
+        const CRGB rightEdge = pLine[MATRIX_WIDTH - 1];
+        memmove(pLine + scrollPixels, pLine, sizeof(CRGB) * (halfWidth - scrollPixels));
+        memmove(pLine2, pLine2 + scrollPixels, sizeof(CRGB) * (halfWidth - scrollPixels));
+        std::fill_n(pLine, scrollPixels, leftEdge);
+        std::fill_n(pLine + MATRIX_WIDTH - scrollPixels, scrollPixels, rightEdge);
     }
 }
 
@@ -145,6 +153,10 @@ void HUB75GFX::MoveOutwardsX(int startY, int endY)
     const int halfWidth = MATRIX_WIDTH / 2;
     if (!leds || halfWidth <= 1)
         return;
+    constexpr int kReferenceMatrixWidth = 64;
+    const int scrollPixels = std::min(
+        halfWidth - 1,
+        std::max(1, (MATRIX_WIDTH + kReferenceMatrixWidth / 2) / kReferenceMatrixWidth));
 
     startY = std::max(0, startY);
     endY = std::min(MATRIX_HEIGHT - 1, endY);
@@ -152,8 +164,12 @@ void HUB75GFX::MoveOutwardsX(int startY, int endY)
     {
         auto pLine = leds + y * MATRIX_WIDTH;
         auto pLine2 = pLine + halfWidth;
-        memmove(pLine, pLine + 1, sizeof(CRGB) * (halfWidth - 1));
-        memmove(pLine2 + 1, pLine2, sizeof(CRGB) * (halfWidth - 1));
+        const CRGB leftCenter = pLine[halfWidth - 1];
+        const CRGB rightCenter = pLine[halfWidth];
+        memmove(pLine, pLine + scrollPixels, sizeof(CRGB) * (halfWidth - scrollPixels));
+        memmove(pLine2 + scrollPixels, pLine2, sizeof(CRGB) * (halfWidth - scrollPixels));
+        std::fill_n(pLine + halfWidth - scrollPixels, scrollPixels, leftCenter);
+        std::fill_n(pLine2, scrollPixels, rightCenter);
     }
 }
 
@@ -194,7 +210,7 @@ void HUB75GFX::PrepareFrame()
     }
 }
 
-void HUB75GFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDrawn)
+void HUB75GFX::PostProcessFrame(size_t localPixelsDrawn, size_t wifiPixelsDrawn)
 {
     if (localPixelsDrawn + wifiPixelsDrawn == 0)
         return;
@@ -263,7 +279,7 @@ void HUB75GFX::FlushFrameToMatrix()
     const float captionAlpha = shouldShowTitle ? gfx.GetCaptionTransparency() : 0.0f;
     if (captionAlpha > 0.0f)
     {
-        const String caption = gfx.GetCaption();
+        const String & caption = gfx.GetCaption();
         constexpr int charWidth = 6;
         constexpr int charHeight = 8;
         const int textWidth = caption.length() * charWidth;

--- a/src/m5tabgfx.cpp
+++ b/src/m5tabgfx.cpp
@@ -15,6 +15,12 @@
 #include "systemcontainer.h"
 #include "values.h"
 
+namespace
+{
+constexpr uint32_t kCaptionFadeInTime = 500;
+constexpr uint32_t kCaptionFadeOutTime = 1000;
+}
+
 M5TabGFX::M5TabGFX(size_t width, size_t height) : GFXBase(width, height)
 {
     leds = static_cast<CRGB *>(heap_caps_calloc(width * height, sizeof(CRGB), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
@@ -78,8 +84,11 @@ void M5TabGFX::fillRectangle(int x0, int y0, int x1, int y1, CRGB color)
 {
     x0 = std::max(0, x0);
     y0 = std::max(0, y0);
-    x1 = std::min(static_cast<int>(_width), x1);
-    y1 = std::min(static_cast<int>(_height), y1);
+    x1 = std::clamp(x1, 0, static_cast<int>(_width));
+    y1 = std::clamp(y1, 0, static_cast<int>(_height));
+
+    if (x0 >= x1 || y0 >= y1)
+        return;
 
     for (int y = y0; y < y1; ++y)
         std::fill(leds + y * _width + x0, leds + y * _width + x1, color);
@@ -94,16 +103,14 @@ void M5TabGFX::SetCaption(const String &caption, uint32_t duration)
 
 float M5TabGFX::CaptionTransparency() const
 {
-    constexpr uint32_t kFadeInTime = 500;
-    constexpr uint32_t kFadeOutTime = 1000;
     const uint32_t elapsed = millis() - _captionStartTime;
-    if (_caption.isEmpty() || elapsed >= kFadeInTime + _captionDuration + kFadeOutTime)
+    if (_caption.isEmpty() || elapsed >= kCaptionFadeInTime + _captionDuration + kCaptionFadeOutTime)
         return 0.0f;
-    if (elapsed < kFadeInTime)
-        return static_cast<float>(elapsed) / kFadeInTime;
-    if (elapsed > kFadeInTime + _captionDuration)
+    if (elapsed < kCaptionFadeInTime)
+        return static_cast<float>(elapsed) / kCaptionFadeInTime;
+    if (elapsed > kCaptionFadeInTime + _captionDuration)
         return 1.0f -
-            static_cast<float>(elapsed - kFadeInTime - _captionDuration) / kFadeOutTime;
+            static_cast<float>(elapsed - kCaptionFadeInTime - _captionDuration) / kCaptionFadeOutTime;
     return 1.0f;
 }
 
@@ -129,9 +136,8 @@ void M5TabGFX::PostProcessFrame(size_t localPixelsDrawn, size_t wifiPixelsDrawn)
     const int captionY = static_cast<int>(_height) - kCaptionHeight - 1;
     if (captionAlpha > 0.0f)
     {
-        constexpr uint32_t kFadeInTime = 500;
-        constexpr uint32_t kFadeOutTime = 1000;
-        const uint32_t totalCaptionTime = kFadeInTime + _captionDuration + kFadeOutTime;
+        const uint32_t totalCaptionTime =
+            kCaptionFadeInTime + _captionDuration + kCaptionFadeOutTime;
         const uint32_t elapsed = millis() - _captionStartTime;
         const int textWidth = _caption.length() * 6;
         const int x = textWidth > static_cast<int>(_width)

--- a/src/m5tabgfx.cpp
+++ b/src/m5tabgfx.cpp
@@ -1,0 +1,198 @@
+#include "globals.h"
+
+#if USE_M5LCD
+
+#include <cstring>
+
+#include <esp_heap_caps.h>
+#include <lgfx/v1/platforms/esp32p4/Panel_DSI.hpp>
+#include <M5Unified.h>
+
+#include "deviceconfig.h"
+#include "effectmanager.h"
+#include "ledstripeffect.h"
+#include "m5tabgfx.h"
+#include "systemcontainer.h"
+#include "values.h"
+
+M5TabGFX::M5TabGFX(size_t width, size_t height) : GFXBase(width, height)
+{
+    leds = static_cast<CRGB *>(heap_caps_calloc(width * height, sizeof(CRGB), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+    if (!leds)
+        throw std::runtime_error("Unable to allocate Tab5 effect framebuffer");
+
+    auto *panel = static_cast<lgfx::Panel_DSI *>(M5.Display.getPanel());
+    _displayBuffer = static_cast<uint16_t *>(panel->config_detail().buffer);
+    if (!_displayBuffer)
+        throw std::runtime_error("Unable to access Tab5 DSI scanout buffer");
+
+    // Rotation changes M5GFX's logical width and height, but it does not
+    // rotate the DSI scanout allocation itself. The Tab5 buffer therefore
+    // remains a portrait, row-major 720x1280 surface at rotation 1.
+    if (M5.Display.getRotation() != 1)
+        throw std::runtime_error("Tab5 effect framebuffer requires display rotation 1");
+    _physicalWidth = panel->config().panel_width;
+    _physicalHeight = panel->config().panel_height;
+    _displayWidth = M5.Display.width();
+    _displayHeight = M5.Display.height();
+    if (_displayWidth != _physicalHeight || _displayHeight != _physicalWidth)
+        throw std::runtime_error("Unexpected Tab5 DSI framebuffer orientation");
+
+    if (width == 0 || height == 0 ||
+        _displayWidth % width != 0 || _displayHeight % height != 0)
+        throw std::runtime_error("Tab5 effect framebuffer must scale evenly to the native display");
+
+    _scaleX = _displayWidth / width;
+    _scaleY = _displayHeight / height;
+    if (_scaleX != _scaleY)
+        throw std::runtime_error("Tab5 effect framebuffer requires uniform scaling");
+
+    _captionCanvas = std::make_unique<GFXcanvas1>(width, 8);
+    if (!_captionCanvas || !_captionCanvas->getBuffer())
+        throw std::runtime_error("Unable to allocate Tab5 caption mask");
+
+    static_assert(sizeof(CRGB) == sizeof(lgfx::bgr888_t));
+    debugI("Tab5 logical matrix surface: %zux%zu, scaling %ux to landscape %ux%u "
+           "(physical buffer %ux%u)",
+           width, height, _scaleX, _displayWidth, _displayHeight,
+           _physicalWidth, _physicalHeight);
+}
+
+M5TabGFX::~M5TabGFX()
+{
+    _displayBuffer = nullptr;
+    heap_caps_free(leds);
+    leds = nullptr;
+}
+
+void M5TabGFX::InitializeHardware(std::vector<std::shared_ptr<GFXBase>> &devices)
+{
+    M5.Display.fillScreen(TFT_BLACK);
+
+    auto display = make_shared_psram<M5TabGFX>(MATRIX_WIDTH, MATRIX_HEIGHT);
+    display->loadPalette(0);
+    devices.push_back(std::move(display));
+}
+
+void M5TabGFX::fillRectangle(int x0, int y0, int x1, int y1, CRGB color)
+{
+    x0 = std::max(0, x0);
+    y0 = std::max(0, y0);
+    x1 = std::min(static_cast<int>(_width), x1);
+    y1 = std::min(static_cast<int>(_height), y1);
+
+    for (int y = y0; y < y1; ++y)
+        std::fill(leds + y * _width + x0, leds + y * _width + x1, color);
+}
+
+void M5TabGFX::SetCaption(const String &caption, uint32_t duration)
+{
+    _caption = caption;
+    _captionStartTime = millis();
+    _captionDuration = duration;
+}
+
+float M5TabGFX::CaptionTransparency() const
+{
+    constexpr uint32_t kFadeInTime = 500;
+    constexpr uint32_t kFadeOutTime = 1000;
+    const uint32_t elapsed = millis() - _captionStartTime;
+    if (_caption.isEmpty() || elapsed >= kFadeInTime + _captionDuration + kFadeOutTime)
+        return 0.0f;
+    if (elapsed < kFadeInTime)
+        return static_cast<float>(elapsed) / kFadeInTime;
+    if (elapsed > kFadeInTime + _captionDuration)
+        return 1.0f -
+            static_cast<float>(elapsed - kFadeInTime - _captionDuration) / kFadeOutTime;
+    return 1.0f;
+}
+
+void M5TabGFX::PostProcessFrame(size_t localPixelsDrawn, size_t wifiPixelsDrawn)
+{
+    if (localPixelsDrawn + wifiPixelsDrawn == 0)
+        return;
+
+    const auto &deviceConfig = g_ptrSystem->GetDeviceConfig();
+    const uint8_t brightness = scale8(deviceConfig.GetBrightness(), g_Values.Fader);
+    if (brightness != _lastBrightness)
+    {
+        M5.Display.setBrightness(brightness);
+        _lastBrightness = brightness;
+    }
+
+    const auto &effectManager = g_ptrSystem->GetEffectManager();
+    const float captionAlpha =
+        effectManager.HasCurrentEffect() && effectManager.GetCurrentEffect().ShouldShowTitle()
+            ? CaptionTransparency()
+            : 0.0f;
+    constexpr int kCaptionHeight = 8;
+    const int captionY = static_cast<int>(_height) - kCaptionHeight - 1;
+    if (captionAlpha > 0.0f)
+    {
+        constexpr uint32_t kFadeInTime = 500;
+        constexpr uint32_t kFadeOutTime = 1000;
+        const uint32_t totalCaptionTime = kFadeInTime + _captionDuration + kFadeOutTime;
+        const uint32_t elapsed = millis() - _captionStartTime;
+        const int textWidth = _caption.length() * 6;
+        const int x = textWidth > static_cast<int>(_width)
+            ? static_cast<int>(_width) -
+                static_cast<int>((static_cast<uint64_t>(elapsed) *
+                                  (textWidth + _width)) / totalCaptionTime)
+            : (static_cast<int>(_width) - textWidth) / 2;
+
+        _captionCanvas->fillScreen(0);
+        _captionCanvas->setTextWrap(false);
+        _captionCanvas->setTextSize(1);
+        _captionCanvas->setTextColor(1);
+        _captionCanvas->setCursor(x, 0);
+        _captionCanvas->print(_caption);
+    }
+
+    const CRGB captionColor(
+        static_cast<uint8_t>(captionAlpha * 255.0f),
+        static_cast<uint8_t>(captionAlpha * 255.0f),
+        static_cast<uint8_t>(captionAlpha * 255.0f));
+
+    // At rotation 1, landscape (x,y) maps to physical
+    // (physicalWidth - 1 - y, x). Build one physical scanline from each
+    // logical column, then replicate it for the horizontal scale factor.
+    // Using displayWidth as the raw stride would incorrectly treat the
+    // portrait DSI allocation as landscape and scatter each logical row.
+    for (size_t sourceX = 0; sourceX < _width; ++sourceX)
+    {
+        uint16_t *firstPhysicalRow =
+            _displayBuffer + sourceX * _scaleX * _physicalWidth;
+        uint16_t *outputPixel = firstPhysicalRow;
+
+        for (size_t sourceY = _height; sourceY-- > 0;)
+        {
+            CRGB pixel = leds[sourceY * _width + sourceX];
+            if (captionAlpha > 0.0f &&
+                sourceY >= static_cast<size_t>(captionY) &&
+                sourceY < static_cast<size_t>(captionY + kCaptionHeight) &&
+                _captionCanvas->getPixel(
+                    sourceX, static_cast<int>(sourceY) - captionY))
+            {
+                pixel = captionColor;
+            }
+            const uint16_t rgb565 = (static_cast<uint16_t>(pixel.r & 0xF8U) << 8U) |
+                                    (static_cast<uint16_t>(pixel.g & 0xFCU) << 3U) |
+                                    (pixel.b >> 3U);
+            for (uint16_t copyY = 0; copyY < _scaleY; ++copyY)
+                *outputPixel++ = rgb565;
+        }
+
+        for (uint16_t copyX = 1; copyX < _scaleX; ++copyX)
+            std::memcpy(firstPhysicalRow + copyX * _physicalWidth,
+                        firstPhysicalRow,
+                        _physicalWidth * sizeof(uint16_t));
+    }
+
+    // Direct writes bypass M5GFX's dirty tracking. Mark the complete logical
+    // display dirty so the P4 cache is written back before DSI scans it.
+    M5.Display.display(0, 0, _displayWidth, _displayHeight);
+    g_Values.Brite = 100.0 * brightness / 255;
+    g_Values.Watts = 0;
+}
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -189,6 +189,9 @@
 #if USE_HUB75
 #include "hub75gfx.h"
 #endif
+#if USE_M5LCD
+#include "m5tabgfx.h"
+#endif
 #if ENABLE_WIFI
 #include "improvserial.h"
 #endif
@@ -570,6 +573,19 @@ void setup()
         debugW("Creating LCD Screen");
         g_ptrSystem->SetupHardwareDisplay(TFT_HEIGHT, TFT_WIDTH);
 
+    #elif M5TAB
+
+        auto m5Config = M5.config();
+        M5.begin(m5Config);
+        M5.Display.setRotation(1);
+        #if ENABLE_WIFI
+            // Tab5 hosts WiFi on its ESP32-C6 coprocessor over SDIO. The
+            // Arduino framework defaults do not match the Tab5 wiring, so
+            // configure the board's SDIO bus before the first WiFi call.
+            WiFi.setPins(GPIO_NUM_12, GPIO_NUM_13, GPIO_NUM_11, GPIO_NUM_10,
+                         GPIO_NUM_9, GPIO_NUM_8, GPIO_NUM_15);
+        #endif
+
     #elif USE_M5
 
         M5.begin();
@@ -611,7 +627,9 @@ void setup()
 
     // Initialize the strand controllers depending on how many channels we have
 
-    #if USE_HUB75
+    #if USE_M5LCD
+        M5TabGFX::InitializeHardware(devices);
+    #elif USE_HUB75
         // HUB75GFX is used for HUB75 projects like the Mesmerizer
         HUB75GFX::InitializeHardware(devices);
     #elif HEXAGON
@@ -650,7 +668,7 @@ void setup()
     #endif
 
     // Show splash effect on matrix
-    #if USE_HUB75
+    #if USE_HUB75 || USE_M5LCD
         debugI("Initializing splash effect manager...");
         InitSplashEffectManager();
 
@@ -783,6 +801,12 @@ void loop()
 
     while(true)
     {
+        #if M5TAB
+            M5.update();
+            if (M5.Touch.getDetail().wasPressed() && g_ptrSystem->HasEffectManager())
+                g_ptrSystem->GetEffectManager().NextEffect();
+        #endif
+
         #if (defined(MESMERIZER_DEVKIT) || defined(MESMERIZER_DEVKIT_S3)) && defined(TOGGLE_BUTTON_0)
             s_nextEffectButton.update();
             if (s_nextEffectButton.pressed() && g_ptrSystem->HasEffectManager())

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -32,6 +32,11 @@
 #include <esp_ota_ops.h>
 #include <fcntl.h>
 
+#if ENABLE_ESPNOW
+    #include <esp_arduino_version.h>
+    #include <esp_now.h>
+#endif
+
 #if ENABLE_WIFI
     #include <algorithm>
     #include <ArduinoOTA.h>
@@ -744,7 +749,11 @@ namespace nd_network
 // Global Support Helpers
 
 #if ENABLE_ESPNOW
+#if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+void onReceiveESPNOW(const esp_now_recv_info_t *, const uint8_t *data, int dataLen)
+#else
 void onReceiveESPNOW(const uint8_t *macAddr, const uint8_t *data, int dataLen)
+#endif
 {
     struct Message { uint8_t cbSize; uint8_t command; uint32_t arg1; } __attribute__((packed));
     Message message;

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -265,7 +265,6 @@ namespace nd_network
 
         static bool bPreviousConnection = false;
         static bool bReportedDisconnected = false;
-        static bool bConnectionAttempted = false;
         static unsigned long millisAtLastAttempt = 0;
         static unsigned long retryDelay = WIFI_WAIT_INIT;
         static String WiFi_ssid;
@@ -293,8 +292,9 @@ namespace nd_network
         }
 
         // (Re)connect if credentials were explicitly provided, or our last attempt was long enough ago
-        if (!isStaAssociated() &&
-            (explicitCredentials || millisAtLastAttempt == 0 || millis() - millisAtLastAttempt >= retryDelay))
+        if (explicitCredentials ||
+            (!isStaAssociated() &&
+             (millisAtLastAttempt == 0 || millis() - millisAtLastAttempt >= retryDelay)))
         {
             millisAtLastAttempt = millis();
             retryDelay = std::min<unsigned long>(retryDelay + WIFI_WAIT_INCREASE, WIFI_WAIT_MAX);
@@ -309,7 +309,7 @@ namespace nd_network
             if (hostname.length() > 0)
                 WiFi.setHostname(hostname.c_str());
 
-            if ((explicitCredentials && bConnectionAttempted) ||
+            if (explicitCredentials ||
                 (!isStaAssociated() && WiFi.status() == WL_CONNECT_FAILED))
             {
                 // Explicit credentials mean Improv or startup asked for a new
@@ -332,13 +332,12 @@ namespace nd_network
             // Association and DHCP callbacks run asynchronously. Re-check
             // immediately before begin() so a connection completed during
             // the setup above is not torn down by Arduino's begin path.
-            if (!isStaAssociated())
+            if (explicitCredentials || !isStaAssociated())
             {
                 debugW("Connecting to Wifi SSID: \"%s\" - ESP32 Free Memory: %zu, PSRAM:%zu, PSRAM Free: %zu\n",
                        WiFi_ssid.c_str(), (size_t)ESP.getFreeHeap(), (size_t)ESP.getPsramSize(), (size_t)ESP.getFreePsram());
 
                 WiFi.begin(WiFi_ssid.c_str(), WiFi_password.c_str());
-                bConnectionAttempted = true;
             }
 
             debugV("Done Wifi.begin, waiting for connection...");

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -241,12 +241,10 @@ namespace nd_network
                 else if (event == ARDUINO_EVENT_WIFI_STA_GOT_IP)
                 {
                     l_HasStaIp.store(true);
-                    DisableWiFiPowerSave("GOT_IP");
-                    debugI("WiFi GOT_IP: ip=%s gateway=%s subnet=%s dns=%s",
-                           WiFi.localIP().toString().c_str(),
-                           WiFi.gatewayIP().toString().c_str(),
-                           WiFi.subnetMask().toString().c_str(),
-                           WiFi.dnsIP().toString().c_str());
+                    // WiFi accessors are ESP-Hosted RPCs on the Tab5. Calling
+                    // them from the hosted event callback can race the normal
+                    // network task and trip hosted_memcpy assertions.
+                    debugI("WiFi GOT_IP");
                 }
                 else if (event == ARDUINO_EVENT_WIFI_STA_LOST_IP)
                 {
@@ -267,12 +265,17 @@ namespace nd_network
 
         static bool bPreviousConnection = false;
         static bool bReportedDisconnected = false;
+        static bool bConnectionAttempted = false;
         static unsigned long millisAtLastAttempt = 0;
         static unsigned long retryDelay = WIFI_WAIT_INIT;
         static String WiFi_ssid;
         static String WiFi_password;
 
         bool explicitCredentials = (ssid != nullptr && password != nullptr);
+        const auto isStaAssociated = []()
+        {
+            return WiFi.isConnected() || WiFi.status() == WL_CONNECTED;
+        };
 
         // If credentials are explicitly supplied, always start a fresh connection attempt.
         // This matters for USB provisioning, where the same SSID may be submitted with a
@@ -290,7 +293,8 @@ namespace nd_network
         }
 
         // (Re)connect if credentials were explicitly provided, or our last attempt was long enough ago
-        if (explicitCredentials || millisAtLastAttempt == 0 || millis() - millisAtLastAttempt >= retryDelay)
+        if (!isStaAssociated() &&
+            (explicitCredentials || millisAtLastAttempt == 0 || millis() - millisAtLastAttempt >= retryDelay))
         {
             millisAtLastAttempt = millis();
             retryDelay = std::min<unsigned long>(retryDelay + WIFI_WAIT_INCREASE, WIFI_WAIT_MAX);
@@ -305,7 +309,8 @@ namespace nd_network
             if (hostname.length() > 0)
                 WiFi.setHostname(hostname.c_str());
 
-            if (explicitCredentials || WiFi.status() == WL_CONNECT_FAILED)
+            if ((explicitCredentials && bConnectionAttempted) ||
+                (!isStaAssociated() && WiFi.status() == WL_CONNECT_FAILED))
             {
                 // Explicit credentials mean Improv or startup asked for a new
                 // connection attempt. Clear the driver's STA AP config so
@@ -324,10 +329,17 @@ namespace nd_network
                     debugW("WiFi remained connected after disconnect request; starting the new attempt anyway.");
             }
 
-            debugW("Connecting to Wifi SSID: \"%s\" - ESP32 Free Memory: %zu, PSRAM:%zu, PSRAM Free: %zu\n",
-                   WiFi_ssid.c_str(), (size_t)ESP.getFreeHeap(), (size_t)ESP.getPsramSize(), (size_t)ESP.getFreePsram());
+            // Association and DHCP callbacks run asynchronously. Re-check
+            // immediately before begin() so a connection completed during
+            // the setup above is not torn down by Arduino's begin path.
+            if (!isStaAssociated())
+            {
+                debugW("Connecting to Wifi SSID: \"%s\" - ESP32 Free Memory: %zu, PSRAM:%zu, PSRAM Free: %zu\n",
+                       WiFi_ssid.c_str(), (size_t)ESP.getFreeHeap(), (size_t)ESP.getPsramSize(), (size_t)ESP.getFreePsram());
 
-            WiFi.begin(WiFi_ssid.c_str(), WiFi_password.c_str());
+                WiFi.begin(WiFi_ssid.c_str(), WiFi_password.c_str());
+                bConnectionAttempted = true;
+            }
 
             debugV("Done Wifi.begin, waiting for connection...");
         }

--- a/src/soundanalyzer_input_init.cpp
+++ b/src/soundanalyzer_input_init.cpp
@@ -65,8 +65,8 @@ void SoundAnalyzerBase::InitI2S_Modern()
         .slot_cfg = I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_32BIT, I2S_SLOT_MODE_STEREO),
         .gpio_cfg = {
             .mclk = I2S_GPIO_UNUSED,
-            .bclk = I2S_BCLK_PIN,
-            .ws = I2S_WS_PIN,
+            .bclk = static_cast<gpio_num_t>(I2S_BCLK_PIN),
+            .ws = static_cast<gpio_num_t>(I2S_WS_PIN),
             .dout = I2S_GPIO_UNUSED,
             .din = static_cast<gpio_num_t>(audioInputPin),
         },

--- a/src/soundanalyzer_input_sampling.cpp
+++ b/src/soundanalyzer_input_sampling.cpp
@@ -57,7 +57,9 @@ size_t SoundAnalyzerBase::SampleI2S_Modern()
         if (i * kChannels >= (bytesRead / 4))
             break;
         int32_t s32 = tempBuffer[i * kChannels]; // Left channel
-        ptrSampleBuffer[i] = (int16_t)std::clamp(s32 >> 15, -32768, 32767);
+        const int32_t scaled = s32 >> 15;
+        ptrSampleBuffer[i] = static_cast<int16_t>(
+            std::clamp(scaled, static_cast<int32_t>(INT16_MIN), static_cast<int32_t>(INT16_MAX)));
     }
     bytesReadTotal = bytesRead / kChannels / 2; // Rough approximation of output samples converted to bytes
 #endif

--- a/src/taskmgr.cpp
+++ b/src/taskmgr.cpp
@@ -27,6 +27,18 @@ void IdleTask::ProcessIdleTime()
     _lastMeasurement = millis();
     counter = 0;
 
+    // Register from inside the task itself. Registering the task handles in
+    // TaskManager::begin() races with these tasks starting, and ESP-IDF 5.5
+    // reports every early reset attempt as "task not found".
+    #if M5TAB
+        // ESP32-P4's system idle-task watchdog subscriptions are managed
+        // explicitly in TaskManager::begin(). Do not subscribe these
+        // replacement CPU-meter tasks as additional watchdog clients.
+        constexpr bool watchdogRegistered = false;
+    #else
+        const bool watchdogRegistered = (esp_task_wdt_add(nullptr) == ESP_OK);
+    #endif
+
     // We need to whack the watchdog so we delay in smaller bites until we've used up all the time
 
     while (true)
@@ -42,7 +54,8 @@ void IdleTask::ProcessIdleTime()
         else
         {
             // Burn a little time and update the counter
-            esp_task_wdt_reset();
+            if (watchdogRegistered)
+                esp_task_wdt_reset();
             delayMicroseconds(kMillisPerLoop*1000);
             counter += kMillisPerLoop;
         }
@@ -73,15 +86,26 @@ void TaskManager::begin()
     // to see how much there is (it's how they measure free CPU).  Thus, we starve the system's normal idle tasks
     // and have to feed the watchdog on our own.
 
-#if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
+#if M5TAB
+    // The P4 Arduino core can leave one system idle task unsubscribable via
+    // esp_task_wdt_delete(), while our replacement idle task then becomes a
+    // stale watchdog client. Reconfigure the intended policy atomically:
+    // no idle-task clients, while preserving the watchdog for tasks/users
+    // that explicitly subscribe themselves.
+    const esp_task_wdt_config_t watchdogConfig = {
+        .timeout_ms = CONFIG_ESP_TASK_WDT_TIMEOUT_S * 1000U,
+        .idle_core_mask = 0,
+        .trigger_panic = true,
+    };
+    if (esp_task_wdt_reconfigure(&watchdogConfig) != ESP_OK)
+        debugW("Unable to reconfigure Tab5 task watchdog");
+#elif ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
     esp_task_wdt_delete(xTaskGetIdleTaskHandleForCore(0));
     esp_task_wdt_delete(xTaskGetIdleTaskHandleForCore(1));
 #else
     esp_task_wdt_delete(xTaskGetIdleTaskHandleForCPU(0));
     esp_task_wdt_delete(xTaskGetIdleTaskHandleForCPU(1));
 #endif
-    esp_task_wdt_add(_hIdle0);
-    esp_task_wdt_add(_hIdle1);
 }
 
 void TaskManager::CheckHeap()

--- a/src/webserver_settings.cpp
+++ b/src/webserver_settings.cpp
@@ -352,6 +352,10 @@ SuccessResultWithMessage CWebServer::SetSettingsIfPresent(AsyncWebServerRequest 
         const auto driver = pRequest->getParam(DeviceConfig::OutputDriverTag, true, false)->value();
         if (driver == "hub75")
             runtimeConfig.outputs.driver = DeviceConfig::OutputDriver::HUB75;
+        else if (driver == "m5lcd")
+            runtimeConfig.outputs.driver = DeviceConfig::OutputDriver::M5LCD;
+        else if (driver == "apa102")
+            runtimeConfig.outputs.driver = DeviceConfig::OutputDriver::APA102;
         else if (driver == "ws281x")
             runtimeConfig.outputs.driver = DeviceConfig::OutputDriver::WS281x;
         else

--- a/src/ws281xgfx.cpp
+++ b/src/ws281xgfx.cpp
@@ -283,7 +283,7 @@ void WS281xGFX::InitializeHardware(std::vector<std::shared_ptr<GFXBase>>& device
 //
 // PostProcessFrame sends the data to the LED strip.  If it's fewer than the size of the strip, we only send that many.
 
-void WS281xGFX::PostProcessFrame(uint16_t localPixelsDrawn, uint16_t wifiPixelsDrawn)
+void WS281xGFX::PostProcessFrame(size_t localPixelsDrawn, size_t wifiPixelsDrawn)
 {
     auto pixelsDrawn = wifiPixelsDrawn > 0 ? wifiPixelsDrawn : localPixelsDrawn;
 

--- a/tools/build_all.py
+++ b/tools/build_all.py
@@ -26,29 +26,36 @@
 #
 #    This script builds all the environment names defined in platformio.ini.
 #
-#    Note that it expects to be executed from the project root directory. That is,
-#    it needs to be run like this:
-#
-#    $ tools/build_all.py
-#
-#    Instead of:
-#
-#    $ cd tools
-#    $ ./build_all.py
+#    The script can be executed from any working directory.
 #
 # History:     Aug-27-2023         Rbergen      Created
 #
 #---------------------------------------------------------------------------
 
-import show_envs
 import subprocess
+
+
+if __package__:
+    from . import show_envs
+else:
+    import show_envs
+
 
 def buildenvs():
     errors = []
+    envs = show_envs.getenvs()
 
-    for env in show_envs.getenvs():
+    if not envs:
+        return ['No PlatformIO environments were found in ' + str(show_envs.PLATFORMIO_INI)]
+
+    for index, env in enumerate(envs, start=1):
+        print(f'[{index}/{len(envs)}] Building {env}...', flush=True)
         try:
-            subprocess.run(['pio', 'run', '-e', env], check=True)
+            subprocess.run(
+                ['pio', 'run', '-e', env],
+                check=True,
+                cwd=show_envs.PROJECT_ROOT,
+            )
         except subprocess.CalledProcessError as cpe:
             errors.append('Process \'' + ' '.join(cpe.cmd) + '\' completed with error code ' + str(cpe.returncode))
 

--- a/tools/merge_image.py
+++ b/tools/merge_image.py
@@ -1,4 +1,6 @@
 import os
+import re
+import subprocess
 
 Import("env")
 
@@ -49,6 +51,23 @@ def merge_bin(target, source, env):
 
     print(f"Creating merged image: {merged_image}")
 
+    # esptool 5 renamed commands and long options from underscores to hyphens.
+    # Detect the bundled tool at build time so older platform environments can
+    # continue using the legacy spelling without producing warnings on v5.
+    version_result = subprocess.run(
+        [env.subst("${PYTHONEXE}"), env.subst("${OBJCOPY}"), "version"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    version_match = re.search(r"(?:esptool v)?(\d+)(?:\.\d+)+", version_result.stdout)
+    modern_cli = version_match is not None and int(version_match.group(1)) >= 5
+
+    merge_command = "merge-bin" if modern_cli else "merge_bin"
+    flash_size_option = "--flash-size" if modern_cli else "--flash_size"
+    flash_mode_option = "--flash-mode" if modern_cli else "--flash_mode"
+    flash_freq_option = "--flash-freq" if modern_cli else "--flash_freq"
+
     # Run esptool to merge images into a single binary.
     env.Execute(
         " ".join(
@@ -57,12 +76,12 @@ def merge_bin(target, source, env):
                 "${OBJCOPY}",
                 "--chip",
                 board_config.get("build.mcu", "esp32"),
-                "merge_bin",
-                "--flash_size",
+                merge_command,
+                flash_size_option,
                 board_config.get("upload.flash_size", "4MB"),
-                "--flash_mode",
+                flash_mode_option,
                 flash_mode,
-                "--flash_freq",
+                flash_freq_option,
                 flash_freq,
                 "-o",
                 merged_image,

--- a/tools/show_envs.py
+++ b/tools/show_envs.py
@@ -28,15 +28,8 @@
 #    platformio.ini.
 #    It is used by this project's GitHub CI workflow.
 #
-#    Note that it expects to be executed from the project root directory. That is,
-#    it needs to be run like this:
-#
-#    $ tools/show_envs.py
-#
-#    Instead of:
-#
-#    $ cd tools
-#    $ ./show_envs.py
+#    The script resolves platformio.ini relative to its own location, so it can
+#    be executed from any working directory.
 #
 # History:     Aug-08-2023         Rbergen      Added header
 #              Aug-27-2023         Rbergen      Make importable
@@ -45,10 +38,17 @@
 
 import configparser
 import json
+from pathlib import Path
 
-def getenvs():
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PLATFORMIO_INI = PROJECT_ROOT / 'platformio.ini'
+
+
+def getenvs(config_path=PLATFORMIO_INI):
     config = configparser.ConfigParser()
-    config.read('platformio.ini')
+    with Path(config_path).open(encoding='utf-8') as config_file:
+        config.read_file(config_file)
 
     envs = []
 

--- a/tools/test_build_tools.py
+++ b/tools/test_build_tools.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tools import build_all, show_envs
+
+
+class ShowEnvsTests(unittest.TestCase):
+    def test_default_config_is_found_outside_project_root(self):
+        previous_cwd = Path.cwd()
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            try:
+                os.chdir(temporary_directory)
+                envs = show_envs.getenvs()
+            finally:
+                os.chdir(previous_cwd)
+
+        self.assertIn('demo', envs)
+
+    def test_missing_config_is_an_error(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            missing_config = Path(temporary_directory) / 'platformio.ini'
+            with self.assertRaises(FileNotFoundError):
+                show_envs.getenvs(missing_config)
+
+
+class BuildAllTests(unittest.TestCase):
+    @mock.patch('tools.build_all.subprocess.run')
+    @mock.patch('tools.build_all.show_envs.getenvs', return_value=['demo', 'spectrum'])
+    def test_builds_each_environment_from_project_root(self, getenvs, run):
+        self.assertEqual([], build_all.buildenvs())
+
+        getenvs.assert_called_once_with()
+        self.assertEqual(
+            [
+                mock.call(
+                    ['pio', 'run', '-e', 'demo'],
+                    check=True,
+                    cwd=show_envs.PROJECT_ROOT,
+                ),
+                mock.call(
+                    ['pio', 'run', '-e', 'spectrum'],
+                    check=True,
+                    cwd=show_envs.PROJECT_ROOT,
+                ),
+            ],
+            run.call_args_list,
+        )
+
+    @mock.patch('tools.build_all.subprocess.run')
+    @mock.patch('tools.build_all.show_envs.getenvs', return_value=[])
+    def test_empty_environment_list_is_an_error(self, getenvs, run):
+        errors = build_all.buildenvs()
+
+        self.assertEqual(1, len(errors))
+        self.assertIn('No PlatformIO environments were found', errors[0])
+        getenvs.assert_called_once_with()
+        run.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds M5 TAB support, including its 1280x720 display.  Renders all effects, some better than others.  FIxed many effects to "draw up" in resolution, as many never had to draw outside the 63x32 box before!

* [X] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [X] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [X] I selected `main` as the target branch.
* [X] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).