### PR TITLE
Cache PlatformIO packages in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,10 +24,71 @@ jobs:
     outputs:
       envs: ${{ steps.envs.outputs.envs }}
 
+  # Downloads the platform, toolchains and tools once, before the build matrix fans out.
+  # A cache written here is readable by every later job in the same run, which a cache
+  # written by the matrix itself would not be: caches are scoped per branch, so fork PRs
+  # can never read the ones this repository's own branches produce.
+  prime-package-cache:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+
+    # Falls back to the newest existing cache when the pin in platformio.ini is unchanged
+    # and only unrelated lines moved, which turns a re-key into a no-op instead of a
+    # full re-download. Only an exact miss writes a new entry further down.
+    - name: Restore PlatformIO packages
+      id: cache
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ~/.platformio/platforms
+          ~/.platformio/packages
+        key: pio-espressif32-${{ hashFiles('platformio.ini') }}
+        restore-keys: pio-espressif32-
+
+    - name: Install PlatformIO
+      run: |
+        curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py -o get-platformio.py
+        python get-platformio.py
+        echo "/home/runner/.platformio/penv/bin" >> $GITHUB_PATH
+
+    - name: Copy secrets and clear SSID
+      run: |
+        grep -v "^#define cszSSID" include/secrets.example.h > include/secrets.h
+        echo '#define cszSSID ""' >> include/secrets.h
+
+    # One environment per toolchain family: demo is xtensa (esp32/esp32s3 share the
+    # unified toolchain), mesmerizer_tab is riscv32 (esp32p4). Full builds rather than
+    # "pio pkg install" because pioarduino defers part of its setup - esptool, scons -
+    # to build time; installing packages alone leaves those out of the cache.
+    - name: Prime package cache
+      run: |
+        for attempt in 1 2 3; do
+          pio run -e demo -e mesmerizer_tab && exit 0
+          echo "::warning title=Retrying cache priming::Attempt $attempt failed"
+          sleep $((attempt * 30))
+        done
+        exit 1
+
+    - name: Save PlatformIO packages
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ~/.platformio/platforms
+          ~/.platformio/packages
+        key: pio-espressif32-${{ hashFiles('platformio.ini') }}
+
   build-environment:
     runs-on: ubuntu-latest
 
-    needs: [collect-environments]
+    needs: [collect-environments, prime-package-cache]
 
     strategy:
       fail-fast: false
@@ -42,6 +103,16 @@ jobs:
       with:
         python-version: '3.11'
 
+    # Restore only. 61 jobs saving the same key would be 60 wasted uploads.
+    - name: Restore PlatformIO packages
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ~/.platformio/platforms
+          ~/.platformio/packages
+        key: pio-espressif32-${{ hashFiles('platformio.ini') }}
+        restore-keys: pio-espressif32-
+
     - name: Install PlatformIO
       run: |
         curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py -o get-platformio.py
@@ -52,6 +123,18 @@ jobs:
       run: |
         grep -v "^#define cszSSID" include/secrets.example.h > include/secrets.h
         echo '#define cszSSID ""' >> include/secrets.h
+
+    # Concentrates every download this environment still needs - notably the workspace-local
+    # .pio/libdeps, which the package cache does not cover - into one retryable step, so the
+    # build below can fail fast on real errors instead of recompiling three times.
+    - name: "Install packages: ${{ matrix.envname }}"
+      run: |
+        for attempt in 1 2 3; do
+          pio pkg install -e ${{ matrix.envname }} && exit 0
+          echo "::warning title=Retrying package install::Attempt $attempt failed for ${{ matrix.envname }}"
+          sleep $((attempt * 30))
+        done
+        exit 1
 
     - name: "Build environment: ${{ matrix.envname }}"
       run: pio run -e ${{ matrix.envname }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,7 @@ jobs:
     # full re-download. Only an exact miss writes a new entry further down.
     - name: Restore PlatformIO packages
       id: cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       with:
         path: |
           ~/.platformio/platforms
@@ -85,7 +85,7 @@ jobs:
 
     - name: Save PlatformIO packages
       if: steps.cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v6
       with:
         path: |
           ~/.platformio/platforms
@@ -112,7 +112,7 @@ jobs:
 
     # Restore only. 61 jobs saving the same key would be 60 wasted uploads.
     - name: Restore PlatformIO packages
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       with:
         path: |
           ~/.platformio/platforms

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,13 +52,19 @@ jobs:
         key: pio-espressif32-${{ hashFiles('platformio.ini') }}
         restore-keys: pio-espressif32-
 
+    # Everything below is skipped on an exact hit: the cache is already complete, and the
+    # priming builds would only add ~8 minutes to the critical path of every run. They do
+    # run when the restore-keys fallback matched, which is what makes a re-key cheap - the
+    # builds are near no-ops when the platform pin itself did not move.
     - name: Install PlatformIO
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         curl -fsSL https://raw.githubusercontent.com/platformio/platformio-core-installer/master/get-platformio.py -o get-platformio.py
         python get-platformio.py
         echo "/home/runner/.platformio/penv/bin" >> $GITHUB_PATH
 
     - name: Copy secrets and clear SSID
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         grep -v "^#define cszSSID" include/secrets.example.h > include/secrets.h
         echo '#define cszSSID ""' >> include/secrets.h
@@ -68,6 +74,7 @@ jobs:
     # "pio pkg install" because pioarduino defers part of its setup - esptool, scons -
     # to build time; installing packages alone leaves those out of the cache.
     - name: Prime package cache
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         for attempt in 1 2 3; do
           pio run -e demo -e mesmerizer_tab && exit 0


### PR DESCRIPTION
## Description

Every CI job downloads the ESP32 platform and toolchains straight from GitHub release assets. Since #902 standardized all environments on pinned pioarduino, that is roughly 230MB per job across 61 jobs, pulled from github.com rather than PlatformIO's registry CDN. GitHub throttles it. Run 1963 lost 21 environments to 503s and `RemoteDisconnected` errors, and run 1964 needed a full 61-job re-run because `m5plusdemo` alone hit an I/O error.

This caches the PlatformIO package directories, primed in a job of its own ahead of the build matrix.

A cache bolted onto the matrix job would not have fixed it. The run that stampedes is the one with a cold cache, so all 61 jobs still miss and still download. A separate primer job populates it once, and what that job writes is readable by the rest of the run - including on fork PRs, which cannot read this repository's branch-scoped caches at all.

The primer builds one environment per toolchain family (`demo` for xtensa, `mesmerizer_tab` for riscv32) instead of only installing packages. pioarduino defers part of its setup - esptool, scons, the toolchain wiring - to build time. That is what left `tool-esptoolpy` half-installed and produced the `xtensa-esp32-elf-objcopy: not found` failures in run 1963. On an exact cache hit the primer skips those builds and costs 31s.

Per-environment downloads are split out of the build into a retried `pio pkg install` step. A flaky fetch now costs a retry instead of a matrix re-run, and a genuine compile error still fails on the first attempt.

The cache actions are on `v6` rather than `v4`. v4 targets Node 20, which the runners force onto Node 24 and warn about once per job, and its bundled dependencies add `punycode` and `url.parse` deprecation notices on top. v5 moved the action to Node 24 and v6 migrated it to ESM with updated packages. `path`, `key`, `restore-keys` and the `cache-hit` output are identical between v4 and v6, so cache behaviour is unchanged. The floating major matches how `checkout` and `setup-python` are pinned here.

### Results

|                | before  | cold cache | warm cache |
| -------------- | ------- | ---------- | ---------- |
| primer job     | -       | 504s       | 31s        |
| mean job       | 5.3 min | 4.3 min    | 4.3 min    |
| matrix compute | 322 min | 261 min    | 262 min    |

Cache entry is 1.4GB. The key hashes `platformio.ini`, with a `pio-espressif32-` prefix fallback so an unrelated edit to that file restores the previous entry and re-keys cheaply rather than re-downloading.

### Known residual

Each job still re-fetches the ~20MB platform zip, because PlatformIO reinstalls URL-specified platforms unconditionally. Per-job release-asset traffic drops from ~230MB to ~20MB, and the retry covers a 503 there.

Adding `~/.platformio/.cache/downloads` to the cached paths would close the gap, at the cost of growing the cache from 1.4GB to over 2GB against the 10GB per-repository limit. Left out deliberately - worth revisiting only if the flakiness recurs.

### Validation

All four runs green across all 61 environments, with zero retries fired.

Fork, where the timings above were measured:

* Cold cache: https://github.com/rbergen/NightDriverStrip/actions/runs/31880142449
* Warm cache: https://github.com/rbergen/NightDriverStrip/actions/runs/31887509847

Here, in this repository's own cache scope:

* Cold cache: https://github.com/PlummersSoftwareLLC/NightDriverStrip/actions/runs/31890066097
* Warm cache, on `v6`: https://github.com/PlummersSoftwareLLC/NightDriverStrip/actions/runs/31891146622

Also confirmed on those runs: the two primer environments cover both toolchain families, so no S3 environment downloads a toolchain of its own; the `pre:` scripts in `platformio.ini` do not fire during `pio pkg install`; and the v6 run carries no annotations at all across its 64 jobs, against 62 deprecation annotations on the v4 run.

## Contributing requirements

* [x] I read the contribution guidelines in [CONTRIBUTING.md](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/CONTRIBUTING.md).
* [x] I understand the BlinkenPerBit metric, and maximized it in this PR.
* [x] I selected `main` as the target branch.
* [x] All code herein is subjected to the license terms in [COPYING.txt](http://github.com/PlummersSoftwareLLC/NightDriverStrip/blob/main/COPYING.txt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

